### PR TITLE
Drop ksonnet as a dependency in jsonnetfile.json

### DIFF
--- a/jsonnet/prometheus-operator/jsonnetfile.json
+++ b/jsonnet/prometheus-operator/jsonnetfile.json
@@ -1,14 +1,4 @@
 {
     "dependencies": [
-        {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "master"
-        }
     ]
 }


### PR DESCRIPTION
Drop the dependency on ksonnet from jsonnetfile.json. 


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:change

Unless you choose release-note:none, please add a release note.
-->

```release-node:change
Drop ksonnet as a dependency in jsonnetfile.json
```
