### PR TITLE
pkg/prometheus: ensure minimal version for target limits

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -634,7 +634,8 @@ func (cg *configGenerator) generatePodMonitorConfig(
 		cfg = append(cfg, yaml.MapItem{Key: "sample_limit", Value: getLimit(m.Spec.SampleLimit, enforcedSampleLimit)})
 	}
 
-	if m.Spec.TargetLimit > 0 || enforcedTargetLimit != nil {
+	if version.Major == 2 && version.Minor >= 21 &&
+		(m.Spec.TargetLimit > 0 || enforcedTargetLimit != nil) {
 		cfg = append(cfg, yaml.MapItem{Key: "target_limit", Value: getLimit(m.Spec.TargetLimit, enforcedTargetLimit)})
 	}
 
@@ -1104,7 +1105,8 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 		cfg = append(cfg, yaml.MapItem{Key: "sample_limit", Value: getLimit(m.Spec.SampleLimit, enforcedSampleLimit)})
 	}
 
-	if m.Spec.TargetLimit > 0 || enforcedTargetLimit != nil {
+	if version.Major == 2 && version.Minor >= 21 &&
+		(m.Spec.TargetLimit > 0 || enforcedTargetLimit != nil) {
 		cfg = append(cfg, yaml.MapItem{Key: "target_limit", Value: getLimit(m.Spec.TargetLimit, enforcedTargetLimit)})
 	}
 


### PR DESCRIPTION
The target_limit configuration field is only supported since Prometheus
v2.21.0. In the initial commit implementing target limits for the
Prometheus resource, we forgot to check which Prometheus version is
being deployed.