### PR TITLE
pkg/prometheus: Export the `prometheus.ConfigGenerator` type

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -87,7 +87,7 @@ type Operator struct {
 	kubeletSyncEnabled     bool
 	config                 operator.Config
 
-	configGenerator *configGenerator
+	configGenerator *ConfigGenerator
 }
 
 // New creates a new controller.
@@ -140,7 +140,7 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		kubeletObjectNamespace: kubeletObjectNamespace,
 		kubeletSyncEnabled:     kubeletSyncEnabled,
 		config:                 conf,
-		configGenerator:        newConfigGenerator(logger),
+		configGenerator:        NewConfigGenerator(logger),
 		metrics:                operator.NewMetrics("prometheus", r),
 		nodeAddressLookupErrors: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_operator_node_address_lookup_errors_total",
@@ -1501,7 +1501,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 
 	// Update secret based on the most recent configuration.
-	conf, err := c.configGenerator.generateConfig(
+	conf, err := c.configGenerator.GenerateConfig(
 		p,
 		smons,
 		pmons,

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -43,12 +43,14 @@ var (
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )
 
-type configGenerator struct {
+// ConfigGenerator is used to create Prometheus configurations from operator resources.
+type ConfigGenerator struct {
 	logger log.Logger
 }
 
-func newConfigGenerator(logger log.Logger) *configGenerator {
-	cg := &configGenerator{
+// NewConfigGenerator creates a ConfigGenerator instance using the provided Logger.
+func NewConfigGenerator(logger log.Logger) *ConfigGenerator {
+	cg := &ConfigGenerator{
 		logger: logger,
 	}
 	return cg
@@ -153,7 +155,8 @@ func buildExternalLabels(p *v1.Prometheus) yaml.MapSlice {
 	return stringMapToMapSlice(m)
 }
 
-func (cg *configGenerator) generateConfig(
+// GenerateConfig creates a serialized YAML representation of a Prometheus configuration using the provided resources.
+func (cg *ConfigGenerator) GenerateConfig(
 	p *v1.Prometheus,
 	sMons map[string]*v1.ServiceMonitor,
 	pMons map[string]*v1.PodMonitor,
@@ -428,7 +431,7 @@ func initRelabelings() []yaml.MapSlice {
 	}
 }
 
-func (cg *configGenerator) generatePodMonitorConfig(
+func (cg *ConfigGenerator) generatePodMonitorConfig(
 	version semver.Version,
 	m *v1.PodMonitor,
 	ep v1.PodMetricsEndpoint,
@@ -669,7 +672,7 @@ func (cg *configGenerator) generatePodMonitorConfig(
 	return cfg
 }
 
-func (cg *configGenerator) generateProbeConfig(
+func (cg *ConfigGenerator) generateProbeConfig(
 	version semver.Version,
 	m *v1.Probe,
 	apiserverConfig *v1.APIServerConfig,
@@ -892,7 +895,7 @@ func (cg *configGenerator) generateProbeConfig(
 	return cfg
 }
 
-func (cg *configGenerator) generateServiceMonitorConfig(
+func (cg *ConfigGenerator) generateServiceMonitorConfig(
 	version semver.Version,
 	m *v1.ServiceMonitor,
 	ep v1.Endpoint,
@@ -1241,7 +1244,7 @@ func getNamespacesFromNamespaceSelector(nsel *v1.NamespaceSelector, namespace st
 	return nsel.MatchNames
 }
 
-func (cg *configGenerator) generateK8SSDConfig(namespaces []string, apiserverConfig *v1.APIServerConfig, basicAuthSecrets map[string]assets.BasicAuthCredentials, role string) yaml.MapItem {
+func (cg *ConfigGenerator) generateK8SSDConfig(namespaces []string, apiserverConfig *v1.APIServerConfig, basicAuthSecrets map[string]assets.BasicAuthCredentials, role string) yaml.MapItem {
 	k8sSDConfig := yaml.MapSlice{
 		{
 			Key:   "role",
@@ -1298,7 +1301,7 @@ func (cg *configGenerator) generateK8SSDConfig(namespaces []string, apiserverCon
 	}
 }
 
-func (cg *configGenerator) generateAlertmanagerConfig(version semver.Version, am v1.AlertmanagerEndpoints, apiserverConfig *v1.APIServerConfig, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapSlice {
+func (cg *ConfigGenerator) generateAlertmanagerConfig(version semver.Version, am v1.AlertmanagerEndpoints, apiserverConfig *v1.APIServerConfig, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapSlice {
 	if am.Scheme == "" {
 		am.Scheme = "http"
 	}
@@ -1359,7 +1362,7 @@ func (cg *configGenerator) generateAlertmanagerConfig(version semver.Version, am
 	return cfg
 }
 
-func (cg *configGenerator) generateRemoteReadConfig(version semver.Version, p *v1.Prometheus, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapItem {
+func (cg *ConfigGenerator) generateRemoteReadConfig(version semver.Version, p *v1.Prometheus, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapItem {
 
 	cfgs := []yaml.MapSlice{}
 
@@ -1421,7 +1424,7 @@ func (cg *configGenerator) generateRemoteReadConfig(version semver.Version, p *v
 	}
 }
 
-func (cg *configGenerator) generateRemoteWriteConfig(version semver.Version, p *v1.Prometheus, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapItem {
+func (cg *ConfigGenerator) generateRemoteWriteConfig(version semver.Version, p *v1.Prometheus, basicAuthSecrets map[string]assets.BasicAuthCredentials) yaml.MapItem {
 
 	cfgs := []yaml.MapSlice{}
 

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -190,8 +190,8 @@ alerting:
 	}
 
 	for _, tc := range testcases {
-		cg := &configGenerator{}
-		cfg, err := cg.generateConfig(
+		cg := &ConfigGenerator{}
+		cfg, err := cg.GenerateConfig(
 			&monitoringv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: monitoringv1.PrometheusSpec{
@@ -326,7 +326,7 @@ func TestNamespaceSetCorrectly(t *testing.T) {
 `,
 		},
 	}
-	cg := &configGenerator{}
+	cg := &ConfigGenerator{}
 
 	for _, tc := range testcases {
 		selectedNamespaces := getNamespacesFromNamespaceSelector(&tc.ServiceMonitor.Spec.NamespaceSelector, tc.ServiceMonitor.Namespace, tc.IgnoreNamespaceSelectors)
@@ -357,7 +357,7 @@ func TestNamespaceSetCorrectlyForPodMonitor(t *testing.T) {
 		},
 	}
 
-	cg := &configGenerator{}
+	cg := &ConfigGenerator{}
 	selectedNamespaces := getNamespacesFromNamespaceSelector(&pm.Spec.NamespaceSelector, pm.Namespace, false)
 	c := cg.generateK8SSDConfig(selectedNamespaces, nil, nil, kubernetesSDRolePod)
 	s, err := yaml.Marshal(yaml.MapSlice{c})
@@ -379,8 +379,8 @@ func TestNamespaceSetCorrectlyForPodMonitor(t *testing.T) {
 }
 
 func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -496,8 +496,8 @@ alerting:
 }
 
 func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -607,8 +607,8 @@ alerting:
 }
 
 func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -713,8 +713,8 @@ alerting:
 }
 
 func TestProbeIngressSDConfigGeneration(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -842,8 +842,8 @@ alerting:
 }
 
 func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -989,7 +989,7 @@ func TestK8SSDConfigGeneration(t *testing.T) {
 		},
 	}
 
-	cg := &configGenerator{}
+	cg := &ConfigGenerator{}
 
 	testcases := []struct {
 		apiserverConfig  *monitoringv1.APIServerConfig
@@ -1055,8 +1055,8 @@ func TestK8SSDConfigGeneration(t *testing.T) {
 }
 
 func TestAlertmanagerBearerToken(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1133,8 +1133,8 @@ alerting:
 }
 
 func TestAlertmanagerAPIVersion(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1212,8 +1212,8 @@ alerting:
 }
 
 func TestAlertmanagerTimeoutConfig(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1293,8 +1293,8 @@ alerting:
 }
 
 func TestAdditionalAlertRelabelConfigs(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1374,8 +1374,8 @@ alerting:
 }
 
 func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1536,8 +1536,8 @@ alerting:
 	}
 }
 func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1680,8 +1680,8 @@ alerting:
 }
 
 func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1833,8 +1833,8 @@ alerting:
 }
 
 func TestAdditionalAlertmanagers(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -1912,8 +1912,8 @@ alerting:
 }
 
 func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2054,8 +2054,8 @@ alerting:
 }
 
 func TestSettingHonorTimestampsInPodMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2177,8 +2177,8 @@ alerting:
 }
 
 func TestHonorTimestampsOverriding(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2320,8 +2320,8 @@ alerting:
 }
 
 func TestSettingHonorLabels(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2460,8 +2460,8 @@ alerting:
 }
 
 func TestHonorLabelsOverriding(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2601,8 +2601,8 @@ alerting:
 }
 
 func TestTargetLabels(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2741,8 +2741,8 @@ alerting:
 }
 
 func TestPodTargetLabels(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -2880,8 +2880,8 @@ alerting:
 }
 
 func TestPodTargetLabelsFromPodMonitor(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -3000,8 +3000,8 @@ alerting:
 }
 
 func TestEmptyEndointPorts(t *testing.T) {
-	cg := &configGenerator{}
-	cfg, err := cg.generateConfig(
+	cg := &ConfigGenerator{}
+	cfg, err := cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -3120,9 +3120,9 @@ alerting:
 }
 
 func generateTestConfig(version string) ([]byte, error) {
-	cg := &configGenerator{}
+	cg := &ConfigGenerator{}
 	replicas := int32(1)
-	return cg.generateConfig(
+	return cg.GenerateConfig(
 		&monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
@@ -3754,7 +3754,7 @@ alerting:
 		},
 	} {
 		t.Run(fmt.Sprintf("enforcedlimit(%d) limit(%d)", tc.enforcedLimit, tc.limit), func(t *testing.T) {
-			cg := &configGenerator{}
+			cg := &ConfigGenerator{}
 
 			prometheus := monitoringv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3796,7 +3796,7 @@ alerting:
 				serviceMonitor.Spec.SampleLimit = uint64(tc.limit)
 			}
 
-			cfg, err := cg.generateConfig(
+			cfg, err := cg.GenerateConfig(
 				&prometheus,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
@@ -4025,7 +4025,7 @@ alerting:
 		},
 	} {
 		t.Run(fmt.Sprintf("%s enforcedlimit(%d) limit(%d)", tc.version, tc.enforcedLimit, tc.limit), func(t *testing.T) {
-			cg := &configGenerator{}
+			cg := &ConfigGenerator{}
 
 			prometheus := monitoringv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
@@ -4067,7 +4067,7 @@ alerting:
 				serviceMonitor.Spec.TargetLimit = uint64(tc.limit)
 			}
 
-			cfg, err := cg.generateConfig(
+			cfg, err := cg.GenerateConfig(
 				&prometheus,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
@@ -4198,7 +4198,7 @@ remote_write:
 		},
 	} {
 		t.Run(fmt.Sprintf("version=%s", tc.version), func(t *testing.T) {
-			cg := &configGenerator{}
+			cg := &ConfigGenerator{}
 
 			prometheus := monitoringv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
@@ -4216,7 +4216,7 @@ remote_write:
 				},
 			}
 
-			cfg, err := cg.generateConfig(
+			cfg, err := cg.GenerateConfig(
 				&prometheus,
 				nil,
 				nil,


### PR DESCRIPTION
This makes the `prometheus.ConfigGenerator` type and its `GenerateConfig()`
method exported and available to consumers outside of the `prometheus` package.

Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

```release-note:change
The prometheus.ConfigGenerator type and its GenerateConfig method are now exported.
```

