### PR TITLE
.github/workflows: run actions only in specific scenarios

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,13 @@
 name: ci
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - 'release-*'
+      - 'master'
+      - 'main'
+    tags:
+      - 'v*'
 env:
   golang-version: '1.16'
   kind-version: 'v0.10.0'


### PR DESCRIPTION
Actions should run only on:
- all pull_requests
- pushes to:
  - master/main branches
  - release-* branches
  - tags prefixed with `v`

This should reduce time spent waiting for CI.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
