### PR TITLE
Fix: Preserve user added labels and annotations on Services, Endpoints and StatefulSets

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -704,7 +704,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	operator.SanitizeSTS(sset)
-	_, err = ssetClient.Update(ctx, sset, metav1.UpdateOptions{})
+	err = k8sutil.UpdateStatefulSet(ctx, ssetClient, sset)
 	sErr, ok := err.(*apierrors.StatusError)
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
@@ -837,7 +837,7 @@ func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *
 		_, err = sClient.Create(ctx, generatedConfigSecret, metav1.CreateOptions{})
 		level.Debug(c.logger).Log("msg", "created generated config secret", "secretname", generatedConfigSecret.Name)
 	} else {
-		_, err = sClient.Update(ctx, generatedConfigSecret, metav1.UpdateOptions{})
+		err = k8sutil.UpdateSecret(ctx, sClient, generatedConfigSecret)
 		level.Debug(c.logger).Log("msg", "updated generated config secret", "secretname", generatedConfigSecret.Name)
 	}
 
@@ -1321,7 +1321,7 @@ func (c *Operator) createOrUpdateTLSAssetSecret(ctx context.Context, am *monitor
 		level.Debug(c.logger).Log("msg", "created tlsAssetsSecret", "secretname", tlsAssetsSecret.Name)
 
 	} else {
-		_, err = sClient.Update(ctx, tlsAssetsSecret, metav1.UpdateOptions{})
+		err = k8sutil.UpdateSecret(ctx, sClient, tlsAssetsSecret)
 		level.Debug(c.logger).Log("msg", "updated tlsAssetsSecret", "secretname", tlsAssetsSecret.Name)
 	}
 

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -175,6 +175,23 @@ func UpdateStatefulSet(ctx context.Context, sstClient clientappsv1.StatefulSetIn
 	return nil
 }
 
+// UpdateSecret merges metadata of existing Secret with new one and updates it.
+func UpdateSecret(ctx context.Context, secretClient clientv1.SecretInterface, secret *v1.Secret) error {
+	existingSecret, err := secretClient.Get(ctx, secret.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "getting secret object failed")
+	}
+
+	mergeMetadata(&secret.ObjectMeta, existingSecret.ObjectMeta)
+
+	_, err = secretClient.Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetMinorVersion returns the minor version as an integer
 func GetMinorVersion(dclient discovery.DiscoveryInterface) (int, error) {
 	v, err := dclient.ServerVersion()

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -237,6 +237,9 @@ func mergeMetadata(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
 }
 
 func mergeMaps(new map[string]string, old map[string]string) map[string]string {
+	if old == nil {
+		old = make(map[string]string, len(new))
+	}
 	for k, v := range new {
 		old[k] = v
 	}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/discovery"
+	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -120,6 +123,8 @@ func CreateOrUpdateService(ctx context.Context, sclient clientv1.ServiceInterfac
 		svc.ResourceVersion = service.ResourceVersion
 		svc.Spec.IPFamilies = service.Spec.IPFamilies
 		svc.SetOwnerReferences(mergeOwnerReferences(service.GetOwnerReferences(), svc.GetOwnerReferences()))
+		mergeMetadata(&svc.ObjectMeta, service.ObjectMeta)
+
 		_, err := sclient.Update(ctx, svc, metav1.UpdateOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrap(err, "updating service object failed")
@@ -142,10 +147,29 @@ func CreateOrUpdateEndpoints(ctx context.Context, eclient clientv1.EndpointsInte
 		}
 	} else {
 		eps.ResourceVersion = endpoints.ResourceVersion
+		mergeMetadata(&eps.ObjectMeta, endpoints.ObjectMeta)
+
 		_, err = eclient.Update(ctx, eps, metav1.UpdateOptions{})
 		if err != nil {
 			return errors.Wrap(err, "updating kubelet endpoints object failed")
 		}
+	}
+
+	return nil
+}
+
+// UpdateStatefulSet merges metadata of existing StatefulSet with new one and updates it.
+func UpdateStatefulSet(ctx context.Context, sstClient clientappsv1.StatefulSetInterface, sset *appsv1.StatefulSet) error {
+	existingSset, err := sstClient.Get(ctx, sset.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "getting stateful set object failed")
+	}
+
+	mergeMetadata(&sset.ObjectMeta, existingSset.ObjectMeta)
+
+	_, err = sstClient.Update(ctx, sset, metav1.UpdateOptions{})
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -186,6 +210,18 @@ func mergeOwnerReferences(old []metav1.OwnerReference, new []metav1.OwnerReferen
 		if _, ok := existing[ownerRef]; !ok {
 			old = append(old, ownerRef)
 		}
+	}
+	return old
+}
+
+func mergeMetadata(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
+	new.SetLabels(mergeMaps(new.Labels, old.Labels))
+	new.SetAnnotations(mergeMaps(new.Annotations, old.Annotations))
+}
+
+func mergeMaps(new map[string]string, old map[string]string) map[string]string {
+	for k, v := range new {
+		old[k] = v
 	}
 	return old
 }

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -15,8 +15,16 @@
 package k8sutil
 
 import (
+	"context"
+	"reflect"
 	"strings"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -58,4 +66,198 @@ func Test_SanitizeVolumeName(t *testing.T) {
 			t.Errorf("expected test case %d to be %q but got %q", i, c.expected, out)
 		}
 	}
+}
+
+func TestMergeMetadata(t *testing.T) {
+	testCases := []struct {
+		name                string
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+		modifiedLabels      map[string]string
+		modifiedAnnotations map[string]string
+	}{
+		{
+			name: "no change",
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+			},
+			expectedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+			},
+		},
+		{
+			name: "added label and annotation",
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+				"label":                  "value",
+			},
+			modifiedLabels: map[string]string{
+				"label": "value",
+			},
+			expectedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+				"annotation":             "value",
+			},
+			modifiedAnnotations: map[string]string{
+				"annotation": "value",
+			},
+		},
+		{
+			name: "overridden label amd annotation",
+			expectedLabels: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+			},
+			modifiedLabels: map[string]string{
+				"app.kubernetes.io/name": "overridden-value",
+			},
+			expectedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "kube-state-metrics",
+			},
+			modifiedAnnotations: map[string]string{
+				"app.kubernetes.io/name": "overridden-value",
+			},
+		},
+	}
+
+	namespace := "ns-1"
+
+	t.Run("CreateOrUpdateService", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				service := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "prometheus-operated",
+						Namespace:   namespace,
+						Labels:      map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+						Annotations: map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+					},
+					Spec:   corev1.ServiceSpec{},
+					Status: corev1.ServiceStatus{},
+				}
+
+				svcClient := fake.NewSimpleClientset(service).CoreV1().Services(namespace)
+
+				modifiedSvc := service.DeepCopy()
+				for l, v := range tc.modifiedLabels {
+					modifiedSvc.Labels[l] = v
+				}
+				for a, v := range tc.modifiedAnnotations {
+					modifiedSvc.Annotations[a] = v
+				}
+				_, err := svcClient.Update(context.TODO(), modifiedSvc, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = CreateOrUpdateService(context.TODO(), svcClient, service)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				updatedSvc, err := svcClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(tc.expectedAnnotations, updatedSvc.Annotations) {
+					t.Errorf("expected annotations %q, got %q", tc.expectedAnnotations, updatedSvc.Annotations)
+				}
+				if !reflect.DeepEqual(tc.expectedLabels, updatedSvc.Labels) {
+					t.Errorf("expected labels %q, got %q", tc.expectedLabels, updatedSvc.Labels)
+				}
+			})
+		}
+	})
+
+	t.Run("CreateOrUpdateEndpoints", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				endpoints := &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "prometheus-operated",
+						Namespace:   namespace,
+						Labels:      map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+						Annotations: map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+					},
+				}
+
+				endpointsClient := fake.NewSimpleClientset(endpoints).CoreV1().Endpoints(namespace)
+
+				modifiedEndpoints := endpoints.DeepCopy()
+				for l, v := range tc.modifiedLabels {
+					modifiedEndpoints.Labels[l] = v
+				}
+				for a, v := range tc.modifiedAnnotations {
+					modifiedEndpoints.Annotations[a] = v
+				}
+				_, err := endpointsClient.Update(context.TODO(), modifiedEndpoints, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = CreateOrUpdateEndpoints(context.TODO(), endpointsClient, endpoints)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				updatedEndpoints, err := endpointsClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(tc.expectedAnnotations, updatedEndpoints.Annotations) {
+					t.Errorf("expected annotations %q, got %q", tc.expectedAnnotations, updatedEndpoints.Annotations)
+				}
+				if !reflect.DeepEqual(tc.expectedLabels, updatedEndpoints.Labels) {
+					t.Errorf("expected labels %q, got %q", tc.expectedLabels, updatedEndpoints.Labels)
+				}
+			})
+		}
+	})
+
+	t.Run("UpdateStatefulSet", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				sset := &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "prometheus",
+						Namespace:   namespace,
+						Labels:      map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+						Annotations: map[string]string{"app.kubernetes.io/name": "kube-state-metrics"},
+					},
+				}
+
+				ssetClient := fake.NewSimpleClientset(sset).AppsV1().StatefulSets(namespace)
+
+				modifiedSset := sset.DeepCopy()
+				for l, v := range tc.modifiedLabels {
+					modifiedSset.Labels[l] = v
+				}
+				for a, v := range tc.modifiedAnnotations {
+					modifiedSset.Annotations[a] = v
+				}
+				_, err := ssetClient.Update(context.TODO(), modifiedSset, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = UpdateStatefulSet(context.TODO(), ssetClient, sset)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				updatedSset, err := ssetClient.Get(context.TODO(), "prometheus", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(tc.expectedAnnotations, updatedSset.Annotations) {
+					t.Errorf("expected annotations %q, got %q", tc.expectedAnnotations, updatedSset.Annotations)
+				}
+				if !reflect.DeepEqual(tc.expectedLabels, updatedSset.Labels) {
+					t.Errorf("expected labels %q, got %q", tc.expectedLabels, updatedSset.Labels)
+				}
+			})
+		}
+	})
 }

--- a/pkg/k8sutil/merge.go
+++ b/pkg/k8sutil/merge.go
@@ -17,8 +17,9 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1226,7 +1226,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 		level.Debug(c.logger).Log("msg", "updating current Prometheus statefulset")
 
-		_, err = ssetClient.Update(ctx, sset, metav1.UpdateOptions{})
+		err = k8sutil.UpdateStatefulSet(ctx, ssetClient, sset)
 		sErr, ok := err.(*apierrors.StatusError)
 
 		if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1546,8 +1546,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 
 	level.Debug(c.logger).Log("msg", "updating Prometheus configuration secret")
-	_, err = sClient.Update(ctx, s, metav1.UpdateOptions{})
-	return err
+	return k8sutil.UpdateSecret(ctx, sClient, s)
 }
 
 func (c *Operator) createOrUpdateTLSAssetSecret(ctx context.Context, p *monitoringv1.Prometheus, store *assets.Store) error {
@@ -1590,7 +1589,7 @@ func (c *Operator) createOrUpdateTLSAssetSecret(ctx context.Context, p *monitori
 		level.Debug(c.logger).Log("msg", "created tlsAssetsSecret", "secretname", tlsAssetsSecret.Name)
 
 	} else {
-		_, err = sClient.Update(ctx, tlsAssetsSecret, metav1.UpdateOptions{})
+		err = k8sutil.UpdateSecret(ctx, sClient, tlsAssetsSecret)
 		level.Debug(c.logger).Log("msg", "updated tlsAssetsSecret", "secretname", tlsAssetsSecret.Name)
 	}
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -649,7 +649,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	_, err = ssetClient.Update(ctx, sset, metav1.UpdateOptions{})
+	err = k8sutil.UpdateStatefulSet(ctx, ssetClient, sset)
 	sErr, ok := err.(*apierrors.StatusError)
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1264,8 +1264,8 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	// Set label on CR to trigger reconcile
-	alertManager.SetLabels(mergeMap(alertManager.GetLabels(), map[string]string{"test": "reconcile"}))
+	// Ensure resource reconciles
+	alertManager.Spec.Replicas = proto.Int32(2)
 	alertManager, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, alertManager)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -151,6 +151,7 @@ func testAllNSAlertmanager(t *testing.T) {
 		"AMZeroDowntimeRollingDeployment": testAMZeroDowntimeRollingDeployment,
 		"AMAlertmanagerConfigCRD":         testAlertmanagerConfigCRD,
 		"AMUserDefinedAlertmanagerConfig": testUserDefinedAlertmanagerConfig,
+		"AMPreserveUserAddedMetadata":     testAMPreserveUserAddedMetadata,
 	}
 
 	for name, f := range testFuncs {
@@ -205,7 +206,8 @@ func testAllNSPrometheus(t *testing.T) {
 func testAllNSThanosRuler(t *testing.T) {
 	skipThanosRulerTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"ThanosRulerCreateDeleteCluster": testTRCreateDeleteCluster,
+		"ThanosRulerCreateDeleteCluster":       testTRCreateDeleteCluster,
+		"ThanosRulerPreserveUserAddedMetadata": testTRPreserveUserAddedMetadata,
 	}
 	for name, f := range testFuncs {
 		t.Run(name, f)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -194,6 +194,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromStaticProbe":                        testPromStaticProbe,
 		"PromSecurePodMonitor":                   testPromSecurePodMonitor,
 		"PromSharedResourcesReconciliation":      testPromSharedResourcesReconciliation,
+		"PromPreserveUserAddedMetadata":          testPromPreserveUserAddedMetadata,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1900,8 +1900,8 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	// Set label on CR to trigger reconcile
-	prometheusCRD.SetLabels(mergeMap(prometheusCRD.GetLabels(), map[string]string{"test": "reconcile"}))
+	// Ensure resource reconciles
+	prometheusCRD.Spec.Replicas = proto.Int32(2)
 	prometheusCRD, err = framework.UpdatePrometheusAndWaitUntilReady(ns, prometheusCRD)
 	if err != nil {
 		t.Fatal(err)
@@ -1963,9 +1963,9 @@ func asSecret(t *testing.T, object metav1.Object) *v1.Secret {
 	return sec
 }
 
-func containsValues(collection, contains map[string]string) bool {
-	for k, v := range contains {
-		if collection[k] != v {
+func containsValues(got, expected map[string]string) bool {
+	for k, v := range expected {
+		if got[k] != v {
 			return false
 		}
 	}

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -15,9 +15,12 @@
 package e2e
 
 import (
+	"github.com/golang/protobuf/proto"
+
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func testTRCreateDeleteCluster(t *testing.T) {
@@ -104,8 +107,8 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	// Set label on CR to trigger reconcile
-	thanosRuler.SetLabels(mergeMap(thanosRuler.GetLabels(), map[string]string{"test": "reconcile"}))
+	// Ensure resource reconciles
+	thanosRuler.Spec.Replicas = proto.Int32(2)
 	thanosRuler, err = framework.UpdateThanosRulerAndWaitUntilReady(ns, thanosRuler)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: #2018
This PR adds functionality to preserve any labels and annotations manually added by user on Services, Endpoints and Stateful Sets managed by the Operator. Labels and Annotations are preserved as long as the do not conflict with those added by the Operator.

Questions:
- I did not introduce it for Secrets yet as I am not sure if there is a use case for that, but I will add it for consistency sake if requested.
- Do we want e2e test for this functionality?


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Preserve user added labels and annotations on Services, Endpoints and StatefulSets
```
