### PR TITLE
Replace app label names with app.kubernetes.io/name

### DIFF
--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -66,7 +66,7 @@ spec:
   podSelector:
     matchLabels:
       alertmanager: main
-      app: alertmanager
+      app.kubernetes.io/name: alertmanager
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -93,7 +93,7 @@ spec:
   podSelector:
     matchLabels:
       alertmanager: main
-      app: alertmanager
+      app.kubernetes.io/name: alertmanager
 
 ```
 
@@ -114,7 +114,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app: grafana
+      app.kubernetes.io/name: grafana
 ```
 
 #### Prometheus
@@ -134,7 +134,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app: prometheus
+      app.kubernetes.io/name: prometheus
       prometheus: k8s
 ```
 
@@ -166,7 +166,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app: node-exporter
+      app.kubernetes.io/name: node-exporter
 ```
 
 #### Kube-state-metrics
@@ -197,5 +197,5 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app: kube-state-metrics
+      app.kubernetes.io/name: kube-state-metrics
 ```

--- a/Documentation/network-policies.md
+++ b/Documentation/network-policies.md
@@ -114,7 +114,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: grafana
+      app: grafana
 ```
 
 #### Prometheus
@@ -166,7 +166,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: node-exporter
+      app: node-exporter
 ```
 
 #### Kube-state-metrics
@@ -197,5 +197,5 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics
+      app: kube-state-metrics
 ```

--- a/Documentation/user-guides/monitoring-kubernetes-ingress.md
+++ b/Documentation/user-guides/monitoring-kubernetes-ingress.md
@@ -135,7 +135,7 @@ spec:
   routePrefix: /prometheus
   ruleSelector:
     matchLabels:
-      app: prometheus-operator
+      app.kubernetes.io/name: prometheus-operator
   serviceAccountName: prometheus-operator
   serviceMonitorSelector:
     matchLabels:

--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -74,7 +74,7 @@ spec:
       spec:
         selector:
           matchLabels:
-            app: my-example-prometheus
+            app.kubernetes.io/name: my-example-prometheus
         resources:
           requests:
             storage: 50Gi

--- a/example/networkpolicies/alertmanager.yaml
+++ b/example/networkpolicies/alertmanager.yaml
@@ -11,7 +11,7 @@ spec:
   podSelector:
     matchLabels:
       alertmanager: main
-      app: alertmanager
+      app.kubernetes.io/name: alertmanager
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -38,5 +38,5 @@ spec:
   podSelector:
     matchLabels:
       alertmanager: main
-      app: alertmanager
+      app.kubernetes.io/name: alertmanager
 

--- a/example/networkpolicies/prometheus.yaml
+++ b/example/networkpolicies/prometheus.yaml
@@ -9,5 +9,5 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app: prometheus
+      app.kubernetes.io/name: prometheus
       prometheus: k8s

--- a/example/thanos/prometheus-service.yaml
+++ b/example/thanos/prometheus-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: self
   name: prometheus-self
   namespace: default

--- a/example/thanos/prometheus-servicemonitor.yaml
+++ b/example/thanos/prometheus-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: self
   name: prometheus-self
   namespace: default
@@ -12,4 +12,4 @@ spec:
     port: web
   selector:
     matchLabels:
-      app: prometheus
+      app.kubernetes.io/name: prometheus

--- a/example/thanos/prometheus.yaml
+++ b/example/thanos/prometheus.yaml
@@ -13,6 +13,6 @@ spec:
       role: prometheus-rulefiles
   serviceMonitorSelector:
     matchLabels:
-      app: prometheus
+      app.kubernetes.io/name: prometheus
   thanos:
     version: v0.11.2

--- a/example/thanos/query-deployment.yaml
+++ b/example/thanos/query-deployment.yaml
@@ -2,18 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: thanos-query
+    app.kubernetes.io/name: thanos-query
   name: thanos-query
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: thanos-query
+      app.kubernetes.io/name: thanos-query
   template:
     metadata:
       labels:
-        app: thanos-query
+        app.kubernetes.io/name: thanos-query
     spec:
       containers:
       - args:

--- a/example/thanos/query-service.yaml
+++ b/example/thanos/query-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: thanos-query
+    app.kubernetes.io/name: thanos-query
   name: thanos-query
   namespace: default
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 10902
     targetPort: http
   selector:
-    app: thanos-query
+    app.kubernetes.io/name: thanos-query

--- a/example/thanos/sidecar-service.yaml
+++ b/example/thanos/sidecar-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: thanos-sidecar
+    app.kubernetes.io/name: thanos-sidecar
   name: thanos-sidecar
   namespace: default
 spec:

--- a/example/thanos/thanos-ruler-service.yaml
+++ b/example/thanos/thanos-ruler-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: thanos-ruler
+    app.kubernetes.io/name: thanos-ruler
   name: thanos-ruler
   namespace: default
 spec:
@@ -14,4 +14,4 @@ spec:
     port: 10902
     targetPort: web
   selector:
-    app: thanos-ruler
+    app.kubernetes.io/name: thanos-ruler

--- a/example/thanos/thanos-ruler.yaml
+++ b/example/thanos/thanos-ruler.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
   labels:
-    app: thanos-ruler
+    app.kubernetes.io/name: thanos-ruler
   name: thanos-ruler
   namespace: default
 spec:

--- a/jsonnet/thanos/config.libsonnet
+++ b/jsonnet/thanos/config.libsonnet
@@ -32,11 +32,11 @@ local service(name, namespace, labels, selector, ports) = {
       },
       commonLabels: {
         prometheus: 'self',
-        app: 'prometheus',
+        'app.kubernetes.io/name': 'prometheus',
       },
-      queryLabels: { app: 'thanos-query' },
-      sidecarLabels: { app: 'thanos-sidecar' },
-      rulerLabels: { app: 'thanos-ruler' },
+      queryLabels: { 'app.kubernetes.io/name': 'thanos-query' },
+      sidecarLabels: { 'app.kubernetes.io/name': 'thanos-sidecar' },
+      rulerLabels: { 'app.kubernetes.io/name': 'thanos-ruler' },
     },
 
   },
@@ -66,7 +66,7 @@ local service(name, namespace, labels, selector, ports) = {
         replicas: 2,
         serviceMonitorSelector: {
           matchLabels: {
-            app: 'prometheus',
+            'app.kubernetes.io/name': 'prometheus',
           },
         },
         ruleSelector: {
@@ -145,7 +145,7 @@ local service(name, namespace, labels, selector, ports) = {
           ],
           selector: {
             matchLabels: {
-              app: 'prometheus',
+              'app.kubernetes.io/name': 'prometheus',
             },
           },
         },

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1358,8 +1358,8 @@ func checkAlertmanagerSpecDeprecation(key string, a *monitoringv1.Alertmanager, 
 func ListOptions(name string) metav1.ListOptions {
 	return metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"app":          "alertmanager",
-			"alertmanager": name,
+			"app.kubernetes.io/name": "alertmanager",
+			"alertmanager":           name,
 		})).String(),
 	}
 }

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -819,8 +819,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 func TestListOptions(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		o := ListOptions("test")
-		if o.LabelSelector != "app=alertmanager,alertmanager=test" && o.LabelSelector != "alertmanager=test,app=alertmanager" {
-			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app=alertmanager,alertmanager=test\"\n\nGot:      %#+v", o.LabelSelector)
+		if o.LabelSelector != "app.kubernetes.io/name=alertmanager,alertmanager=test" && o.LabelSelector != "alertmanager=test,app.kubernetes.io/name=alertmanager" {
+			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app.kubernetes.io/name=alertmanager,alertmanager=test\"\n\nGot:      %#+v", o.LabelSelector)
 		}
 	}
 }

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -196,7 +196,7 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 				},
 			},
 			Selector: map[string]string{
-				"app": "alertmanager",
+				"app.kubernetes.io/name": "alertmanager",
 			},
 		},
 	}
@@ -314,7 +314,6 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
-		"app":                          "alertmanager",
 		"app.kubernetes.io/name":       "alertmanager",
 		"app.kubernetes.io/version":    amVersion,
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1324,8 +1324,8 @@ func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfi
 func ListOptions(name string) metav1.ListOptions {
 	return metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"app":        "prometheus",
-			"prometheus": name,
+			"app.kubernetes.io/name": "prometheus",
+			"prometheus":             name,
 		})).String(),
 	}
 }

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -29,8 +29,8 @@ import (
 func TestListOptions(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		o := ListOptions("test")
-		if o.LabelSelector != "app=prometheus,prometheus=test" && o.LabelSelector != "prometheus=test,app=prometheus" {
-			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app=prometheus,prometheus=test\"\n\nGot:      %#+v", o.LabelSelector)
+		if o.LabelSelector != "app.kubernetes.io/name=prometheus,prometheus=test" && o.LabelSelector != "prometheus=test,app.kubernetes.io/name=prometheus" {
+			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app.kubernetes.io/name=prometheus,prometheus=test\"\n\nGot:      %#+v", o.LabelSelector)
 		}
 	}
 }

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -293,7 +293,7 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config operator.Config) 
 				},
 			},
 			Selector: map[string]string{
-				"app": "prometheus",
+				"app.kubernetes.io/name": "prometheus",
 			},
 		},
 	}
@@ -596,7 +596,6 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
-		"app":                          "prometheus",
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/version":    version.String(),
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -69,7 +69,6 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	expectedPodLabels := map[string]string{
 		"prometheus":                   "",
-		"app":                          "prometheus",
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/version":    strings.TrimPrefix(operator.DefaultPrometheusVersion, "v"),
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -711,8 +711,8 @@ func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNam
 func ListOptions(name string) metav1.ListOptions {
 	return metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"app":            thanosRulerLabel,
-			thanosRulerLabel: name,
+			"app.kubernetes.io/name": thanosRulerLabel,
+			thanosRulerLabel:         name,
 		})).String(),
 	}
 }

--- a/pkg/thanos/operator_test.go
+++ b/pkg/thanos/operator_test.go
@@ -21,8 +21,8 @@ import (
 func TestListOptions(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		o := ListOptions("test")
-		if o.LabelSelector != "app=thanos-ruler,thanos-ruler=test" && o.LabelSelector != "thanos-ruler=test,app=thanos-ruler" {
-			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app=thanos-ruler,thanos-ruler=test\"\n\nGot:      %#+v", o.LabelSelector)
+		if o.LabelSelector != "app.kubernetes.io/name=thanos-ruler,thanos-ruler=test" && o.LabelSelector != "thanos-ruler=test,app.kubernetes.io/name=thanos-ruler" {
+			t.Fatalf("LabelSelector not computed correctly\n\nExpected: \"app.kubernetes.io/name=thanos-ruler,thanos-ruler=test\"\n\nGot:      %#+v", o.LabelSelector)
 		}
 	}
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -479,7 +479,7 @@ func makeStatefulSetService(tr *monitoringv1.ThanosRuler, config Config) *v1.Ser
 				},
 			},
 			Selector: map[string]string{
-				"app.kubernetes.io/name": "thanos-ruler",
+				"app.kubernetes.io/name": thanosRulerLabel,
 			},
 		},
 	}

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -351,7 +351,6 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			}
 		}
 	}
-	podLabels["app"] = thanosRulerLabel
 	podLabels["app.kubernetes.io/name"] = thanosRulerLabel
 	podLabels["app.kubernetes.io/managed-by"] = "prometheus-operator"
 	podLabels["app.kubernetes.io/instance"] = tr.Name
@@ -480,7 +479,7 @@ func makeStatefulSetService(tr *monitoringv1.ThanosRuler, config Config) *v1.Ser
 				},
 			},
 			Selector: map[string]string{
-				"app": "thanos-ruler",
+				"app.kubernetes.io/name": "thanos-ruler",
 			},
 		},
 	}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -513,13 +513,13 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			Replicas: &whReplicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "alertmanager-webhook",
+					"app.kubernetes.io/name": "alertmanager-webhook",
 				},
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "alertmanager-webhook",
+						"app.kubernetes.io/name": "alertmanager-webhook",
 					},
 				},
 				Spec: v1.PodSpec{
@@ -553,7 +553,7 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 				},
 			},
 			Selector: map[string]string{
-				"app": "alertmanager-webhook",
+				"app.kubernetes.io/name": "alertmanager-webhook",
 			},
 		},
 	}
@@ -566,7 +566,7 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	err := testFramework.WaitForPodsReady(framework.KubeClient, ns, time.Minute*5, 1,
 		metav1.ListOptions{
 			LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-				"app": "alertmanager-webhook",
+				"app.kubernetes.io/name": "alertmanager-webhook",
 			})).String(),
 		},
 	)
@@ -669,7 +669,7 @@ inhibit_rules:
 
 	opts := metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"app": "alertmanager-webhook",
+			"app.kubernetes.io/name": "alertmanager-webhook",
 		})).String(),
 	}
 	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), opts)

--- a/test/framework/probe.go
+++ b/test/framework/probe.go
@@ -36,7 +36,7 @@ func (f *Framework) MakeBlackBoxExporterService(ns, name string) *v1.Service {
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"app": "blackbox-exporter",
+				"app.kubernetes.io/name": "blackbox-exporter",
 			},
 			Ports: []v1.ServicePort{
 				{
@@ -88,13 +88,13 @@ func (f *Framework) createBlackBoxExporterDeploymentAndWaitReady(ns, name string
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "blackbox-exporter",
+					"app.kubernetes.io/name": "blackbox-exporter",
 				},
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "blackbox-exporter",
+						"app.kubernetes.io/name": "blackbox-exporter",
 					},
 				},
 				Spec: v1.PodSpec{

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -262,7 +262,7 @@ func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
 				},
 			},
 			Selector: map[string]string{
-				"app": "thanos-query",
+				"app.kubernetes.io/name": "thanos-query",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Dustin Hooten <dustinhooten@gmail.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR replaces the `app` label names with `app.kubernetes.io/name` where appropriate. That was suggested in [this comment](https://github.com/prometheus-operator/prometheus-operator/issues/3706#issuecomment-734187876). It will allow users to specify an `app` label in `podMetadata` field of the PrometheusSpec.

Closes #3706

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:change
Replace app label names with app.kubernetes.io/name
```
