### PR TITLE
pkg/alertmanager: wait for namespace informers syncs

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -239,9 +239,21 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 		{"StatefulSet", c.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
-			if !operator.WaitForCacheSync(ctx, log.With(c.logger, "informer", infs.name), inf.Informer()) {
+			if !operator.WaitForNamedCacheSync(ctx, "alertmanager", log.With(c.logger, "informer", infs.name), inf.Informer()) {
 				ok = false
 			}
+		}
+	}
+
+	for _, inf := range []struct {
+		name     string
+		informer cache.SharedIndexInformer
+	}{
+		{"AlertmanagerNamespace", c.nsAlrtInf},
+		{"AlertmanagerConfigNamespace", c.nsAlrtCfgInf},
+	} {
+		if !operator.WaitForNamedCacheSync(ctx, "alertmanager", log.With(c.logger, "informer", inf.name), inf.informer) {
+			ok = false
 		}
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -331,7 +331,7 @@ func SanitizeSTS(sts *appsv1.StatefulSet) {
 // than 1 minute, it means that something is stuck and the message will
 // indicate to the admin which informer is the culprit.
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347.
-func WaitForCacheSync(ctx context.Context, logger log.Logger, inf cache.SharedIndexInformer) bool {
+func WaitForNamedCacheSync(ctx context.Context, controllerName string, logger log.Logger, inf cache.SharedIndexInformer) bool {
 	ctx, cancel := context.WithCancel(ctx)
 
 	done := make(chan struct{})
@@ -347,7 +347,7 @@ func WaitForCacheSync(ctx context.Context, logger log.Logger, inf cache.SharedIn
 		}
 	}()
 
-	ok := cache.WaitForCacheSync(ctx.Done(), inf.HasSynced)
+	ok := cache.WaitForNamedCacheSync(controllerName, ctx.Done(), inf.HasSynced)
 	if !ok {
 		level.Error(logger).Log("msg", "failed to sync cache")
 	} else {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -333,7 +333,7 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 		{"StatefulSet", c.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
-			if !operator.WaitForCacheSync(ctx, log.With(c.logger, "informer", infs.name), inf.Informer()) {
+			if !operator.WaitForNamedCacheSync(ctx, "prometheus", log.With(c.logger, "informer", infs.name), inf.Informer()) {
 				ok = false
 			}
 		}
@@ -346,7 +346,7 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 		{"PromNamespace", c.nsPromInf},
 		{"MonNamespace", c.nsMonInf},
 	} {
-		if !operator.WaitForCacheSync(ctx, log.With(c.logger, "informer", inf.name), inf.informer) {
+		if !operator.WaitForNamedCacheSync(ctx, "prometheus", log.With(c.logger, "informer", inf.name), inf.informer) {
 			ok = false
 		}
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -236,7 +236,7 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 		{"StatefulSet", o.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
-			if !operator.WaitForCacheSync(ctx, log.With(o.logger, "informer", infs.name), inf.Informer()) {
+			if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.logger, "informer", infs.name), inf.Informer()) {
 				ok = false
 			}
 		}
@@ -249,7 +249,7 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 		{"ThanosRulerNamespace", o.nsThanosRulerInf},
 		{"RuleNamespace", o.nsRuleInf},
 	} {
-		if !operator.WaitForCacheSync(ctx, log.With(o.logger, "informer", inf.name), inf.informer) {
+		if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.logger, "informer", inf.name), inf.informer) {
 			ok = false
 		}
 	}


### PR DESCRIPTION
#3451 added 2 new informers on namespace resources for `Alertmanager` and `AlertmanagerConfig` but the controller wasn't modified to wait for synchronization to be complete before starting the reconciliation loop.
This change also replaces the use of `cache.WaitForCacheSync` by `cache.WaitForNamedCacheSync` as recommended in the the [`k8s.io/client-go` doc](https://pkg.go.dev/k8s.io/client-go/tools/cache#WaitForCacheSync).