### PR TITLE
Fix handling of the global smtp_require_tls field in Alertmanager configuration

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -61,11 +61,11 @@ templates: []
 `,
 		},
 		{
-			name:    "skeleton base with global smtp_require_tls, no CRs",
+			name:    "skeleton base with global smtp_require_tls set to false, no CRs",
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{
 				Global: &globalConfig{
-					SMTPRequireTLS: false,
+					SMTPRequireTLS: func(b bool) *bool { return &b }(false),
 				},
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
@@ -74,6 +74,27 @@ templates: []
 			expected: `global:
   resolve_timeout: 0s
   smtp_require_tls: false
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []
+`,
+		},
+		{
+			name:    "skeleton base with global smtp_require_tls set to true, no CRs",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Global: &globalConfig{
+					SMTPRequireTLS: func(b bool) *bool { return &b }(true),
+				},
+				Route:     &route{Receiver: "null"},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
+			expected: `global:
+  resolve_timeout: 0s
+  smtp_require_tls: true
 route:
   receiver: "null"
 receivers:

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -61,6 +61,27 @@ templates: []
 `,
 		},
 		{
+			name:    "skeleton base with global smtp_require_tls, no CRs",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Global: &globalConfig{
+					SMTPRequireTLS: false,
+				},
+				Route:     &route{Receiver: "null"},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
+			expected: `global:
+  resolve_timeout: 0s
+  smtp_require_tls: false
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []
+`,
+		},
+		{
 			name:    "base with sub route, no CRs",
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -39,7 +39,7 @@ type alertmanagerConfig struct {
 type globalConfig struct {
 	// ResolveTimeout is the time after which an alert is declared resolved
 	// if it has not been updated.
-	ResolveTimeout model.Duration `yaml:"resolve_timeout" json:"resolve_timeout"`
+	ResolveTimeout *model.Duration `yaml:"resolve_timeout,omitempty" json:"resolve_timeout,omitempty"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -50,7 +50,7 @@ type globalConfig struct {
 	SMTPAuthPassword string          `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
 	SMTPAuthSecret   string          `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
 	SMTPAuthIdentity string          `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
-	SMTPRequireTLS   bool            `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
+	SMTPRequireTLS   *bool           `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
 	SlackAPIURL      *config.URL     `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
 	PagerdutyURL     *config.URL     `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
 	HipchatAPIURL    *config.URL     `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`


### PR DESCRIPTION
Continuation of #3830. @mdostal-hci I tried to push to your branch but your fork is protected, anyway I've preserved your initial commit so you can get credit :)

Closes #3829 

I noticed that the global `resolve_timeout` field had a similar problem: if it wasn't defined in the main configuration secret, it would default to 0s.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Allow `smtp_require_tls` to be false
```
