### PR TITLE
Do not default to continue being true within second level routes of generated AlertmanagerConfig

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -122,11 +122,6 @@ func (cg *configGenerator) generateConfig(
 }
 
 func convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName, firstLevelRoute bool) *route {
-	// Enforce "continue" to be true for the top-level route.
-	cont := in.Continue
-	if firstLevelRoute {
-		cont = true
-	}
 
 	match := map[string]string{}
 	matchRE := map[string]string{}
@@ -175,7 +170,7 @@ func convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName, firs
 		GroupWait:      in.GroupWait,
 		GroupInterval:  in.GroupInterval,
 		RepeatInterval: in.RepeatInterval,
-		Continue:       cont,
+		Continue:       in.Continue,
 		Match:          match,
 		MatchRE:        matchRE,
 		Routes:         routes,

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -87,6 +87,34 @@ templates: []
 `,
 		},
 		{
+			name:    "base with explicitly set continue, no CRs",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+					Routes: []*route{{
+						Receiver: "custom",
+						Continue: true,
+					}},
+				},
+				Receivers: []*receiver{
+					{Name: "null"},
+					{Name: "custom"},
+				},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
+			expected: `route:
+  receiver: "null"
+  routes:
+  - receiver: custom
+    continue: true
+receivers:
+- name: "null"
+- name: custom
+templates: []
+`,
+		},
+		{
 			name:    "skeleton base, simple CR",
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{
@@ -113,7 +141,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test
@@ -200,7 +227,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
   - receiver: "null"
 receivers:
 - name: "null"
@@ -257,7 +283,6 @@ templates: []
   - receiver: mynamespace-myamc-test-pd
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test-pd
@@ -302,7 +327,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test
@@ -360,7 +384,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test
@@ -422,7 +445,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test
@@ -484,7 +506,6 @@ templates: []
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test
@@ -550,7 +571,6 @@ route:
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
-    continue: true
 receivers:
 - name: "null"
 - name: mynamespace-myamc-test

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1051,7 +1051,6 @@ route:
     match:
       namespace: %s
       service: webapp
-    continue: true
     routes:
     - receiver: %s-e2e-test-amconfig-sub-routes-e2e
       group_by:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This removes the default of `continue: true` within the `routes` for generated alertmanager configurations.

Fixes: https://github.com/prometheus-operator/prometheus-operator/issues/3908


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:
[BUGFIX] Generated Alertmanager config nodes do not default to continue: true if they are at the top level of an AlertmanagerConfig 

```
