### PR TITLE
tests, docs: update admissionregistration.k8s.io/v1beta1 to admissionregistration.k8s.io/v1

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -44,7 +44,7 @@ variant also adds annotations to validated `PrometheusRule`s
 The following example deploys the validating admission webhook:
 
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: prometheus-operator-rulesvalidation

--- a/test/framework/ressources/prometheus-operator-mutatingwebhook.yaml
+++ b/test/framework/ressources/prometheus-operator-mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: prometheus-operator-rulesvalidation

--- a/test/framework/ressources/prometheus-operator-validatingwebhook.yaml
+++ b/test/framework/ressources/prometheus-operator-validatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: prometheus-operator-rulesvalidation


### PR DESCRIPTION
This PR resolves #3584 by updating all references to the deprecated api group `admissionregistration.k8s.io/v1beta1`