### PR TITLE
.github: specify Go version for publish action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.golang-version }}
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
I've just noticed that the "publish" action builds with Go 1.14.x.

```
$ docker run --rm quay.io/prometheus-operator/prometheus-operator:master
level=info ts=2020-12-23T11:04:49.784627835Z caller=main.go:235 msg="Starting Prometheus Operator" version="version=0.44.1, branch=master, revision=02a5bac9610299372e9f77cbbe0c824ce636795b)"
level=info ts=2020-12-23T11:04:49.784670957Z caller=main.go:236 build_context="(go=go1.14.13, user=simonpasquier, date=20201222-12:15:23)"
```

**Release Note**

```release-note:none
```
