### PR TITLE
Update prometheus and thanos versions

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -57,6 +57,10 @@ The versions of Prometheus compatible to be run with the Prometheus Operator are
 * v2.23.0
 * v2.24.0
 * v2.24.1
+* v2.25.0
+* v2.25.1
+* v2.25.2
+* v2.26.0
 
 ## Alertmanager
 

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -20,7 +20,7 @@ const (
 	DefaultAlertmanagerVersion   = "v0.21.0"
 	DefaultAlertmanagerBaseImage = "quay.io/prometheus/alertmanager"
 	DefaultAlertmanagerImage     = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
-	DefaultThanosVersion         = "v0.17.2"
+	DefaultThanosVersion         = "v0.18.0"
 	DefaultThanosBaseImage       = "quay.io/thanos/thanos"
 	DefaultThanosImage           = DefaultThanosBaseImage + ":" + DefaultThanosVersion
 )
@@ -67,6 +67,10 @@ var (
 		"v2.23.0",
 		"v2.24.0",
 		"v2.24.1",
+		"v2.25.0",
+		"v2.25.1",
+		"v2.25.2",
+		"v2.26.0",
 	}
 	DefaultPrometheusVersion   = PrometheusCompatibilityMatrix[len(PrometheusCompatibilityMatrix)-1]
 	DefaultPrometheusBaseImage = "quay.io/prometheus/prometheus"

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -3632,7 +3632,7 @@ func isAlertmanagerDiscoveryWorking(ns, promSVCName, alertmanagerName string) fu
 		}
 		expectedAlertmanagerTargets := []string{}
 		for _, p := range pods.Items {
-			expectedAlertmanagerTargets = append(expectedAlertmanagerTargets, fmt.Sprintf("http://%s:9093/api/v1/alerts", p.Status.PodIP))
+			expectedAlertmanagerTargets = append(expectedAlertmanagerTargets, fmt.Sprintf("http://%s:9093/api/v2/alerts", p.Status.PodIP))
 		}
 
 		response, err := framework.PrometheusSVCGetRequest(ns, promSVCName, "/api/v1/alertmanagers", map[string]string{})


### PR DESCRIPTION
This PR updates the prometheus and thanos versions to the latest ones
closes #3950 

```release-note:enhancement
Update Prometheus and Thanos versions
```

```release-note:bug
Fix configuration of remote write headers
```
