### PR TITLE
.github: bump golang to 1.16 and kind to 0.10.0 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,8 @@ on:
   - push
   - pull_request
 env:
-  golang-version: '1.15'
-  kind-version: 'v0.9.0'
+  golang-version: '1.16'
+  kind-version: 'v0.10.0'
   kind-image: 'kindest/node:v1.20.0'  # Image defines which k8s version is used
 jobs:
   generate:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As in title, just some version bumps ;)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
