### PR TITLE
helm: update chart reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ stack based on Prometheus and the Prometheus Operator.  This includes deployment
 metrics exporters such as the node_exporter for gathering node metrics, scrape target configuration linking Prometheus to various
 metrics endpoints, and example alerting rules for notification of potential issues in the cluster.
 
-The [stable/prometheus-operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
-helm chart provides a similar feature set to kube-prometheus. This chart is maintained by the Helm community.
-For more information, please see the [chart's readme](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator)
+The [prometheus-community/kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+helm chart provides a similar feature set to kube-prometheus. This chart is maintained by the Prometheus community.
+For more information, please see the [chart's readme](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#kube-prometheus-stack)
 
 ## Prerequisites
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,12 +1,12 @@
 # Moved
-The helm charts originally developed as part of this repository have been moved to [stable/prometheus-operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator).
+The helm charts originally developed as part of this repository have been moved to [prometheus-community/kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
 
 The multiple charts built in this repository have been combined into a single chart that installs prometheus operator, prometheus, alertmanager, grafana as well as the multitude of exporters necessary to monitor a cluster.
 
-There is no direct migration path from this chart to the stable/prometheus-operator chart - there are numerous changes and capability enhancements. For more information, please check the [migrated chart readme](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator) for the set of components used and for [migration suggestions from this chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator#migrating-from-coreosprometheus-operator-chart)
+There is no direct migration path from this chart to the prometheus-community/kube-prometheus-stack chart - there are numerous changes and capability enhancements. For more information, please check the [migrated chart readme](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#kube-prometheus-stack) for the set of components used and for [migration suggestions from this chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#migrating-from-coreosprometheus-operator-chart)
 
 It is still possible to run multiple prometheus instances on a single cluster - you will need to disable the parts of the chart you do not wish to deploy.
 
-Issues and pull requests should be tracked using the [helm/charts](https://github.com/helm/charts) repository.
+Issues and pull requests should be tracked using the [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts) repository.
 
 You can check out the tickets for this change [here](https://github.com/prometheus-operator/prometheus-operator/issues/592) and [here](https://github.com/helm/charts/pull/6765)


### PR DESCRIPTION
This PR updates chart references from the deprecated [stable/prometheus-operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) chart to the [prometheus-community/kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) chart based on the deprecation notice listed [here](https://github.com/helm/charts/tree/master/stable/prometheus-operator#%EF%B8%8F--deprecated).