### PR TITLE
Adds default container annotation to Thanos ruler pod

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -358,6 +358,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	podLabels[thanosRulerLabel] = tr.Name
 	finalLabels := config.Labels.Merge(podLabels)
 
+	podAnnotations["kubectl.kubernetes.io/default-container"] = "thanos-ruler"
+
 	storageVolName := volumeName(tr.Name)
 	if tr.Spec.Storage != nil {
 		if tr.Spec.Storage.VolumeClaimTemplate.Name != "" {

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -101,10 +101,10 @@ func TestPodLabelsAnnotations(t *testing.T) {
 		},
 	}, defaultTestConfig, nil, "")
 	require.NoError(t, err)
-	if _, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok {
+	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
 		t.Fatal("Pod labels are not properly propagated")
 	}
-	if !reflect.DeepEqual(annotations, sset.Spec.Template.ObjectMeta.Annotations) {
+	if val, ok := sset.Spec.Template.ObjectMeta.Annotations["testannotation"]; !ok || val != "testvalue" {
 		t.Fatal("Pod annotations are not properly propagated")
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Follow up to https://github.com/prometheus-operator/prometheus-operator/pull/3971 and https://github.com/prometheus-operator/prometheus-operator/pull/3978


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Add default container annotation to Thanos ruler pod
```

