### PR TITLE
secondary stage to push images to quay.io/coreos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,17 @@ jobs:
   - name: "Push Docker Image"
     stage: push-docker-image
     script: ./scripts/travis-push-docker-image.sh
+  # TODO(paulfantom): remove after v0.43.0 release
+  - name: "Push CoreOS Docker Image"
+    stage: push-docker-image-coreos
+    script: ./scripts/travis-push-docker-image.sh
+    env:
+      - REPO=quay.io/coreos/prometheus-operator
+      - REPO_PROMETHEUS_CONFIG_RELOADER=quay.io/coreos/prometheus-config-reloader
 
 stages:
   - test
   - name: push-docker-image
     if: type != pull_request
+  - name: push-docker-image-coreos
+    if: type != pull_request AND branch != master

--- a/scripts/travis-push-docker-image.sh
+++ b/scripts/travis-push-docker-image.sh
@@ -14,11 +14,8 @@ trap defer EXIT
 CPU_ARCHS="amd64 arm64 arm"
 
 # Push to Quay '-dev' repo if it's not a git tag or master branch build.
-# TODO(paulfantom): coreos repository should be deprecated after v0.43.0 release and OLD_ variables should be removed
-export OLD_REPO="quay.io/coreos/prometheus-operator"
-export OLD_REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/coreos/prometheus-config-reloader"
-export REPO="quay.io/prometheus-operator/prometheus-operator"
-export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/prometheus-operator/prometheus-config-reloader"
+export REPO="${REPO:-"quay.io/prometheus-operator/prometheus-operator"}"
+export REPO_PROMETHEUS_CONFIG_RELOADER="${REPO_PROMETHEUS_CONFIG_RELOADER:-"quay.io/prometheus-operator/prometheus-config-reloader"}"
 
 if [[ "${TRAVIS_TAG}" == "" ]] && [[ "${TRAVIS_BRANCH}" != master ]]; then
 	export REPO="quay.io/prometheus-operator/prometheus-operator-dev"
@@ -37,9 +34,14 @@ if [ "$TRAVIS" == "true" ]; then
 	sudo chmod o+x /etc/docker
 fi
 
-echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
+# TODO(paulfantom): Remove this after v0.43.0 release as it won't be needed
+if [ -z "${QUAY_COREOS_PASSWORD+x}" ]; then
+	echo "${QUAY_COREOS_PASSWORD}" | docker login -u "${QUAY_COREOS_USERNAME}" --password-stdin quay.io
+else
+	echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
+fi
 export DOCKER_CLI_EXPERIMENTAL=enabled
-for r in ${OLD_REPO} ${OLD_REPO_PROMETHEUS_CONFIG_RELOADER} ${REPO} ${REPO_PROMETHEUS_CONFIG_RELOADER}; do
+for r in ${REPO} ${REPO_PROMETHEUS_CONFIG_RELOADER}; do
 	# Images need to be on remote registry before creating manifests
 	for arch in $CPU_ARCHS; do
 		docker push "${r}:${TAG}-$arch"


### PR DESCRIPTION
Two changes allowing to push images to another quay repository:
- Additional CI job triggered only on branches which are not `master` with additional environment variables.
- Script change allowing to use `REPO` and `REPO_PROMETHEUS_CONFIG_RELOADER` set outside of `travis-push-docker-image.sh` script. 

Before merging this we need to set QUAY_COREOS_USERNAME and QUAY_COREOS_PASSWORD in travis settings.