### PR TITLE
Format code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ format: go-fmt jsonnet-fmt check-license shellcheck
 
 .PHONY: go-fmt
 go-fmt:
-	go fmt $(pkgs)
+	gofmt -s -w .
 
 .PHONY: jsonnet-fmt
 jsonnet-fmt: $(JSONNETFMT_BINARY)

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -163,7 +163,7 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 				"operated-alertmanager": "true",
 			}),
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					Name:       p.GetName(),
 					Kind:       p.Kind,
 					APIVersion: p.APIVersion,

--- a/pkg/apis/monitoring/v1/types_test.go
+++ b/pkg/apis/monitoring/v1/types_test.go
@@ -56,9 +56,9 @@ func TestMarshallServiceMonitor(t *testing.T) {
 
 func TestValidateSecretOrConfigMap(t *testing.T) {
 	for _, good := range []SecretOrConfigMap{
-		SecretOrConfigMap{},
-		SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
-		SecretOrConfigMap{ConfigMap: &v1.ConfigMapKeySelector{}},
+		{},
+		{Secret: &v1.SecretKeySelector{}},
+		{ConfigMap: &v1.ConfigMapKeySelector{}},
 	} {
 		if err := good.Validate(); err != nil {
 			t.Errorf("expected validation of %+v not to fail, err: %s", good, err)

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -25,19 +25,19 @@ func TestIdenticalNamespaces(t *testing.T) {
 	}{
 		{
 			a: map[string]struct{}{
-				"foo": struct{}{},
+				"foo": {},
 			},
 			b: map[string]struct{}{
-				"foo": struct{}{},
+				"foo": {},
 			},
 			ret: true,
 		},
 		{
 			a: map[string]struct{}{
-				"foo": struct{}{},
+				"foo": {},
 			},
 			b: map[string]struct{}{
-				"bar": struct{}{},
+				"bar": {},
 			},
 			ret: false,
 		},

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -67,13 +67,13 @@ func TestGetNodeAddresses(t *testing.T) {
 			name: "simple",
 			nodes: &v1.NodeList{
 				Items: []v1.Node{
-					v1.Node{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node-0",
 						},
 						Status: v1.NodeStatus{
 							Addresses: []v1.NodeAddress{
-								v1.NodeAddress{
+								{
 									Address: "10.0.0.1",
 									Type:    v1.NodeInternalIP,
 								},
@@ -90,26 +90,26 @@ func TestGetNodeAddresses(t *testing.T) {
 			name: "missing ip on one node",
 			nodes: &v1.NodeList{
 				Items: []v1.Node{
-					v1.Node{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node-0",
 						},
 						Status: v1.NodeStatus{
 							Addresses: []v1.NodeAddress{
-								v1.NodeAddress{
+								{
 									Address: "node-0",
 									Type:    v1.NodeHostName,
 								},
 							},
 						},
 					},
-					v1.Node{
+					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "node-1",
 						},
 						Status: v1.NodeStatus{
 							Addresses: []v1.NodeAddress{
-								v1.NodeAddress{
+								{
 									Address: "10.0.0.1",
 									Type:    v1.NodeInternalIP,
 								},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -397,7 +397,7 @@ func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -515,7 +515,7 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -625,7 +625,7 @@ func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -731,7 +731,7 @@ func TestProbeStaticTargetsConfigGenerationWithoutModule(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -833,7 +833,7 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -963,7 +963,7 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
-			"probe1": &monitoringv1.Probe{
+			"probe1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testprobe1",
 					Namespace: "default",
@@ -1486,7 +1486,7 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 			Spec: monitoringv1.PrometheusSpec{},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"test": &monitoringv1.ServiceMonitor{
+			"test": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",
@@ -1794,7 +1794,7 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"test": &monitoringv1.ServiceMonitor{
+			"test": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",
@@ -2031,7 +2031,7 @@ func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -2297,7 +2297,7 @@ func TestHonorTimestampsOverriding(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -2438,7 +2438,7 @@ func TestSettingHonorLabels(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -2579,7 +2579,7 @@ func TestHonorLabelsOverriding(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -2720,7 +2720,7 @@ func TestTargetLabels(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -2859,7 +2859,7 @@ func TestPodTargetLabels(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"testservicemonitor1": &monitoringv1.ServiceMonitor{
+			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testservicemonitor1",
 					Namespace: "default",
@@ -3111,7 +3111,7 @@ func TestEmptyEndointPorts(t *testing.T) {
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{
-			"test": &monitoringv1.ServiceMonitor{
+			"test": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -274,7 +274,7 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config operator.Config) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: governingServiceName,
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					Name:       p.GetName(),
 					Kind:       p.Kind,
 					APIVersion: p.APIVersion,

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -458,7 +458,7 @@ func makeStatefulSetService(tr *monitoringv1.ThanosRuler, config Config) *v1.Ser
 				"operated-thanos-ruler": "true",
 			}),
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					Name:       tr.GetName(),
 					Kind:       tr.Kind,
 					APIVersion: tr.APIVersion,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -512,7 +512,7 @@ func TestPodTemplateConfig(t *testing.T) {
 		NodeAffinity: &v1.NodeAffinity{},
 		PodAffinity: &v1.PodAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
-				v1.WeightedPodAffinityTerm{
+				{
 					PodAffinityTerm: v1.PodAffinityTerm{
 						Namespaces: []string{"foo"},
 					},
@@ -524,7 +524,7 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 
 	tolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key: "key",
 		},
 	}

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -21,13 +21,13 @@ package tools
 import (
 	_ "github.com/brancz/gojsontoyaml"
 	_ "github.com/campoy/embedmd"
-	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/go-jsonnet/cmd/jsonnet"
 	_ "github.com/google/go-jsonnet/cmd/jsonnetfmt"
+	_ "github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb"
+	_ "github.com/yeya24/promlinter/cmd/promlinter"
 	_ "k8s.io/code-generator/cmd/client-gen"
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
-	_ "github.com/yeya24/promlinter/cmd/promlinter"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 )

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -193,7 +193,7 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 	simple.Spec.Template.Spec.Containers[0].Args = []string{"--cert-path=/etc/certs"}
 
 	simple.Spec.Template.Spec.Volumes = []v1.Volume{
-		v1.Volume{
+		{
 			Name: "tls-certs",
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
@@ -224,11 +224,11 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeLoadBalancer,
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name: "web",
 					Port: 8080,
 				},
-				v1.ServicePort{
+				{
 					Name: "mtls",
 					Port: 8081,
 				},
@@ -2704,7 +2704,7 @@ func testPromGetAuthSecret(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type: v1.ServiceTypeLoadBalancer,
 					Ports: []v1.ServicePort{
-						v1.ServicePort{
+						{
 							Name: "web",
 							Port: 8080,
 						},
@@ -3154,10 +3154,10 @@ func mountTLSFiles(p *monitoringv1.Prometheus, secretName string) {
 			},
 		})
 	p.Spec.Containers = []v1.Container{
-		v1.Container{
+		{
 			Name: "prometheus",
 			VolumeMounts: []v1.VolumeMount{
-				v1.VolumeMount{
+				{
 					Name:      volumeName,
 					MountPath: "/etc/ca-certificates",
 				},
@@ -3214,7 +3214,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	simple.Spec.Template.Spec.Containers[0].Args = []string{"--cert-path=/etc/certs"}
 
 	simple.Spec.Template.Spec.Volumes = []v1.Volume{
-		v1.Volume{
+		{
 			Name: "tls-certs",
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
@@ -3245,11 +3245,11 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeLoadBalancer,
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name: "web",
 					Port: 8080,
 				},
-				v1.ServicePort{
+				{
 					Name: "mtls",
 					Port: 8081,
 				},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`go fmt` and `gofmt` produce different results and since we were running only the former, our "go report card" isn't reporting 100% :( This PR should change this state and prevent it in the future.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```

/cc @prometheus-operator/prometheus-operator-reviewers 
