### PR TITLE
Root AlertmanagerConfig name in Alertmanager spec, skips namespace matcher

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -207,6 +207,7 @@ AlertmanagerSpec is a specification of the desired behavior of the Alertmanager 
 | forceEnableClusterMode | ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica. Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each. | bool | false |
 | alertmanagerConfigSelector | AlertmanagerConfigs to be selected for to merge and configure Alertmanager with. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta) | false |
 | alertmanagerConfigNamespaceSelector | Namespaces to be selected for AlertmanagerConfig discovery. If nil, only check own namespace. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta) | false |
+| baseAlertmanagerConfiguration | Root AlertmanagerConfig to be used which skips namespace matcher. This has to be present in the same namespace as the Alertmanager CRD. | *[BaseAlertmanagerConfiguration]#BaseAlertmanagerConfiguration | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -863,6 +864,16 @@ StorageSpec defines the configured storage for a group Prometheus servers. If ne
 | disableMountSubPath | Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary. DisableMountSubPath allows to remove any subPath usage in volume mounts. | bool | false |
 | emptyDir | EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir | *[v1.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#emptydirvolumesource-v1-core) | false |
 | volumeClaimTemplate | A PVC spec to be used by the Prometheus StatefulSets. | [EmbeddedPersistentVolumeClaim](#embeddedpersistentvolumeclaim) | false |
+
+[Back to TOC](#table-of-contents)
+
+## BaseAlertmanagerConfiguration
+
+BaseAlertmanagerConfiguration specifies the name of the root AlertmanagerConfig to be used. It skips the namespace matcher.
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| alertmanagerConfigName | The name of the root AlertmanagerConfig which won't have the namespace matcher | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -207,7 +207,7 @@ AlertmanagerSpec is a specification of the desired behavior of the Alertmanager 
 | forceEnableClusterMode | ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica. Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each. | bool | false |
 | alertmanagerConfigSelector | AlertmanagerConfigs to be selected for to merge and configure Alertmanager with. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta) | false |
 | alertmanagerConfigNamespaceSelector | Namespaces to be selected for AlertmanagerConfig discovery. If nil, only check own namespace. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta) | false |
-| baseAlertmanagerConfiguration | Root AlertmanagerConfig to be used which skips namespace matcher. This has to be present in the same namespace as the Alertmanager CRD. | *[BaseAlertmanagerConfiguration]#BaseAlertmanagerConfiguration | false |
+| baseAlertmanagerConfiguration | Root AlertmanagerConfig to be used which skips namespace matcher. This has to be present in the same namespace as the Alertmanager CRD. | *[BaseAlertmanagerConfiguration](#BaseAlertmanagerConfiguration) | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -452,6 +452,13 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+              baseAlertmanagerConfiguration:
+                description: Base AlertmanagerConfig to be used to configure Alertmanager with. This will be in the same namespace as the AlertmanagerConfig CRD.
+                properties:
+                  alertmanagerConfigName:
+                    description: AlertmanagerConfigName specifies the name of the root AlertmanagerConfig which won't have the namespace matcher.
+                    type: string
+                type: object                
               baseImage:
                 description: 'Base image that is used to deploy pods, without tag. Deprecated: use ''image'' instead'
                 type: string

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -173,7 +173,7 @@ func convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName, firs
 			match[matcher.Name] = matcher.Value
 		}
 	}
-	if firstLevelRoute && flag==0{
+	if firstLevelRoute && flag == 0 {
 		match["namespace"] = crKey.Namespace
 		delete(matchRE, "namespace")
 	}

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -167,17 +167,25 @@ templates: []
 					},
 					Receivers: []monitoringv1alpha1.Receiver{{Name: "test"}},
 				},
-			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace-baseamc-test
-    continue: true
+			}, expected: `route:
+  receiver: mynamespace-baseamc-test
 receivers:
-- name: "null"
 - name: mynamespace-baseamc-test
 templates: []
 `,
+
+			/*
+							expected: `route:
+				  receiver: "null"
+				  routes:
+				  - receiver: mynamespace-baseamc-test
+				    continue: true
+				receivers:
+				- name: "null"
+				- name: mynamespace-baseamc-test
+				templates: []
+				`, */
+
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -245,22 +253,33 @@ templates: []
 						Receivers: []monitoringv1alpha1.Receiver{{Name: "test"}},
 					},
 				},
-			},
-			expected: `route:
-  receiver: "null"
+			}, expected: `route:
+  receiver: mynamespace-baseamc-test
   routes:
-  - receiver: mynamespace-baseamc-test
-    continue: true
   - receiver: mynamespace-myamc-test
     match:
       namespace: mynamespace
     continue: true
 receivers:
-- name: "null"
 - name: mynamespace-baseamc-test
 - name: mynamespace-myamc-test
 templates: []
 `,
+			/* expected: `route:
+			  receiver: "null"
+			  routes:
+			  - receiver: mynamespace-baseamc-test
+			    continue: true
+			  - receiver: mynamespace-myamc-test
+			    match:
+			      namespace: mynamespace
+			    continue: true
+			receivers:
+			- name: "null"
+			- name: mynamespace-baseamc-test
+			- name: mynamespace-myamc-test
+			templates: []
+			`, */
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only",

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -173,19 +173,6 @@ receivers:
 - name: mynamespace-baseamc-test
 templates: []
 `,
-
-			/*
-							expected: `route:
-				  receiver: "null"
-				  routes:
-				  - receiver: mynamespace-baseamc-test
-				    continue: true
-				receivers:
-				- name: "null"
-				- name: mynamespace-baseamc-test
-				templates: []
-				`, */
-
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -265,21 +252,6 @@ receivers:
 - name: mynamespace-myamc-test
 templates: []
 `,
-			/* expected: `route:
-			  receiver: "null"
-			  routes:
-			  - receiver: mynamespace-baseamc-test
-			    continue: true
-			  - receiver: mynamespace-myamc-test
-			    match:
-			      namespace: mynamespace
-			    continue: true
-			receivers:
-			- name: "null"
-			- name: mynamespace-baseamc-test
-			- name: mynamespace-myamc-test
-			templates: []
-			`, */
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only",

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1005,19 +1005,19 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 
 	var resBase *monitoringv1alpha1.AlertmanagerConfig
 	if baseAmConfig != nil {
-			if err := checkAlertmanagerConfig(ctx, baseAmConfig, store); err != nil {
-				rejected++
-				level.Warn(c.logger).Log(
-					"msg", "skipping alertmanagerconfig",
-					"error", err.Error(),
-					"alertmanagerconfig", baseAmConfigNamespaceAndName,
-					"namespace", am.Namespace,
-					"alertmanager", am.Name,
-				)
-			} else {
-				accepted++
-				resBase = baseAmConfig
-			}
+		if err := checkAlertmanagerConfig(ctx, baseAmConfig, store); err != nil {
+			rejected++
+			level.Warn(c.logger).Log(
+				"msg", "skipping alertmanagerconfig",
+				"error", err.Error(),
+				"alertmanagerconfig", baseAmConfigNamespaceAndName,
+				"namespace", am.Namespace,
+				"alertmanager", am.Name,
+			)
+		} else {
+			accepted++
+			resBase = baseAmConfig
+		}
 	}
 
 	res := make(map[string]*monitoringv1alpha1.AlertmanagerConfig, len(amConfigs))

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1342,13 +1342,14 @@ type AlertmanagerSpec struct {
 	AlertmanagerConfigNamespaceSelector *metav1.LabelSelector `json:"alertmanagerConfigNamespaceSelector,omitempty"`
 	// Base AlertmanagerConfig to be used to configure Alertmanager with. This will be in the same namespace
 	// as the AlertmanagerConfig CRD.
-	BaseAlertmanagerConfiguration	BaseAlertmanagerConfiguration	`json:"baseAlertmanagerConfiguration,omitempty"`
-    // TODO: add enforcedNamespaceLabel  to enable/disable enforcement of namespace matchers in routing tree.
+	BaseAlertmanagerConfiguration BaseAlertmanagerConfiguration `json:"baseAlertmanagerConfiguration,omitempty"`
+	// TODO: add enforcedNamespaceLabel  to enable/disable enforcement of namespace matchers in routing tree.
 }
 
+// BaseAlertmanagerConfiguration supports adding root alertmanagerConfig name.
 type BaseAlertmanagerConfiguration struct {
 	// AlertmanagerConfigName specifies the name of the root AlertmanagerConfig which won't have the namespace matcher.
-	AlertmanagerConfigName string	`json:"alertmanagerConfigName,omitempty"`
+	AlertmanagerConfigName string `json:"alertmanagerConfigName,omitempty"`
 	// TODO: add global and template fields.
 }
 

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1340,6 +1340,16 @@ type AlertmanagerSpec struct {
 	// Namespaces to be selected for AlertmanagerConfig discovery. If nil, only
 	// check own namespace.
 	AlertmanagerConfigNamespaceSelector *metav1.LabelSelector `json:"alertmanagerConfigNamespaceSelector,omitempty"`
+	// Base AlertmanagerConfig to be used to configure Alertmanager with. This will be in the same namespace
+	// as the AlertmanagerConfig CRD.
+	BaseAlertmanagerConfiguration	BaseAlertmanagerConfiguration	`json:"baseAlertmanagerConfiguration,omitempty"`
+    // TODO: add enforcedNamespaceLabel  to enable/disable enforcement of namespace matchers in routing tree.
+}
+
+type BaseAlertmanagerConfiguration struct {
+	// AlertmanagerConfigName specifies the name of the root AlertmanagerConfig which won't have the namespace matcher.
+	AlertmanagerConfigName string	`json:"alertmanagerConfigName,omitempty"`
+	// TODO: add global and template fields.
 }
 
 // AlertmanagerList is a list of Alertmanagers.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR addresses the first objective here: https://github.com/prometheus-operator/prometheus-operator/issues/4033
Other issue: https://github.com/prometheus-operator/prometheus-operator/issues/3737
Motivation from the work done here: https://github.com/prometheus-operator/prometheus-operator/pull/3821

Usage: 
Add this to the Alertmanager Spec:
```
  baseAlertmanagerConfiguration:
    alertmanagerConfigName: config-example
```
And then create an AlertmanagerConfig in the same namespace with the name `config-example`, all the routes mentioned here wont have the namespace matcher and will be used to setup base alertmanager secret (`baseConfig.Route`), that is - unlike other `alertmanagerConfigs` where the `spec.Route` transforms into `baseConfig.Route.Routes[]`

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
--> 
**Release Note Template (will be copied)**

```
Specify a root AlertmangerConfig in the Alertmanager spec, for which namespace matcher will be skipped. 
```
