### PR TITLE
Fix ci unit test under mac os system

### DIFF
--- a/pkg/versionutil/cli_test.go
+++ b/pkg/versionutil/cli_test.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/prometheus/common/version"
@@ -50,7 +51,7 @@ func TestShouldPrintVersion(t *testing.T) {
 					"  build user:       test-value\n"+
 					"  build date:       test-value\n"+
 					"  go version:       test-value\n"+
-					"  platform:         linux/amd64", program),
+					"  platform:         "+runtime.GOOS+"/amd64", program),
 		},
 	}
 	for tn, tc := range tests {


### PR DESCRIPTION
Fix ci unit test under mac os system.

```release-note:REPLACEME
Fix ci unit test under mac os system.
```
