### PR TITLE
Link to getting started guide instead of blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The Prometheus operator includes, but is not limited to, the following features:
 * **Prometheus Target Configuration**: Automatically generate monitoring target configurations based
   on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
 
-For an introduction to the Prometheus Operator, see the initial [blog
-post](https://coreos.com/blog/the-prometheus-operator.html).
+For an introduction to the Prometheus Operator, see the [getting started](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md) guide.
 
 ## Prometheus Operator vs. kube-prometheus vs. community helm chart
 


### PR DESCRIPTION
The blog post is from 2016, but it's market as outdated and redirects to getting started guide anyway.