### PR TITLE
Update CreateOrUpdateService in k8sutil

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -118,6 +118,7 @@ func CreateOrUpdateService(ctx context.Context, sclient clientv1.ServiceInterfac
 		}
 	} else {
 		svc.ResourceVersion = service.ResourceVersion
+		svc.Spec.IPFamily = service.Spec.IPFamily
 		svc.SetOwnerReferences(mergeOwnerReferences(service.GetOwnerReferences(), svc.GetOwnerReferences()))
 		_, err := sclient.Update(ctx, svc, metav1.UpdateOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
When updating the service, set the `IPFamily` attribute of the service spec.

fixes https://github.com/prometheus-operator/prometheus-operator/issues/3411

---

Along with https://github.com/n1kofr, I am also experiencing the issue where prometheus operator is failing to sync/update governing services. The root cause I believe is within these lines of code https://github.com/prometheus-operator/prometheus-operator/blob/master/pkg/k8sutil/k8sutil.go#L108-L129. When prometheus-operator is updating the service, the svc object in the CreateOrUpdateService function does not have the IPFamily attribute set in its object spec, thus it's effectively nil which explains the following error;

```log
E0921 17:20:17.185103       1 operator.go:322] Sync "system/prometheus-operator-kube-p-alertmanager" failed: synchronizing governing service failed: updating service object failed: Service "alertmanager-operated" is invalid: [spec.ipFamily: Invalid value: "null": field is immutable, spec.ipFamily: Required value]
```