### PR TITLE
pkg/prometheus: allow Probes without "module" parameter

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -710,9 +710,11 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: m.Spec.ProberSpec.Scheme})
 	}
 
-	cfg = append(cfg, yaml.MapItem{Key: "params", Value: yaml.MapSlice{
-		{Key: "module", Value: []string{m.Spec.Module}},
-	}})
+	if m.Spec.Module != "" {
+		cfg = append(cfg, yaml.MapItem{Key: "params", Value: yaml.MapSlice{
+			{Key: "module", Value: []string{m.Spec.Module}},
+		}})
+	}
 
 	relabelings := initRelabelings()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`module` parameter is optional in ProbeSpec and as such it shouldn't be passed to prometheus configuration when field is empty. Allowing such configuration extends usability of `Probe` CRD to other exporters that are based on similar concept to blackbox_exporter (for example [pagespeed_exporter](https://github.com/foomo/pagespeed_exporter)).

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Generate correct scraping configuration for Probes with empty or unset `module` parameter
```
