### PR TITLE
Support kind >=0.6.x  in  README file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ kubectl delete --ignore-not-found customresourcedefinitions \
 #### Running *end-to-end* tests on local kind cluster:
 
 1. `kind create cluster --image=kindest/node:<latest>`. e.g `v1.16.2` version.
-2. `export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"`
+2. `kubectl cluster-info --context kind-kind`. kind version >= 0.6.x
 3. `make image` - build Prometheus Operator  docker image locally.
 4. `for n in "operator" "config-reloader"; do kind load docker-image "quay.io/prometheus-operator/prometheus-$n:$(git rev-parse --short HEAD)"; done` - publish
 built locally images to be accessible inside kind.


### PR DESCRIPTION
Support kind >=0.6.x  in  README file .
Reference : https://github.com/kubernetes-sigs/cluster-api/issues/1796
**Release Note Template (will be copied)**

```release-note:REPLACEME
Support kind >=0.6.x  in  README file .
```
