### PR TITLE
.github: Close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,8 @@ daysUntilStale: 60
 daysUntilClose: 120
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: []
+onlyLabels:
+  - "stale"
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Let's close issues marked as `stale` after 120 days of staleness.

Note: `stale` label is assigned after 60 days without any activity on the issue which means the issue needs to be stale for ~6 months before it gets closed.

/cc @brancz @metalmatze @simonpasquier  :)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
