### PR TITLE
Switch to go 1.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   - push
   - pull_request
 env:
-  golang-version: '1.14'
+  golang-version: '1.15'
   kind-version: 'v0.8.1'
   kind-image: 'kindest/node:v1.18.8'  # Image defines which k8s version is used
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-operator/prometheus-operator
 
-go 1.14
+go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-operator/prometheus-operator/tooling
 
-go 1.14
+go 1.15
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect


### PR DESCRIPTION
Due to issues with go 1.14 it would be good to switch to the recent golang version. This version is also used now to build kubernetes.