### PR TITLE
bugfix: Remove whitespace and escape characters from URLs that are taken from secrets

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -305,7 +305,7 @@ func (cg *configGenerator) convertWebhookConfig(ctx context.Context, in monitori
 		if err != nil {
 			return nil, errors.Errorf("failed to get key %q from secret %q", in.URLSecret.Key, in.URLSecret.Name)
 		}
-		out.URL = url
+		out.URL = strings.TrimSpace(url)
 	} else if in.URL != nil {
 		out.URL = *in.URL
 	}
@@ -352,7 +352,7 @@ func (cg *configGenerator) convertSlackConfig(ctx context.Context, in monitoring
 		if err != nil {
 			return nil, errors.Errorf("failed to get key %q from secret %q", in.APIURL.Key, in.APIURL.Name)
 		}
-		out.APIURL = url
+		out.APIURL = strings.TrimSpace(url)
 	}
 
 	var actions []slackAction


### PR DESCRIPTION
When decoding from a kubernetes secret the slack url may have whitespace or escape characters appended to its suffix or prefix, this removes these so that it can correctly be parsed into alertmanager config

fixes #4037

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Fixed bug in Alertmanager config where URLS that are taken from Kubernetes secrets might contain whitespace or newline characters
```


