### PR TITLE
operator: don't wait to retry watching certificate reloader

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -429,15 +429,11 @@ func Main() int {
 		tlsConfig.GetCertificate = r.GetCertificate
 
 		wg.Go(func() error {
-			t := time.NewTicker(cfg.ServerTLSConfig.ReloadInterval)
 			for {
-				select {
-				case <-t.C:
-				case <-ctx.Done():
-					return nil
-				}
+				// r.Watch will wait ReloadInterval, so this is not
+				// a hot loop
 				if err := r.Watch(ctx); err != nil {
-					level.Warn(logger).Log("msg", "error reloading server TLS certificate",
+					level.Warn(logger).Log("msg", "error watching certificate reloader",
 						"err", err)
 				} else {
 					return nil


### PR DESCRIPTION
`r.Watch` will wait already.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
