### PR TITLE
pkg/alertmanager: change 'send_resolved' fields to *bool

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -291,10 +291,8 @@ func (cg *configGenerator) convertReceiver(ctx context.Context, in *monitoringv1
 }
 
 func (cg *configGenerator) convertWebhookConfig(ctx context.Context, in monitoringv1alpha1.WebhookConfig, crKey types.NamespacedName) (*webhookConfig, error) {
-	out := &webhookConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &webhookConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.URLSecret != nil {
@@ -323,10 +321,8 @@ func (cg *configGenerator) convertWebhookConfig(ctx context.Context, in monitori
 }
 
 func (cg *configGenerator) convertSlackConfig(ctx context.Context, in monitoringv1alpha1.SlackConfig, crKey types.NamespacedName) (*slackConfig, error) {
-	out := &slackConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &slackConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.APIURL != nil {
@@ -469,10 +465,8 @@ func (cg *configGenerator) convertSlackConfig(ctx context.Context, in monitoring
 }
 
 func (cg *configGenerator) convertPagerdutyConfig(ctx context.Context, in monitoringv1alpha1.PagerDutyConfig, crKey types.NamespacedName) (*pagerdutyConfig, error) {
-	out := &pagerdutyConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &pagerdutyConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.RoutingKey != nil {
@@ -544,10 +538,8 @@ func (cg *configGenerator) convertPagerdutyConfig(ctx context.Context, in monito
 }
 
 func (cg *configGenerator) convertOpsgenieConfig(ctx context.Context, in monitoringv1alpha1.OpsGenieConfig, crKey types.NamespacedName) (*opsgenieConfig, error) {
-	out := &opsgenieConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &opsgenieConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.APIKey != nil {
@@ -623,10 +615,8 @@ func (cg *configGenerator) convertOpsgenieConfig(ctx context.Context, in monitor
 
 func (cg *configGenerator) convertWeChatConfig(ctx context.Context, in monitoringv1alpha1.WeChatConfig, crKey types.NamespacedName) (*weChatConfig, error) {
 
-	out := &weChatConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &weChatConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.APISecret != nil {
@@ -681,10 +671,8 @@ func (cg *configGenerator) convertWeChatConfig(ctx context.Context, in monitorin
 }
 
 func (cg *configGenerator) convertEmailConfig(ctx context.Context, in monitoringv1alpha1.EmailConfig, crKey types.NamespacedName) (*emailConfig, error) {
-	out := &emailConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &emailConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	if in.To == nil || *in.To == "" {
@@ -767,11 +755,10 @@ func (cg *configGenerator) convertEmailConfig(ctx context.Context, in monitoring
 }
 
 func (cg *configGenerator) convertVictorOpsConfig(ctx context.Context, in monitoringv1alpha1.VictorOpsConfig, crKey types.NamespacedName) (*victorOpsConfig, error) {
-	out := &victorOpsConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &victorOpsConfig{
+		VSendResolved: in.SendResolved,
 	}
+
 	if in.APIKey != nil {
 		apiKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.APIKey)
 		if err != nil {
@@ -834,10 +821,8 @@ func (cg *configGenerator) convertVictorOpsConfig(ctx context.Context, in monito
 }
 
 func (cg *configGenerator) convertPushoverConfig(ctx context.Context, in monitoringv1alpha1.PushoverConfig, crKey types.NamespacedName) (*pushoverConfig, error) {
-	out := &pushoverConfig{}
-
-	if in.SendResolved != nil {
-		out.VSendResolved = *in.SendResolved
+	out := &pushoverConfig{
+		VSendResolved: in.SendResolved,
 	}
 
 	{

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -98,14 +98,14 @@ type receiver struct {
 }
 
 type webhookConfig struct {
-	VSendResolved bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	URL           string            `yaml:"url,omitempty" json:"url,omitempty"`
 	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	MaxAlerts     int32             `yaml:"max_alerts,omitempty" json:"max_alerts,omitempty"`
 }
 
 type pagerdutyConfig struct {
-	VSendResolved bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	ServiceKey    string            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
 	RoutingKey    string            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
@@ -123,7 +123,7 @@ type pagerdutyConfig struct {
 }
 
 type opsgenieConfig struct {
-	VSendResolved bool                `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool               `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig    *httpClientConfig   `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	APIKey        string              `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIURL        string              `yaml:"api_url,omitempty" json:"api_url,omitempty"`
@@ -138,7 +138,7 @@ type opsgenieConfig struct {
 }
 
 type weChatConfig struct {
-	VSendResolved bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	APISecret     string            `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
 	APIURL        string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	CorpID        string            `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
@@ -152,7 +152,7 @@ type weChatConfig struct {
 }
 
 type slackConfig struct {
-	VSendResolved bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	APIURL        string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Channel       string            `yaml:"channel,omitempty" json:"channel,omitempty"`
@@ -232,7 +232,7 @@ type slackConfirmationField struct {
 }
 
 type emailConfig struct {
-	VSendResolved bool                `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool               `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	To            string              `yaml:"to,omitempty" json:"to,omitempty"`
 	From          string              `yaml:"from,omitempty" json:"from,omitempty"`
 	Hello         string              `yaml:"hello,omitempty" json:"hello,omitempty"`
@@ -249,7 +249,7 @@ type emailConfig struct {
 }
 
 type pushoverConfig struct {
-	VSendResolved bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	UserKey       string            `yaml:"user_key,omitempty" json:"user_key,omitempty"`
 	Token         string            `yaml:"token,omitempty" json:"token,omitempty"`
@@ -279,7 +279,7 @@ func (d duration) MarshalText() ([]byte, error) {
 }
 
 type victorOpsConfig struct {
-	VSendResolved     bool              `yaml:"send_resolved" json:"send_resolved"`
+	VSendResolved     *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig        *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	APIKey            string            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIURL            string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -843,6 +843,9 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					}("testingCorpID"),
 				}},
 				EmailConfigs: []monitoringv1alpha1.EmailConfig{{
+					SendResolved: func(b bool) *bool {
+						return &b
+					}(true),
 					To: func(str string) *string {
 						return &str
 					}("test@example.com"),
@@ -1075,14 +1078,11 @@ receivers:
 - name: "null"
 - name: %v-e2e-test-amconfig-many-receivers-e2e
   opsgenie_configs:
-  - send_resolved: false
-    api_key: 1234abc
+  - api_key: 1234abc
   pagerduty_configs:
-  - send_resolved: false
-    routing_key: 1234abc
+  - routing_key: 1234abc
   slack_configs:
-  - send_resolved: false
-    api_url: http://slack.example.com
+  - api_url: http://slack.example.com
     fields:
     - title: title
       value: value
@@ -1093,29 +1093,24 @@ receivers:
       confirm:
         text: text
   webhook_configs:
-  - send_resolved: false
-    url: http://test.url
+  - url: http://test.url
   wechat_configs:
-  - send_resolved: false
-    api_secret: 1234abc
+  - api_secret: 1234abc
     corp_id: testingCorpID
   email_configs:
-  - send_resolved: false
+  - send_resolved: true
     to: test@example.com
     auth_password: 1234abc
     auth_secret: 1234abc
   pushover_configs:
-  - send_resolved: false
-    user_key: 1234abc
+  - user_key: 1234abc
     token: 1234abc
   victorops_configs:
-  - send_resolved: false
-    api_key: 1234abc
+  - api_key: 1234abc
     routing_key: abc
 - name: %s-e2e-test-amconfig-sub-routes-e2e
   webhook_configs:
-  - send_resolved: false
-    url: http://test.url
+  - url: http://test.url
 templates: []
 `, ns, ns, ns, ns, ns, ns, ns, ns, ns)
 


### PR DESCRIPTION
Depending on the integration, the default value of 'send_resolved' can
be either 'true' or 'false'. This means that we need to represent it as
a pointer to bool in the Alertmanager configuration struct so the field
isn't rendered if nil.