### PR TITLE
fix #3726 - omit empty responder from list

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -589,7 +589,7 @@ func (cg *configGenerator) convertOpsgenieConfig(ctx context.Context, in monitor
 
 	var responders []opsgenieResponder
 	if l := len(in.Responders); l > 0 {
-		responders = make([]opsgenieResponder, l)
+		responders = []opsgenieResponder{}
 		for _, r := range in.Responders {
 			var responder opsgenieResponder = opsgenieResponder{
 				ID:       r.ID,

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -589,7 +589,7 @@ func (cg *configGenerator) convertOpsgenieConfig(ctx context.Context, in monitor
 
 	var responders []opsgenieResponder
 	if l := len(in.Responders); l > 0 {
-		responders = []opsgenieResponder{}
+		responders = make([]opsgenieResponder, 0, l)
 		for _, r := range in.Responders {
 			var responder opsgenieResponder = opsgenieResponder{
 				ID:       r.ID,

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -337,6 +337,71 @@ templates: []
 `,
 		},
 		{
+			name: "CR with Opsgenie Team Responder",
+			kclient: fake.NewSimpleClientset(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "am-og-test-receiver",
+						Namespace: "mynamespace",
+					},
+					Data: map[string][]byte{
+						"apiKey": []byte("1234abc"),
+					},
+				},
+			),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{
+							Name: "test",
+							OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{{
+								APIKey: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "am-og-test-receiver",
+									},
+									Key: "apiKey",
+								},
+								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{{
+									Name: "myname",
+									Type: "team",
+								}},
+							}},
+						}},
+					},
+				},
+			},
+			expected: `route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace-myamc-test
+    match:
+      namespace: mynamespace
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace-myamc-test
+  opsgenie_configs:
+  - api_key: 1234abc
+    responders:
+    - name: myname
+      type: team
+templates: []
+`,
+		},
+		{
 			name: "CR with WeChat Receiver",
 			kclient: fake.NewSimpleClientset(
 				&corev1.Secret{


### PR DESCRIPTION
Fix for #3726 - original code initializes a list of Responder with an empty first object, which results in the config rendering with an invalid responder.

**Release Note Template (will be copied)**

```release-note:bug
Omit invalid (empty) responder from opsgenie config
```
