### PR TITLE
Update Helm installation repository url.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,7 +9,7 @@ labels: kind/bug
 Feel free to ask questions in #prometheus-operator on Kubernetes Slack!
 
 Note: This repository is about prometheus-operator itself, if you have questions about:
-- helm installation, go to https://github.com/helm/charts repository
+- helm installation, go to https://github.com/prometheus-community/helm-charts repository
 - kube-prometheus setup, go to https://github.com/prometheus-operator/kube-prometheus
 
 -->

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -9,7 +9,7 @@ labels: kind/support
 Feel free to ask questions in #prometheus-operator on Kubernetes Slack!
 
 Note: This repository is about prometheus-operator itself, if you have questions about:
-- helm installation, go to https://github.com/helm/charts repository
+- helm installation, go to https://github.com/prometheus-community/helm-charts repository
 - kube-prometheus setup, go to https://github.com/prometheus-operator/kube-prometheus
 
 -->


### PR DESCRIPTION
https://github.com/helm/charts has been deprecated. Update to new location https://github.com/prometheus-community/helm-charts.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
