### PR TITLE
ServicemonitorKey

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -492,9 +492,8 @@ func (cg *configGenerator) generateServiceMonitorConfig(version semver.Version, 
 	// as a fallback the port number.
 
 	relabelings = append(relabelings, yaml.MapSlice{
-		{Key: "source_labels", Value: []string{"__meta_kubernetes_service_name"}},
 		{Key: "target_label", Value: "job"},
-		{Key: "replacement", Value: "${1}"},
+		{Key: "replacement", Value: fmt.Sprintf("%s/%s", m.GetNamespace(), m.GetName())},
 	})
 	if m.Spec.JobLabel != "" {
 		relabelings = append(relabelings, yaml.MapSlice{

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -497,10 +497,8 @@ scrape_configs:
     target_label: env
     regex: (.+)
     replacement: ${1}
-  - source_labels:
-    - __meta_kubernetes_service_name
-    target_label: job
-    replacement: ${1}
+  - target_label: job
+    replacement: default/testservicemonitor1
   - target_label: endpoint
     replacement: web
 alerting:
@@ -618,10 +616,8 @@ scrape_configs:
     target_label: env
     regex: (.+)
     replacement: ${1}
-  - source_labels:
-    - __meta_kubernetes_service_name
-    target_label: job
-    replacement: ${1}
+  - target_label: job
+    replacement: default/testservicemonitor1
   - target_label: endpoint
     replacement: web
 alerting:
@@ -723,10 +719,8 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
-  - source_labels:
-    - __meta_kubernetes_service_name
-    target_label: job
-    replacement: ${1}
+  - target_label: job
+    replacement: default/test
 alerting:
   alert_relabel_configs:
   - action: labeldrop


### PR DESCRIPTION
Use the ServiceMonitor key as the default job name as proposed by @brancz in https://github.com/coreos/prometheus-operator/pull/2566#discussion_r291619343.