### PR TITLE
pkg/operator: bump default Thanos version to v0.19.0

### DIFF
--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -20,7 +20,7 @@ const (
 	DefaultAlertmanagerVersion   = "v0.21.0"
 	DefaultAlertmanagerBaseImage = "quay.io/prometheus/alertmanager"
 	DefaultAlertmanagerImage     = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
-	DefaultThanosVersion         = "v0.18.0"
+	DefaultThanosVersion         = "v0.19.0"
 	DefaultThanosBaseImage       = "quay.io/thanos/thanos"
 	DefaultThanosImage           = DefaultThanosBaseImage + ":" + DefaultThanosVersion
 )


### PR DESCRIPTION


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
