### PR TITLE
Add metrics for selected/rejected resources and sync status

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -21,6 +21,16 @@ groups:
     for: 15m
     labels:
       severity: warning
+  - alert: PrometheusOperatorSyncFailed
+    annotations:
+      description: Controller {{ $labels.controller }} in {{ $labels.namespace }}
+        namespace fails to reconcile {{ $value }} objects.
+      summary: Last controller reconciliation failed
+    expr: |
+      min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator"}[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
   - alert: PrometheusOperatorReconcileErrors
     annotations:
       description: '{{ $value | humanizePercentage }} of reconciling operations failed

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -33,6 +33,20 @@
             'for': '15m',
           },
           {
+            alert: 'PrometheusOperatorSyncFailed',
+            expr: |||
+              min_over_time(prometheus_operator_syncs{status="failed",%(prometheusOperatorSelector)s}[5m]) > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Controller {{ $labels.controller }} in {{ $labels.namespace }} namespace fails to reconcile {{ $value }} objects.',
+              summary: 'Last controller reconciliation failed',
+            },
+            'for': '10m',
+          },
+          {
             alert: 'PrometheusOperatorReconcileErrors',
             expr: |||
               (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{%(prometheusOperatorSelector)s}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.1

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -280,6 +280,7 @@ func (c *Operator) processNextWorkItem(ctx context.Context) bool {
 
 	c.metrics.ReconcileCounter().Inc()
 	err := c.sync(ctx, key.(string))
+	c.metrics.SetSyncStatus(key.(string), err == nil)
 	if err == nil {
 		c.queue.Forget(key)
 		return true
@@ -399,6 +400,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	aobj, err := c.alrtInfs.Get(key)
 
 	if apierrors.IsNotFound(err) {
+		c.metrics.ForgetObject(key)
 		// Dependent resources are cleaned up by K8s via OwnerReferences
 		return nil
 	}

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -213,14 +213,18 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 		"prometheus", p.Name,
 	)
 
+	if pKey, ok := c.keyFunc(p); ok {
+		c.metrics.SetSelectedResources(pKey, monitoringv1.PrometheusRuleKind, len(rules))
+		c.metrics.SetRejectedResources(pKey, monitoringv1.PrometheusRuleKind, 0)
+	}
+
 	return rules, nil
 }
 
 func generateContent(promRule monitoringv1.PrometheusRuleSpec) (string, error) {
-
 	content, err := yaml.Marshal(promRule)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal content")
+		return "", errors.Wrap(err, "failed to marshal content")
 	}
 	return string(content), nil
 }

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -561,6 +561,7 @@ func (o *Operator) processNextWorkItem(ctx context.Context) bool {
 
 	o.metrics.ReconcileCounter().Inc()
 	err := o.sync(ctx, key.(string))
+	o.metrics.SetSyncStatus(key.(string), err == nil)
 	if err == nil {
 		o.queue.Forget(key)
 		return true
@@ -576,6 +577,7 @@ func (o *Operator) processNextWorkItem(ctx context.Context) bool {
 func (o *Operator) sync(ctx context.Context, key string) error {
 	trobj, err := o.thanosRulerInfs.Get(key)
 	if apierrors.IsNotFound(err) {
+		o.metrics.ForgetObject(key)
 		// Dependent resources are cleaned up by K8s via OwnerReferences
 		return nil
 	}

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -213,6 +213,10 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 		"thanos", t.Name,
 	)
 
+	if tKey, ok := o.keyFunc(t); ok {
+		o.metrics.SetSelectedResources(tKey, monitoringv1.PrometheusRuleKind, len(rules))
+		o.metrics.SetRejectedResources(tKey, monitoringv1.PrometheusRuleKind, 0)
+	}
 	return rules, nil
 }
 
@@ -220,7 +224,7 @@ func generateContent(promRule monitoringv1.PrometheusRuleSpec) (string, error) {
 
 	content, err := yaml.Marshal(promRule)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal content")
+		return "", errors.Wrap(err, "failed to marshal content")
 	}
 	return string(content), nil
 }


### PR DESCRIPTION
This change adds two metrics:
* `prometheus_operator_managed_resources`, the number of resources managed by the controller per state (either selected or rejected).
* `prometheus_operator_syncs`, number of sync operations per status and controller.
    
It also adds a new `PrometheusOperatorSyncFailed` alert that fires when `prometheus_operator_syncs{status="failed"}` is greater than 0.

Closes #3327 