### PR TITLE
Fix sharding bug where not all statefulsets are created

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1186,6 +1186,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	// Ensure we have a StatefulSet running Prometheus deployed and that StatefulSet names are created correctly.
 	expected := expectedStatefulSetShardNames(p)
+	level.Debug(c.logger).Log("msg", "about to reconcile shards", "shardnames", strings.Join(expected, ", "))
 	for shard, ssetName := range expected {
 		level.Debug(c.logger).Log("msg", "reconciling statefulset", "statefulset", ssetName, "shard", fmt.Sprintf("%d", shard))
 
@@ -1217,7 +1218,8 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			if _, err := ssetClient.Create(ctx, sset, metav1.CreateOptions{}); err != nil {
 				return errors.Wrap(err, "creating statefulset failed")
 			}
-			return nil
+			level.Debug(c.logger).Log("msg", "created Prometheus statefulset", "statefulset", ssetName)
+			continue
 		}
 
 		oldSSetInputHash := obj.(*appsv1.StatefulSet).ObjectMeta.Annotations[sSetInputHashName]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses https://github.com/prometheus-community/helm-charts/issues/765 and https://github.com/prometheus-operator/prometheus-operator/issues/3801.  

All this does is continue on to the next shard after a creating a statefulset for a particular shard does not exist.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug

```
