### PR TITLE
Bump Prometheus and Thanos versions

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -66,6 +66,9 @@ The versions of Prometheus compatible to be run with the Prometheus Operator are
 * v2.20.1
 * v2.21.0
 * v2.22.0
+* v2.22.1
+* v2.22.2
+* v2.23.0
 
 ## Alertmanager
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -20,7 +20,7 @@ const (
 	DefaultAlertmanagerVersion   = "v0.21.0"
 	DefaultAlertmanagerBaseImage = "quay.io/prometheus/alertmanager"
 	DefaultAlertmanagerImage     = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
-	DefaultThanosVersion         = "v0.16.0"
+	DefaultThanosVersion         = "v0.17.1"
 	DefaultThanosBaseImage       = "quay.io/thanos/thanos"
 	DefaultThanosImage           = DefaultThanosBaseImage + ":" + DefaultThanosVersion
 )
@@ -76,6 +76,9 @@ var (
 		"v2.20.1",
 		"v2.21.0",
 		"v2.22.0",
+		"v2.22.1",
+		"v2.22.2",
+		"v2.23.0",
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"


### PR DESCRIPTION
Update the compatibility matrix with the latest releases of Prometheus and update the default Thanos version to the latest release.