### PR TITLE
operator.go: Update failure message shown to user

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -799,7 +799,14 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		c.metrics.StsDeleteCreateCounter().Inc()
-		level.Info(c.logger).Log("msg", "recreating AlertManager StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
+
+		// Gather only reason for failed update
+		failMsg := make([]string, len(sErr.ErrStatus.Details.Causes))
+		for i, cause := range sErr.ErrStatus.Details.Causes {
+			failMsg[i] = cause.Message
+		}
+
+		level.Info(c.logger).Log("msg", "recreating AlertManager StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -799,7 +799,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		c.metrics.StsDeleteCreateCounter().Inc()
-		level.Info(c.logger).Log("msg", "resolving illegal update of Alertmanager StatefulSet", "details", sErr.ErrStatus.Details)
+		level.Info(c.logger).Log("msg", "recreating AlertManager StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -19,11 +19,12 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -1299,7 +1300,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 		if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 			c.metrics.StsDeleteCreateCounter().Inc()
-			level.Info(c.logger).Log("msg", "resolving illegal update of Prometheus StatefulSet", "details", sErr.ErrStatus.Details)
+			level.Info(c.logger).Log("msg", "recreating Prometheus StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
 			propagationPolicy := metav1.DeletePropagationForeground
 			if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 				return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1300,7 +1300,14 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 		if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 			c.metrics.StsDeleteCreateCounter().Inc()
-			level.Info(c.logger).Log("msg", "recreating Prometheus StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
+
+			// Gather only reason for failed update
+			failMsg := make([]string, len(sErr.ErrStatus.Details.Causes))
+			for i, cause := range sErr.ErrStatus.Details.Causes {
+				failMsg[i] = cause.Message
+			}
+
+			level.Info(c.logger).Log("msg", "recreating Prometheus StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
 			propagationPolicy := metav1.DeletePropagationForeground
 			if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 				return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -709,7 +709,14 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		o.metrics.StsDeleteCreateCounter().Inc()
-		level.Info(o.logger).Log("msg", "recreating ThanosRuler StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
+
+		// Gather only reason for failed update
+		failMsg := make([]string, len(sErr.ErrStatus.Details.Causes))
+		for i, cause := range sErr.ErrStatus.Details.Causes {
+			failMsg[i] = cause.Message
+		}
+
+		level.Info(o.logger).Log("msg", "recreating ThanosRuler StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -709,7 +709,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 
 	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
 		o.metrics.StsDeleteCreateCounter().Inc()
-		level.Info(o.logger).Log("msg", "resolving illegal update of ThanosRuler StatefulSet", "details", sErr.ErrStatus.Details)
+		level.Info(o.logger).Log("msg", "recreating ThanosRuler StatefulSet because the update operation wasn't possible", "reason", sErr.ErrStatus.Details.Causes[0].Message)
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")


### PR DESCRIPTION
This is to make reason for stateful update failure more readable for the user

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME
Make failure to update StatefulSet more readable
```
