### PR TITLE
Use wildcard serviceMonitorSelector in example

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -189,8 +189,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: example-app
-  labels:
-    team: frontend
 spec:
   selector:
     matchLabels:
@@ -255,8 +253,6 @@ For more information, see the [Prometheus Operator RBAC guide][prom-rbac].
 
 ## Include ServiceMonitors
 
-Finally, a Prometheus object defines the `serviceMonitorSelector` to specify which ServiceMonitors should be included. Above the label `team: frontend` was specified, so that's what the Prometheus object selects by.
-
 [embedmd]:# (../../example/user-guides/getting-started/prometheus.yaml)
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -264,9 +260,7 @@ kind: Prometheus
 metadata:
   name: prometheus
 spec:
-  serviceMonitorSelector:
-    matchLabels:
-      team: frontend
+  serviceMonitorSelector: {}
   resources:
     requests:
       memory: 400Mi
@@ -275,6 +269,9 @@ spec:
 > If you have RBAC authorization activated, use the RBAC aware [Prometheus manifest][prometheus-manifest] instead.
 
 This enables the frontend team to create new ServiceMonitors and Services which allow Prometheus to be dynamically reconfigured.
+
+Note: `serviceMonitorSelector: {}` selects all service monitors.  If you omit this key altogether, it won't auto-detect any 
+service monitors at all.
 
 ## Expose the Prometheus instance
 

--- a/example/user-guides/getting-started/example-app-service-monitor.yaml
+++ b/example/user-guides/getting-started/example-app-service-monitor.yaml
@@ -2,8 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: example-app
-  labels:
-    team: frontend
 spec:
   selector:
     matchLabels:

--- a/example/user-guides/getting-started/prometheus.yaml
+++ b/example/user-guides/getting-started/prometheus.yaml
@@ -3,9 +3,7 @@ kind: Prometheus
 metadata:
   name: prometheus
 spec:
-  serviceMonitorSelector:
-    matchLabels:
-      team: frontend
+  serviceMonitorSelector: {}
   resources:
     requests:
       memory: 400Mi

--- a/helm/prometheus/templates/prometheus.yaml
+++ b/helm/prometheus/templates/prometheus.yaml
@@ -60,9 +60,7 @@ spec:
   serviceMonitorSelector:
 {{ toYaml .Values.serviceMonitorsSelector | indent 4 }}
 {{- else }}
-  serviceMonitorSelector:
-    matchLabels:
-      prometheus: {{ .Release.Name }}
+  serviceMonitorSelector: {}
 {{- end }}
 {{- if .Values.rulesSelector }}
   ruleSelector:


### PR DESCRIPTION
Specifying a specific `serviceMonitorSelector` is a more advanced topic, it's not needed for "getting started".

See also https://github.com/coreos/prometheus-operator/issues/1053
