### PR TITLE
Fix alertmanager sts update

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -604,6 +604,10 @@ func (c *Operator) handleAlertmanagerDelete(obj interface{}) {
 }
 
 func (c *Operator) handleAlertmanagerUpdate(old, cur interface{}) {
+	if old.(*monitoringv1.Alertmanager).ResourceVersion == cur.(*monitoringv1.Alertmanager).ResourceVersion {
+		return
+	}
+	
 	key, ok := c.keyFunc(cur)
 	if !ok {
 		return

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -607,7 +607,7 @@ func (c *Operator) handleAlertmanagerUpdate(old, cur interface{}) {
 	if old.(*monitoringv1.Alertmanager).ResourceVersion == cur.(*monitoringv1.Alertmanager).ResourceVersion {
 		return
 	}
-	
+
 	key, ok := c.keyFunc(cur)
 	if !ok {
 		return

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -621,12 +621,18 @@ func (c *Operator) handleAlertmanagerUpdate(old, cur interface{}) {
 
 func (c *Operator) handleStatefulSetDelete(obj interface{}) {
 	if a := c.alertmanagerForStatefulSet(obj); a != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet delete")
+		c.metrics.TriggerByCounter("StatefulSet", "delete").Inc()
+
 		c.enqueue(a)
 	}
 }
 
 func (c *Operator) handleStatefulSetAdd(obj interface{}) {
 	if a := c.alertmanagerForStatefulSet(obj); a != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet added")
+		c.metrics.TriggerByCounter("StatefulSet", "add").Inc()
+
 		c.enqueue(a)
 	}
 }
@@ -645,6 +651,9 @@ func (c *Operator) handleStatefulSetUpdate(oldo, curo interface{}) {
 
 	// Wake up Alertmanager resource the deployment belongs to.
 	if a := c.alertmanagerForStatefulSet(cur); a != nil {
+		level.Debug(c.logger).Log("msg", "StatefulSet updated")
+		c.metrics.TriggerByCounter("StatefulSet", "update").Inc()
+
 		c.enqueue(a)
 	}
 }

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -42,6 +42,7 @@ const (
 	alertmanagerConfigDir  = "/etc/alertmanager/config"
 	alertmanagerConfigFile = "alertmanager.yaml"
 	alertmanagerStorageDir = "/alertmanager"
+	sSetInputHashName      = "prometheus-operator-input-hash"
 	defaultPortName        = "web"
 )
 
@@ -50,7 +51,7 @@ var (
 	probeTimeoutSeconds int32 = 3
 )
 
-func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, config Config) (*appsv1.StatefulSet, error) {
+func makeStatefulSet(am *monitoringv1.Alertmanager, config Config, inputHash string) (*appsv1.StatefulSet, error) {
 	// TODO(fabxc): is this the right point to inject defaults?
 	// Ideally we would do it before storing but that's currently not possible.
 	// Potentially an update handler on first insertion.
@@ -84,6 +85,7 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 	// do not transfer kubectl annotations to the statefulset so it is not
 	// pruned by kubectl
 	annotations := make(map[string]string)
+	annotations[sSetInputHashName] = inputHash
 	for key, value := range am.ObjectMeta.Annotations {
 		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
 			annotations[key] = value
@@ -141,10 +143,6 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, old *appsv1.StatefulSet, con
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)
-	}
-
-	if old != nil {
-		statefulset.Annotations = old.Annotations
 	}
 
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, am.Spec.Volumes...)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
My [previous PR](https://github.com/prometheus-operator/prometheus-operator/pull/3943) didn't fix all infinite loop of reconciliation.
By adding missing metrics on `handleStatefulSet*` functions (cf. the [first commit](https://github.com/prometheus-operator/prometheus-operator/commit/3f4c6bf14b0e57c46275016ceac6157238df53ab)) I spotted unexpected reconciliation triggers on sts update.
Indeed, the each sts update changes the resourceVersion, which trigger a new reconciliation.

```bash
$ kubectl -n monitoring get sts alertmanager-infra-prometheus-kube-prom-alertmanager -ojson > /tmp/0.json
$ # wait few seconds
$ kubectl -n monitoring get sts alertmanager-infra-prometheus-kube-prom-alertmanager -ojson > /tmp/1.json
$ $ diff /tmp/0.json /tmp/1.json
296c296
<                 "time": "2021-04-01T09:08:02Z"
---
>                 "time": "2021-04-01T09:08:08Z"
311c311
<         "resourceVersion": "179788588",
---
>         "resourceVersion": "179788727",
```

I imitated the [solution implemented](https://github.com/prometheus-operator/prometheus-operator/blob/4826c904d86c93cffaed293c5ce85ad6b2051995/pkg/prometheus/operator.go#L1225) in the prometheus operator to avoid this issue.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
