### PR TITLE
jsonnet: set default container name for prometheus-operator pod

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14155,6 +14155,8 @@ spec:
       app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator

--- a/example/non-rbac/prometheus-operator.yaml
+++ b/example/non-rbac/prometheus-operator.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/name: prometheus-operator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -151,7 +151,12 @@ function(params) {
         replicas: 1,
         selector: { matchLabels: po.config.selectorLabels },
         template: {
-          metadata: { labels: po.config.commonLabels },
+          metadata: {
+            labels: po.config.commonLabels,
+            annotations: {
+              "kubectl.kubernetes.io/default-container": container.name,
+            }
+          },
           spec: {
             containers: [container],
             nodeSelector: {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This works with kubectl >= 1.21

Similar to https://github.com/prometheus-operator/prometheus-operator/pull/3978 and https://github.com/prometheus-operator/prometheus-operator/pull/3971 but for prometheus-operator

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
jsonnet: set default container in prometheus-operator pod 
```
