### PR TITLE
Move version label from label selectors into the pod labels for prometheus and alertmanager sts.

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -310,12 +310,13 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config) (*appsv1.S
 	}
 
 	podAnnotations := map[string]string{}
-	podLabels := map[string]string{}
+	podLabels := map[string]string{
+		"app.kubernetes.io/version":    version.String(),
+	}
 	podSelectorLabels := map[string]string{
 		// TODO(paulfantom): remove `app` label after 0.50 release
 		"app":                          "alertmanager",
 		"app.kubernetes.io/name":       "alertmanager",
-		"app.kubernetes.io/version":    version.String(),
 		"app.kubernetes.io/managed-by": "prometheus-operator",
 		"app.kubernetes.io/instance":   a.Name,
 		"alertmanager":                 a.Name,

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -594,12 +594,13 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	}
 
 	podAnnotations := map[string]string{}
-	podLabels := map[string]string{}
+	podLabels := map[string]string{
+		"app.kubernetes.io/version":    version.String(),
+	}
 	podSelectorLabels := map[string]string{
 		// TODO(fpetkovski): remove `app` label after 0.50 release
 		"app":                          "prometheus",
 		"app.kubernetes.io/name":       "prometheus",
-		"app.kubernetes.io/version":    version.String(),
 		"app.kubernetes.io/managed-by": "prometheus-operator",
 		"app.kubernetes.io/instance":   p.Name,
 		"prometheus":                   p.Name,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

#3841 added a `app.kubernetes.io/version` label selector which causes statefulset recreations on version upgrade of prometheus and alertmanager. 

This change moves the version label from label selectors into the pod labels.
   
Resolves #4076.  


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:change
Remove `app.kubernetes.io/version` label selector from prometheus and alertmanager statefulsets.
```
