### PR TITLE
Keep `app` label and fix version label for alertmanager

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -317,7 +317,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 		// TODO(paulfantom): remove `app` label after 0.50 release
 		"app":                          "alertmanager",
 		"app.kubernetes.io/name":       "alertmanager",
-		"app.kubernetes.io/version":    amVersion,
+		"app.kubernetes.io/version":    version.String(),
 		"app.kubernetes.io/managed-by": "prometheus-operator",
 		"app.kubernetes.io/instance":   a.Name,
 		"alertmanager":                 a.Name,

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -314,6 +314,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
+		// TODO(paulfantom): remove `app` label after 0.50 release
+		"app":                          "alertmanager",
 		"app.kubernetes.io/name":       "alertmanager",
 		"app.kubernetes.io/version":    amVersion,
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -351,6 +351,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			}
 		}
 	}
+	// TODO(paulfantom): remove `app` label after 0.50 release
+	podLabels["app"] = thanosRulerLabel
 	podLabels["app.kubernetes.io/name"] = thanosRulerLabel
 	podLabels["app.kubernetes.io/managed-by"] = "prometheus-operator"
 	podLabels["app.kubernetes.io/instance"] = tr.Name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

We recently removed all `app` labels and replaced them with `app.kubernetes.io/name` (#3939). This can lead to issues with upgrades in user environments. Let's put a proper deprecation notice and keep `app` label on pods till 0.50 release.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
leaves `app` label on pods indirectly managed by prometheus-operator. Deprecation notice: label should be removed in 0.50
remove `v` prefix from app.kubernetes.io/version in alertmanager pods
```
