### PR TITLE
jsonnet/mixin/alerts: add list alerts

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -1,13 +1,23 @@
 groups:
 - name: prometheus-operator
   rules:
+  - alert: PrometheusOperatorListErrors
+    annotations:
+      description: Errors while performing List operations in controller {{$labels.controller}}
+        in {{$labels.namespace}} namespace.
+      summary: Errors while performing list operations in controller.
+    expr: |
+      (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator"}[10m]))) > 0.4
+    for: 15m
+    labels:
+      severity: warning
   - alert: PrometheusOperatorWatchErrors
     annotations:
       description: Errors while performing watch operations in controller {{$labels.controller}}
         in {{$labels.namespace}} namespace.
       summary: Errors while performing watch operations in controller.
     expr: |
-      (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator"}[1h])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator"}[1h]))) > 0.1
+      (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator"}[10m]))) > 0.4
     for: 15m
     labels:
       severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -5,9 +5,23 @@
         name: 'prometheus-operator',
         rules: [
           {
+            alert: 'PrometheusOperatorListErrors',
+            expr: |||
+              (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{%(prometheusOperatorSelector)s}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{%(prometheusOperatorSelector)s}[10m]))) > 0.4
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Errors while performing List operations in controller {{$labels.controller}} in {{$labels.namespace}} namespace.',
+              summary: 'Errors while performing list operations in controller.',
+            },
+            'for': '15m',
+          },
+          {
             alert: 'PrometheusOperatorWatchErrors',
             expr: |||
-              (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[1h])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[1h]))) > 0.1
+              (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[10m]))) > 0.4
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
port https://github.com/prometheus-operator/kube-prometheus/pull/610

This is necessary to move prometheus-operator alerts out of kube-prometheus