### PR TITLE
*: fix reconciliation when 2 resources share the same secret

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -379,16 +379,7 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 	}
 	ns := nsObject.(*v1.Namespace)
 
-	objs, err := c.alrtInfs.List(labels.Everything())
-	if err != nil {
-		level.Error(c.logger).Log(
-			"msg", "listing all Alertmanager instances from cache failed",
-			"err", err,
-		)
-		return
-	}
-
-	for _, obj := range objs {
+	err = c.alrtInfs.ListAll(labels.Everything(), func(obj interface{}) {
 		// Check for Alertmanager instances in the namespace.
 		am := obj.(*monitoringv1.Alertmanager)
 		if am.Namespace == nsName {
@@ -411,6 +402,12 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 			c.enqueue(am)
 			return
 		}
+	})
+	if err != nil {
+		level.Error(c.logger).Log(
+			"msg", "listing all Alertmanager instances from cache failed",
+			"err", err,
+		)
 	}
 }
 

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -99,20 +99,17 @@ func (w *ForResource) HasSynced() bool {
 	return true
 }
 
-// List lists based on the requested selector.
-// It invokes all wrapped informers, the result is concatenated.
-func (w *ForResource) List(selector labels.Selector) ([]runtime.Object, error) {
-	var ret []runtime.Object
-
+// ListAll invokes the ListAll method for all wrapped informers passing the
+// same selector and appendFn.
+func (w *ForResource) ListAll(selector labels.Selector, appendFn cache.AppendFunc) error {
 	for _, inf := range w.informers {
-		objs, err := inf.Lister().List(selector)
+		err := cache.ListAll(inf.Informer().GetIndexer(), selector, appendFn)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		ret = append(ret, objs...)
 	}
 
-	return ret, nil
+	return nil
 }
 
 // ListAllByNamespace invokes all wrapped informers passing the same appendFn.

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -797,9 +797,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	}
 	ns := nsObject.(*v1.Namespace)
 
-	objs, err := o.thanosRulerInfs.List(labels.Everything())
-
-	for _, obj := range objs {
+	err = o.thanosRulerInfs.ListAll(labels.Everything(), func(obj interface{}) {
 		// Check for ThanosRuler instances in the namespace.
 		tr := obj.(*monitoringv1.ThanosRuler)
 		if tr.Namespace == nsName {
@@ -822,7 +820,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 			o.enqueue(tr)
 			return
 		}
-	}
+	})
 	if err != nil {
 		level.Error(o.logger).Log(
 			"msg", "listing all ThanosRuler instances from cache failed",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -190,6 +190,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"Thanos":                                 testThanos,
 		"PromStaticProbe":                        testPromStaticProbe,
 		"PromSecurePodMonitor":                   testPromSecurePodMonitor,
+		"PromSharedResourcesReconciliation":      testPromSharedResourcesReconciliation,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
When the operator detects a change to a secret, service monitor, ..., it
enqueues the object's namespace and triggers a reconciliation for each
operated resource that watches this namespace. Instead of looping over
all operated resources, the operator stopped after the first resource.
If 2 Prometheus objects were depending on the same secret (referenced by
additionalScrapeConfigs for instance) then only one of them would be
reconciled when the secret was updated.

The regression has been introduced by #3440.

Fixes #3552 