### PR TITLE
Don't block when namespace aren't found

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -41,3 +41,13 @@ groups:
     for: 10m
     labels:
       severity: warning
+  - alert: PrometheusOperatorNotReady
+    annotations:
+      description: Prometheus operator in {{ $labels.namespace }} namespace isn't
+        ready to reconcile {{ $labels.controller }} resources.
+      summary: Prometheus operator not ready
+    expr: |
+      min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator"}[5m]) == 0)
+    for: 5m
+    labels:
+      severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -60,6 +60,20 @@
             },
             'for': '10m',
           },
+          {
+            alert: 'PrometheusOperatorNotReady',
+            expr: |||
+              min by(namespace, controller) (max_over_time(prometheus_operator_ready{%(prometheusOperatorSelector)s}[5m]) == 0)
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: "Prometheus operator in {{ $labels.namespace }} namespace isn't ready to reconcile {{ $labels.controller }} resources.",
+              summary: 'Prometheus operator not ready',
+            },
+            'for': '5m',
+          },
         ],
       },
     ],

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -217,6 +217,7 @@ func (c *Operator) Run(ctx context.Context) error {
 	}
 	c.addHandlers()
 
+	c.metrics.Ready().Set(1)
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -15,6 +15,11 @@
 package operator
 
 import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -200,4 +205,40 @@ func SanitizeSTS(sts *appsv1.StatefulSet) {
 		sts.Spec.VolumeClaimTemplates[i].APIVersion = ""
 		sts.Spec.VolumeClaimTemplates[i].Kind = ""
 	}
+}
+
+// WaitForCacheSync synchronizes the informer's cache and will log a warning
+// every minute if the operation hasn't completed yet.
+// Under normal circumstances, the cache sync should be fast. If it takes more
+// than 1 minute, it means that something is stuck and the message will
+// indicate to the admin which informer is the culprit.
+// See https://github.com/prometheus-operator/prometheus-operator/issues/3347.
+func WaitForCacheSync(ctx context.Context, logger log.Logger, inf cache.SharedIndexInformer) bool {
+	ctx, cancel := context.WithCancel(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		t := time.NewTicker(time.Minute)
+		defer t.Stop()
+
+		select {
+		case <-t.C:
+			level.Warn(logger).Log("msg", "cache sync not yet completed")
+		case <-ctx.Done():
+			close(done)
+		}
+	}()
+
+	ok := cache.WaitForCacheSync(ctx.Done(), inf.HasSynced)
+	if !ok {
+		level.Error(logger).Log("msg", "failed to sync cache")
+	} else {
+		level.Debug(logger).Log("msg", "successfully synced cache")
+	}
+
+	// Stop the logging goroutine and wait for its exit.
+	cancel()
+	<-done
+
+	return ok
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -467,6 +467,7 @@ func (c *Operator) Run(ctx context.Context) error {
 		go c.reconcileNodeEndpoints(ctx)
 	}
 
+	c.metrics.Ready().Set(1)
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -326,6 +326,7 @@ func (o *Operator) Run(ctx context.Context) error {
 	}
 	o.addHandlers()
 
+	o.metrics.Ready().Set(1)
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -223,7 +223,7 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 }
 
 // waitForCacheSync waits for the informers' caches to be synced.
-func (o *Operator) waitForCacheSync(stopc <-chan struct{}) error {
+func (o *Operator) waitForCacheSync(ctx context.Context) error {
 	ok := true
 
 	for _, infs := range []struct {
@@ -236,33 +236,28 @@ func (o *Operator) waitForCacheSync(stopc <-chan struct{}) error {
 		{"StatefulSet", o.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
-			if !cache.WaitForCacheSync(stopc, inf.Informer().HasSynced) {
-				level.Error(o.logger).Log("msg", fmt.Sprintf("failed to sync %s cache", infs.name))
+			if !operator.WaitForCacheSync(ctx, log.With(o.logger, "informer", infs.name), inf.Informer()) {
 				ok = false
-			} else {
-				level.Debug(o.logger).Log("msg", fmt.Sprintf("successfully synced %s cache", infs.name))
 			}
 		}
 	}
 
-	informers := []struct {
+	for _, inf := range []struct {
 		name     string
 		informer cache.SharedIndexInformer
 	}{
 		{"ThanosRulerNamespace", o.nsThanosRulerInf},
 		{"RuleNamespace", o.nsRuleInf},
-	}
-	for _, inf := range informers {
-		if !cache.WaitForCacheSync(stopc, inf.informer.HasSynced) {
-			level.Error(o.logger).Log("msg", fmt.Sprintf("failed to sync %s cache", inf.name))
+	} {
+		if !operator.WaitForCacheSync(ctx, log.With(o.logger, "informer", inf.name), inf.informer) {
 			ok = false
-		} else {
-			level.Debug(o.logger).Log("msg", fmt.Sprintf("successfully synced %s cache", inf.name))
 		}
 	}
+
 	if !ok {
 		return errors.New("failed to sync caches")
 	}
+
 	level.Info(o.logger).Log("msg", "successfully synced all caches")
 	return nil
 }
@@ -326,7 +321,7 @@ func (o *Operator) Run(ctx context.Context) error {
 		go o.nsThanosRulerInf.Run(ctx.Done())
 	}
 	go o.ssetInfs.Start(ctx.Done())
-	if err := o.waitForCacheSync(ctx.Done()); err != nil {
+	if err := o.waitForCacheSync(ctx); err != nil {
 		return err
 	}
 	o.addHandlers()

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -236,9 +236,10 @@ func TestDenylist(t *testing.T) {
 func TestPromInstanceNs(t *testing.T) {
 	skipPrometheusTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"AllNs":     testPrometheusInstanceNamespaces_AllNs,
-		"AllowList": testPrometheusInstanceNamespaces_AllowList,
-		"DenyList":  testPrometheusInstanceNamespaces_DenyList,
+		"AllNs":             testPrometheusInstanceNamespaces_AllNs,
+		"AllowList":         testPrometheusInstanceNamespaces_AllowList,
+		"DenyList":          testPrometheusInstanceNamespaces_DenyList,
+		"NamespaceNotFound": testPrometheusInstanceNamespaces_NamespaceNotFound,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -314,3 +314,107 @@ func testPrometheusInstanceNamespaces_AllowList(t *testing.T) {
 		}
 	}
 }
+
+// testPrometheusInstanceNamespaces_NamespaceNotFound verifies that the
+// operator can reconcile Prometheus and associated resources even when
+// it's configured to watch namespaces that don't exist.
+// See https://github.com/prometheus-operator/prometheus-operator/issues/3347
+func testPrometheusInstanceNamespaces_NamespaceNotFound(t *testing.T) {
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
+
+	// create three namespaces:
+	//
+	// 1. "operator" ns:
+	//   - hosts the prometheus operator deployment
+	//
+	// 2. "instance" ns:
+	//   - will be configured on prometheus operator as --prometheus-instance-namespaces="instance"
+	//   - hosts a prometheus CR which must be reconciled.
+	//     This prometheus instance must pick up targets (service monitors)
+	//     in the "allowed" namespace.
+	//
+	// 3. "allowed" ns:
+	//   - will be configured on prometheus operator as --namespaces="allowed"
+	//   - hosts a service monitor CR which must be reconciled
+	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
+	allowedNs := ctx.CreateNamespace(t, framework.KubeClient)
+	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
+	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+
+	for _, ns := range []string{allowedNs, instanceNs} {
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+			"monitored": "true",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
+	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Prometheus custom resource in the "instance" namespace.
+	// Let this Prometheus custom resource match service monitors in namespaces having the label `"monitored": "true"`.
+	// This will match the service monitors created in the "allowed" namespace.
+	// Expose the created Prometheus service.
+	{
+		p := framework.MakeBasicPrometheus(instanceNs, "instance", "instance", 1)
+
+		p.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"monitored": "true",
+			},
+		}
+
+		p.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"group": "monitored",
+			},
+		}
+
+		// Create the prometheus service and wait until it is ready.
+		_, err := framework.CreatePrometheusAndWaitUntilReady(instanceNs, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+	}
+
+	{
+		// Create a simple echo server in the "allowed" namespace,
+		// Expose a service pointing to it, and create a service monitor
+		// pointing to that service.
+		// Wait, until that service appears as a target in the "instance" Prometheus.
+		echo := framework.MakeEchoDeployment("allowed")
+
+		if err := testFramework.CreateDeployment(framework.KubeClient, allowedNs, echo); err != nil {
+			t.Fatal(err)
+		}
+
+		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
+		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, allowedNs, svc); err != nil {
+			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		} else {
+			ctx.AddFinalizerFn(finalizerFn)
+		}
+
+		s := framework.MakeBasicServiceMonitor("monitored")
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+			t.Fatal("Creating ServiceMonitor failed: ", err)
+		}
+
+		if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
The namespaces listerwatcher shouldn't return an error when some of the monitored namespaces don't exist. Otherwise the operator will block while waiting for the informers to sync their cache and it will never be able to reconcile resources.
    
Closes #3347
