### PR TITLE
Remove redundant namespace on ClusterRole and ClusterRoleBinding in Thanos example

### DIFF
--- a/example/thanos/prometheus-cluster-role-binding.yaml
+++ b/example/thanos/prometheus-cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-self
-  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/example/thanos/prometheus-cluster-role.yaml
+++ b/example/thanos/prometheus-cluster-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-self
-  namespace: default
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Remove redundant namespace on `ClusterRole` and `ClusterRoleBinding` in Thanos example.

`ClusterRole` and `ClusterRoleBinding` resources are cluster-wide, setting the namespace on these resources does nothing.