### PR TITLE
pkg/prometheus/statefulset.go: revert app label

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -596,6 +596,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	podSelectorLabels := map[string]string{
+		// TODO(fpetkovski): remove `app` label after 0.50 release
+		"app":                          "prometheus",
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/version":    version.String(),
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -69,6 +69,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 
 	expectedPodLabels := map[string]string{
 		"prometheus":                   "",
+		"app":                          "prometheus",
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/version":    strings.TrimPrefix(operator.DefaultPrometheusVersion, "v"),
 		"app.kubernetes.io/managed-by": "prometheus-operator",


### PR DESCRIPTION
In #3939 the app label from prometheus, alertmanager and thanos pods was removed. 
This caused a breaking change which prevents seamless upgrades. 
The issue was fixed for alertmanager and thanos in #4010.

This change reverts the removal of the app label for prometheus pods.

Fixes #4050

```release-note:bug
added an `app` label on Prometheus pods 
```
