### PR TITLE
Do not return error when sub-route does not contain a receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ we recommend upgrading Kubernetes first and then the Prometheus Operator.
 
 ## CustomResourceDefinitions
 
-A core feature of the Prometheus Operator~ is to monitor the Kubernetes API server for changes
+A core feature of the Prometheus Operator is to monitor the Kubernetes API server for changes
 to specific objects and ensure that the current Prometheus deployments match these objects.
 The Operator acts on the following [custom resource definitions (CRDs)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/):
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ we recommend upgrading Kubernetes first and then the Prometheus Operator.
 
 ## CustomResourceDefinitions
 
-A core feature of the Prometheus Operator is to monitor the Kubernetes API server for changes
+A core feature of the Prometheus Operator~ is to monitor the Kubernetes API server for changes
 to specific objects and ensure that the current Prometheus deployments match these objects.
 The Operator acts on the following [custom resource definitions (CRDs)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/):
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1233,7 +1233,7 @@ func checkAlertmanagerRoutes(r *monitoringv1alpha1.Route, receivers map[string]s
 		return nil
 	}
 
-	if _, found := receivers[r.Receiver]; !found {
+	if _, found := receivers[r.Receiver]; r.Receiver != "" && !found {
 		return errors.Errorf("receiver %q not found", r.Receiver)
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -922,7 +922,7 @@ func checkAlertmanagerConfig(ctx context.Context, amc *monitoringv1alpha1.Alertm
 		return err
 	}
 
-	return checkAlertmanagerRoutes(amc.Spec.Route, receiverNames)
+	return checkAlertmanagerRoutes(amc.Spec.Route, receiverNames, true)
 }
 
 func checkReceivers(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, store *assets.Store) (map[string]struct{}, error) {
@@ -1228,12 +1228,12 @@ func checkPushoverConfigs(ctx context.Context, configs []monitoringv1alpha1.Push
 }
 
 // checkAlertmanagerRoutes verifies that the given route and all its children are semantically valid.
-func checkAlertmanagerRoutes(r *monitoringv1alpha1.Route, receivers map[string]struct{}) error {
+func checkAlertmanagerRoutes(r *monitoringv1alpha1.Route, receivers map[string]struct{}, topLevelRoute bool) error {
 	if r == nil {
 		return nil
 	}
 
-	if _, found := receivers[r.Receiver]; r.Receiver != "" && !found {
+	if _, found := receivers[r.Receiver]; !found && (r.Receiver != "" || topLevelRoute) {
 		return errors.Errorf("receiver %q not found", r.Receiver)
 	}
 
@@ -1243,7 +1243,7 @@ func checkAlertmanagerRoutes(r *monitoringv1alpha1.Route, receivers map[string]s
 	}
 
 	for i := range children {
-		if err := checkAlertmanagerRoutes(&children[i], receivers); err != nil {
+		if err := checkAlertmanagerRoutes(&children[i], receivers, false); err != nil {
 			return errors.Wrapf(err, "route[%d]", i)
 		}
 	}

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -124,6 +124,22 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "top-level-route-without-receiver",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}},
+				},
+			},
+			ok: false,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "duplicate-receivers",
 					Namespace: "ns1",
 				},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -128,8 +128,7 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					Namespace: "ns1",
 				},
 				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
-					Route: &monitoringv1alpha1.Route{
-					},
+					Route: &monitoringv1alpha1.Route{},
 					Receivers: []monitoringv1alpha1.Receiver{{
 						Name: "recv1",
 					}},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -102,6 +102,28 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nested-routes-without-receiver",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{Raw: []byte(`{"routes": [{"receiver": "recv2"}]}`)},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}, {
+						Name: "recv2",
+					}},
+				},
+			},
+			ok: true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "duplicate-receivers",
 					Namespace: "ns1",
 				},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR updates the `checkAlertmanagerRoutes` function to not return an error when a route's receiver is not set. This is a valid configuration in Prometheus and is specified as valid configuration in the prometheus-operator API documentation.

Fixes #3748 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```
release-note:Fix child routes to not require a receiver
```
