### PR TITLE
Support pushing images to other container registries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,11 +161,17 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.golang-version }}
-      - name: Login to Quay.io
+      - name: login to quay.io
         uses: docker/login-action@v1
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          username: ${{ secrets.quay_username }}
+          password: ${{ secrets.quay_password }}
+      - name: login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build images and push
         run: ./scripts/push-docker-image.sh

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@ else
 endif
 
 GO_PKG=github.com/prometheus-operator/prometheus-operator
-REPO?=quay.io/prometheus-operator/prometheus-operator
-REPO_PROMETHEUS_CONFIG_RELOADER?=quay.io/prometheus-operator/prometheus-config-reloader
-REPO_PROMETHEUS_OPERATOR_LINT?=quay.io/prometheus-operator/prometheus-operator-lint
+IMAGE_OPERATOR?=quay.io/prometheus-operator/prometheus-operator
+IMAGE_RELOADER?=quay.io/prometheus-operator/prometheus-config-reloader
 TAG?=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 
@@ -141,14 +140,14 @@ image: .hack-operator-image .hack-prometheus-config-reloader-image
 # Create empty target file, for the sole purpose of recording when this target
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(REPO):$(TAG) .
+	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(IMAGE_OPERATOR):$(TAG) .
 	touch $@
 
 .hack-prometheus-config-reloader-image: cmd/prometheus-config-reloader/Dockerfile prometheus-config-reloader
 # Create empty target file, for the sole purpose of recording when this target
 # was last executed via the last-modification timestamp on the file. See
 # https://www.gnu.org/software/make/manual/make.html#Empty-Targets
-	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(REPO_PROMETHEUS_CONFIG_RELOADER):$(TAG) -f cmd/prometheus-config-reloader/Dockerfile .
+	docker build --build-arg ARCH=$(ARCH) --build-arg OS=$(GOOS) -t $(IMAGE_RELOADER):$(TAG) -f cmd/prometheus-config-reloader/Dockerfile .
 	touch $@
 
 .PHONY: update-go-deps
@@ -270,7 +269,7 @@ test/e2e/remote_write_certs/ca.key test/e2e/remote_write_certs/ca.crt test/e2e/r
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e: test/instrumented-sample-app/certs/cert.pem test/instrumented-sample-app/certs/key.pem
-	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(REPO):$(TAG) -count=1
+	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(IMAGE_OPERATOR):$(TAG) -count=1
 
 ############
 # Binaries #

--- a/scripts/push-docker-image.sh
+++ b/scripts/push-docker-image.sh
@@ -1,31 +1,71 @@
 #!/usr/bin/env bash
+#
+# Script is meant to build multi-arch container images and publish them to multiple container registries
+# 
+# Script is:
+# - figuring out if an image is a development one (by default suffixed with `-dev` in image name)
+# - figuring out the image tag (aka version) based on GITHUB_REF value
+#
+# Script is not:
+# - directly executing `docker build`. This is done in Makefile
+# - logging to registries 
+#
+
 # exit immediately when a command fails
 set -e
 # only exit with zero if all commands of the pipeline exit successfully
 set -o pipefail
-# error on unset variables
-set -u
 
 CPU_ARCHS="amd64 arm64 arm"
+REGISTRIES="${REGISTRIES:-"quay.io ghcr.io"}"
 
+# IMAGE_OPERATOR and IMAGER_RELOADER need to be exported to be used by `make`
+export IMAGE_OPERATOR="${IMAGE_OPERATOR:-"prometheus-operator/prometheus-operator"}"
+export IMAGE_RELOADER="${IMAGE_RELOADER:-"prometheus-operator/prometheus-config-reloader"}"
+
+# Figure out if current commit is tagged
 export TAG="${GITHUB_REF##*/}"
 
 # Push `-dev` images unless commit is tagged
-export REPO="${REPO:-"quay.io/prometheus-operator/prometheus-operator-dev"}"
-export REPO_PROMETHEUS_CONFIG_RELOADER="${REPO_PROMETHEUS_CONFIG_RELOADER:-"quay.io/prometheus-operator/prometheus-config-reloader-dev"}"
+IMAGE_SUFFIX="-dev"
 
 # Use main image repositories if TAG is a semver tag or it is a master branch
+# Prepare image tag from VERSION file and short commit SHA in other cases
 if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+ ]] || [ "${TAG}" == "master" ]; then
-	export REPO="quay.io/prometheus-operator/prometheus-operator"
-	export REPO_PROMETHEUS_CONFIG_RELOADER="quay.io/prometheus-operator/prometheus-config-reloader"
+	# Reset suffixes as images are not development ones
+	IMAGE_SUFFIX=""
+else
+	TAG="v$(cat "$(git rev-parse --show-toplevel)/VERSION")-$(git rev-parse --short HEAD)"
 fi
 
-for arch in ${CPU_ARCHS}; do
-	make --always-make image GOARCH="$arch" TAG="${TAG}-$arch"
+# Compose full image names for retagging and publishing to remote container registries
+OPERATORS=""
+RELOADERS=""
+for i in ${REGISTRIES}; do
+	OPERATORS="$i/${IMAGE_OPERATOR}${IMAGE_SUFFIX} ${OPERATORS}"
+	RELOADERS="$i/${IMAGE_RELOADER}${IMAGE_SUFFIX} ${RELOADERS}"
 done
 
+for img in ${OPERATORS} ${RELOADERS}; do
+	echo "Building multi-arch image: $img:$TAG"
+done
+
+# Build images and rename them for each remote registry
+for arch in ${CPU_ARCHS}; do
+	make --always-make image GOARCH="$arch" TAG="${TAG}-$arch"
+	# Retag operator image
+	for i in ${OPERATORS}; do
+		docker tag "${IMAGE_OPERATOR}:${TAG}-$arch" "${i}:${TAG}-$arch"
+	done
+	# Retag reloader image
+	for i in ${RELOADERS}; do
+		docker tag "${IMAGE_RELOADER}:${TAG}-$arch" "${i}:${TAG}-$arch"
+	done
+done
+
+# Compose multi-arch images and push them to remote repositories
 export DOCKER_CLI_EXPERIMENTAL=enabled
-for r in ${REPO} ${REPO_PROMETHEUS_CONFIG_RELOADER}; do
+for r in ${OPERATORS} ${RELOADERS}; do
 	# Images need to be on remote registry before creating manifests
 	for arch in $CPU_ARCHS; do
 		docker push "${r}:${TAG}-$arch"


### PR DESCRIPTION
Signed-off-by: paulfantom <pawel@krupa.net.pl>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* add easy way to add new registries (just add their prefix to `REGISTRIES` var) 
* push images to github container registry
* ability to run locally
* better tagging of development images

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Added publishing images on GitHub Container Registry
```
