### PR TITLE
pkg/prometheus: remove dead code

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -567,24 +567,6 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 
 	var readinessProbeHandler v1.Handler
 	{
-		healthyPath := path.Clean(webRoutePrefix + "/-/healthy")
-		if p.Spec.ListenLocal {
-			localHealthyPath := fmt.Sprintf("http://localhost:9090%s", healthyPath)
-			readinessProbeHandler.Exec = &v1.ExecAction{
-				Command: []string{
-					"sh",
-					"-c",
-					fmt.Sprintf(localProbe, localHealthyPath, localHealthyPath),
-				},
-			}
-		} else {
-			readinessProbeHandler.HTTPGet = &v1.HTTPGetAction{
-				Path: healthyPath,
-				Port: intstr.FromString(p.Spec.PortName),
-			}
-		}
-	}
-	{
 		readyPath := path.Clean(webRoutePrefix + "/-/ready")
 		if p.Spec.ListenLocal {
 			localReadyPath := fmt.Sprintf("http://localhost:9090%s", readyPath)


### PR DESCRIPTION
Removes setup code for the readiness handler that gets immediately
reassigned. The setup targets prometheus' /-/healthy/ endpoint and would
be a bad readiness probe anyway.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Really just a minor cleanup.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
