### PR TITLE
.github: close non-feature issues after 120d of inactivity

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: false
+daysUntilClose: 120
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
@@ -28,7 +28,7 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had any activity in last 60d.
+  This issue has been automatically marked as stale because it has not had any activity in the last 60 days.
   Thank you for your contributions.
 
 # Comment to post when removing the stale label.
@@ -36,8 +36,8 @@ markComment: >
 #   Your comment here.
 
 # Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
+closeComment: >
+  This issue was closed because it has not had any activity in the last 120 days. Please reopen if you feel this is still valid.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
Automatically closing issues after an extended period of inactivity.

Closes #3568

/cc @prometheus-operator/prometheus-operator-reviewers 