### PR TITLE
*: fix global HTTP configuration for Alertmanager

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -29,7 +29,6 @@ import (
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
 	"github.com/prometheus/alertmanager/config"
-	commoncfg "github.com/prometheus/common/config"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -826,8 +825,8 @@ func (cg *configGenerator) convertHTTPConfig(ctx context.Context, in monitoringv
 	return out, nil
 }
 
-func (cg *configGenerator) convertTLSConfig(ctx context.Context, in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) commoncfg.TLSConfig {
-	out := commoncfg.TLSConfig{
+func (cg *configGenerator) convertTLSConfig(ctx context.Context, in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) tlsConfig {
+	out := tlsConfig{
 		ServerName:         in.ServerName,
 		InsecureSkipVerify: in.InsecureSkipVerify,
 	}

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/prometheus/alertmanager/config"
-	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )
 
@@ -41,7 +40,7 @@ type globalConfig struct {
 	// if it has not been updated.
 	ResolveTimeout *model.Duration `yaml:"resolve_timeout,omitempty" json:"resolve_timeout,omitempty"`
 
-	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	HTTPConfig *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	SMTPFrom         string          `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
 	SMTPHello        string          `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
@@ -177,11 +176,19 @@ type slackConfig struct {
 }
 
 type httpClientConfig struct {
-	BasicAuth       *basicAuth          `yaml:"basic_auth,omitempty"`
-	BearerToken     string              `yaml:"bearer_token,omitempty"`
-	BearerTokenFile string              `yaml:"bearer_token_file,omitempty"`
-	ProxyURL        string              `yaml:"proxy_url,omitempty"`
-	TLSConfig       commoncfg.TLSConfig `yaml:"tls_config,omitempty"`
+	BasicAuth       *basicAuth `yaml:"basic_auth,omitempty"`
+	BearerToken     string     `yaml:"bearer_token,omitempty"`
+	BearerTokenFile string     `yaml:"bearer_token_file,omitempty"`
+	ProxyURL        string     `yaml:"proxy_url,omitempty"`
+	TLSConfig       tlsConfig  `yaml:"tls_config,omitempty"`
+}
+
+type tlsConfig struct {
+	CAFile             string `yaml:"ca_file,omitempty"`
+	CertFile           string `yaml:"cert_file,omitempty"`
+	KeyFile            string `yaml:"key_file,omitempty"`
+	ServerName         string `yaml:"server_name,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
 }
 
 type basicAuth struct {
@@ -232,20 +239,20 @@ type slackConfirmationField struct {
 }
 
 type emailConfig struct {
-	VSendResolved *bool               `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
-	To            string              `yaml:"to,omitempty" json:"to,omitempty"`
-	From          string              `yaml:"from,omitempty" json:"from,omitempty"`
-	Hello         string              `yaml:"hello,omitempty" json:"hello,omitempty"`
-	Smarthost     config.HostPort     `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
-	AuthUsername  string              `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
-	AuthPassword  string              `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
-	AuthSecret    string              `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
-	AuthIdentity  string              `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
-	Headers       map[string]string   `yaml:"headers,omitempty" json:"headers,omitempty"`
-	HTML          string              `yaml:"html,omitempty" json:"html,omitempty"`
-	Text          string              `yaml:"text,omitempty" json:"text,omitempty"`
-	RequireTLS    *bool               `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
-	TLSConfig     commoncfg.TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
+	To            string            `yaml:"to,omitempty" json:"to,omitempty"`
+	From          string            `yaml:"from,omitempty" json:"from,omitempty"`
+	Hello         string            `yaml:"hello,omitempty" json:"hello,omitempty"`
+	Smarthost     config.HostPort   `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
+	AuthUsername  string            `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
+	AuthPassword  string            `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
+	AuthSecret    string            `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
+	AuthIdentity  string            `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
+	Headers       map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	HTML          string            `yaml:"html,omitempty" json:"html,omitempty"`
+	Text          string            `yaml:"text,omitempty" json:"text,omitempty"`
+	RequireTLS    *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+	TLSConfig     tlsConfig         `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
 }
 
 type pushoverConfig struct {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -359,6 +359,7 @@ func testAMReloadConfig(t *testing.T) {
 	firstConfig := `
 global:
   resolve_timeout: 5m
+  http_config: {}
 route:
   group_by: ['job']
   group_wait: 30s


### PR DESCRIPTION
The bump of github.com/prometheus/common from v0.15.0 to v0.20.0
introduced a breaking change [1] for users that configure the
`http_config` parameter in the `global` section. In practice the
configuration generated by the operator would contain a
`follow_redirects: true` stanza that isn't supported by Alertmanager <=
v0.21.0.

Instead of importing the structs from github.com/prometheus/common, we
duplicate them in the internal representation of the Alertmanager
configuration.

[1] https://github.com/prometheus/common/commit/47ee79a16821e03c31ca741659d4f7919aed91c1

Closes #4009 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME
Don't generate broken Alertmanager configuration when `http_config` is defined in the global parameters.
```
