### PR TITLE
Reconcile resources on namespace updates 

### DIFF
--- a/pkg/k8sutil/labels.go
+++ b/pkg/k8sutil/labels.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// LabelSelectionHasChanged returns true if the selector doesn't yield the same results
+// for the old and current labels.
+func LabelSelectionHasChanged(old, current map[string]string, selector *metav1.LabelSelector) (bool, error) {
+	// If the labels haven't changed, the selector won't return different results.
+	if reflect.DeepEqual(old, current) {
+		return false, nil
+	}
+
+	sel, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to convert selector %q", selector.String())
+	}
+
+	// The selector doesn't restrict the selection thus old and current labels always match.
+	if sel.Empty() {
+		return false, nil
+	}
+
+	return sel.Matches(labels.Set(old)) != sel.Matches(labels.Set(current)), nil
+}

--- a/pkg/k8sutil/labels_test.go
+++ b/pkg/k8sutil/labels_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLabelSelectionHasChanged(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+
+		old      map[string]string
+		current  map[string]string
+		selector *metav1.LabelSelector
+
+		expected    bool
+		expectedErr bool
+	}{
+		{
+			name: "no label change",
+			old: map[string]string{
+				"app": "foo",
+			},
+			current: map[string]string{
+				"app": "foo",
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "foo"},
+			},
+		},
+		{
+			name: "old matches and current doesn't match",
+			old: map[string]string{
+				"app": "foo",
+			},
+			current: map[string]string{
+				"app": "bar",
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "foo"},
+			},
+			expected: true,
+		},
+		{
+			name: "old doesn't match and current matches",
+			old: map[string]string{
+				"app": "bar",
+			},
+			current: map[string]string{
+				"app": "foo",
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "foo"},
+			},
+			expected: true,
+		},
+		{
+			name: "match-all label selector",
+			old: map[string]string{
+				"app": "foo",
+			},
+			current: map[string]string{
+				"app": "bar",
+			},
+			selector: &metav1.LabelSelector{},
+		},
+		{
+			name: "match-nothing label selector",
+			old: map[string]string{
+				"app": "foo",
+			},
+			current: map[string]string{
+				"app": "bar",
+			},
+			selector: nil,
+		},
+		{
+			name: "invalid label selector",
+			old: map[string]string{
+				"app": "foo",
+			},
+			current: map[string]string{
+				"app": "bar",
+			},
+			selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "foo",
+						Operator: metav1.LabelSelectorOperator("invalid"),
+					},
+				},
+			},
+			expectedErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed, err := LabelSelectionHasChanged(tc.old, tc.current, tc.selector)
+
+			if tc.expectedErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+
+			if tc.expected != changed {
+				t.Errorf("expected %v, got %v", tc.expected, changed)
+			}
+		})
+	}
+}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -290,6 +290,15 @@ func (o *Operator) addHandlers() {
 		DeleteFunc: o.handleStatefulSetDelete,
 		UpdateFunc: o.handleStatefulSetUpdate,
 	})
+
+	// The controller needs to watch the namespaces in which the rules live
+	// because a label change on a namespace may trigger a configuration
+	// change.
+	// It doesn't need to watch on addition/deletion though because it's
+	// already covered by the event handlers on rules.
+	o.nsRuleInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: o.handleNamespaceUpdate,
+	})
 }
 
 // Run the controller.
@@ -570,10 +579,50 @@ func (o *Operator) processNextWorkItem(ctx context.Context) bool {
 	}
 
 	o.metrics.ReconcileErrorsCounter().Inc()
-	utilruntime.HandleError(errors.Wrap(err, fmt.Sprintf("Sync %q failed", key)))
+	utilruntime.HandleError(errors.Wrapf(err, "Sync %q failed", key))
 	o.queue.AddRateLimited(key)
 
 	return true
+}
+
+func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
+	old := oldo.(*v1.Namespace)
+	cur := curo.(*v1.Namespace)
+
+	level.Debug(o.logger).Log("msg", "update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+
+	// Periodic resync may resend the Namespace without changes in-between.
+	if old.ResourceVersion == cur.ResourceVersion {
+		return
+	}
+
+	level.Debug(o.logger).Log("msg", "Namespace updated", "namespace", cur.GetName())
+	o.metrics.TriggerByCounter("Namespace", "update").Inc()
+
+	// Check for ThanosRuler instances selecting PrometheusRules in the namespace.
+	err := o.thanosRulerInfs.ListAll(labels.Everything(), func(obj interface{}) {
+		tr := obj.(*monitoringv1.ThanosRuler)
+
+		sync, err := k8sutil.LabelSelectionHasChanged(old.Labels, cur.Labels, tr.Spec.RuleNamespaceSelector)
+		if err != nil {
+			level.Error(o.logger).Log(
+				"err", err,
+				"name", tr.Name,
+				"namespace", tr.Namespace,
+			)
+			return
+		}
+
+		if sync {
+			o.enqueue(tr)
+		}
+	})
+	if err != nil {
+		level.Error(o.logger).Log(
+			"msg", "listing all ThanosRuler instances from cache failed",
+			"err", err,
+		)
+	}
 }
 
 func (o *Operator) sync(ctx context.Context, key string) error {
@@ -793,7 +842,8 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	}
 	if !exists {
 		level.Error(o.logger).Log(
-			"msg", fmt.Sprintf("get namespace to enqueue ThanosRuler instances failed: namespace %q does not exist", nsName),
+			"msg", "get namespace to enqueue ThanosRuler instances failed: namespace does not exist",
+			"namespace", nsName,
 		)
 		return
 	}
@@ -812,8 +862,10 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		ruleNSSelector, err := metav1.LabelSelectorAsSelector(tr.Spec.RuleNamespaceSelector)
 		if err != nil {
 			level.Error(o.logger).Log(
-				"msg", fmt.Sprintf("failed to convert RuleNamespaceSelector of %q to selector", tr.Name),
-				"err", err,
+				"err", errors.Wrap(err, "failed to convert RuleNamespaceSelector"),
+				"name", tr.Name,
+				"namespace", tr.Namespace,
+				"selector", tr.Spec.RuleNamespaceSelector,
 			)
 			return
 		}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -725,11 +725,20 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup(t)
 	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	configNs := ctx.CreateNamespace(t, framework.KubeClient)
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
 	alertmanager := framework.MakeBasicAlertmanager("amconfig-crd", 1)
 	alertmanager.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	alertmanager.Spec.AlertmanagerConfigNamespaceSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"monitored": "true"},
+	}
+	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testFramework.AddLabelsToNamespace(framework.KubeClient, configNs, map[string]string{"monitored": "true"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -744,7 +753,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			testingSecretKey: []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), testingKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), testingKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -756,7 +765,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-key": []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), apiKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), apiKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -768,15 +777,14 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-url": []byte("http://slack.example.com"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// A valid AlertmanagerConfig resource with many receivers.
 	configCR := &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e-test-amconfig-many-receivers",
-			Namespace: ns,
+			Name: "e2e-test-amconfig-many-receivers",
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -889,15 +897,14 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Another AlertmanagerConfig object with nested routes.
 	configCR = &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e-test-amconfig-sub-routes",
-			Namespace: ns,
+			Name: "e2e-test-amconfig-sub-routes",
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -952,7 +959,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -960,8 +967,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// should be rejected by the operator.
 	configCR = &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e-test-amconfig-missing-secret",
-			Namespace: ns,
+			Name: "e2e-test-amconfig-missing-secret",
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -982,7 +988,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -990,8 +996,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// It should be rejected by the operator.
 	configCR = &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e-test-amconfig-invalid-route",
-			Namespace: ns,
+			Name: "e2e-test-amconfig-invalid-route",
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -1015,24 +1020,22 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for the change above to take effect.
 	var lastErr error
-	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), "alertmanager-amconfig-crd-generated", metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			lastErr = errors.New("Generated configuration secret not found")
-			return false, nil
-		}
+	amConfigSecretName := fmt.Sprintf("alertmanager-%s-generated", alertmanager.Name)
+	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
-			return false, err
+			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
+			return false, nil
 		}
 
 		if cfgSecret.Data["alertmanager.yaml"] == nil {
-			lastErr = errors.New("'alertmanager.yaml' key is missing")
+			lastErr = errors.New("'alertmanager.yaml' key is missing in generated configuration secret")
 			return false, nil
 		}
 
@@ -1113,17 +1116,65 @@ receivers:
   webhook_configs:
   - url: http://test.url
 templates: []
-`, ns, ns, ns, ns, ns, ns, ns, ns, ns)
+`, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs)
 
 		if diff := cmp.Diff(string(cfgSecret.Data["alertmanager.yaml"]), expected); diff != "" {
-			t.Log("got(-), want(+):\n" + diff)
+			lastErr = errors.Errorf("got(-), want(+):\n%s", diff)
 			return false, nil
 		}
 
 		return true, nil
 	})
 	if err != nil {
-		t.Fatalf("%v: %v", err, lastErr)
+		t.Fatalf("waiting for generated alertmanager configuration: %v: %v", err, lastErr)
+	}
+
+	// Remove the selecting label from the namespace holding the
+	// AlertmanagerConfig resources and wait until the Alertmanager
+	// configuration gets regenerated.
+	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
+	if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, configNs, "monitored"); err != nil {
+		t.Fatal(err)
+	}
+
+	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), amConfigSecretName, metav1.GetOptions{})
+		if err != nil {
+			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
+			return false, nil
+		}
+
+		if cfgSecret.Data["alertmanager.yaml"] == nil {
+			lastErr = errors.New("'alertmanager.yaml' key is missing in generated configuration secret")
+			return false, nil
+		}
+		expected := `global:
+  resolve_timeout: 5m
+route:
+  receiver: "null"
+  group_by:
+  - job
+  routes:
+  - receiver: "null"
+    match:
+      alertname: DeadMansSwitch
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+receivers:
+- name: "null"
+templates: []
+`
+
+		if diff := cmp.Diff(string(cfgSecret.Data["alertmanager.yaml"]), expected); diff != "" {
+			lastErr = errors.Errorf("got(-), want(+):\n%s", diff)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("waiting for alertmanager configuration: %v: %v", err, lastErr)
 	}
 }
 

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -211,7 +211,7 @@ func testDenyThanosRuler(t *testing.T) {
 	}
 
 	for _, denied := range deniedNamespaces {
-		tr := framework.MakeBasicThanosRuler("denied", 1)
+		tr := framework.MakeBasicThanosRuler("denied", 1, "http://test.example.com")
 		_, err = framework.MonClientV1.ThanosRulers(denied).Create(context.TODO(), tr, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", tr.Spec.Replicas, tr.Name, err)
@@ -221,7 +221,7 @@ func testDenyThanosRuler(t *testing.T) {
 	for _, allowed := range allowedNamespaces {
 		ctx.SetupPrometheusRBAC(t, allowed, framework.KubeClient)
 
-		if _, err := framework.CreateThanosRulerAndWaitUntilReady(allowed, framework.MakeBasicThanosRuler("allowed", 1)); err != nil {
+		if _, err := framework.CreateThanosRulerAndWaitUntilReady(allowed, framework.MakeBasicThanosRuler("allowed", 1, "http://test.example.com")); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -206,8 +206,9 @@ func testAllNSPrometheus(t *testing.T) {
 func testAllNSThanosRuler(t *testing.T) {
 	skipThanosRulerTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"ThanosRulerCreateDeleteCluster":       testTRCreateDeleteCluster,
-		"ThanosRulerPreserveUserAddedMetadata": testTRPreserveUserAddedMetadata,
+		"ThanosRulerCreateDeleteCluster":                testThanosRulerCreateDeleteCluster,
+		"ThanosRulerPrometheusRuleInDifferentNamespace": testThanosRulerPrometheusRuleInDifferentNamespace,
+		"ThanosRulerPreserveUserAddedMetadata":          testTRPreserveUserAddedMetadata,
 	}
 	for name, f := range testFuncs {
 		t.Run(name, f)

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -295,6 +295,21 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 1); err != nil {
 			t.Fatal(err)
 		}
+
+		// FIXME(simonpasquier): the unprivileged namespace lister/watcher
+		// isn't notified of updates properly so the code below fails.
+		// Uncomment the test once the lister/watcher is fixed.
+		//
+		// Remove the selecting label on the "allowed" namespace and check that
+		// the target is removed.
+		// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
+		//if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, allowedNs, "monitored"); err != nil {
+		//	t.Fatal(err)
+		//}
+
+		//if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 0); err != nil {
+		//	t.Fatal(err)
+		//}
 	}
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -532,7 +532,7 @@ func (f *Framework) CheckPrometheusFiringAlert(ns, svcName, alertName string) (b
 		ns,
 		svcName,
 		"/api/v1/query",
-		map[string]string{"query": fmt.Sprintf("ALERTS{alertname=\"%v\"}", alertName)},
+		map[string]string{"query": fmt.Sprintf(`ALERTS{alertname="%v",alertstate="firing"}`, alertName)},
 	)
 	if err != nil {
 		return false, err
@@ -547,12 +547,7 @@ func (f *Framework) CheckPrometheusFiringAlert(ns, svcName, alertName string) (b
 		return false, errors.Errorf("expected 1 query result but got %v", len(q.Data.Result))
 	}
 
-	alertstate, ok := q.Data.Result[0].Metric["alertstate"]
-	if !ok {
-		return false, errors.Errorf("could not retrieve 'alertstate' label from query result: %v", q.Data.Result[0])
-	}
-
-	return alertstate == "firing", nil
+	return true, nil
 }
 
 // PrintPrometheusLogs prints the logs for each Prometheus replica.
@@ -586,8 +581,8 @@ func (f *Framework) WaitForPrometheusFiringAlert(ns, svcName, alertName string) 
 		return errors.Errorf(
 			"waiting for alert '%v' to fire: %v: %v",
 			alertName,
-			err.Error(),
-			loopError.Error(),
+			err,
+			loopError,
 		)
 	}
 	return nil


### PR DESCRIPTION
Say that you have a Prometheus spec with
`serviceMonitorNamespaceSelector: {monitored: "true"}` and
`serviceMonitorSelector: {}` as well as a service monitor in namespace
"foo" which has the `monitored="true"` label. Then the operator wouldn't
remove the service monitor's targets when the `monitored="true"` label
is removed from namespace "foo" as one would expect. If namespace "foo"
doesn't have the selecting label initially, adding it later wouldn't
trigger the reconciliation either.

The same issue existed for pod monitors, probes, rules (Prometheus and
Thanos ruler) and alertmanager configurations.

This change adds logic to deal with namespace updates and trigger the
reconciliation if the namespace's labels have changed in a way that may
return different resources than previously. However it works only when
the operator uses a privileged lister/watcher on namespaces (e.g.  when
it isn't restricted to a set of allowed namespaces). In the other case,
the unprivileged lister/watcher doesn't propagate namespace updates as
expected, leaving the operator out-of-sync. This will be tackled in a
following change.

Relates #3847 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Reconcile resources on namespace updates when using privileged lister/watcher
```
