### PR TITLE
pkg/prometheus: fix watched namespaces for configmaps

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -237,7 +237,7 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 
 	c.cmapInfs, err = informers.NewInformersForResource(
 		informers.NewKubeInformerFactories(
-			c.config.Namespaces.AllowList,
+			c.config.Namespaces.PrometheusAllowList,
 			c.config.Namespaces.DenyList,
 			c.kclient,
 			resyncPeriod,


### PR DESCRIPTION
The configmaps informer should watch the same namespaces as the
Prometheus and secrets informers.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Watch configmaps from the Prometheus allowed namespaces only.
```
