### PR TITLE
pkg/operator: remove CreationTime zero value hack

### DIFF
--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -27,10 +27,9 @@ func MakeVolumeClaimTemplate(e monitoringv1.EmbeddedPersistentVolumeClaim) *v1.P
 			Kind:       e.Kind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              e.Name,
-			Labels:            e.Labels,
-			Annotations:       e.Annotations,
-			CreationTimestamp: metav1.Time{},
+			Name:        e.Name,
+			Labels:      e.Labels,
+			Annotations: e.Annotations,
 		},
 		Spec:   e.Spec,
 		Status: e.Status,


### PR DESCRIPTION
Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```

We have done all the groundwork for openapi to recognize the `nil` value for `CreationTimestamp`. We can remove the central hack of initializing the non-nil zero value.

Nevertheless asking for a critical set of eyes @prometheus-operator/prometheus-operator-reviewers 

Fixes #2824