### PR TITLE
Docs: Remove redundant step for add. scrape config

### DIFF
--- a/Documentation/additional-scrape-config.md
+++ b/Documentation/additional-scrape-config.md
@@ -32,19 +32,6 @@ Then you will need to make a secret out of this configuration.
 kubectl create secret generic additional-scrape-configs --from-file=prometheus-additional.yaml --dry-run -oyaml > additional-scrape-configs.yaml
 ```
 
-Next, create a new secret using the base64 encoded output as the value for
-`prometheus-additional.yaml` in the secret.
-
-```
-apiVersion: v1
-data:
-  prometheus-additional.yaml: LSBqb2JfbmFtZTogInByb21ldGhldXMiCiAgc3RhdGljX2NvbmZpZ3M6CiAgLSB0YXJnZXRzOiBbImxvY2FsaG9zdDo5MDkwIl0K
-kind: Secret
-metadata:
-  creationTimestamp: null
-  name: additional-scrape-configs
-```
-
 Finally, reference this additional configuration in your `prometheus.yaml` CRD.
 
 ```


### PR DESCRIPTION
Two steps in the instructions have the same result, making one of them redundant.

We remove the more "complicated" one (purely subjective and a feeling).

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is a minor fix of the documentation on additional scrape configs.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
