### PR TITLE
Adds default container annotation to Prometheus pod

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -622,6 +622,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		podLabels[k] = v
 	}
 
+	podAnnotations["kubectl.kubernetes.io/default-container"] = "prometheus"
+
 	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
 	finalLabels := c.Labels.Merge(podLabels)
 

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -120,11 +120,11 @@ func TestPodLabelsAnnotations(t *testing.T) {
 		},
 	}, defaultTestConfig, nil, "", 0)
 	require.NoError(t, err)
-	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
-		t.Fatal("Pod labes are not properly propagated")
+	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
+		t.Fatal("Pod labels are not properly propagated")
 	}
-	if !reflect.DeepEqual(annotations, sset.Spec.Template.ObjectMeta.Annotations) {
-		t.Fatal("Pod annotaitons are not properly propagated")
+	if val, ok := sset.Spec.Template.ObjectMeta.Annotations["testannotation"]; !ok || val != "testvalue" {
+		t.Fatal("Pod annotations are not properly propagated")
 	}
 }
 func TestPodLabelsShouldNotBeSelectorLabels(t *testing.T) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds [default container annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) to Prometheus pod, so that kubectl fetches logs from the Prometheus container if no container is specified. Requires kubectl >= 1.21.0.

Without patch:

```
$ kubectl logs -f prometheus-prometheus-0
error: a container name must be specified for pod prometheus-prometheus-0, choose one of: [prometheus config-reloader]
```

With patch:

```
$ kubectl logs -f prometheus-prometheus-0
level=info ts=2021-04-09T19:36:12.550Z caller=main.go:418 msg="Starting Prometheus" version="(version=2.26.0, branch=HEAD, revision=3cafc58827d1ebd1a67749f88be4218f0bab3d8d)"
...
```
```
$ kubectl logs -f prometheus-prometheus-0 prometheus
level=info ts=2021-04-09T19:36:12.550Z caller=main.go:418 msg="Starting Prometheus" version="(version=2.26.0, branch=HEAD, revision=3cafc58827d1ebd1a67749f88be4218f0bab3d8d)"
```
```
$ kubectl logs -f prometheus-prometheus-0 config-reloader
level=info ts=2021-04-09T19:36:11.481259701Z caller=main.go:147 msg="Starting prometheus-config-reloader" version="(version=0.46.0, branch=refs/tags/pkg/client/v0.46.0, revision=7f94a06b86d41c20176f0d5b53aa0100fdc361e6)"
...
```

tl;dr - i always forget to specify the prometheus container and this makes that so much more awesome


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Add default container annotation to Prometheus pod
```
