### PR TITLE
PrometheusSpec: StatefulSetMetadata

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -323,6 +323,7 @@ PrometheusSpec is a specification of the desired behavior of the Prometheus clus
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| statefulSetMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus statefulsets. | *[metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#objectmeta-v1-meta) | false |
 | podMetadata | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | *[metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#objectmeta-v1-meta) | false |
 | serviceMonitorSelector | ServiceMonitors to be selected for target discovery. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#labelselector-v1-meta) | false |
 | serviceMonitorNamespaceSelector | Namespaces to be selected for ServiceMonitor discovery. If nil, only check own namespace. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#labelselector-v1-meta) | false |

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -79,6 +79,10 @@ type PrometheusList struct {
 // https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status
 // +k8s:openapi-gen=true
 type PrometheusSpec struct {
+	// Standard object's metadata. More info:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+	// Metadata Labels and Annotations gets propagated to the prometheus statefulsets.
+	StatefulSetMetadata *metav1.ObjectMeta `json:"statefulSetMetadata,omitempty"`
 	// Standard object’s metadata. More info:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
 	// Metadata Labels and Annotations gets propagated to the prometheus pods.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -158,6 +158,22 @@ func makeStatefulSet(
 		return nil, errors.Wrap(err, "make StatefulSet spec")
 	}
 
+	if p.Spec.StatefulSetMetadata != nil {
+		if p.Spec.StatefulSetMetadata.Labels != nil {
+			for k, v := range p.Spec.StatefulSetMetadata.Labels {
+				p.ObjectMeta.Labels[k] = v
+			}
+		}
+	}
+
+	if p.Spec.StatefulSetMetadata != nil {
+		if p.Spec.StatefulSetMetadata.Annotations != nil {
+			for k, v := range p.Spec.StatefulSetMetadata.Annotations {
+				p.ObjectMeta.Annotations[k] = v
+			}
+		}
+	}
+
 	boolTrue := true
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -75,6 +75,31 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	}
 }
 
+func TestStatefulSetMetaDataLabelingAndAnnotations(t *testing.T) {
+	annotations := map[string]string{
+		"testannotation": "testvalue",
+	}
+	labels := map[string]string{
+		"testlabel": "testlabel",
+	}
+	sset, err := makeStatefulSet(monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: monitoringv1.PrometheusSpec{
+			StatefulSetMetadata: &metav1.ObjectMeta{
+				Annotations: annotations,
+				Labels:	     labels,
+			},			
+		},
+	}, defaultTestConfig, nil, "")
+	require.NoError(t, err)
+	if _, ok := sset.ObjectMeta.Labels["testlabel"]; !ok {
+		t.Fatal("StatefulSet labels are not properly propagated")
+	}
+	if !reflect.DeepEqual(annotations, sset.ObjectMeta.Annotations) {
+		t.Fatal("StatefulSet annotations are not properly propagated")
+	}
+}
+
 func TestPodLabelsAnnotations(t *testing.T) {
 	annotations := map[string]string{
 		"testannotation": "testvalue",


### PR DESCRIPTION
Allow user to set the StatefulSetMetadata labels and annotations to be applied
to the StatefulSet generated by the PrometheusSpec

Fixes #2642