### PR TITLE
Add flags for CPU/Memory requests/limits

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -172,11 +172,11 @@ func init() {
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
 	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.49.
 	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
-	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-req", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured.")
 	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.49.
 	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
-	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-req", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image (path without tag/version)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -252,6 +252,14 @@ func Main() int {
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
+	// logger setup happens after flag parsing!
+	if cfg.ReloaderConfig.CPULimit != "100m" {
+		level.Warn(logger).Log("The --config-reloader-cpu flag has been deprecated! Please use --config-reloader-cpu-limit and --config-reloader-cpu-request according to your use-case.")
+	}
+	if cfg.ReloaderConfig.MemoryLimit != "50Mi" {
+		level.Warn(logger).Log("The --config-reloader-memory flag has been deprecated! Please use --config-reloader-memory-limit and --config-reloader-memory-request according to your use-case.")
+	}
+
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
 	klog.SetLogger(log.With(logger, "component", "k8s_client_runtime"))

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -170,10 +170,12 @@ func init() {
 	// the Prometheus Operator version if no Prometheus config reloader image is
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
-	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured.")
+	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.49.
+	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-req", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured.")
-	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured.")
+	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.49.
+	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-req", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/prometheus/common/version"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	klog "k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
 )
@@ -67,6 +68,11 @@ const (
 
 const (
 	defaultOperatorTLSDir = "/etc/tls/private"
+)
+
+const (
+	defaultReloaderCPU    = "100m"
+	defaultReloaderMemory = "50Mi"
 )
 
 var (
@@ -136,7 +142,8 @@ var (
 		logFormatLogfmt,
 		logFormatJson,
 	}
-	cfg = operator.Config{}
+	cfg             = operator.Config{}
+	rcCPU, rcMemory string
 
 	rawTLSCipherSuites string
 	serverTLS          bool
@@ -171,13 +178,11 @@ func init() {
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
 	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.48.
-	var rcCPU string
-	flagset.StringVar(&rcCPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
+	flagset.StringVar(&rcCPU, "config-reloader-cpu", defaultReloaderCPU, "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "config-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
 	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.48.
-	var rcMemory string
-	flagset.StringVar(&rcMemory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
+	flagset.StringVar(&rcMemory, "config-reloader-memory", defaultReloaderMemory, "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-memory` for the memory limit")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
@@ -197,26 +202,6 @@ func init() {
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-field-selector", "", "Field selector to filter Secrets to watch")
-
-	// Prioritize specific flags over generic ones
-	// If config.CPU has been set but not config.CPURequest/config.CPULimit, default "" to config.CPU
-	// If config.Memory has been set but not config.MemoryRequest or config.MemoryLimit, default "" to config.Memory
-	if rcCPU != "" {
-		if cfg.ReloaderConfig.CPURequest == "" {
-			cfg.ReloaderConfig.CPURequest = rcCPU
-		}
-		if cfg.ReloaderConfig.CPULimit == "" {
-			cfg.ReloaderConfig.CPULimit = rcCPU
-		}
-	}
-	if rcMemory != "" {
-		if cfg.ReloaderConfig.MemoryRequest == "" {
-			cfg.ReloaderConfig.MemoryRequest = rcMemory
-		}
-		if cfg.ReloaderConfig.MemoryLimit == "" {
-			cfg.ReloaderConfig.MemoryLimit = rcMemory
-		}
-	}
 }
 
 func Main() int {
@@ -252,12 +237,51 @@ func Main() int {
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
-	// logger setup happens after flag parsing!
-	if cfg.ReloaderConfig.CPULimit != "100m" {
-		level.Warn(logger).Log("The \"--config-reloader-cpu\" flag has been deprecated! Please use \"--config-reloader-cpu-limit\" and \"--config-reloader-cpu-request\" according to your use-case.")
+	// Prioritize specific flags over generic ones
+	// If rcCPU has been set but not config.CPURequest/config.CPULimit, default "" to rcCPU
+	// If rcMemory has been set but not config.MemoryRequest or config.MemoryLimit, default "" to rcMemory
+	if rcCPU != "" {
+		if cfg.ReloaderConfig.CPURequest == "" {
+			cfg.ReloaderConfig.CPURequest = rcCPU
+		}
+		if cfg.ReloaderConfig.CPULimit == "" {
+			cfg.ReloaderConfig.CPULimit = rcCPU
+		}
 	}
-	if cfg.ReloaderConfig.MemoryLimit != "50Mi" {
-		level.Warn(logger).Log("The \"--config-reloader-memory\" flag has been deprecated! Please use \"--config-reloader-memory-limit\" and \"--config-reloader-memory-request\" according to your use-case.")
+	if rcMemory != "" {
+		if cfg.ReloaderConfig.MemoryRequest == "" {
+			cfg.ReloaderConfig.MemoryRequest = rcMemory
+		}
+		if cfg.ReloaderConfig.MemoryLimit == "" {
+			cfg.ReloaderConfig.MemoryLimit = rcMemory
+		}
+	}
+	// Check validity of reloader resource values given to flags
+	_, err1 := resource.ParseQuantity(cfg.ReloaderConfig.CPULimit)
+	if err1 != nil {
+		fmt.Fprintf(os.Stderr, "The CPU limit specified for reloader \"%v\" is not a valid quantity! %v\n", cfg.ReloaderConfig.CPULimit, err1)
+	}
+	_, err2 := resource.ParseQuantity(cfg.ReloaderConfig.CPURequest)
+	if err2 != nil {
+		fmt.Fprintf(os.Stderr, "The CPU request specified for reloader \"%v\" is not a valid quantity! %v\n", cfg.ReloaderConfig.CPURequest, err2)
+	}
+	_, err3 := resource.ParseQuantity(cfg.ReloaderConfig.MemoryLimit)
+	if err3 != nil {
+		fmt.Fprintf(os.Stderr, "The Memory limit specified for reloader \"%v\" is not a valid quantity! %v\n", cfg.ReloaderConfig.MemoryLimit, err3)
+	}
+	_, err4 := resource.ParseQuantity(cfg.ReloaderConfig.MemoryRequest)
+	if err4 != nil {
+		fmt.Fprintf(os.Stderr, "The Memory request specified for reloader \"%v\" is not a valid quantity! %v\n", cfg.ReloaderConfig.MemoryRequest, err4)
+	}
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return 1
+	}
+	// Warn users that could be utilizing --config-reloader-cpu and --config-reloader-memory of their deprecated nature
+	if rcCPU != defaultReloaderCPU {
+		level.Warn(logger).Log("msg", "The '--config-reloader-cpu' flag has been deprecated! Please use '--config-reloader-cpu-limit' and '--config-reloader-cpu-request' according to your use-case.")
+	}
+	if rcMemory != defaultReloaderMemory {
+		level.Warn(logger).Log("msg", "The '--config-reloader-memory' flag has been deprecated! Please use '--config-reloader-memory-limit' and '--config-reloader-memory-request' according to your use-case.")
 	}
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -172,12 +172,12 @@ func init() {
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
 	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.49.
 	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
-	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured.")
-	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
+	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
 	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.49.
 	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
-	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
-	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request")
+	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-memory` for the memory limit")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image (path without tag/version)")
 	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", operator.DefaultThanosBaseImage, "Thanos default base image (path without tag/version)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -171,11 +171,13 @@ func init() {
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
 	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.49.
-	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
+	var rcCPU string
+	flagset.StringVar(&rcCPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
 	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.49.
-	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
+	var rcMemory string
+	flagset.StringVar(&rcMemory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-memory` for the memory limit")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
@@ -195,6 +197,26 @@ func init() {
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-field-selector", "", "Field selector to filter Secrets to watch")
+
+	// Prioritize specific flags over generic ones
+	// If config.CPU has been set but not config.CPURequest/config.CPULimit, default "" to config.CPU
+	// If config.Memory has been set but not config.MemoryRequest or config.MemoryLimit, default "" to config.Memory
+	if rcCPU != "" {
+		if cfg.ReloaderConfig.CPURequest == "" {
+			cfg.ReloaderConfig.CPURequest = rcCPU
+		}
+		if cfg.ReloaderConfig.CPULimit == "" {
+			cfg.ReloaderConfig.CPULimit = rcCPU
+		}
+	}
+	if rcMemory != "" {
+		if cfg.ReloaderConfig.MemoryRequest == "" {
+			cfg.ReloaderConfig.MemoryRequest = rcMemory
+		}
+		if cfg.ReloaderConfig.MemoryLimit == "" {
+			cfg.ReloaderConfig.MemoryLimit = rcMemory
+		}
+	}
 }
 
 func Main() int {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -174,7 +174,7 @@ func init() {
 	var rcCPU string
 	flagset.StringVar(&rcCPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
-	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
+	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "config-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
 	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.48.
 	var rcMemory string
 	flagset.StringVar(&rcMemory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -171,7 +171,11 @@ func init() {
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
 	flagset.StringVar(&cfg.ReloaderConfig.CPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-req", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.ReloaderConfig.Memory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-req", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured.")
+	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured.")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
 	flagset.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image (path without tag/version)")
 	flagset.StringVar(&cfg.ThanosDefaultBaseImage, "thanos-default-base-image", operator.DefaultThanosBaseImage, "Thanos default base image (path without tag/version)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -170,14 +170,14 @@ func init() {
 	// the Prometheus Operator version if no Prometheus config reloader image is
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
-	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.49.
+	// TODO(JJJJJones): remove the '--config-reloader-cpu' flag before releasing v0.48.
 	var rcCPU string
-	flagset.StringVar(&rcCPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
+	flagset.StringVar(&rcCPU, "config-reloader-cpu", "100m", "Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", "", "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "confiig-reloader-cpu-limit", "", "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
-	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.49.
+	// TODO(JJJJJones): remove the '--config-reloader-memory' flag before releasing v0.48.
 	var rcMemory string
-	flagset.StringVar(&rcMemory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0.")
+	flagset.StringVar(&rcMemory, "config-reloader-memory", "50Mi", "Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.48.0.")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", "", "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryLimit, "config-reloader-memory-limit", "", "Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-memory` for the memory limit")
 	flagset.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -254,10 +254,10 @@ func Main() int {
 
 	// logger setup happens after flag parsing!
 	if cfg.ReloaderConfig.CPULimit != "100m" {
-		level.Warn(logger).Log("The --config-reloader-cpu flag has been deprecated! Please use --config-reloader-cpu-limit and --config-reloader-cpu-request according to your use-case.")
+		level.Warn(logger).Log("The \"--config-reloader-cpu\" flag has been deprecated! Please use \"--config-reloader-cpu-limit\" and \"--config-reloader-cpu-request\" according to your use-case.")
 	}
 	if cfg.ReloaderConfig.MemoryLimit != "50Mi" {
-		level.Warn(logger).Log("The --config-reloader-memory flag has been deprecated! Please use --config-reloader-memory-limit and --config-reloader-memory-request according to your use-case.")
+		level.Warn(logger).Log("The \"--config-reloader-memory\" flag has been deprecated! Please use \"--config-reloader-memory-limit\" and \"--config-reloader-memory-request\" according to your use-case.")
 	}
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -33,9 +33,11 @@ import (
 var (
 	defaultTestConfig = Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "100m",
-			Memory: "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
 		},
 		AlertmanagerDefaultBaseImage: "quay.io/prometheus/alertmanager",
 	}
@@ -450,9 +452,11 @@ func TestAdditionalSecretsMounted(t *testing.T) {
 func TestAlertManagerDefaultBaseImageFlag(t *testing.T) {
 	alertManagerBaseImageConfig := Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "100m",
-			Memory: "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
 		},
 		AlertmanagerDefaultBaseImage: "nondefaultuseflag/quay.io/prometheus/alertmanager",
 	}
@@ -607,9 +611,11 @@ func TestAdditionalConfigMap(t *testing.T) {
 func TestSidecarsNoCPULimits(t *testing.T) {
 	testConfig := Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "0",
-			Memory: "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "0",
+			CPULimit:      "0",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
 		},
 		AlertmanagerDefaultBaseImage: "quay.io/prometheus/alertmanager",
 	}
@@ -638,9 +644,11 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 func TestSidecarsNoMemoryLimits(t *testing.T) {
 	testConfig := Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "100m",
-			Memory: "0",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "0",
+			MemoryLimit:   "0",
 		},
 		AlertmanagerDefaultBaseImage: "quay.io/prometheus/alertmanager",
 	}

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -45,9 +45,13 @@ type Config struct {
 }
 
 type ReloaderConfig struct {
-	CPU    string
-	Memory string
-	Image  string
+	CPU           string
+	CPURequest    string
+	CPULimit      string
+	Memory        string
+	MemoryRequest string
+	MemoryLimit   string
+	Image         string
 }
 
 type Labels struct {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -45,10 +45,8 @@ type Config struct {
 }
 
 type ReloaderConfig struct {
-	CPU           string
 	CPURequest    string
 	CPULimit      string
-	Memory        string
 	MemoryRequest string
 	MemoryLimit   string
 	Image         string

--- a/pkg/operator/statefulset.go
+++ b/pkg/operator/statefulset.go
@@ -75,13 +75,38 @@ func CreateConfigReloader(
 		Limits:   v1.ResourceList{},
 		Requests: v1.ResourceList{},
 	}
-	if config.CPU != "0" {
-		resources.Limits[v1.ResourceCPU] = resource.MustParse(config.CPU)
-		resources.Requests[v1.ResourceCPU] = resource.MustParse(config.CPU)
+
+	// Prioritize specific flags over generic ones
+	// If config.CPU has been set but not config.CPURequest/config.CPULimit, default "" to config.CPU
+	// If config.Memory has been set but not config.MemoryRequest or config.MemoryLimit, default "" to config.Memory
+	if config.CPU != "" {
+		if config.CPURequest == "" {
+			config.CPURequest = config.CPU
+		}
+		if config.CPULimit == "" {
+			config.CPULimit = config.CPU
+		}
 	}
-	if config.Memory != "0" {
-		resources.Limits[v1.ResourceMemory] = resource.MustParse(config.Memory)
-		resources.Requests[v1.ResourceMemory] = resource.MustParse(config.Memory)
+	if config.Memory != "" {
+		if config.MemoryRequest == "" {
+			config.MemoryRequest = config.Memory
+		}
+		if config.MemoryLimit == "" {
+			config.MemoryLimit = config.Memory
+		}
+	}
+
+	if config.CPURequest != "0" {
+		resources.Requests[v1.ResourceCPU] = resource.MustParse(config.CPURequest)
+	}
+	if config.CPULimit != "0" {
+		resources.Limits[v1.ResourceCPU] = resource.MustParse(config.CPULimit)
+	}
+	if config.MemoryRequest != "0" {
+		resources.Requests[v1.ResourceMemory] = resource.MustParse(config.MemoryRequest)
+	}
+	if config.MemoryLimit != "0" {
+		resources.Limits[v1.ResourceMemory] = resource.MustParse(config.MemoryLimit)
 	}
 
 	return v1.Container{

--- a/pkg/operator/statefulset.go
+++ b/pkg/operator/statefulset.go
@@ -76,26 +76,6 @@ func CreateConfigReloader(
 		Requests: v1.ResourceList{},
 	}
 
-	// Prioritize specific flags over generic ones
-	// If config.CPU has been set but not config.CPURequest/config.CPULimit, default "" to config.CPU
-	// If config.Memory has been set but not config.MemoryRequest or config.MemoryLimit, default "" to config.Memory
-	if config.CPU != "" {
-		if config.CPURequest == "" {
-			config.CPURequest = config.CPU
-		}
-		if config.CPULimit == "" {
-			config.CPULimit = config.CPU
-		}
-	}
-	if config.Memory != "" {
-		if config.MemoryRequest == "" {
-			config.MemoryRequest = config.Memory
-		}
-		if config.MemoryLimit == "" {
-			config.MemoryLimit = config.Memory
-		}
-	}
-
 	if config.CPURequest != "0" {
 		resources.Requests[v1.ResourceCPU] = resource.MustParse(config.CPURequest)
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -34,9 +34,11 @@ import (
 var (
 	defaultTestConfig = &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "100m",
-			Memory: "25Mi",
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "quay.io/thanos/thanos",
@@ -600,9 +602,11 @@ func TestTagAndShaAndVersion(t *testing.T) {
 func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 	prometheusBaseImageConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "100m",
-			Memory: "25Mi",
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "nondefaultuseflag/quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "nondefaultuseflag/quay.io/thanos/thanos",
@@ -633,9 +637,11 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	thanosBaseImageConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "100m",
-			Memory: "25Mi",
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "nondefaultuseflag/quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "nondefaultuseflag/quay.io/thanos/thanos",
@@ -1131,9 +1137,11 @@ func TestRetention(t *testing.T) {
 func TestSidecarsNoCPULimits(t *testing.T) {
 	testConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "0",
-			Memory: "50Mi",
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "0",
+			CPULimit:      "0",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
@@ -1163,9 +1171,11 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 func TestReplicasConfigurationWithSharding(t *testing.T) {
 	testConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "0",
-			Memory: "50Mi",
-			Image:  "quay.io/coreos/prometheus-config-reloader:latest",
+			CPURequest:    "0",
+			CPULimit:      "0",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/coreos/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
@@ -1204,9 +1214,11 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 func TestSidecarsNoMemoryLimits(t *testing.T) {
 	testConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			CPU:    "100m",
-			Memory: "0",
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "0",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 		},
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -28,6 +28,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,8 +38,8 @@ var (
 			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 			CPURequest:    "100m",
 			CPULimit:      "100m",
-			MemoryRequest: "25Mi",
-			MemoryLimit:   "25Mi",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
 		},
 		ThanosDefaultBaseImage: "quay.io/thanos/thanos",
 	}
@@ -66,9 +67,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: monitoringv1.ThanosRulerSpec{
-			QueryEndpoints: emptyQueryEndpoints,
-		},
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
 	}, defaultTestConfig, nil, "")
 
 	require.NoError(t, err)
@@ -116,8 +115,8 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 			CPURequest:    "100m",
 			CPULimit:      "100m",
-			MemoryRequest: "25Mi",
-			MemoryLimit:   "25Mi",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
 		},
 		ThanosDefaultBaseImage: "nondefaultuseflag/quay.io/thanos/thanos",
 	}
@@ -186,9 +185,7 @@ func TestStatefulSetVolumes(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
-		Spec: monitoringv1.ThanosRulerSpec{
-			QueryEndpoints: emptyQueryEndpoints,
-		},
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
 	}, defaultTestConfig, []string{"rules-configmap-one"}, "")
 	require.NoError(t, err)
 	if !reflect.DeepEqual(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes) {
@@ -596,4 +593,299 @@ func TestExternalQueryURL(t *testing.T) {
 		}
 	}
 	t.Fatalf("Thanos ruler is missing expected argument: %s", expectedArg)
+}
+
+func TestSidecarsNoResources(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "0",
+			CPULimit:      "0",
+			MemoryRequest: "0",
+			MemoryLimit:   "0",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits:   v1.ResourceList{},
+		Requests: v1.ResourceList{},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoRequests(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "0",
+			CPULimit:      "100m",
+			MemoryRequest: "0",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoLimits(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "100m",
+			CPULimit:      "0",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "0",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoCPUResources(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "0",
+			CPULimit:      "0",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoCPURequests(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "0",
+			CPULimit:      "100m",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoCPULimits(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "100m",
+			CPULimit:      "0",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoMemoryResources(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "0",
+			MemoryLimit:   "0",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoMemoryRequests(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "0",
+			MemoryLimit:   "50Mi",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
+}
+
+func TestSidecarsNoMemoryLimits(t *testing.T) {
+	testConfig := Config{
+		ReloaderConfig: operator.ReloaderConfig{
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "0",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+		ThanosDefaultBaseImage: "quay.io/thanos/thanos:v0.7.0",
+	}
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+	}, testConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	expectedResources := v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("100m"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
+			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		}
+	}
 }

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -34,9 +34,11 @@ import (
 var (
 	defaultTestConfig = Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "100m",
-			Memory: "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
 		},
 		ThanosDefaultBaseImage: "quay.io/thanos/thanos",
 	}
@@ -111,9 +113,11 @@ func TestPodLabelsAnnotations(t *testing.T) {
 func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	thanosBaseImageConfig := Config{
 		ReloaderConfig: operator.ReloaderConfig{
-			Image:  "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-			CPU:    "100m",
-			Memory: "25Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "25Mi",
+			MemoryLimit:   "25Mi",
 		},
 		ThanosDefaultBaseImage: "nondefaultuseflag/quay.io/thanos/thanos",
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Config Reloader's CPU requests/CPU limits and Memory requests/Memory limits are set whatever is given to their respective flags, this allows them to be independently set (EG CPU requests of 100m but no CPU limits) #3825

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:feature

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME
[FEATURE] Allow Config Reloader CPU requests/limits and memory requests/limits to be set independently #3825 
```
