### PR TITLE
docs: fix linting user-guide with updated docker image

### DIFF
--- a/Documentation/user-guides/linting.md
+++ b/Documentation/user-guides/linting.md
@@ -35,7 +35,7 @@ lint_files() {
   elif [ -x "$(command -v docker)" ]; then
     echo "Using Dockerized linter."
     docker run --rm --volume "$PWD:/data:ro" --workdir /data ${LINTER} \
-    /bin/bash -c "find $1/$2 | xargs /go/bin/po-lint"
+    /bin/bash -c "/go/bin/po-lint $1/$2"
   else
     echo "Linter executable not found."
     exit 1

--- a/Documentation/user-guides/linting.md
+++ b/Documentation/user-guides/linting.md
@@ -17,8 +17,7 @@ Here is an example script to lint a `src` sub-directory full of Prometheus Opera
 ```sh
 #!/bin/sh
 
-LINTER="quay.io/coreos/prometheus-operator-lint"
-SCRIPT=$(basename "$0")
+LINTER="quay.io/coreos/po-tooling"
 
 lint_files() {
   if [ -x "$(command -v po-lint)" ]; then
@@ -35,17 +34,13 @@ lint_files() {
     exit ${had_errors}
   elif [ -x "$(command -v docker)" ]; then
     echo "Using Dockerized linter."
-    docker run \
-           --rm \
-           --volume "$(pwd):/data:ro" \
-           --entrypoint "/data/${SCRIPT}" \
-           --workdir /data \
-           "${LINTER}" "${1}" "${2}"
+    docker run --rm --volume "$PWD:/data:ro" --workdir /data ${LINTER} \
+    /bin/bash -c "find $1/$2 | xargs /go/bin/po-lint"
   else
     echo "Linter executable not found."
     exit 1
   fi
 }
 
-lint_files "src" "*.yaml"
+lint_files "./src" "*.yaml"
 ```


### PR DESCRIPTION
# Summary
Fixes a bug in the example script as mentioned in #3667 

# The Bug
**Expected:**
Example script lints a sub-directory full of Prometheus Operator CRD files with ether local po-lint or Dockerized version
**Actual:**
Because the previous Docker image was deprecated/removed, the script no longer works; leaving no working po-lint example using the po-tooling docker image.

# The Fix
I updated the script to use the new po-tooling docker image.

## Alternative fixes
I would be happy to simplify the docs significantly by instead providing two short and separate examples for users without the need for a new user to parse this shell script to understand how to run the docker / local commands. 