### PR TITLE
Adds default container annotation to Alertmanager pod

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -337,6 +337,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		podLabels[k] = v
 	}
 
+	podAnnotations["kubectl.kubernetes.io/default-container"] = "alertmanager"
+
 	var clusterPeerDomain string
 	if config.ClusterDomain != "" {
 		clusterPeerDomain = fmt.Sprintf("%s.%s.svc.%s.", governingServiceName, a.Namespace, config.ClusterDomain)

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -125,11 +125,11 @@ func TestPodLabelsAnnotations(t *testing.T) {
 		},
 	}, nil, defaultTestConfig)
 	require.NoError(t, err)
-	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
-		t.Fatal("Pod labes are not properly propagated")
+	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
+		t.Fatal("Pod labels are not properly propagated")
 	}
-	if !reflect.DeepEqual(annotations, sset.Spec.Template.ObjectMeta.Annotations) {
-		t.Fatal("Pod annotaitons are not properly propagated")
+	if val, ok := sset.Spec.Template.ObjectMeta.Annotations["testannotation"]; !ok || val != "testvalue" {
+		t.Fatal("Pod annotations are not properly propagated")
 	}
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds [default container annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) to Alertmanager pod, so that kubectl fetches logs from the Alertmanager container if no container is specified. Requires kubectl >= 1.21.0.

e.g, without:
```
$ kubectl logs -f alertmanager-alertmanager-0
error: a container name must be specified for pod alertmanager-alertmanager-0, choose one of: [alertmanager config-reloader]
```

with:
```
$ kubectl logs -f alertmanager-alertmanager-0
level=info ts=2021-04-12T16:00:47.351Z caller=main.go:216 msg="Starting Alertmanager" version="(version=0.21.0, branch=HEAD, revision=4c6c03ebfe21009c546e4d1e9b92c371d67c021d)"
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Add default container annotation to Alertmanager pod
```
