### PR TITLE
Support for custom relabeling_configs

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -145,6 +145,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | bearerTokenFile | File to read bearer token for scraping targets. | string | false |
 | honorLabels | HonorLabels chooses the metric's labels on collisions with target labels. | bool | false |
 | basicAuth | BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints | *[BasicAuth](#basicauth) | false |
+| relabelings | RelabelConfigs to apply before scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<relabel_config> | []*[RelabelConfig](#relabelconfig) | false |
 | metricRelabelings | MetricRelabelConfigs to apply to samples before ingestion. | []*[RelabelConfig](#relabelconfig) | false |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/user-guides/blackbox-exporter.md
+++ b/Documentation/user-guides/blackbox-exporter.md
@@ -1,0 +1,39 @@
+<br>
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-exclamation-triangle"></i><b> Note:</b> Starting with v0.12.0, Prometheus Operator requires use of Kubernetes v1.7.x and up.
+</div>
+
+# Blackbox exporter
+
+The (blackbox exporter)[https://github.com/prometheus/blackbox_exporter] needs to be
+passed the target as a parameter, relabelings can be used to label metrics with the target.
+
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: blackbox-exporter
+  namespace: default
+  labels:
+    app: blackbox-exporter
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  endpoints:
+  - port: web
+    path: /probe
+    params:
+      module:
+        - http_2xx
+      target:
+        - http://domain.com
+    relabelings:
+      - sourceLabels:
+          - __param_target
+        targetLabel: target
+      - sourceLabels:
+          - __param_module
+        targetLabel: module
+```

--- a/pkg/client/monitoring/v1/types.go
+++ b/pkg/client/monitoring/v1/types.go
@@ -294,6 +294,9 @@ type Endpoint struct {
 	// BasicAuth allow an endpoint to authenticate over basic authentication
 	// More info: https://prometheus.io/docs/operating/configuration/#endpoints
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
+	// RelabelConfigs to apply before scraping.
+	// More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<relabel_config>
+	RelabelConfigs []*RelabelConfig `json:"relabelings,omitempty"`
 	// MetricRelabelConfigs to apply to samples before ingestion.
 	MetricRelabelConfigs []*RelabelConfig `json:"metricRelabelings,omitempty"`
 }

--- a/pkg/client/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/client/monitoring/v1/zz_generated.deepcopy.go
@@ -400,6 +400,18 @@ func (in *Endpoint) DeepCopyInto(out *Endpoint) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.RelabelConfigs != nil {
+		in, out := &in.RelabelConfigs, &out.RelabelConfigs
+		*out = make([]*RelabelConfig, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(RelabelConfig)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
+		}
+	}
 	if in.MetricRelabelConfigs != nil {
 		in, out := &in.MetricRelabelConfigs, &out.MetricRelabelConfigs
 		*out = make([]*RelabelConfig, len(*in))

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -368,6 +368,40 @@ func generateServiceMonitorConfig(version semver.Version, m *v1.ServiceMonitor, 
 		})
 	}
 
+	if ep.RelabelConfigs != nil {
+		for _, c := range ep.RelabelConfigs {
+			relabeling := yaml.MapSlice{
+				{Key: "source_labels", Value: c.SourceLabels},
+			}
+
+			if c.Separator != "" {
+				relabeling = append(relabeling, yaml.MapItem{Key: "separator", Value: c.Separator})
+			}
+
+			if c.TargetLabel != "" {
+				relabeling = append(relabeling, yaml.MapItem{Key: "target_label", Value: c.TargetLabel})
+			}
+
+			if c.Regex != "" {
+				relabeling = append(relabeling, yaml.MapItem{Key: "regex", Value: c.Regex})
+			}
+
+			if c.Modulus != uint64(0) {
+				relabeling = append(relabeling, yaml.MapItem{Key: "modulus", Value: c.Modulus})
+			}
+
+			if c.Replacement != "" {
+				relabeling = append(relabeling, yaml.MapItem{Key: "replacement", Value: c.Replacement})
+			}
+
+			if c.Action != "" {
+				relabeling = append(relabeling, yaml.MapItem{Key: "action", Value: c.Action})
+			}
+
+			relabelings = append(relabelings, relabeling)
+		}
+	}
+
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	if ep.MetricRelabelConfigs != nil {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -211,5 +211,43 @@ func makeServiceMonitors() map[string]*monitoringv1.ServiceMonitor {
 		},
 	}
 
+	res["servicemonitor5"] = &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservicemonitor5",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group8",
+			},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"group":  "group8",
+					"group3": "group9",
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				monitoringv1.Endpoint{
+					Port:     "web",
+					Interval: "60s",
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						&monitoringv1.RelabelConfig{
+							SourceLabels: []string{"__address__"},
+							TargetLabel:  "__param_target",
+						},
+						&monitoringv1.RelabelConfig{
+							SourceLabels: []string{"__param_target"},
+							TargetLabel:  "instance",
+						},
+						&monitoringv1.RelabelConfig{
+							TargetLabel: "__address__",
+							Replacement: "127.0.0.1:9115",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	return res
 }


### PR DESCRIPTION
Add support for custom relabelings with the relabel_configs property. This PR is heavily based on #843. 

It doesn't seems like `__param_target` was available when using MetricRelabelConfigs, with this change I was able to scrape the blackbox exporter and correctly attaching labels. 

This change manipulates the `relabel_config ` property that prometheus-operator tries to automate by using selectors. Let me know if this is something this project would consider as a useful feature or not.



