### PR TITLE
Issue #3256: ignore max_retries for Prometheus ver. 2.11.0+

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1541,8 +1541,10 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(version semver.Version, p *
 				queueConfig = append(queueConfig, yaml.MapItem{Key: "batch_send_deadline", Value: spec.QueueConfig.BatchSendDeadline})
 			}
 
-			if spec.QueueConfig.MaxRetries != int(0) {
-				queueConfig = append(queueConfig, yaml.MapItem{Key: "max_retries", Value: spec.QueueConfig.MaxRetries})
+			if version.LT(semver.MustParse("2.11.0")) {
+				if spec.QueueConfig.MaxRetries != int(0) {
+					queueConfig = append(queueConfig, yaml.MapItem{Key: "max_retries", Value: spec.QueueConfig.MaxRetries})
+				}
 			}
 
 			if spec.QueueConfig.MinBackoff != "" {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -4246,7 +4246,6 @@ remote_write:
     max_shards: 10
     max_samples_per_send: 100
     batch_send_deadline: 20s
-    max_retries: 3
     min_backoff: 1s
     max_backoff: 10s
 `,
@@ -4292,12 +4291,104 @@ remote_write:
     max_shards: 10
     max_samples_per_send: 100
     batch_send_deadline: 20s
-    max_retries: 3
     min_backoff: 1s
     max_backoff: 10s
   metadata_config:
     send: false
     send_interval: 1m
+`,
+		},
+		{
+			version: "v2.23.0",
+			remoteWrite: monitoringv1.RemoteWriteSpec{
+				URL: "http://example.com",
+				QueueConfig: &monitoringv1.QueueConfig{
+					Capacity:          1000,
+					MinShards:         1,
+					MaxShards:         10,
+					MaxSamplesPerSend: 100,
+					BatchSendDeadline: "20s",
+					MinBackoff:        "1s",
+					MaxBackoff:        "10s",
+				},
+				MetadataConfig: &monitoringv1.MetadataConfig{
+					Send:         false,
+					SendInterval: "1m",
+				},
+			},
+			expected: `global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+rule_files: []
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers: []
+remote_write:
+- url: http://example.com
+  remote_timeout: 30s
+  queue_config:
+    capacity: 1000
+    min_shards: 1
+    max_shards: 10
+    max_samples_per_send: 100
+    batch_send_deadline: 20s
+    min_backoff: 1s
+    max_backoff: 10s
+  metadata_config:
+    send: false
+    send_interval: 1m
+`,
+		},
+		{
+			version: "v2.10.0",
+			remoteWrite: monitoringv1.RemoteWriteSpec{
+				URL: "http://example.com",
+				QueueConfig: &monitoringv1.QueueConfig{
+					Capacity:          1000,
+					MinShards:         1,
+					MaxShards:         10,
+					MaxSamplesPerSend: 100,
+					BatchSendDeadline: "20s",
+					MaxRetries:        3,
+					MinBackoff:        "1s",
+					MaxBackoff:        "10s",
+				},
+				MetadataConfig: &monitoringv1.MetadataConfig{
+					Send:         false,
+					SendInterval: "1m",
+				},
+			},
+			expected: `global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+rule_files: []
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers: []
+remote_write:
+- url: http://example.com
+  remote_timeout: 30s
+  queue_config:
+    capacity: 1000
+    min_shards: 1
+    max_shards: 10
+    max_samples_per_send: 100
+    batch_send_deadline: 20s
+    max_retries: 3
+    min_backoff: 1s
+    max_backoff: 10s
 `,
 		},
 	} {


### PR DESCRIPTION
Operator does not generate ``max_retries`` option in ``remote_write`` for Prometheus version 2.11.0 and higher. Prometheus no longer have this option since 2.11.0.

Please refer to [this issue](https://github.com/prometheus-operator/prometheus-operator/issues/3256) for more details.

Closes #3256

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Operator does not generate ``max_retries`` option in ``remote_write`` for Prometheus version 2.11.0 and higher.
```
