### PR TITLE
Remove pkg/errors dep from apis/monitoring module

### DIFF
--- a/pkg/apis/monitoring/go.mod
+++ b/pkg/apis/monitoring/go.mod
@@ -3,7 +3,6 @@ module github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
 go 1.14
 
 require (
-	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3
 )

--- a/pkg/apis/monitoring/go.sum
+++ b/pkg/apis/monitoring/go.sum
@@ -55,8 +55,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -15,9 +15,9 @@
 package v1alpha1
 
 import (
+	"errors"
 	"regexp"
 
-	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	v1 "k8s.io/api/core/v1"
@@ -141,11 +141,11 @@ type OpsGenieConfigResponder struct {
 // Validate ensures OpsGenieConfigResponder is valid
 func (r *OpsGenieConfigResponder) Validate() error {
 	if r.ID == "" && r.Name == "" && r.Username == "" {
-		return errors.Errorf("responder must have at least an ID, a Name or an Username defined")
+		return errors.New("responder must have at least an ID, a Name or an Username defined")
 	}
 
 	if !opsGenieTypeRe.MatchString(r.Type) {
-		return errors.Errorf("responder type should match team, user, escalation or schedule")
+		return errors.New("responder type should match team, user, escalation or schedule")
 	}
 
 	return nil


### PR DESCRIPTION
I think this dependency is usually not needed any longer, given that the standard library has the likes of errors.New, and fmt.Errorf.

My understanding is that apis/monitoring is a standalong module now to make it easier for other projects to import it, with a minimal set of transitive dependecies to worry about. If I'm correct, then github.com/pkg/errors is an easy one to keep out.

I noticed this while catching up with the recent changes around AlertManagerConfigs, so it was only recently introduced in #3593.