### PR TITLE
Add support for prometheus, alertmanager to be hostNetworked

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -98,6 +98,7 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 | resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
+| hostNetwork | If specified, the pod's hostNetwork will be true | bool | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -213,6 +214,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 | remoteWrite | If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteWriteSpec](#remotewritespec) | false |
 | remoteRead | If specified, the remote_read spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteReadSpec](#remotereadspec) | false |
 | SecurityContext | SecurityContext holds pod-level security attributes and common container settings. This defaults to non root user with uid 1000 and gid 2000 for Prometheus >v2.0 and default PodSecurityContext for other versions. | *v1.PodSecurityContext | false |
+| hostNetwork | If specified, the pod hostNetwork is enabled | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -98,7 +98,7 @@ Specification of the desired behavior of the Alertmanager cluster. More info: ht
 | resources | Define resources requests and limits for single Pods. | [v1.ResourceRequirements](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core) | false |
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
-| hostNetwork | If specified, the pod's hostNetwork will be true | bool | false |
+| hostNetwork | If set to true, the pod's hostNetwork will be enabled. | bool | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -214,7 +214,7 @@ Specification of the desired behavior of the Prometheus cluster. More info: http
 | remoteWrite | If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteWriteSpec](#remotewritespec) | false |
 | remoteRead | If specified, the remote_read spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteReadSpec](#remotereadspec) | false |
 | SecurityContext | SecurityContext holds pod-level security attributes and common container settings. This defaults to non root user with uid 1000 and gid 2000 for Prometheus >v2.0 and default PodSecurityContext for other versions. | *v1.PodSecurityContext | false |
-| hostNetwork | If specified, the pod hostNetwork is enabled | bool | false |
+| hostNetwork | If set to true, the pod's hostNetwork will be enabled. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -200,13 +200,14 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*v1beta1.
 		},
 	}
 
-	// If hostNetwork is true, then set podSpec.HostNetwork: true, and podSpec.DnsPolicy to
 	var hostNetwork bool
 	var dnsPolicy v1.DNSPolicy
 	hostNetwork = a.Spec.HostNetwork
 	if hostNetwork {
+		// If hostNetwork is true, set DNSPolicy to `v1.DNSClusterFirstWithHostNet`.
 		dnsPolicy = v1.DNSClusterFirstWithHostNet
 	} else {
+		// Otherwise, use default value.
 		dnsPolicy = v1.DNSClusterFirst
 	}
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -200,6 +200,16 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*v1beta1.
 		},
 	}
 
+	// If hostNetwork is true, then set podSpec.HostNetwork: true, and podSpec.DnsPolicy to
+	var hostNetwork bool
+	var dnsPolicy v1.DNSPolicy
+	hostNetwork = a.Spec.HostNetwork
+	if hostNetwork {
+		dnsPolicy = v1.DNSClusterFirstWithHostNet
+	} else {
+		dnsPolicy = v1.DNSClusterFirst
+	}
+
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	if a.Spec.PodMetadata != nil {
@@ -326,6 +336,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*v1beta1.
 				},
 				Tolerations: a.Spec.Tolerations,
 				Affinity:    a.Spec.Affinity,
+				HostNetwork: hostNetwork,
+				DNSPolicy:   dnsPolicy,
 			},
 		},
 	}, nil

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -176,3 +176,28 @@ func TestStatefulEmptyDir(t *testing.T) {
 		t.Fatal("Error adding EmptyDir Spec to StatefulSetSpec")
 	}
 }
+
+func TestHostNetwork(t *testing.T) {
+	labels := map[string]string{
+		"testlabel": "testlabelvalue",
+	}
+	annotations := map[string]string{
+		"testannotation": "testannotationvalue",
+	}
+
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			HostNetwork: true,
+		},
+	}, nil, defaultTestConfig, []*v1.ConfigMap{})
+
+	require.NoError(t, err)
+
+	if sset.Spec.Template.Spec.HostNetwork != true || sset.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirstWithHostNet {
+		t.Fatal("HostNetwork is not set correctlly for prometheus statefulset")
+	}
+}

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -185,19 +185,18 @@ func TestHostNetwork(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+	sset, err := makeStatefulSet(&monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: monitoringv1.PrometheusSpec{
+		Spec: monitoringv1.AlertmanagerSpec{
 			HostNetwork: true,
 		},
-	}, nil, defaultTestConfig, []*v1.ConfigMap{})
+	}, nil, defaultTestConfig)
 
 	require.NoError(t, err)
-
 	if sset.Spec.Template.Spec.HostNetwork != true || sset.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirstWithHostNet {
-		t.Fatal("HostNetwork is not set correctlly for prometheus statefulset")
+		t.Fatal("HostNetwork is not set correctlly for alertamanager statefulset")
 	}
 }

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -122,6 +122,8 @@ type PrometheusSpec struct {
 	// This defaults to non root user with uid 1000 and gid 2000 for Prometheus >v2.0 and
 	// default PodSecurityContext for other versions.
 	SecurityContext *v1.PodSecurityContext
+	// If specified, the pod hostNetwork is enabled
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 // Most recent observed status of the Prometheus cluster. Read-only. Not
@@ -389,6 +391,8 @@ type AlertmanagerSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// If specified, the pod's tolerations.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	// If specified, the pod's hostNetwork will be true
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 // A list of Alertmanagers.

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -122,7 +122,7 @@ type PrometheusSpec struct {
 	// This defaults to non root user with uid 1000 and gid 2000 for Prometheus >v2.0 and
 	// default PodSecurityContext for other versions.
 	SecurityContext *v1.PodSecurityContext
-	// If specified, the pod hostNetwork is enabled
+	// If set to true, the pod's hostNetwork will be enabled.
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
@@ -391,7 +391,7 @@ type AlertmanagerSpec struct {
 	Affinity *v1.Affinity `json:"affinity,omitempty"`
 	// If specified, the pod's tolerations.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
-	// If specified, the pod's hostNetwork will be true
+	// If set to true, the pod's hostNetwork will be enabled.
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -503,6 +503,16 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 		livenessProbeInitialDelaySeconds = 300
 	}
 
+	// If hostNetwork is true, then set podSpec.HostNetwork: true, and podSpec.DnsPolicy to
+	var hostNetwork bool
+	var dnsPolicy v1.DNSPolicy
+	hostNetwork = p.Spec.HostNetwork
+	if hostNetwork {
+		dnsPolicy = v1.DNSClusterFirstWithHostNet
+	} else {
+		dnsPolicy = v1.DNSClusterFirst
+	}
+
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	if p.Spec.PodMetadata != nil {
@@ -579,6 +589,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 				Volumes:     volumes,
 				Tolerations: p.Spec.Tolerations,
 				Affinity:    p.Spec.Affinity,
+				HostNetwork: hostNetwork,
+				DNSPolicy:   dnsPolicy,
 			},
 		},
 	}, nil

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -503,13 +503,14 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *Config, ruleConfigMaps []
 		livenessProbeInitialDelaySeconds = 300
 	}
 
-	// If hostNetwork is true, then set podSpec.HostNetwork: true, and podSpec.DnsPolicy to
 	var hostNetwork bool
 	var dnsPolicy v1.DNSPolicy
 	hostNetwork = p.Spec.HostNetwork
 	if hostNetwork {
+		// If hostNetwork is true, set DNSPolicy to `v1.DNSClusterFirstWithHostNet`.
 		dnsPolicy = v1.DNSClusterFirstWithHostNet
 	} else {
+		// Otherwise, use default value.
 		dnsPolicy = v1.DNSClusterFirst
 	}
 

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -15,14 +15,15 @@
 package prometheus
 
 import (
+	"reflect"
+	"testing"
+
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
-	"testing"
 )
 
 var (

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -317,3 +317,28 @@ func makeConfigMap() *v1.ConfigMap {
 
 	return res
 }
+
+func TestHostNetwork(t *testing.T) {
+	labels := map[string]string{
+		"testlabel": "testlabelvalue",
+	}
+	annotations := map[string]string{
+		"testannotation": "testannotationvalue",
+	}
+
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			HostNetwork: true,
+		},
+	}, nil, defaultTestConfig, []*v1.ConfigMap{})
+
+	require.NoError(t, err)
+
+	if sset.Spec.Template.Spec.HostNetwork != true || sset.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirstWithHostNet {
+		t.Fatal("HostNetwork is not set correctlly for prometheus statefulset")
+	}
+}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -15,15 +15,14 @@
 package prometheus
 
 import (
-	"reflect"
-	"testing"
-
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
 )
 
 var (


### PR DESCRIPTION
Prometheus Operator is great.

In our company, the prometheus and alertmanager belongs to system components which are very important and must be hostnetworked , so we add prometheus-operator to support deploying hostnetworked prometheus and alertmanager.
