### PR TITLE
Update the getting-started documentation ClusterRole definition

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -38,6 +38,11 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  resourceNames:
+    - servicemonitors.monitoring.coreos.com
+    - prometheusrules.monitoring.coreos.com
+    - prometheuses.monitoring.coreos.com
+    - alertmanagers.monitoring.coreos.com
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
The ClusterRole scope on the definition provided by the manifest in the
getting started was too wide regarding customresourcedefinitions. Since
the resourceNames were not specified, the ClusteRole could modify any
customresourcedefinitions in the cluster.

This commit fixes that by reducing the scope of the permissions
regarding customresourcedefinitions, only to servicemonitors,
prometheusrules, prometheuses and alertmanagers.