### PR TITLE
adapt container image repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
+all: build
+
+REPO = quay.io/coreos/prometheus-operator
+TAG = latest
+
 build:
 	./scripts/check_license.sh
 	go build github.com/coreos/prometheus-operator/cmd/operator
 
 container:
-	docker build -t quay.io/coreos/prometheus-operator.
+	docker build -t $(REPO):$(TAG) .
+
+.PHONY: all build container


### PR DESCRIPTION
@fabxc 

image already pushed with this, will leave it out for the alertmanager operator as it can be done when merging/renaming it

but will already push an image to the alertmanager container repo to move forward on deployment object manifests in kube-prometheus