### PR TITLE
Fix validation logic for SecretOrConfigMap

### DIFF
--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -897,7 +897,7 @@ func (e *SecretOrConfigMapValidationError) Error() string {
 
 // Validate semantically validates the given TLSConfig.
 func (c *SecretOrConfigMap) Validate() error {
-	if &c.Secret != nil && &c.ConfigMap != nil {
+	if c.Secret != nil && c.ConfigMap != nil {
 		return &SecretOrConfigMapValidationError{"SecretOrConfigMap can not specify both Secret and ConfigMap"}
 	}
 

--- a/pkg/apis/monitoring/v1/types_test.go
+++ b/pkg/apis/monitoring/v1/types_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,5 +51,22 @@ func TestMarshallServiceMonitor(t *testing.T) {
 	rs := string(r)
 	if rs != expected {
 		t.Fatalf("Got %s expected: %s ", rs, expected)
+	}
+}
+
+func TestValidateSecretOrConfigMap(t *testing.T) {
+	for _, good := range []SecretOrConfigMap{
+		SecretOrConfigMap{},
+		SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
+		SecretOrConfigMap{ConfigMap: &v1.ConfigMapKeySelector{}},
+	} {
+		if err := good.Validate(); err != nil {
+			t.Errorf("expected validation of %+v not to fail, err: %s", good, err)
+		}
+	}
+
+	bad := SecretOrConfigMap{Secret: &v1.SecretKeySelector{}, ConfigMap: &v1.ConfigMapKeySelector{}}
+	if err := bad.Validate(); err == nil {
+		t.Errorf("expected validation of %+v to fail, but not no error", bad)
 	}
 }

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2629,7 +2629,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 					},
 				},
 			},
-			expectTargets: false,
+			expectTargets: true,
 		},
 		{
 			name: "allowed-tls-configmap",
@@ -2699,7 +2699,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 					},
 				},
 			},
-			expectTargets: false,
+			expectTargets: true,
 		},
 	}
 


### PR DESCRIPTION
This was flagged by
[golangci-lint](https://staticcheck.io/docs/checks#SA4022). The check
was for the address of the pointer, not the value. Add a test (failing
on master) to verify this, and fix the validation logic.

Follow-up to #2716.

Signed-off-by: Matthias Rampke <matthias@rampke.de>