### PR TITLE
Fix shellcheck Make target (ignore vendored files)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ check-license:
 
 .PHONY: shellcheck
 shellcheck: $(SHELLCHECK_BINARY)
-	$(SHELLCHECK_BINARY) $(shell find . -type f -name "*.sh")
+	$(SHELLCHECK_BINARY) $(shell find . -type f -name "*.sh" -not -path "*/vendor/*")
 
 ###########
 # Testing #


### PR DESCRIPTION
Before this change, the following error occurs for the shellcheck
target (which is a prerequisite for other targets like format):

```
In ./scripts/generate/vendor/github.com/ksonnet/ksonnet-lib/scripts/install_jsonnet.sh line 7:
JSONNET_VERSION=$
^-------------^ SC2034: JSONNET_VERSION appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- JSONNET_VERSION appears unused. V...
make: *** [Makefile:246: shellcheck] Error 1
```