### PR TITLE
Change thanos ruler's http port to the default web

### DIFF
--- a/example/thanos/thanos-ruler-service.yaml
+++ b/example/thanos/thanos-ruler-service.yaml
@@ -14,4 +14,4 @@ spec:
     targetPort: grpc
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: web


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin@yunify.com>
Thanos ruler UI cannot be accessed if target port is HTTP :
The default http port name is web : 
https://github.com/prometheus-operator/prometheus-operator/blob/master/pkg/apis/monitoring/v1/thanos_types.go#L135
https://github.com/prometheus-operator/prometheus-operator/blob/master/pkg/thanos/statefulset.go#L38