### PR TITLE
feat: unset storage.tsdb.no-lockfile flag

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -349,7 +349,6 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		fmt.Sprintf("-storage.tsdb.path=%s", storageDir),
 		retentionTimeFlag+p.Spec.Retention,
 		"-web.enable-lifecycle",
-		"-storage.tsdb.no-lockfile",
 	)
 
 	if p.Spec.Query != nil && p.Spec.Query.LookbackDelta != nil {


### PR DESCRIPTION
Unsets storage.tsdb.no-lockfile flag as locking behaviour has been reverted.

Close #4048

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:change

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:change
Flag "storage.tsdb.no-lockfile" will now default to false
```
