### PR TITLE
.github: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+*  @prometheus-operator/prometheus-operator-reviewers
+
+/scripts/ @paulfantom


### PR DESCRIPTION
This will allow github to automatically assign people to PRs.

I took a liberty of assigning all PRs which touch any tooling (`scripts/`) directory to myself. This is just a test to see what is possible :)

/cc @prometheus-operator/prometheus-operator-reviewers 