### PR TITLE
*: copy information about security policy to separate file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security
+
+If you find a security vulnerability related to the Prometheus Operator, please
+do not report it by opening a GitHub issue, but instead please send an e-mail to
+the maintainers of the project found in the [MAINTAINERS.md](MAINTAINERS.md) file.
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

~Moved~ Copied security policy information to separate file as it is treated differently by github (more in [github docs](https://docs.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository))

I also removed an unused link in README.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
