### PR TITLE
CI fixes after release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,8 +88,11 @@ jobs:
       with:
         version: ${{ env.kind-version }}
         image: ${{ env.kind-image }}
-    - name: Check cluster
+    - name: Wait for cluster to finish bootstraping
       run: |
+        until [ "$(kubectl get pods --all-namespaces --no-headers | grep -cEv '([0-9]+)/\1')" -eq 0 ]; do
+            sleep 5s
+        done
         kubectl cluster-info
         kubectl get pods -A
     - name: Build and load images

--- a/scripts/push-docker-image.sh
+++ b/scripts/push-docker-image.sh
@@ -8,16 +8,24 @@ set -u
 
 CPU_ARCHS="amd64 arm64 arm"
 
+# Use branch name as dev image tags
+export TAG="${GITHUB_REF#refs/heads/}"
+
 # Push `-dev` images unless commit is tagged
 export REPO="${REPO:-"quay.io/prometheus-operator/prometheus-operator-dev"}"
 export REPO_PROMETHEUS_CONFIG_RELOADER="${REPO_PROMETHEUS_CONFIG_RELOADER:-"quay.io/prometheus-operator/prometheus-config-reloader-dev"}"
-if git describe --exact-match; then
+
+# If TAG is not a branch name, push tagged release
+if [[ ! "${TAG}" =~ ^refs ]]; then
+	export TAG="${GITHUB_REF#refs/tags/}"
 	export REPO="quay.io/prometheus-operator/prometheus-operator"
 	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/prometheus-operator/prometheus-config-reloader"
-	export TAG="${GITHUB_REF#refs/tags/}"
-else
-	# Use branch name as dev image tags
-	TAG="${GITHUB_REF#refs/heads/}"
+fi
+
+# Push mutable `master` tag to main repositories
+if [ "${TAG}" == "master" ]; then
+	export REPO="quay.io/prometheus-operator/prometheus-operator"
+	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/prometheus-operator/prometheus-config-reloader"
 fi
 
 for arch in ${CPU_ARCHS}; do


### PR DESCRIPTION
Follow-up to https://github.com/prometheus-operator/prometheus-operator/pull/3475

- fixing issues with alertmanager e2e test failures due to cluster not being fully initialized
- fixing issues with image builds from releases (tagged builds)
- add pushing `master` tag to main image repositories