### PR TITLE
alertmanager: make listen local also affect the cluster.listen-addres flag

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -234,9 +234,17 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	}
 
 	if *a.Spec.Replicas == 1 && !a.Spec.ForceEnableClusterMode {
-		amArgs = append(amArgs, "--cluster.listen-address=")
+		if a.Spec.ListenLocal {
+			amArgs = append(amArgs, "--cluster.listen-address=127.0.0.1:9094")
+		} else {
+			amArgs = append(amArgs, "--cluster.listen-address=")
+		}
 	} else {
-		amArgs = append(amArgs, "--cluster.listen-address=[$(POD_IP)]:9094")
+		if a.Spec.ListenLocal {
+			amArgs = append(amArgs, "--cluster.listen-address=127.0.0.1:9094")
+		} else {
+			amArgs = append(amArgs, "--cluster.listen-address=[$(POD_IP)]:9094")
+		}
 	}
 
 	if a.Spec.ListenLocal {


### PR DESCRIPTION
Enables the use of alertmanager in istio

Fixes #3857

Also updated unit tests for cluster.listen-address with table tests to enable easier overview of the different constellations/outcomes of these different settings.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
