### PR TITLE
thanos-ruler: Always add web port to pod specs

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -196,22 +196,25 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		trCLIArgs = append(trCLIArgs, fmt.Sprintf("--alert.label-drop=%s", lb))
 	}
 
+	if tr.Spec.PortName == "" {
+		tr.Spec.PortName = defaultPortName
+	}
+
 	ports := []v1.ContainerPort{
+		{
+			Name:          tr.Spec.PortName,
+			ContainerPort: 10902,
+			Protocol:      v1.ProtocolTCP,
+		},
 		{
 			Name:          "grpc",
 			ContainerPort: 10901,
 			Protocol:      v1.ProtocolTCP,
 		},
 	}
+
 	if tr.Spec.ListenLocal {
 		trCLIArgs = append(trCLIArgs, "--http-address=localhost:10902")
-	} else {
-		ports = append(ports,
-			v1.ContainerPort{
-				Name:          tr.Spec.PortName,
-				ContainerPort: 10902,
-				Protocol:      v1.ProtocolTCP,
-			})
 	}
 
 	if tr.Spec.LogLevel != "" && tr.Spec.LogLevel != "info" {


### PR DESCRIPTION
When the Thanos Ruler CR is used together with Istio, we have to enable the listenLocal option, so that the Thanos Ruler isn't bind against the Pod IP.

When this option is enabled the "web" port isn't added to the Pod specification, so that the corresponding endpoints for the Thanos Ruler service doesn't contain the port. Because of this we can not use a ServiceMonitor to scrape the Prometheus metrics of the Thanos Ruler.

As workaround we can add the following in the Thanos Ruler CR:

```
spec:
  podMetadata:
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "10902"
      prometheus.io/path: "/metrics"
```

When the `enablePrometheusMerge` option of Istio is enabled, this allows us to get the Thanos Ruler metrics via the metrics endpoint of the Istio Proxy.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note: change
Add web port to Pod specification, when "listenLocal" option is "true"
```
