### PR TITLE
Fix admission webhook example

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -68,6 +68,8 @@ webhooks:
           - UPDATE
         resources:
           - prometheusrules
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
 ```
 
 The `caBundle` contains the base64-encoded CA certificate used to sign the


### PR DESCRIPTION
`admissionReviewVersions` and `sideEffects` fields are now required for `admissionregistration.k8s.io/v1`