### PR TITLE
fix the loss of EmailConfig.headers key

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -593,7 +593,7 @@ func (cg *configGenerator) convertEmailConfig(ctx context.Context, in monitoring
 
 		var key string
 		for _, d := range in.Headers {
-			key = strings.Title(key)
+			key = strings.Title(d.Key)
 			if _, ok := headers[key]; ok {
 				return nil, errors.Errorf("duplicate header %q in email config", key)
 			}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -857,6 +857,10 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 						},
 						Key: testingSecretKey,
 					},
+					Headers: []monitoringv1alpha1.KeyValue{
+						{Key: "Subject", Value: "subject"},
+						{Key: "Comment", Value: "comment"},
+					},
 				}},
 				VictorOpsConfigs: []monitoringv1alpha1.VictorOpsConfig{{
 					APIKey: &v1.SecretKeySelector{
@@ -1096,6 +1100,9 @@ receivers:
     to: test@example.com
     auth_password: 1234abc
     auth_secret: 1234abc
+    headers:
+      Comment: comment
+      Subject: subject
   pushover_configs:
   - user_key: 1234abc
     token: 1234abc


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes: https://github.com/prometheus-operator/prometheus-operator/issues/3835

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug

Unless you choose release-note:none, please add a release note.
-->

```release-note:bug
fix the loss of EmailConfig.headers key
```
