### PR TITLE
RELEASE.md: update release shepherd list

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,9 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v0.48   | 2021-05-19                                 | Matthias Loibl (GitHub: @metalmatze)        |
 | v0.49   | 2021-06-30                                 | Pawel Krupa (GitHub: @paulfantom)           |
 | v0.50   | 2021-08-11                                 | **searching for volunteer**                 |
+| v0.51   | 2021-09-08                                 | Simon Pasquier (GitHub: @simonpasquier)     |
+| v0.52   | 2021-10-20                                 | **searching for volunteer**                 |
+| v0.53   | 2021-12-15                                 | **searching for volunteer**                 |
 
 # How to cut a new release
 


### PR DESCRIPTION
Adding myself for v0.51. We need someone for v0.50 (August 11th): I'll be on vacation this week but if nobody is available either, we can maybe delay a bit and I should be able to handle it the week after.

cc @prometheus-operator/prometheus-operator-reviewers 


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
