### PR TITLE
Remove context.TODO() from client_go function calls

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1335,7 +1335,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		}
 
 		propagationPolicy := metav1.DeletePropagationForeground
-		if err := ssetClient.Delete(context.TODO(), s.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+		if err := ssetClient.Delete(ctx, s.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			level.Error(c.logger).Log("err", err, "name", s.GetName(), "namespace", s.GetNamespace())
 		}
 	})
@@ -1418,7 +1418,7 @@ func Status(ctx context.Context, kclient kubernetes.Interface, p *monitoringv1.P
 	var oldPods []v1.Pod
 	expected := expectedStatefulSetShardNames(p)
 	for _, ssetName := range expected {
-		sset, err := kclient.AppsV1().StatefulSets(p.Namespace).Get(context.TODO(), ssetName, metav1.GetOptions{})
+		sset, err := kclient.AppsV1().StatefulSets(p.Namespace).Get(ctx, ssetName, metav1.GetOptions{})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "retrieving stateful set failed")
 		}

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -53,7 +52,7 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 
 	am := framework.MakeBasicAlertmanager("non-instance", 3)
 	am.Namespace = nonInstanceNs
-	_, err = framework.MonClientV1.Alertmanagers(nonInstanceNs).Create(context.TODO(), am, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(nonInstanceNs).Create(framework.Ctx, am, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.TODO(), "alertmanager-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(framework.Ctx, "alertmanager-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -153,7 +152,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	}
 
 	// Create an Alertmanager resource in the "allowedNs" namespace which must *not* be reconciled.
-	_, err = framework.MonClientV1.Alertmanagers(allowedNs).Create(context.TODO(), am.DeepCopy(), metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(allowedNs).Create(framework.Ctx, am.DeepCopy(), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +163,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	}
 
 	// Check that the Alertmanager resource created in the "allowed" namespace hasn't been reconciled.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.TODO(), "alertmanager-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(framework.Ctx, "alertmanager-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -187,11 +186,11 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 		},
 	}
 
-	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(instanceNs).Create(context.TODO(), amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(instanceNs).Create(framework.Ctx, amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(allowedNs).Create(context.TODO(), amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(allowedNs).Create(framework.Ctx, amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -150,13 +149,13 @@ func testAMStorageUpdate(t *testing.T) {
 		},
 	}
 
-	_, err = framework.MonClientV1.Alertmanagers(ns).Update(context.TODO(), am, metav1.UpdateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(ns).Update(framework.Ctx, am, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), alertmanager.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, alertmanager.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -201,7 +200,7 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 
 	proxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
-	_, err := request.DoRaw(context.TODO())
+	_, err := request.DoRaw(framework.Ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,11 +442,11 @@ An Alert test
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.TODO(), templateCfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(framework.Ctx, templateCfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), templateSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, templateSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -455,7 +454,7 @@ An Alert test
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.TODO(), cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -465,7 +464,7 @@ An Alert test
 	}
 	cfg.Data["alertmanager.yaml"] = []byte(secondConfig)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.TODO(), cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -477,7 +476,7 @@ An Alert test
 
 	priorToReloadTime := time.Now()
 	templateCfg.Data[templateFileKey] = secondTemplate
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(context.TODO(), templateCfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(framework.Ctx, templateCfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -487,7 +486,7 @@ An Alert test
 
 	priorToReloadTime = time.Now()
 	templateSecret.Data[templateSecretFileKey] = []byte(secondTemplate)
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.TODO(), templateSecret, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, templateSecret, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -606,11 +605,11 @@ inhibit_rules:
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), amcfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, amcfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(context.TODO(), alertmanager, metav1.CreateOptions{})
+	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(framework.Ctx, alertmanager, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -673,7 +672,7 @@ inhibit_rules:
 			"app.kubernetes.io/name": "alertmanager-webhook",
 		})).String(),
 	}
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +695,7 @@ inhibit_rules:
 	// We need to force a rolling update, e.g. by changing one of the command
 	// line flags via the Retention.
 	alertmanager.Spec.Retention = "1h"
-	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(context.TODO(), alertmanager, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(framework.Ctx, alertmanager, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Wait for the change above to take effect.
@@ -754,7 +753,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			testingSecretKey: []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), testingKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, testingKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -766,7 +765,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-key": []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), apiKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, apiKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -778,7 +777,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-url": []byte("http://slack.example.com"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.TODO(), slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -898,7 +897,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -960,7 +959,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -989,7 +988,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1021,7 +1020,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.TODO(), configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1029,7 +1028,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	var lastErr error
 	amConfigSecretName := fmt.Sprintf("alertmanager-%s-generated", alertmanager.Name)
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1139,7 +1138,7 @@ templates: []
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1202,7 +1201,7 @@ receivers:
 			"template1.tmpl":    []byte(`template1`),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1215,7 +1214,7 @@ receivers:
 	// Wait for the change above to take effect.
 	var lastErr error
 	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), "alertmanager-user-amconfig-generated", metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, "alertmanager-user-amconfig-generated", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			lastErr = err
 			return false, nil
@@ -1282,28 +1281,28 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "alertmanager-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(context.TODO(), "alertmanager-operated", metav1.GetOptions{})
+				return svcClient.Get(framework.Ctx, "alertmanager-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(context.TODO(), asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(framework.Ctx, asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(context.TODO(), "alertmanager-test", metav1.GetOptions{})
+				return ssetClient.Get(framework.Ctx, "alertmanager-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(context.TODO(), asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(framework.Ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager secret",
 			get: func() (metav1.Object, error) {
-				return secretClient.Get(context.TODO(), "alertmanager-test-generated", metav1.GetOptions{})
+				return secretClient.Get(framework.Ctx, "alertmanager-test-generated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return secretClient.Update(context.TODO(), asSecret(t, object), metav1.UpdateOptions{})
+				return secretClient.Update(framework.Ctx, asSecret(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -46,7 +45,7 @@ func testDenyPrometheus(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		ctx.SetupPrometheusRBAC(t, denied, framework.KubeClient)
 		p := framework.MakeBasicPrometheus(denied, "denied", "denied", 1)
-		_, err = framework.MonClientV1.Prometheuses(denied).Create(context.TODO(), p, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.Prometheuses(denied).Create(framework.Ctx, p, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 		}
@@ -64,7 +63,7 @@ func testDenyPrometheus(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.TODO(), "prometheus-denied", metav1.GetOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(framework.Ctx, "prometheus-denied", metav1.GetOptions{})
 		if !api_errors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}
@@ -142,7 +141,7 @@ func testDenyServiceMonitor(t *testing.T) {
 
 		// create the service monitor in a way, that it matches the label selector used in the allowed namespace.
 		s := framework.MakeBasicServiceMonitor("allowed")
-		if _, err := framework.MonClientV1.ServiceMonitors(denied).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(denied).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
@@ -163,7 +162,7 @@ func testDenyServiceMonitor(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("allowed")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowed).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowed).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
@@ -185,7 +184,7 @@ func testDenyServiceMonitor(t *testing.T) {
 	}
 
 	for _, allowed := range allowedNamespaces {
-		if err := framework.MonClientV1.ServiceMonitors(allowed).Delete(context.TODO(), "allowed", metav1.DeleteOptions{}); err != nil {
+		if err := framework.MonClientV1.ServiceMonitors(allowed).Delete(framework.Ctx, "allowed", metav1.DeleteOptions{}); err != nil {
 			t.Fatal("Deleting ServiceMonitor failed: ", err)
 		}
 
@@ -212,7 +211,7 @@ func testDenyThanosRuler(t *testing.T) {
 
 	for _, denied := range deniedNamespaces {
 		tr := framework.MakeBasicThanosRuler("denied", 1, "http://test.example.com")
-		_, err = framework.MonClientV1.ThanosRulers(denied).Create(context.TODO(), tr, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.ThanosRulers(denied).Create(framework.Ctx, tr, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", tr.Spec.Replicas, tr.Name, err)
 		}
@@ -229,7 +228,7 @@ func testDenyThanosRuler(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied thanos ruler.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.TODO(), "thanosruler-denied", metav1.GetOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(framework.Ctx, "thanosruler-denied", metav1.GetOptions{})
 		if !api_errors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"flag"
 	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 	"log"
@@ -111,7 +110,7 @@ func TestAllNS(t *testing.T) {
 		"app.kubernetes.io/name": "prometheus-operator",
 	})).String()}
 
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +282,7 @@ func testServerTLS(t *testing.T, namespace string) func(t *testing.T) {
 
 		operatorService := framework.KubeClient.CoreV1().Services(namespace)
 		request := operatorService.ProxyGet("https", prometheusOperatorServiceName, "https", "/healthz", make(map[string]string))
-		_, err := request.DoRaw(context.TODO())
+		_, err := request.DoRaw(framework.Ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -40,7 +39,7 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 	}
 
 	p := framework.MakeBasicPrometheus(nonInstanceNs, "non-instance", "non-instance", 1)
-	_, err = framework.MonClientV1.Prometheuses(nonInstanceNs).Create(context.TODO(), p, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(nonInstanceNs).Create(framework.Ctx, p, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -52,7 +51,7 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.TODO(), "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(framework.Ctx, "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -102,7 +101,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		// create Prometheus custom resources in "denied" namespaces.
 		// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
 		p := framework.MakeBasicPrometheus(deniedNs, "denied", "denied", 1)
-		_, err = framework.MonClientV1.Prometheuses(deniedNs).Create(context.TODO(), p, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.Prometheuses(deniedNs).Create(framework.Ctx, p, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 		}
@@ -125,7 +124,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(deniedNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(deniedNs).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
@@ -152,7 +151,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
@@ -172,7 +171,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get(context.TODO(), "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get(framework.Ctx, "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -224,7 +223,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	// create Prometheus custom resources in "allowed" namespaces.
 	// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
 	p := framework.MakeBasicPrometheus(allowedNs, "allowed", "allowed", 1)
-	_, err = framework.MonClientV1.Prometheuses(allowedNs).Create(context.TODO(), p, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(allowedNs).Create(framework.Ctx, p, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -264,7 +263,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
@@ -288,7 +287,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
@@ -314,7 +313,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.TODO(), "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(framework.Ctx, "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -427,7 +426,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -169,14 +169,14 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 	}
 
 	for _, s = range secrets {
-		_, err := framework.KubeClient.CoreV1().Secrets(s.ObjectMeta.Namespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		_, err := framework.KubeClient.CoreV1().Secrets(s.ObjectMeta.Namespace).Create(framework.Ctx, s, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	for _, cm = range configMaps {
-		_, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.TODO(), cm, metav1.CreateOptions{})
+		_, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(framework.Ctx, cm, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -243,7 +243,7 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 		t.Fatal(err)
 	}
 
-	svc, err = framework.KubeClient.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	svc, err = framework.KubeClient.CoreV1().Services(ns).Get(framework.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func createK8sAppMonitoring(
 		},
 	}
 
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, sm, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "creating ServiceMonitor failed")
 	}
 
@@ -756,7 +756,7 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				})).String(),
 			}
 
-			appPodList, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), appOpts)
+			appPodList, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, appOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -904,7 +904,7 @@ func testPromResourceUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), prometheus.ListOptions(name))
+	pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, prometheus.ListOptions(name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -919,13 +919,13 @@ func testPromResourceUpdate(t *testing.T) {
 			v1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
-	p, err = framework.MonClientV1.Prometheuses(ns).Update(context.TODO(), p, metav1.UpdateOptions{})
+	p, err = framework.MonClientV1.Prometheuses(ns).Update(framework.Ctx, p, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -993,7 +993,7 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(framework.Ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1051,13 +1051,13 @@ func testPromStorageUpdate(t *testing.T) {
 			},
 		},
 	}
-	_, err = framework.MonClientV1.Prometheuses(ns).Update(context.TODO(), p, metav1.UpdateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(ns).Update(framework.Ctx, p, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -1122,7 +1122,7 @@ scrape_configs:
 
 	svc := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), cfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, cfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1158,13 +1158,13 @@ scrape_configs:
 	}
 	secondConfigCompressed := bufTwo.Bytes()
 
-	cfg, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), cfg.Name, metav1.GetOptions{})
+	cfg, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, cfg.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "could not retrieve previous secret"))
 	}
 
 	cfg.Data["prometheus.yaml.gz"] = secondConfigCompressed
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.TODO(), cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1186,7 +1186,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -1203,7 +1203,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 			"prometheus-additional.yaml": []byte(additionalConfig),
 		},
 	}
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, &secret, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1244,7 +1244,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -1262,7 +1262,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 			"prometheus-additional.yaml": []byte(additionalConfig),
 		},
 	}
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, &secret, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1672,7 +1672,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 				return framework.
 					MonClientV1.
 					Prometheuses(ns).
-					Get(context.TODO(), prometheusName, metav1.GetOptions{})
+					Get(framework.Ctx, prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1683,7 +1683,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					ConfigMaps(ns).
-					Get(context.TODO(), "prometheus-"+prometheusName+"-rulefiles-0", metav1.GetOptions{})
+					Get(framework.Ctx, "prometheus-"+prometheusName+"-rulefiles-0", metav1.GetOptions{})
 			},
 			// The Prometheus Operator first creates the ConfigMap for the
 			// given Prometheus stateful set and then updates it with the matching
@@ -1697,7 +1697,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Secrets(ns).
-					Get(context.TODO(), "prometheus-"+prometheusName, metav1.GetOptions{})
+					Get(framework.Ctx, "prometheus-"+prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 2,
 		},
@@ -1708,7 +1708,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Secrets(ns).
-					Get(context.TODO(), "prometheus-"+prometheusName+"-tls-assets", metav1.GetOptions{})
+					Get(framework.Ctx, "prometheus-"+prometheusName+"-tls-assets", metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 2,
 		},
@@ -1719,7 +1719,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					AppsV1().
 					StatefulSets(ns).
-					Get(context.TODO(), "prometheus-"+prometheusName, metav1.GetOptions{})
+					Get(framework.Ctx, "prometheus-"+prometheusName, metav1.GetOptions{})
 			},
 			// First is the creation of the StatefulSet itself, following is the
 			// update of e.g. the ReadyReplicas status field
@@ -1732,7 +1732,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Services(ns).
-					Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+					Get(framework.Ctx, "prometheus-operated", metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1742,7 +1742,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 				return framework.
 					MonClientV1.
 					ServiceMonitors(ns).
-					Get(context.TODO(), prometheusName, metav1.GetOptions{})
+					Get(framework.Ctx, prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1797,7 +1797,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	}
 
 	s := framework.MakeBasicServiceMonitor(name)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -1883,37 +1883,37 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "prometheus-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				return svcClient.Get(framework.Ctx, "prometheus-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(context.TODO(), asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(framework.Ctx, asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(context.TODO(), "prometheus-test", metav1.GetOptions{})
+				return ssetClient.Get(framework.Ctx, "prometheus-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(context.TODO(), asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(framework.Ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus-operated endpoints",
 			get: func() (metav1.Object, error) {
-				return endpointsClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				return endpointsClient.Get(framework.Ctx, "prometheus-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return endpointsClient.Update(context.TODO(), asEndpoints(t, object), metav1.UpdateOptions{})
+				return endpointsClient.Update(framework.Ctx, asEndpoints(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus secret",
 			get: func() (metav1.Object, error) {
-				return secretClient.Get(context.TODO(), "prometheus-test", metav1.GetOptions{})
+				return secretClient.Get(framework.Ctx, "prometheus-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return secretClient.Update(context.TODO(), asSecret(t, object), metav1.UpdateOptions{})
+				return secretClient.Update(framework.Ctx, asSecret(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}
@@ -2075,7 +2075,7 @@ func testPromDiscovery(t *testing.T) {
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2091,7 +2091,7 @@ func testPromDiscovery(t *testing.T) {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Generated Secret could not be retrieved: ", err)
 	}
@@ -2111,7 +2111,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
 
 	s := framework.MakeBasicServiceMonitor("reconcile-test")
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Creating ServiceMonitor failed: %v", err)
 	}
 
@@ -2130,7 +2130,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 			ctx.AddFinalizerFn(finalizerFn)
 		}
 
-		_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+		_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Generated Secret could not be retrieved for %s: %v", prometheusName, err)
 		}
@@ -2141,7 +2141,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 		}
 	}
 
-	if err := framework.MonClientV1.ServiceMonitors(ns).Delete(context.TODO(), "reconcile-test", metav1.DeleteOptions{}); err != nil {
+	if err := framework.MonClientV1.ServiceMonitors(ns).Delete(framework.Ctx, "reconcile-test", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Deleting ServiceMonitor failed: %v", err)
 	}
 
@@ -2168,7 +2168,7 @@ func testShardingProvisioning(t *testing.T) {
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2241,7 +2241,7 @@ func testResharding(t *testing.T) {
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2264,12 +2264,12 @@ func testResharding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2281,13 +2281,13 @@ func testResharding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(time.Second, 1*time.Minute, func() (bool, error) {
-		_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
+		_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
 		}
@@ -2328,11 +2328,11 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 	}
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Creating ServiceMonitor failed: %v", err)
 	}
 
-	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Generated Secret could not be retrieved: %v", err)
 	}
@@ -2372,7 +2372,7 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 
 	ProxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", service.Name, "web", "/metrics", make(map[string]string))
-	_, err := request.DoRaw(context.TODO())
+	_, err := request.DoRaw(framework.Ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2412,7 +2412,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 			},
 		},
 	}
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, sm, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2427,7 +2427,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.TODO(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Generated Secret could not be retrieved: ", err)
 	}
@@ -2464,7 +2464,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 
 	s := framework.MakeBasicServiceMonitor(group)
 
-	if _, err := framework.MonClientV1.ServiceMonitors(serviceMonitorNSName).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(serviceMonitorNSName).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2514,12 +2514,12 @@ func testThanos(t *testing.T) {
 	}
 
 	promSvc := framework.MakePrometheusService(prom.Name, "test-group", v1.ServiceTypeClusterIP)
-	if _, err := framework.KubeClient.CoreV1().Services(ns).Create(context.TODO(), promSvc, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Services(ns).Create(framework.Ctx, promSvc, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	}
 
 	svcMon := framework.MakeBasicServiceMonitor("test-group")
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), svcMon, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, svcMon, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2555,7 +2555,7 @@ func testThanos(t *testing.T) {
 			"query": "prometheus_build_info",
 			"dedup": "false",
 		})
-		b, err := request.DoRaw(context.TODO())
+		b, err := request.DoRaw(framework.Ctx)
 		if err != nil {
 			t.Logf("Error performing request against Thanos query: %v\n\nretrying...", err)
 			return false, nil
@@ -2690,7 +2690,7 @@ func testPromGetAuthSecret(t *testing.T) {
 			}
 
 			authSecret := test.secret
-			if _, err := framework.KubeClient.CoreV1().Secrets(testNamespace).Create(context.TODO(), authSecret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(testNamespace).Create(framework.Ctx, authSecret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -2722,7 +2722,7 @@ func testPromGetAuthSecret(t *testing.T) {
 				ctx.AddFinalizerFn(finalizerFn)
 			}
 
-			if _, err := framework.MonClientV1.ServiceMonitors(testNamespace).Create(context.TODO(), sm, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.ServiceMonitors(testNamespace).Create(framework.Ctx, sm, metav1.CreateOptions{}); err != nil {
 				t.Fatal("Creating ServiceMonitor failed: ", err)
 			}
 
@@ -3082,7 +3082,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), tlsCertsSecret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, tlsCertsSecret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3095,13 +3095,13 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.TODO(), tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(framework.Ctx, tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			s := framework.MakeBasicServiceMonitor(name)
 			s.Spec.Endpoints[0] = test.endpoint
-			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, s, metav1.CreateOptions{}); err != nil {
 				t.Fatal("creating ServiceMonitor failed: ", err)
 			}
 
@@ -3202,7 +3202,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), tlsCertsSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, tlsCertsSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3296,7 +3296,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.TODO(), sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(framework.Ctx, sm, metav1.CreateOptions{}); err != nil {
 		t.Fatal("creating ServiceMonitor failed: ", err)
 	}
 
@@ -3375,7 +3375,7 @@ func testPromStaticProbe(t *testing.T) {
 	targets := []string{svc.Name + ":9090"}
 
 	probe := framework.MakeBasicStaticProbe(group, proberURL, targets)
-	if _, err := framework.MonClientV1.Probes(ns).Create(context.TODO(), probe, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.Probes(ns).Create(framework.Ctx, probe, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating Probe failed: ", err)
 	}
 
@@ -3585,7 +3585,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, secret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3598,7 +3598,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.TODO(), tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(framework.Ctx, tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3643,7 +3643,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 			pm := framework.MakeBasicPodMonitor(name)
 			pm.Spec.PodMetricsEndpoints[0] = test.endpoint
 
-			if _, err := framework.MonClientV1.PodMonitors(ns).Create(context.TODO(), pm, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.PodMonitors(ns).Create(framework.Ctx, pm, metav1.CreateOptions{}); err != nil {
 				t.Fatal("failed to create PodMonitor: ", err)
 			}
 
@@ -3696,7 +3696,7 @@ func testPromWebTLS(t *testing.T) {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	promPods, err := kubeClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+	promPods, err := kubeClient.CoreV1().Pods(ns).List(framework.Ctx, metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3740,7 +3740,7 @@ func testPromWebTLS(t *testing.T) {
 
 func isAlertmanagerDiscoveryWorking(ns, promSVCName, alertmanagerName string) func() (bool, error) {
 	return func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.TODO(), alertmanager.ListOptions(alertmanagerName))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, alertmanager.ListOptions(alertmanagerName))
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -155,19 +154,19 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "thanos-ruler-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(context.TODO(), "thanos-ruler-operated", metav1.GetOptions{})
+				return svcClient.Get(framework.Ctx, "thanos-ruler-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(context.TODO(), asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(framework.Ctx, asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "thanos-ruler stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(context.TODO(), "thanos-ruler-test", metav1.GetOptions{})
+				return ssetClient.Get(framework.Ctx, "thanos-ruler-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(context.TODO(), asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(framework.Ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -122,12 +121,12 @@ func (f *Framework) CreateAlertmanagerAndWaitUntilReady(ns string, a *monitoring
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("making alertmanager config secret %v failed", amConfigSecretName))
 	}
-	_, err = f.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), s, metav1.CreateOptions{})
+	_, err = f.KubeClient.CoreV1().Secrets(ns).Create(f.Ctx, s, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("creating alertmanager config secret %v failed", s.Name))
 	}
 
-	a, err = f.MonClientV1.Alertmanagers(ns).Create(context.TODO(), a, metav1.CreateOptions{})
+	a, err = f.MonClientV1.Alertmanagers(ns).Create(f.Ctx, a, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("creating alertmanager %v failed", a.Name))
 	}
@@ -168,7 +167,7 @@ func (f *Framework) WaitForAlertmanagerReady(ns, name string, replicas int, forc
 }
 
 func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(ns string, a *monitoringv1.Alertmanager) (*monitoringv1.Alertmanager, error) {
-	a, err := f.MonClientV1.Alertmanagers(ns).Update(context.TODO(), a, metav1.UpdateOptions{})
+	a, err := f.MonClientV1.Alertmanagers(ns).Update(f.Ctx, a, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -188,12 +187,12 @@ func (f *Framework) UpdateAlertmanagerAndWaitUntilReady(ns string, a *monitoring
 }
 
 func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(ns, name string) error {
-	_, err := f.MonClientV1.Alertmanagers(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	_, err := f.MonClientV1.Alertmanagers(ns).Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("requesting Alertmanager tpr %v failed", name))
 	}
 
-	if err := f.MonClientV1.Alertmanagers(ns).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+	if err := f.MonClientV1.Alertmanagers(ns).Delete(f.Ctx, name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting Alertmanager tpr %v failed", name))
 	}
 
@@ -207,7 +206,7 @@ func (f *Framework) DeleteAlertmanagerAndWaitUntilGone(ns, name string) error {
 		return errors.Wrap(err, fmt.Sprintf("waiting for Alertmanager tpr (%s) to vanish timed out", name))
 	}
 
-	return f.KubeClient.CoreV1().Secrets(ns).Delete(context.TODO(), fmt.Sprintf("alertmanager-%s", name), metav1.DeleteOptions{})
+	return f.KubeClient.CoreV1().Secrets(ns).Delete(f.Ctx, fmt.Sprintf("alertmanager-%s", name), metav1.DeleteOptions{})
 }
 
 func (f *Framework) WaitForAlertmanagerInitialized(ns, name string, amountPeers int, forceEnableClusterMode bool) error {
@@ -258,7 +257,7 @@ func (f *Framework) WaitForAlertmanagerInitialized(ns, name string, amountPeers 
 func (f *Framework) GetAlertmanagerStatus(ns, n string) (models.AlertmanagerStatus, error) {
 	var amStatus models.AlertmanagerStatus
 	request := ProxyGetPod(f.KubeClient, ns, n, "/api/v2/status")
-	resp, err := request.DoRaw(context.TODO())
+	resp, err := request.DoRaw(f.Ctx)
 
 	if err != nil {
 		return amStatus, err
@@ -272,7 +271,7 @@ func (f *Framework) GetAlertmanagerStatus(ns, n string) (models.AlertmanagerStat
 
 func (f *Framework) GetAlertmanagerMetrics(ns, n string) (textparse.Parser, error) {
 	request := ProxyGetPod(f.KubeClient, ns, n, "/metrics")
-	resp, err := request.DoRaw(context.TODO())
+	resp, err := request.DoRaw(f.Ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +286,7 @@ func (f *Framework) CreateSilence(ns, n string) (string, error) {
 		"/api/v2/silences",
 		`{"createdBy":"Max Mustermann","comment":"1234","startsAt":"2030-04-09T09:16:15.114Z","endsAt":"2031-04-09T11:16:15.114Z","matchers":[{"name":"test","value":"123","isRegex":false}]}`,
 	)
-	resp, err := request.DoRaw(context.TODO())
+	resp, err := request.DoRaw(f.Ctx)
 	if err != nil {
 		return "", err
 	}
@@ -316,7 +315,7 @@ func (f *Framework) SendAlertToAlertmanager(ns, n string) error {
 	}
 
 	request := ProxyPostPod(f.KubeClient, ns, n, "api/v2/alerts", string(b))
-	_, err = request.DoRaw(context.TODO())
+	_, err = request.DoRaw(f.Ctx)
 	if err != nil {
 		return err
 	}
@@ -327,7 +326,7 @@ func (f *Framework) GetSilences(ns, n string) (models.GettableSilences, error) {
 	var getSilencesResponse models.GettableSilences
 
 	request := ProxyGetPod(f.KubeClient, ns, n, "/api/v2/silences")
-	resp, err := request.DoRaw(context.TODO())
+	resp, err := request.DoRaw(f.Ctx)
 	if err != nil {
 		return getSilencesResponse, err
 	}

--- a/test/framework/config_map.go
+++ b/test/framework/config_map.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -58,7 +57,7 @@ func (f *Framework) WaitForConfigMapExist(ns, name string) (*v1.ConfigMap, error
 			KubeClient.
 			CoreV1().
 			ConfigMaps(ns).
-			Get(context.TODO(), name, metav1.GetOptions{})
+			Get(f.Ctx, name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
 			return false, nil
@@ -79,7 +78,7 @@ func (f *Framework) WaitForConfigMapNotExist(ns, name string) error {
 			KubeClient.
 			CoreV1().
 			ConfigMaps(ns).
-			Get(context.TODO(), name, metav1.GetOptions{})
+			Get(f.Ctx, name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
 			return true, nil

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -44,7 +44,7 @@ func (f *Framework) NewTestCtx(t *testing.T) TestCtx {
 
 	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 36)
 	return TestCtx{
-		ID: id,
+		ID:  id,
 	}
 }
 

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -33,7 +32,7 @@ import (
 
 // GetCRD gets a custom resource definition from the apiserver.
 func (f *Framework) GetCRD(name string) (*v1.CustomResourceDefinition, error) {
-	crd, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
+	crd, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get CRD with name %v", name)
 	}
@@ -42,7 +41,7 @@ func (f *Framework) GetCRD(name string) (*v1.CustomResourceDefinition, error) {
 
 // ListCRDs gets a list of custom resource definitions from the apiserver.
 func (f *Framework) ListCRDs() (*v1.CustomResourceDefinitionList, error) {
-	crds, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+	crds, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().List(f.Ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list CRDs")
 	}
@@ -51,13 +50,13 @@ func (f *Framework) ListCRDs() (*v1.CustomResourceDefinitionList, error) {
 
 // CreateCRD creates a custom resource definition on the apiserver.
 func (f *Framework) CreateCRD(crd *v1.CustomResourceDefinition) error {
-	_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(f.Ctx, crd.Name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "getting CRD: %s", crd.Spec.Names.Kind)
 	}
 
 	if apierrors.IsNotFound(err) {
-		_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+		_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(f.Ctx, crd, metav1.CreateOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "create CRD: %s", crd.Spec.Names.Kind)
 		}

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ import (
 
 // PrintEvents prints the Kubernetes events to standard out.
 func (f *Framework) PrintEvents() error {
-	events, err := f.KubeClient.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})
+	events, err := f.KubeClient.CoreV1().Events("").List(f.Ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -58,6 +58,7 @@ type Framework struct {
 	MasterHost        string
 	DefaultTimeout    time.Duration
 	RestConfig        *rest.Config
+	Ctx               context.Context
 }
 
 // New setups a test framework and returns it.
@@ -101,6 +102,7 @@ func New(kubeconfig, opImage string) (*Framework, error) {
 		APIServerClient:   apiCli,
 		HTTPClient:        httpc,
 		DefaultTimeout:    time.Minute,
+		Ctx:               context.Background(),
 	}
 
 	return f, nil
@@ -224,56 +226,56 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.AlertmanagerName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.Alertmanagers(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.Alertmanagers(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize Alertmanager CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.PodMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.PodMonitors(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.PodMonitors(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize PodMonitor CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.ProbeName, func(opts metav1.ListOptions) (object runtime.Object, err error) {
-		return f.MonClientV1.Probes(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.Probes(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize Probe CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.PrometheusName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.Prometheuses(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.Prometheuses(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize Prometheus CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.PrometheusRuleName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.PrometheusRules(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.PrometheusRules(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize PrometheusRule CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.ServiceMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.ServiceMonitors(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.ServiceMonitors(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize ServiceMonitor CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1.ThanosRulerName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.ThanosRulers(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1.ThanosRulers(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize ThanosRuler CRD")
 	}
 
 	err = f.CreateCRDAndWaitUntilReady(monitoringv1alpha1.AlertmanagerConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1alpha1.AlertmanagerConfigs(v1.NamespaceAll).List(context.TODO(), opts)
+		return f.MonClientV1alpha1.AlertmanagerConfigs(v1.NamespaceAll).List(f.Ctx, opts)
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize AlertmanagerConfig CRD")

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"k8s.io/client-go/tools/portforward"
@@ -36,14 +35,14 @@ import (
 
 // PrintPodLogs prints the logs of a specified Pod
 func (f *Framework) PrintPodLogs(ns, p string) error {
-	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(context.TODO(), p, metav1.GetOptions{})
+	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(f.Ctx, p, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to print logs of pod '%v': failed to get pod", p)
 	}
 
 	for _, c := range pod.Spec.Containers {
 		req := f.KubeClient.CoreV1().Pods(ns).GetLogs(p, &v1.PodLogOptions{Container: c.Name})
-		resp, err := req.DoRaw(context.TODO())
+		resp, err := req.DoRaw(f.Ctx)
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve logs of pod '%v'", p)
 		}
@@ -58,7 +57,7 @@ func (f *Framework) PrintPodLogs(ns, p string) error {
 // GetPodRestartCount returns a map of container names and their restart counts for
 // a given pod.
 func (f *Framework) GetPodRestartCount(ns, podName string) (map[string]int32, error) {
-	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(f.Ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrieve pod to get restart count")
 	}

--- a/test/framework/probe.go
+++ b/test/framework/probe.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -67,8 +66,7 @@ func (f *Framework) createBlackBoxExporterConfigMapAndWaitExists(ns, name string
 `,
 		},
 	}
-	ctx := context.TODO()
-	if _, err := f.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+	if _, err := f.KubeClient.CoreV1().ConfigMaps(ns).Create(f.Ctx, cm, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
@@ -135,14 +133,13 @@ func (f *Framework) createBlackBoxExporterDeploymentAndWaitReady(ns, name string
 			},
 		},
 	}
-	ctx := context.TODO()
 	deploymentInterface := f.KubeClient.AppsV1().Deployments(ns)
-	if _, err := deploymentInterface.Create(ctx, deploy, metav1.CreateOptions{}); err != nil {
+	if _, err := deploymentInterface.Create(f.Ctx, deploy, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
 	return wait.Poll(2*time.Second, f.DefaultTimeout, func() (bool, error) {
-		blackbox, err := deploymentInterface.Get(ctx, name, metav1.GetOptions{})
+		blackbox, err := deploymentInterface.Get(f.Ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -270,7 +269,7 @@ func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
 }
 
 func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
-	result, err := f.MonClientV1.Prometheuses(ns).Create(context.TODO(), p, metav1.CreateOptions{})
+	result, err := f.MonClientV1.Prometheuses(ns).Create(f.Ctx, p, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -283,7 +282,7 @@ func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *monitoringv1
 }
 
 func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
-	result, err := f.MonClientV1.Prometheuses(ns).Update(context.TODO(), p, metav1.UpdateOptions{})
+	result, err := f.MonClientV1.Prometheuses(ns).Update(f.Ctx, p, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +297,7 @@ func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout t
 	var pollErr error
 
 	err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
-		st, _, pollErr := prometheus.Status(context.Background(), f.KubeClient, p)
+		st, _, pollErr := prometheus.Status(f.Ctx, f.KubeClient, p)
 
 		if pollErr != nil {
 			return false, nil
@@ -319,12 +318,12 @@ func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout t
 }
 
 func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
-	_, err := f.MonClientV1.Prometheuses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	_, err := f.MonClientV1.Prometheuses(ns).Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus custom resource %v failed", name))
 	}
 
-	if err := f.MonClientV1.Prometheuses(ns).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+	if err := f.MonClientV1.Prometheuses(ns).Delete(f.Ctx, name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus custom resource %v failed", name))
 	}
 
@@ -412,7 +411,7 @@ func (f *Framework) WaitForDiscoveryWorking(ns, svcName, prometheusName string) 
 	var loopErr error
 
 	err := wait.Poll(time.Second, 5*f.DefaultTimeout, func() (bool, error) {
-		pods, loopErr := f.KubeClient.CoreV1().Pods(ns).List(context.TODO(), prometheus.ListOptions(prometheusName))
+		pods, loopErr := f.KubeClient.CoreV1().Pods(ns).List(f.Ctx, prometheus.ListOptions(prometheusName))
 		if loopErr != nil {
 			return false, loopErr
 		}
@@ -491,7 +490,7 @@ func assertExpectedTargets(targets []*Target, expectedTargets []string) error {
 func (f *Framework) PrometheusSVCGetRequest(ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
 	ProxyGet := f.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", svcName, "web", endpoint, query)
-	return request.DoRaw(context.TODO())
+	return request.DoRaw(f.Ctx)
 }
 
 func (f *Framework) GetActiveTargets(ns, svcName string) ([]*Target, error) {

--- a/test/framework/prometheus_rule.go
+++ b/test/framework/prometheus_rule.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -42,7 +41,7 @@ func (f *Framework) MakeBasicRule(ns, name string, groups []monitoringv1.RuleGro
 }
 
 func (f *Framework) CreateRule(ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Create(context.TODO(), ar, metav1.CreateOptions{})
+	result, err := f.MonClientV1.PrometheusRules(ns).Create(f.Ctx, ar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("creating %v RuleFile failed: %v", ar.Name, err)
 	}
@@ -51,7 +50,7 @@ func (f *Framework) CreateRule(ns string, ar *monitoringv1.PrometheusRule) (*mon
 }
 
 func (f *Framework) GetRule(ns, name string) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	result, err := f.MonClientV1.PrometheusRules(ns).Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting %v Rule failed: %v", name, err)
 	}
@@ -107,7 +106,7 @@ func (f *Framework) MakeAndCreateInvalidRule(ns, name, alertName string) (*monit
 // namespace.
 func (f *Framework) WaitForRule(ns, name string) error {
 	return wait.Poll(time.Second, f.DefaultTimeout, func() (bool, error) {
-		_, err := f.MonClientV1.PrometheusRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		_, err := f.MonClientV1.PrometheusRules(ns).Get(f.Ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		} else if err != nil {
@@ -118,7 +117,7 @@ func (f *Framework) WaitForRule(ns, name string) error {
 }
 
 func (f *Framework) UpdateRule(ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Update(context.TODO(), ar, metav1.UpdateOptions{})
+	result, err := f.MonClientV1.PrometheusRules(ns).Update(f.Ctx, ar, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("updating %v RuleFile failed: %v", ar.Name, err)
 	}
@@ -127,7 +126,7 @@ func (f *Framework) UpdateRule(ns string, ar *monitoringv1.PrometheusRule) (*mon
 }
 
 func (f *Framework) DeleteRule(ns string, r string) error {
-	err := f.MonClientV1.PrometheusRules(ns).Delete(context.TODO(), r, metav1.DeleteOptions{})
+	err := f.MonClientV1.PrometheusRules(ns).Delete(f.Ctx, r, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("deleting %v Prometheus rule in namespace %v failed: %v", r, ns, err.Error())
 	}

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -45,7 +45,7 @@ func (f *Framework) MakeBasicThanosRuler(name string, replicas int32, queryEndpo
 }
 
 func (f *Framework) CreateThanosRulerAndWaitUntilReady(ns string, tr *monitoringv1.ThanosRuler) (*monitoringv1.ThanosRuler, error) {
-	result, err := f.MonClientV1.ThanosRulers(ns).Create(context.TODO(), tr, metav1.CreateOptions{})
+	result, err := f.MonClientV1.ThanosRulers(ns).Create(f.Ctx, tr, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("creating %v ThanosRuler instances failed (%v): %v", tr.Spec.Replicas, tr.Name, err)
 	}
@@ -58,7 +58,7 @@ func (f *Framework) CreateThanosRulerAndWaitUntilReady(ns string, tr *monitoring
 }
 
 func (f *Framework) UpdateThanosRulerAndWaitUntilReady(ns string, tr *monitoringv1.ThanosRuler) (*monitoringv1.ThanosRuler, error) {
-	result, err := f.MonClientV1.ThanosRulers(ns).Update(context.TODO(), tr, metav1.UpdateOptions{})
+	result, err := f.MonClientV1.ThanosRulers(ns).Update(f.Ctx, tr, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -164,16 +164,16 @@ func (f *Framework) CheckThanosFiringAlert(ns, svcName, alertName string) (bool,
 func (f *Framework) ThanosSVCGetRequest(ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
 	ProxyGet := f.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", svcName, "web", endpoint, query)
-	return request.DoRaw(context.TODO())
+	return request.DoRaw(f.Ctx)
 }
 
 func (f *Framework) DeleteThanosRulerAndWaitUntilGone(ns, name string) error {
-	_, err := f.MonClientV1.ThanosRulers(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	_, err := f.MonClientV1.ThanosRulers(ns).Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("requesting ThanosRuler custom resource %v failed", name))
 	}
 
-	if err := f.MonClientV1.ThanosRulers(ns).Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+	if err := f.MonClientV1.ThanosRulers(ns).Delete(f.Ctx, name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting ThanosRuler custom resource %v failed", name))
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->






<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
This PR removes context.TODO() from most of the function calls. We still have some more to remove which needs to check further. Since the Go tests have no context wrapping them added a context.Context field to the [Framework](https://github.com/prometheus-operator/prometheus-operator/blob/2b93704fc1d1d5dbc4e7aa98c2a1425a48bbca42/test/framework/framework.go#L52-L61) struct, initialised it to context.Background() and propagated it to tests.

Remaining files which has context.TODO()

```
▒▓    ~/gi/s/prometheus-operator  on   remove_context_todo ⇣1⇡1  find . -name "*go" | xargs grep -l context.TODO       ✔  2.7.17   1.16.4   2.7.3   at admin/openshift-monitoring ⎈  at 18:50:34  ▓▒░
./test/framework/deployment.go
./test/framework/service.go
./test/framework/role-binding.go
./test/framework/cluster_role.go
./test/framework/service_account.go
./test/framework/ingress.go
./test/framework/admission-webhooks.go
./test/framework/cluster_role_binding.go
./test/framework/secret.go
./test/framework/helpers.go
./test/framework/namespace.go
./test/framework/replication-controller.go
./pkg/alertmanager/amcfg_test.go
./pkg/k8sutil/k8sutil_test.go
./pkg/client/informers/externalversions/monitoring/v1/podmonitor.go
./pkg/client/informers/externalversions/monitoring/v1/prometheusrule.go
./pkg/client/informers/externalversions/monitoring/v1/servicemonitor.go
./pkg/client/informers/externalversions/monitoring/v1/alertmanager.go
./pkg/client/informers/externalversions/monitoring/v1/probe.go
./pkg/client/informers/externalversions/monitoring/v1/prometheus.go
./pkg/client/informers/externalversions/monitoring/v1/thanosruler.go
./pkg/client/informers/externalversions/monitoring/v1alpha1/alertmanagerconfig.go

░▒▓    ~/gi/s/prometheus-operator  on   remove_context_todo ⇣1⇡1   
```

Related to https://github.com/prometheus-operator/prometheus-operator/issues/3158

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

**Release Note Template (will be copied)**

```release-note:REPLACEME
Removes context.TODO() from most of the files
```
