### PR TITLE
Add namespace label to static probes

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -726,10 +726,16 @@ func (cg *configGenerator) generateProbeConfig(
 		}
 
 		if m.Spec.Targets.StaticConfig.Labels != nil {
-			staticConfig = append(staticConfig, yaml.MapSlice{
-				{Key: "labels", Value: m.Spec.Targets.StaticConfig.Labels},
-			}...)
+			if _, ok := m.Spec.Targets.StaticConfig.Labels["namespace"]; !ok {
+				m.Spec.Targets.StaticConfig.Labels["namespace"] = m.Namespace
+			}
+		} else {
+			m.Spec.Targets.StaticConfig.Labels = map[string]string{"namespace": m.Namespace}
 		}
+
+		staticConfig = append(staticConfig, yaml.MapSlice{
+			{Key: "labels", Value: m.Spec.Targets.StaticConfig.Labels},
+		}...)
 
 		cfg = append(cfg, yaml.MapItem{
 			Key:   "static_configs",

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/swag"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -457,6 +458,7 @@ scrape_configs:
     - prometheus.io
     - promcon.io
     labels:
+      namespace: default
       static: label
   relabel_configs:
   - source_labels:
@@ -475,8 +477,8 @@ alerting:
 `
 
 	result := string(cfg)
-	if expected != result {
-		t.Fatalf("Unexpected result.\n\nGot:\n\n%s\n\nExpected:\n\n%s\n\n", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Fatalf("Unexpected result got(-) want(+)\n%s\n", diff)
 	}
 }
 
@@ -522,7 +524,8 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
 								"promcon.io",
 							},
 							Labels: map[string]string{
-								"static": "label",
+								"namespace": "custom",
+								"static":    "label",
 							},
 						},
 					},
@@ -561,6 +564,7 @@ scrape_configs:
     - prometheus.io
     - promcon.io
     labels:
+      namespace: custom
       static: label
   relabel_configs:
   - source_labels:
@@ -581,8 +585,8 @@ alerting:
 `
 
 	result := string(cfg)
-	if expected != result {
-		t.Fatalf("Unexpected result.\n\nGot:\n\n%s\n\nExpected:\n\n%s\n\n", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Fatalf("Unexpected result got(-) want(+)\n%s\n", diff)
 	}
 }
 
@@ -627,9 +631,6 @@ func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
 								"prometheus.io",
 								"promcon.io",
 							},
-							Labels: map[string]string{
-								"static": "label",
-							},
 						},
 					},
 				},
@@ -667,7 +668,7 @@ scrape_configs:
     - prometheus.io
     - promcon.io
     labels:
-      static: label
+      namespace: default
   relabel_configs:
   - target_label: job
     replacement: blackbox
@@ -687,8 +688,8 @@ alerting:
 `
 
 	result := string(cfg)
-	if expected != result {
-		t.Fatalf("Unexpected result.\n\nGot:\n\n%s\n\nExpected:\n\n%s\n\n", result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Fatalf("Unexpected result got(-) want(+)\n%s\n", diff)
 	}
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Right now when creating staticConfig Probes namespace label is not populated. This PR aims to fix this that

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Add namespace label to static probe metrics
```
