### PR TITLE
Fix Syntax error in alert manager network policy

### DIFF
--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -60,13 +60,13 @@ metadata:
 spec:
   ingress:
   - from:
+    - podSelector:
+      matchLabels:
+        alertmanager: main
+        app: alertmanager
     ports:
     - port: 9093
       protocol: TCP
-  podSelector:
-    matchLabels:
-      alertmanager: main
-      app: alertmanager
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
There is a small syntax error in the api for a network policy. This should make it easier for people to copy and paste in NPs