### PR TITLE
update thanos example rbac

### DIFF
--- a/example/thanos/prometheus-cluster-role-binding.yaml
+++ b/example/thanos/prometheus-cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: prometheus-self
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: prometheus-self
 subjects:
 - kind: ServiceAccount

--- a/example/thanos/prometheus-cluster-role.yaml
+++ b/example/thanos/prometheus-cluster-role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: prometheus-self
   namespace: default
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - nodes
+  - nodes/metrics
   - services
   - endpoints
   - pods
@@ -15,3 +16,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]


### PR DESCRIPTION
Hi,
trying to making work the example, I found the rbac for the thanos example was out of date. I used the same permissions specifieds in: [https://github.com/kiddo3/prometheus-operator/blob/master/Documentation/rbac.md](https://github.com/kiddo3/prometheus-operator/blob/master/Documentation/rbac.md)