### PR TITLE
Documentation: Add missing CRDs to design doc

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -10,10 +10,13 @@ This document describes the design and interaction between the custom resource d
 The custom resources that the Prometheus Operator introduces are:
 
 * `Prometheus`
-* `ServiceMonitor`
-* `PodMonitor` 
 * `Alertmanager`
+* `ThanosRuler`
+* `ServiceMonitor`
+* `PodMonitor`
+* `Probe`
 * `PrometheusRule`
+* `AlertmanagerConfig`
 
 ## Prometheus
 
@@ -24,6 +27,24 @@ For each `Prometheus` resource, the Operator deploys a properly configured `Stat
 The CRD specifies which `ServiceMonitor`s should be covered by the deployed Prometheus instances based on label selection. The Operator then generates a configuration based on the included `ServiceMonitor`s and updates it in the `Secret` containing the configuration. It continuously does so for all changes that are made to `ServiceMonitor`s or the `Prometheus` resource itself.
 
 If no selection of `ServiceMonitor`s is provided, the Operator leaves management of the `Secret` to the user, which allows to provide custom configurations while still benefiting from the Operator's capabilities of managing Prometheus setups.
+
+
+## Alertmanager
+
+The `Alertmanager` custom resource definition (CRD) declaratively defines a desired Alertmanager setup to run in a Kubernetes cluster. It provides options to configure replication and persistent storage.
+
+For each `Alertmanager` resource, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Alertmanager pods are configured to include a `Secret` called `<alertmanager-name>` which holds the used configuration file in the key `alertmanager.yaml`.
+
+When there are two or more configured replicas the operator runs the Alertmanager instances in high availability mode.
+
+
+## ThanosRuler
+
+The `ThanosRuler` custom resource definition (CRD) declaratively defines a desired [Thanos Ruler](https://github.com/thanos-io/thanos/blob/master/docs/components/rule.md) setup to run in a Kubernetes cluster. With Thanos Ruler recording and alerting rules can be processed across multiple Prometheus instances.
+
+A `ThanosRuler` instance requires at least one `queryEndpoint` which points to the location of Thanos Queriers or Prometheus instances.  The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos runtime.
+Further information can also be found in the [Thanos doc](thanos.md).
+
 
 ## ServiceMonitor
 
@@ -47,6 +68,7 @@ spec:
     any: true
 ```
 
+
 ## PodMonitor
 
 The `PodMonitor` custom resource definition (CRD) allows to declaratively define how a dynamic set of pods should be monitored.
@@ -55,7 +77,7 @@ This allows an organization to introduce conventions around how metrics are expo
 
 A `Pod` is a collection of one or more containers which can expose Prometheus metrics on a number of ports.
 
-The `PodMonitor` object introduced by the Prometheus Operator discovers these pods and generates the relevant configuration for the Prometheus server in order to monitor them. 
+The `PodMonitor` object introduced by the Prometheus Operator discovers these pods and generates the relevant configuration for the Prometheus server in order to monitor them.
 
 The `PodMetricsEndpoints` section of the `PodMonitorSpec`, is used to configure which ports of a pod are going to be scraped for metrics, and with which parameters.
 
@@ -68,16 +90,20 @@ spec:
     any: true
 ```
 
-## Alertmanager
 
-The `Alertmanager` custom resource definition (CRD) declaratively defines a desired Alertmanager setup to run in a Kubernetes cluster. It provides options to configure replication and persistent storage.
+## Probe
 
-For each `Alertmanager` resource, the Operator deploys a properly configured `StatefulSet` in the same namespace. The Alertmanager pods are configured to include a `Secret` called `<alertmanager-name>` which holds the used configuration file in the key `alertmanager.yaml`.
+The `Probe` custom resource definition (CRD) allows to declarative define how groups of ingresses and static targets should be monitored. Besides the target, the `Probe` object requires a `prober` which is the service that monitors the target and provides metrics for Prometheus to scrape. This could be for example achieved using the [blackbox exporter](https://github.com/prometheus/blackbox_exporter/).
 
-When there are two or more configured replicas the operator runs the Alertmanager instances in high availability mode.
 
 ## PrometheusRule
 
-The `PrometheusRule` CRD declaratively defines a desired Prometheus rule to be consumed by one or more Prometheus instances. 
+The `PrometheusRule` custom resource definition (CRD) declaratively defines a desired Prometheus rule to be consumed by one or more Prometheus instances.
 
 Alerts and recording rules can be saved and applied as YAML files, and dynamically loaded without requiring any restart.
+
+
+## AlertmanagerConfig
+
+The `AlertmanagerConfig` custom resource definition (CRD) declaratively specifies subsections of the Alertmanager configuration, allowing routing of alerts to custom receivers, and setting inhibit rules. The `AlertmanagerConfig` can be defined on a namespace level providing an aggregated config to Alertmanager. An example on how to use it is provided [here](../example/user-guides/alerting/alertmanager-config-example.yaml). Please be aware that this CRD is not stable yet.
+

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -90,7 +90,7 @@ responsible for compactions on a global, object storage level.
 ## Thanos Ruler
 
 The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/master/docs/components/rule.md) component allows recording and alerting rules to be processed across
-multiple Promtheus instances.  A `ThanosRuler` instance requires at least one `queryEndpoint` which points to the location of Thanos Queriers or Prometheus instances.  The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos runtime.
+multiple Prometheus instances.  A `ThanosRuler` instance requires at least one `queryEndpoint` which points to the location of Thanos Queriers or Prometheus instances.  The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos runtime.
 
 ```
 ...


### PR DESCRIPTION
First attempt at providing some doc for https://github.com/prometheus-operator/prometheus-operator/issues/3740

This adds the missing CRDs to the design doc.