### PR TITLE
Set gRPC endpoint when listen local is specified in thanos ruler

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -182,7 +182,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	if tr.Spec.ListenLocal {
-		trCLIArgs = append(trCLIArgs, "--http-address=localhost:10902")
+		trCLIArgs = append(trCLIArgs, "--grpc-address=127.0.0.1:10901")
+		trCLIArgs = append(trCLIArgs, "--http-address=127.0.0.1:10902")
 	}
 	if tr.Spec.LogLevel != "" && tr.Spec.LogLevel != "info" {
 		trCLIArgs = append(trCLIArgs, fmt.Sprintf("--log.level=%s", tr.Spec.LogLevel))

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -154,3 +154,30 @@ func TestStatefulSetVolumes(t *testing.T) {
 		t.Fatal("expected volume mounts to match")
 	}
 }
+
+func TestListenLocal(t *testing.T) {
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{
+			QueryEndpoints: []string{""},
+			ListenLocal:    true,
+		},
+	}, nil, defaultTestConfig, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	foundGrpcFlag := false
+	foundHTTPFlag := false
+	for _, flag := range sset.Spec.Template.Spec.Containers[0].Args {
+		if flag == "--grpc-address=127.0.0.1:10901" {
+			foundGrpcFlag = true
+		}
+		if flag == "--http-address=127.0.0.1:10902" {
+			foundHTTPFlag = true
+		}
+	}
+
+	if !foundGrpcFlag || !foundHTTPFlag {
+		t.Fatal("Thanos Ruler not listening on loopback when it should.")
+	}
+}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Thanos ruler now has https://github.com/coreos/prometheus-operator/issues/2435 problem as well so it should also set gRPC endpoint to 127.0.0.1

Basically copied from https://github.com/coreos/prometheus-operator/pull/2728.