### PR TITLE
WIP pkg/listwatch: err out with multiple resource versions in List

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -159,6 +159,11 @@ func (mlw multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, 
 			resourceVersions.Insert(metaObj.GetResourceVersion())
 		}
 	}
+
+	if len(resourceVersions) > 1 {
+		return nil, fmt.Errorf("list: expected resource version to have 1 part, got %d", len(resourceVersions))
+	}
+
 	// Combine the resource versions so that the composite Watch method can
 	// distribute appropriate versions to each underlying Watch func.
 	l.ListMeta.ResourceVersion = strings.Join(resourceVersions.List(), "/")
@@ -174,7 +179,7 @@ func (mlw multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface
 	if options.ResourceVersion != "" {
 		rvs := strings.Split(options.ResourceVersion, "/")
 		if len(rvs) > 1 {
-			return nil, fmt.Errorf("expected resource version to have 1 part, got %d", len(rvs))
+			return nil, fmt.Errorf("watch: expected resource version to have 1 part, got %d", len(rvs))
 		}
 		resourceVersions = options.ResourceVersion
 	}


### PR DESCRIPTION
https://github.com/prometheus-operator/prometheus-operator/pull/3340 added a workaround to err out if multiple resource versions are reported from api server.

However the preceeding List function allows multiple resource versions to slip through.
This causes potential cascading failures.

Note: as #3340 this is not a final fix but a try to cause additional cascading failures due to different resource versions being reported by API server.

/cc @lilic @brancz @paulfantom @metalmatze 