### PR TITLE
.github/workflows: fix typo to enable excluding thanos ruler tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
       run: >
         EXCLUDE_ALERTMANAGER_TESTS=${{ matrix.alertmanager }}
         EXCLUDE_PROMETHEUS_TESTS=${{ matrix.prometheus }}
-        EXCLUDE_THANOS_TESTS=${{ matrix.thanosruler }}
+        EXCLUDE_THANOSRULER_TESTS=${{ matrix.thanosruler }}
         make test-e2e
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Setting the EXCLUDE_THANOSRULER_TESTS env var excludes all thanos
ruler tests in the e2e suite. The CI workflow currently has a typo
and sets EXCLUDE_THANOS_TESTS instead.
This change fixes the typo in the CI workflow.

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>