### PR TITLE
jsonnet: consistent dash in flags

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -115,7 +115,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -97,7 +97,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - -logtostderr=true
+        - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.23.0
         image: quay.io/coreos/prometheus-operator:v0.23.0

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -121,7 +121,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
           '--kubelet-service=kube-system/kubelet',
           // Prometheus Operator is run with a read-only root file system. By
           // default glog saves logfiles to /tmp. Make it log to stderr instead.
-          '-logtostderr=true',
+          '--logtostderr=true',
           '--config-reloader-image=' + $._config.imageRepos.configmapReloader + ':' + $._config.versions.configmapReloader,
           '--prometheus-config-reloader=' + $._config.imageRepos.prometheusConfigReloader + ':' + $._config.versions.prometheusOperator,
         ]) +


### PR DESCRIPTION
The Prometheus Operator manifests all use double dashes for long flags
exept for the `logtostderr` flag, which uses one dash. This commit
adjusts the Prometheus Operator libsonnet to fix this. The
kube-prometheus project will need to be bumped later to pick up this
change.