### PR TITLE
pkg/prometheus: Add liveness probe

### DIFF
--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -406,6 +406,25 @@ func TestListenLocal(t *testing.T) {
 		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)
 	}
 
+	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
+	expectedLivenessProbe := &v1.Probe{
+		Handler: v1.Handler{
+			Exec: &v1.ExecAction{
+				Command: []string{
+					`sh`,
+					`-c`,
+					`if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/healthy; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/healthy; else exit 1; fi`,
+				},
+			},
+		},
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+	if !reflect.DeepEqual(actualLivenessProbe, expectedLivenessProbe) {
+		t.Fatalf("Liveness probe doesn't match expected. \n\nExpected: %v\n\nGot: %v", expectedLivenessProbe, actualLivenessProbe)
+	}
+
 	if len(sset.Spec.Template.Spec.Containers[0].Ports) != 0 {
 		t.Fatal("Prometheus container should have 0 ports defined")
 	}


### PR DESCRIPTION
This reverts 35b2954459569674710f7eaf25066658e41c83f6. The liveness
probe doesn't actually fail during WAL replay, in the reports
(https://github.com/prometheus-operator/prometheus-operator/issues/3094
and
https://github.com/prometheus-operator/prometheus-operator/issues/3391)
prometheus was probably killed by some other watchdog.

Fixes: https://github.com/prometheus-operator/prometheus-operator/issues/3211
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```
release-note:bug

```
