### PR TITLE
Common labels for Alertmanager/Prometheus/ThanosRuler objects

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -316,8 +316,12 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
-		"app":          "alertmanager",
-		"alertmanager": a.Name,
+		"app":                          "alertmanager",
+		"app.kubernetes.io/name":       "alertmanager",
+		"app.kubernetes.io/version":    amVersion,
+		"app.kubernetes.io/managed-by": "prometheus-operator",
+		"app.kubernetes.io/instance":   a.Name,
+		"alertmanager":                 a.Name,
 	}
 	if a.Spec.PodMetadata != nil {
 		if a.Spec.PodMetadata.Labels != nil {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -616,10 +616,14 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
-		"app":                   "prometheus",
-		"prometheus":            p.Name,
-		shardLabelName:          fmt.Sprintf("%d", shard),
-		prometheusNameLabelName: p.Name,
+		"app":                          "prometheus",
+		"app.kubernetes.io/name":       "prometheus",
+		"app.kubernetes.io/version":    version.String(),
+		"app.kubernetes.io/managed-by": "prometheus-operator",
+		"app.kubernetes.io/instance":   p.Name,
+		"prometheus":                   p.Name,
+		shardLabelName:                 fmt.Sprintf("%d", shard),
+		prometheusNameLabelName:        p.Name,
 	}
 	if p.Spec.PodMetadata != nil {
 		if p.Spec.PodMetadata.Labels != nil {

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -61,7 +61,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 		"testannotation":                 "testannotationvalue",
 	}
 
-	expectedStatufulSetLabels := map[string]string{
+	expectedStatefulSetLabels := map[string]string{
 		"testlabel":                    "testlabelvalue",
 		"operator.prometheus.io/name":  "",
 		"operator.prometheus.io/shard": "0",
@@ -70,6 +70,10 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 	expectedPodLabels := map[string]string{
 		"prometheus":                   "",
 		"app":                          "prometheus",
+		"app.kubernetes.io/name":       "prometheus",
+		"app.kubernetes.io/version":    strings.TrimPrefix(operator.DefaultPrometheusVersion, "v"),
+		"app.kubernetes.io/managed-by": "prometheus-operator",
+		"app.kubernetes.io/instance":   "",
 		"operator.prometheus.io/name":  "",
 		"operator.prometheus.io/shard": "0",
 	}
@@ -83,8 +87,8 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	require.NoError(t, err)
 
-	if !reflect.DeepEqual(expectedStatufulSetLabels, sset.Labels) {
-		t.Log(pretty.Compare(expectedStatufulSetLabels, sset.Labels))
+	if !reflect.DeepEqual(expectedStatefulSetLabels, sset.Labels) {
+		t.Log(pretty.Compare(expectedStatefulSetLabels, sset.Labels))
 		t.Fatal("Labels are not properly being propagated to the StatefulSet")
 	}
 
@@ -583,7 +587,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 		sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
 				SHA:   "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
-				Tag:   "my-unrealted-tag",
+				Tag:   "my-unrelated-tag",
 				Image: &image,
 			},
 		}, defaultTestConfig, nil, "", 0)

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -354,6 +354,9 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		}
 	}
 	podLabels["app"] = thanosRulerLabel
+	podLabels["app.kubernetes.io/name"] = thanosRulerLabel
+	podLabels["app.kubernetes.io/managed-by"] = "prometheus-operator"
+	podLabels["app.kubernetes.io/instance"] = tr.Name
 	podLabels[thanosRulerLabel] = tr.Name
 	finalLabels := config.Labels.Merge(podLabels)
 

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -102,10 +102,10 @@ func TestPodLabelsAnnotations(t *testing.T) {
 	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
 	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
-		t.Fatal("Pod labes are not properly propagated")
+		t.Fatal("Pod labels are not properly propagated")
 	}
 	if !reflect.DeepEqual(annotations, sset.Spec.Template.ObjectMeta.Annotations) {
-		t.Fatal("Pod annotaitons are not properly propagated")
+		t.Fatal("Pod annotations are not properly propagated")
 	}
 }
 


### PR DESCRIPTION
```release-note:enhancement
alertmanager/prometheus/thanos: Add common kubernetes labels to prometheus-operator managed statefulsets 
```
alertmanager/prometheus/thanos: Set common labels on stateful set
This is helpful to identify which system sets those objects up.  
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/3839