### PR TITLE
pkg: add ability to specify alertmanagers

### DIFF
--- a/example/prometheus-rules.yaml
+++ b/example/prometheus-rules.yaml
@@ -4,5 +4,5 @@ metadata:
   name: prometheus-main-rules
 data:
   test.rules: |
-    ALERT Test
-    IF true
+    ALERT SomethingIsUp
+    IF up == 1

--- a/example/prometheus.yaml
+++ b/example/prometheus.yaml
@@ -14,3 +14,6 @@ spec:
   - selector:
       matchLabels:
         app: node-exporter
+  alertmanagers:
+  - namespace: monitoring
+    name: alertmanager-cluster

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,6 +42,7 @@ type Controller struct {
 	smonInf cache.SharedIndexInformer
 	cmapInf cache.SharedIndexInformer
 	psetInf cache.SharedIndexInformer
+	epntInf cache.SharedIndexInformer
 
 	queue *queue
 
@@ -112,6 +113,10 @@ func (c *Controller) Run(stopc <-chan struct{}) error {
 		cache.NewListWatchFromClient(c.kclient.Apps().GetRESTClient(), "petsets", api.NamespaceAll, nil),
 		&v1alpha1.PetSet{}, resyncPeriod, cache.Indexers{},
 	)
+	c.epntInf = cache.NewSharedIndexInformer(
+		cache.NewListWatchFromClient(c.kclient.Core().GetRESTClient(), "endpoints", api.NamespaceAll, nil),
+		&v1.Endpoints{}, resyncPeriod, cache.Indexers{},
+	)
 
 	c.promInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(p interface{}) {
@@ -163,13 +168,53 @@ func (c *Controller) Run(stopc <-chan struct{}) error {
 			c.updatePetSet(old, cur)
 		},
 	})
+	c.epntInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		// TODO(brancz): refactor duplication.
+		AddFunc: func(o interface{}) {
+			e := o.(*v1.Endpoints)
+			c.enqueuePrometheusIf(func(p *spec.Prometheus) bool {
+				for _, a := range p.Spec.Alertmanagers {
+					if a.Namespace == e.ObjectMeta.Namespace && a.Name == e.ObjectMeta.Name {
+						c.logger.Log("msg", "enqueuePrometheus", "trigger", "am service add")
+						return true
+					}
+				}
+				return false
+			})
+		},
+		UpdateFunc: func(_, cur interface{}) {
+			e := cur.(*v1.Endpoints)
+			c.enqueuePrometheusIf(func(p *spec.Prometheus) bool {
+				for _, a := range p.Spec.Alertmanagers {
+					if a.Namespace == e.ObjectMeta.Namespace && a.Name == e.ObjectMeta.Name {
+						c.logger.Log("msg", "enqueuePrometheus", "trigger", "am service update", "namespace", e.ObjectMeta.Namespace, "name", e.ObjectMeta.Name)
+						return true
+					}
+				}
+				return false
+			})
+		},
+		DeleteFunc: func(o interface{}) {
+			e := o.(*v1.Endpoints)
+			c.enqueuePrometheusIf(func(p *spec.Prometheus) bool {
+				for _, a := range p.Spec.Alertmanagers {
+					if a.Namespace == e.ObjectMeta.Namespace && a.Name == e.ObjectMeta.Name {
+						c.logger.Log("msg", "enqueuePrometheus", "trigger", "am service delete")
+						return true
+					}
+				}
+				return false
+			})
+		},
+	})
 
 	go c.promInf.Run(stopc)
 	go c.smonInf.Run(stopc)
 	go c.cmapInf.Run(stopc)
 	go c.psetInf.Run(stopc)
+	go c.epntInf.Run(stopc)
 
-	for !c.promInf.HasSynced() || !c.smonInf.HasSynced() || !c.cmapInf.HasSynced() || !c.psetInf.HasSynced() {
+	for !c.promInf.HasSynced() || !c.smonInf.HasSynced() || !c.cmapInf.HasSynced() || !c.psetInf.HasSynced() || !c.epntInf.HasSynced() {
 		time.Sleep(100 * time.Millisecond)
 	}
 
@@ -197,6 +242,14 @@ var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
 func (c *Controller) enqueuePrometheus(p interface{}) {
 	c.queue.add(p.(*spec.Prometheus))
+}
+
+func (c *Controller) enqueuePrometheusIf(f func(p *spec.Prometheus) bool) {
+	cache.ListAll(c.promInf.GetStore(), labels.Everything(), func(o interface{}) {
+		if f(o.(*spec.Prometheus)) {
+			c.enqueuePrometheus(o.(*spec.Prometheus))
+		}
+	})
 }
 
 func (c *Controller) enqueueAll() {
@@ -329,13 +382,31 @@ func (c *Controller) reconcile(p *spec.Prometheus) error {
 		return err
 	}
 
+	am := []string{}
+	for _, eselector := range p.Spec.Alertmanagers {
+		epntQ := &v1.Endpoints{}
+		epntQ.Name = eselector.Name
+		epntQ.Namespace = eselector.Namespace
+		obj, exists, err := c.epntInf.GetStore().Get(epntQ)
+		if err != nil {
+			return err
+		}
+		if exists {
+			for _, s := range obj.(*v1.Endpoints).Subsets {
+				for _, a := range s.Addresses {
+					am = append(am, fmt.Sprintf("http://%s:%d", a.IP, s.Ports[0].Port))
+				}
+			}
+		}
+	}
+
 	if !exists {
-		if _, err := psetClient.Create(makePetSet(p, nil)); err != nil {
+		if _, err := psetClient.Create(makePetSet(p, nil, am)); err != nil {
 			return fmt.Errorf("create petset: %s", err)
 		}
 		return nil
 	}
-	if _, err := psetClient.Update(makePetSet(p, obj.(*v1alpha1.PetSet))); err != nil {
+	if _, err := psetClient.Update(makePetSet(p, obj.(*v1alpha1.PetSet), am)); err != nil {
 		return err
 	}
 

--- a/pkg/controller/petset.go
+++ b/pkg/controller/petset.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coreos/kube-prometheus-controller/pkg/spec"
 	"k8s.io/client-go/1.5/pkg/api/v1"
@@ -9,7 +10,7 @@ import (
 	"k8s.io/client-go/1.5/pkg/util/intstr"
 )
 
-func makePetSet(p *spec.Prometheus, old *v1alpha1.PetSet) *v1alpha1.PetSet {
+func makePetSet(p *spec.Prometheus, old *v1alpha1.PetSet, alertmanagers []string) *v1alpha1.PetSet {
 	// TODO(fabxc): is this the right point to inject defaults?
 	// Ideally we would do it before storing but that's currently not possible.
 	// Potentially an update handler on first insertion.
@@ -32,7 +33,7 @@ func makePetSet(p *spec.Prometheus, old *v1alpha1.PetSet) *v1alpha1.PetSet {
 		ObjectMeta: v1.ObjectMeta{
 			Name: p.Name,
 		},
-		Spec: makePetSetSpec(p.Name, image, version, replicas),
+		Spec: makePetSetSpec(p.Name, image, version, replicas, alertmanagers),
 	}
 	if vc := p.Spec.Storage; vc == nil {
 		petset.Spec.Template.Spec.Volumes = append(petset.Spec.Template.Spec.Volumes, v1.Volume{
@@ -105,7 +106,12 @@ func makePetSetService(p *spec.Prometheus) *v1.Service {
 	return svc
 }
 
-func makePetSetSpec(name, image, version string, replicas int32) v1alpha1.PetSetSpec {
+func makePetSetSpec(name, image, version string, replicas int32, alertmanagers []string) v1alpha1.PetSetSpec {
+	amFlag := ""
+	if len(alertmanagers) > 0 {
+		amFlag = "-alertmanager.url=" + strings.Join(alertmanagers, ",")
+	}
+
 	// Prometheus may take quite long to shut down to checkpoint existing data.
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
@@ -140,6 +146,7 @@ func makePetSetSpec(name, image, version string, replicas int32) v1alpha1.PetSet
 							"-storage.local.memory-chunks=500000",
 							"-storage.local.path=/var/prometheus/data",
 							"-config.file=/etc/prometheus/config/prometheus.yaml",
+							amFlag,
 						},
 						VolumeMounts: []v1.VolumeMount{
 							{

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -29,6 +29,7 @@ type PrometheusSpec struct {
 	BaseImage          string                    `json:"baseImage"`
 	Replicas           int32                     `json:"replicas"`
 	Storage            *StorageSpec              `json:"storage"`
+	Alertmanagers      []AlertmanagerEndpoints   `json:"alertmanagers"`
 	// Retention       string                     `json:"retention"`
 	// Replicas        int                        `json:"replicas"`
 	// Resources       apiV1.ResourceRequirements `json:"resources"`
@@ -43,6 +44,13 @@ type StorageSpec struct {
 	Class     string                     `json:"class"`
 	Selector  *unversioned.LabelSelector `json:"selector"`
 	Resources v1.ResourceRequirements    `json:"resources"`
+}
+
+// AlertmanagerEndpoints defines a selection of a single Endpoints object
+// containing alertmanager IPs to fire alerts against.
+type AlertmanagerEndpoints struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
 }
 
 // ServiceMonitorSelection selects service monitors by their labels.


### PR DESCRIPTION
@fabxc drafted out how I thought it makes most sense. There are a couple things that can be improved and optimized, but wanted to hear your opinion before putting more work into it. I also setup a HA AM cluster with the `kube-alertmanager-controller` and it is working nicely together.