### PR TITLE
promcfg: Change label regex to match empty strings

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -534,14 +534,14 @@ func (cg *configGenerator) generatePodMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".*"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "value", Value: "true"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".*"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "value", Value: "true"},
 			})
 		}
 	}
@@ -793,14 +793,14 @@ func (cg *configGenerator) generateProbeConfig(
 			case metav1.LabelSelectorOpExists:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "keep"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: ".*"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
+					{Key: "value", Value: "true"},
 				})
 			case metav1.LabelSelectorOpDoesNotExist:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "drop"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: ".*"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
+					{Key: "value", Value: "true"},
 				})
 			}
 		}
@@ -982,14 +982,14 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".*"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "value", Value: "true"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".*"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "value", Value: "true"},
 			})
 		}
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -535,13 +535,13 @@ func (cg *configGenerator) generatePodMonitorConfig(
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".+"},
+				{Key: "regex", Value: ".*"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".+"},
+				{Key: "regex", Value: ".*"},
 			})
 		}
 	}
@@ -794,13 +794,13 @@ func (cg *configGenerator) generateProbeConfig(
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "keep"},
 					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: ".+"},
+					{Key: "regex", Value: ".*"},
 				})
 			case metav1.LabelSelectorOpDoesNotExist:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "drop"},
 					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: ".+"},
+					{Key: "regex", Value: ".*"},
 				})
 			}
 		}
@@ -983,13 +983,13 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".+"},
+				{Key: "regex", Value: ".*"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: ".+"},
+				{Key: "regex", Value: ".*"},
 			})
 		}
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -534,14 +534,14 @@ func (cg *configGenerator) generatePodMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
-				{Key: "value", Value: "true"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true;.+"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
-				{Key: "value", Value: "true"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true;.+"},
 			})
 		}
 	}
@@ -793,14 +793,14 @@ func (cg *configGenerator) generateProbeConfig(
 			case metav1.LabelSelectorOpExists:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "keep"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
-					{Key: "value", Value: "true"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
+					{Key: "regex", Value: "true;.+"},
 				})
 			case metav1.LabelSelectorOpDoesNotExist:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "drop"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
-					{Key: "value", Value: "true"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
+					{Key: "regex", Value: "true;.+"},
 				})
 			}
 		}
@@ -982,14 +982,14 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
-				{Key: "value", Value: "true"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true;.+"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
-				{Key: "value", Value: "true"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true;.+"},
 			})
 		}
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -534,14 +534,14 @@ func (cg *configGenerator) generatePodMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: "true;.+"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: "true;.+"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true"},
 			})
 		}
 	}
@@ -793,14 +793,14 @@ func (cg *configGenerator) generateProbeConfig(
 			case metav1.LabelSelectorOpExists:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "keep"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: "true;.+"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
+					{Key: "regex", Value: "true"},
 				})
 			case metav1.LabelSelectorOpDoesNotExist:
 				relabelings = append(relabelings, yaml.MapSlice{
 					{Key: "action", Value: "drop"},
-					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_ingress_label_" + sanitizeLabelName(exp.Key)}},
-					{Key: "regex", Value: "true;.+"},
+					{Key: "source_labels", Value: []string{"__meta_kubernetes_ingress_labelpresent_" + sanitizeLabelName(exp.Key)}},
+					{Key: "regex", Value: "true"},
 				})
 			}
 		}
@@ -982,14 +982,14 @@ func (cg *configGenerator) generateServiceMonitorConfig(
 		case metav1.LabelSelectorOpExists:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: "true;.+"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true"},
 			})
 		case metav1.LabelSelectorOpDoesNotExist:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "drop"},
-				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key), "__meta_kubernetes_service_label_" + sanitizeLabelName(exp.Key)}},
-				{Key: "regex", Value: "true;.+"},
+				{Key: "source_labels", Value: []string{"__meta_kubernetes_service_labelpresent_" + sanitizeLabelName(exp.Key)}},
+				{Key: "regex", Value: "true"},
 			})
 		}
 	}


### PR DESCRIPTION
This fixes matching labels with empty values when using Exists/NotExists operators.

I faced this issue while using the following bits of configuration:

ServiceMonitor:
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: generic
  namespace: myns
spec:
  endpoints:
  - port: metrics
  selector:
    matchExpressions:
    - key: scrape-metrics
      operator: Exists
```

Service
```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: storage
    app.kubernetes.io/name: fluentd
    scrape-metrics: ""
  name: fluentd
  namespace: myns
spec:
  clusterIP: None
  ports:
  - name: metrics
    port: 24231
    targetPort: metrics
  selector:
    app.kubernetes.io/component: storage
    app.kubernetes.io/name: fluentd
```

The following selector should have matched `scrape-metris: ""` label, but it didn't:
```yaml
  selector:
    matchExpressions:
    - key: scrape-metrics
      operator: Exists
```

This is the corresponding bit from prometheus config:
```yaml
  relabel_configs:
  - action: keep
    source_labels:
    - __meta_kubernetes_service_label_scrape_metrics
    regex: .+
```


If this change makes sense, I'll update testst accordingly.