### PR TITLE
Fix inconsistency question between the number of pods and shard configuration

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1223,7 +1223,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		oldSSetInputHash := obj.(*appsv1.StatefulSet).ObjectMeta.Annotations[sSetInputHashName]
 		if newSSetInputHash == oldSSetInputHash {
 			level.Debug(c.logger).Log("msg", "new statefulset generation inputs match current, skipping any actions")
-			return nil
+			continue
 		}
 
 		level.Debug(c.logger).Log("msg", "updating current Prometheus statefulset")


### PR DESCRIPTION
#3801 
I found some log by enable debug log level.

```
level=debug ts=2021-04-11T16:10:13.24178926Z caller=operator.go:1190 component=prometheusoperator msg="reconciling statefulset" statefulset=prometheus-main shard=0
level=debug ts=2021-04-11T16:10:13.242372418Z caller=operator.go:1225 component=prometheusoperator msg="new statefulset generation inputs match current, skipping any actions"
``` 

After my analysis, I found a bug. 

When the first shard is created, it exits the loop.

https://github.com/prometheus-operator/prometheus-operator/blob/fb16b71909dfe3feff2b5e77214002e10bad301d/pkg/prometheus/operator.go#L1214-L1219

If the hash value of the first shard in the next loop has not changed, it will exit the loop directly and it will not create the next shard.
https://github.com/prometheus-operator/prometheus-operator/blob/fb16b71909dfe3feff2b5e77214002e10bad301d/pkg/prometheus/operator.go#L1224-L1227


```release-note:REPLACEME
Fix inconsistency question between the number of pods and shard configuration.
```
