### PR TITLE
.github: add initial template for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
+
+
+
+<!-- AUTOCHANGELOG for Downstream PRs.
+
+Please select one of the following "release-note:" headings:
+    - release-note:enhancement
+    - release-note:bug
+    - release-note:feature
+    - release-note:change
+    - release-note:none
+
+Unless you choose release-note:none, please add a release note.
+-->
+**Release Note Template (will be copied)**
+
+```release-note:REPLACEME
+
+```


### PR DESCRIPTION
Just a simple PR template that includes a field for the changelog. It is a first step to having automated changelog generation from PRs (part of #3288).

/cc @prometheus-operator/prometheus-operator-reviewers 
