### PR TITLE
Fixed broken link to coreos blog post

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -264,7 +264,7 @@ Further reading:
 [bundle]: ../../bundle.yaml
 [design-doc]: ../design.md
 [exposing-prom]: exposing-prometheus-and-alertmanager.md
-[introducing-operators]: https://coreos.com/blog/introducing-operators.html
+[introducing-operators]: https://web.archive.org/web/20210210032403/https://coreos.com/blog/introducing-operators.html
 [prom-rbac]: ../rbac.md
 [prometheus-manifest]: ../../example/rbac/prometheus/prometheus.yaml
 [rbac-auth]: https://kubernetes.io/docs/reference/access-authn-authz/authorization/


### PR DESCRIPTION
All CoreOS blog post links are redirecting to OpenShift blog landing page. Added wayback maching link to land on the CoreOS blog post for introducing operators blog post.
