### PR TITLE
example/rbac: add prometheus permissions to list ingresses

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -86,6 +86,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 ```
 
 > Note: A cluster admin is required to create this `ClusterRole` and create a `ClusterRoleBinding` or `RoleBinding` to the `ServiceAccount` used by the Prometheus Operator `Pod`. The `ServiceAccount` used by the Prometheus Operator `Pod` can be specified in the `Deployment` object used to deploy it.
@@ -137,6 +145,11 @@ rules:
   resources:
   - configmaps
   verbs: ["get"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ```

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -125,6 +125,11 @@ rules:
   resources:
   - configmaps
   verbs: ["get"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ```

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -17640,6 +17640,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -69,3 +69,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/example/rbac/prometheus/prometheus-cluster-role.yaml
+++ b/example/rbac/prometheus/prometheus-cluster-role.yaml
@@ -15,5 +15,10 @@ rules:
   resources:
   - configmaps
   verbs: ["get"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -124,7 +124,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                             ]) +
                             policyRule.withVerbs(['get', 'list', 'watch']);
 
-      local rules = [monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
+      local ingressRule = policyRule.new() +
+                          policyRule.withApiGroups(['networking.k8s.io']) +
+                          policyRule.withResources([
+                            'ingresses',
+                          ]) +
+                          policyRule.withVerbs(['get', 'list', 'watch']);
+
+
+      local rules = [monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule, ingressRule];
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withLabels(po.commonLabels) +


### PR DESCRIPTION
Specify necessary permissions to use Probes with Ingress selectors.

/cc @prometheus-operator/prometheus-operator-reviewers 