### PR TITLE
pkg/prometheus/statefulset: Exec requests in local probes

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -556,7 +556,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, ruleConf
 		})
 	}
 
-	const localProbe = `if [ -x "$(command -v curl)" ]; then curl %s; elif [ -x "$(command -v wget)" ]; then wget -q -O /dev/null %s; else exit 1; fi`
+	const localProbe = `if [ -x "$(command -v curl)" ]; then exec curl %s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %s; else exit 1; fi`
 
 	var readinessProbeHandler v1.Handler
 	if (version.Major == 1 && version.Minor >= 8) || version.Major == 2 {

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -428,7 +428,7 @@ func TestListenLocal(t *testing.T) {
 				Command: []string{
 					`sh`,
 					`-c`,
-					`if [ -x "$(command -v curl)" ]; then curl http://localhost:9090/-/ready; elif [ -x "$(command -v wget)" ]; then wget -q -O /dev/null http://localhost:9090/-/ready; else exit 1; fi`,
+					`if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready; else exit 1; fi`,
 				},
 			},
 		},


### PR DESCRIPTION
Reduce the number of processes in play by using [`exec`][1] to transition to the `curl`/`wget` command without creating a new process.  Besides increasing efficiency, this may reduce the chance of [leaking zombie processes][2], or at least reduce the number of processes leaked when an exec-probe zombificaiton occurs.

The `ListenLocal` stuff landed in ca15e870da (#1051), the conditional get/exec probe logic landed in 8011f6364c (#2763), and the conditional `wget`/`curl` logic landed in 5eb9cb53db (#2763).

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exec
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1878772