### PR TITLE
[WIP] Update Status on Operator Custom Resources

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,6 +61,7 @@ var (
 	prometheusRoute = regexp.MustCompile("/apis/monitoring.coreos.com/" + v1.Version + "/namespaces/(.*)/prometheuses/(.*)/status")
 )
 
+// TODO(alecmerdler): Remove this in favor of writing `status` subresource
 func (api *API) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		if prometheusRoute.MatchString(req.URL.Path) {

--- a/pkg/client/monitoring/v1/alertmanager.go
+++ b/pkg/client/monitoring/v1/alertmanager.go
@@ -42,6 +42,7 @@ type AlertmanagerInterface interface {
 	Create(*Alertmanager) (*Alertmanager, error)
 	Get(name string, opts metav1.GetOptions) (*Alertmanager, error)
 	Update(*Alertmanager) (*Alertmanager, error)
+	UpdateStatus(*Alertmanager) (*Alertmanager, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
@@ -111,6 +112,19 @@ func (a *alertmanagers) Update(o *Alertmanager) (*Alertmanager, error) {
 	}
 
 	return AlertmanagerFromUnstructured(ua)
+}
+
+func (a *alertmanagers) UpdateStatus(o *Alertmanager) (*Alertmanager, error) {
+	result := &Alertmanager{}
+	err := a.restClient.Put().
+		Namespace(a.ns).
+		Resource("alertmanagers").
+		Name(o.Name).
+		SubResource("status").
+		Body(o).
+		Do().
+		Into(result)
+	return result, err
 }
 
 func (a *alertmanagers) Delete(name string, options *metav1.DeleteOptions) error {

--- a/pkg/client/monitoring/v1/prometheus.go
+++ b/pkg/client/monitoring/v1/prometheus.go
@@ -42,6 +42,7 @@ type PrometheusInterface interface {
 	Create(*Prometheus) (*Prometheus, error)
 	Get(name string, opts metav1.GetOptions) (*Prometheus, error)
 	Update(*Prometheus) (*Prometheus, error)
+	UpdateStatus(*Prometheus) (*Prometheus, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
@@ -111,6 +112,19 @@ func (p *prometheuses) Update(o *Prometheus) (*Prometheus, error) {
 	}
 
 	return PrometheusFromUnstructured(up)
+}
+
+func (p *prometheuses) UpdateStatus(o *Prometheus) (*Prometheus, error) {
+	result := &Prometheus{}
+	err := p.restClient.Put().
+		Namespace(p.ns).
+		Resource("prometheuses").
+		Name(o.Name).
+		SubResource("status").
+		Body(o).
+		Do().
+		Into(result)
+	return result, err
 }
 
 func (p *prometheuses) Delete(name string, options *metav1.DeleteOptions) error {

--- a/pkg/client/monitoring/v1/prometheusrule.go
+++ b/pkg/client/monitoring/v1/prometheusrule.go
@@ -42,6 +42,7 @@ type PrometheusRuleInterface interface {
 	Create(*PrometheusRule) (*PrometheusRule, error)
 	Get(name string, opts metav1.GetOptions) (*PrometheusRule, error)
 	Update(*PrometheusRule) (*PrometheusRule, error)
+	UpdateStatus(*PrometheusRule) (*PrometheusRule, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
@@ -111,6 +112,19 @@ func (s *prometheusrules) Update(o *PrometheusRule) (*PrometheusRule, error) {
 	}
 
 	return PrometheusRuleFromUnstructured(us)
+}
+
+func (s *prometheusrules) UpdateStatus(o *PrometheusRule) (*PrometheusRule, error) {
+	result := &PrometheusRule{}
+	err := s.restClient.Put().
+		Namespace(s.ns).
+		Resource("prometheusrules").
+		Name(o.Name).
+		SubResource("status").
+		Body(o).
+		Do().
+		Into(result)
+	return result, err
 }
 
 func (s *prometheusrules) Delete(name string, options *metav1.DeleteOptions) error {

--- a/pkg/client/monitoring/v1/servicemonitor.go
+++ b/pkg/client/monitoring/v1/servicemonitor.go
@@ -42,6 +42,7 @@ type ServiceMonitorInterface interface {
 	Create(*ServiceMonitor) (*ServiceMonitor, error)
 	Get(name string, opts metav1.GetOptions) (*ServiceMonitor, error)
 	Update(*ServiceMonitor) (*ServiceMonitor, error)
+	UpdateStatus(*ServiceMonitor) (*ServiceMonitor, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
@@ -111,6 +112,19 @@ func (s *servicemonitors) Update(o *ServiceMonitor) (*ServiceMonitor, error) {
 	}
 
 	return ServiceMonitorFromUnstructured(us)
+}
+
+func (s *servicemonitors) UpdateStatus(o *ServiceMonitor) (*ServiceMonitor, error) {
+	result := &ServiceMonitor{}
+	err := s.restClient.Put().
+		Namespace(s.ns).
+		Resource("servicemonitors").
+		Name(o.Name).
+		SubResource("status").
+		Body(o).
+		Do().
+		Into(result)
+	return result, err
 }
 
 func (s *servicemonitors) Delete(name string, options *metav1.DeleteOptions) error {


### PR DESCRIPTION
### Description

Uses the [Kubernetes CRD `status` sub-resource](https://github.com/kubernetes/kubernetes/pull/55168) to reflect the status for `Prometheus`, `PrometheusRule`, `Alertmanager`, and `ServiceMonitor` instances.

Addresses #887 