### PR TITLE
pkg/alertmanager: remove label selector for AlertmanagerConfig

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -141,6 +141,10 @@ func New(ctx context.Context, c operator.Config, logger log.Logger, r prometheus
 func (c *Operator) bootstrap(ctx context.Context) error {
 	var err error
 
+	if _, err := labels.Parse(c.config.AlertManagerSelector); err != nil {
+		return errors.Wrap(err, "can not parse alertmanager selector value")
+	}
+
 	c.alrtInfs, err = informers.NewInformersForResource(
 		informers.NewMonitoringInformerFactories(
 			c.config.Namespaces.AlertmanagerAllowList,
@@ -163,9 +167,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 			c.config.Namespaces.DenyList,
 			c.mclient,
 			resyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.config.AlertManagerSelector
-			},
+			nil,
 		),
 		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.AlertmanagerConfigName),
 	)

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -111,10 +111,6 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		return nil, errors.Wrap(err, "can not parse prometheus selector value")
 	}
 
-	if _, err := labels.Parse(conf.AlertManagerSelector); err != nil {
-		return nil, errors.Wrap(err, "can not parse alertmanager selector value")
-	}
-
 	secretListWatchSelector, err := fields.ParseSelector(conf.SecretListWatchSelector)
 	if err != nil {
 		return nil, errors.Wrap(err, "can not parse secrets selector value")


### PR DESCRIPTION
`--alertmanager-instance-selector` should only apply to
Alertmanager resources and not AlertmanagerConfig.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Apply `--alertmanager-instance-selector` selector to Alertmanager resources only.
```
