### PR TITLE
Issue #3104: Automatically Generate Document for Operator Executable

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -1,0 +1,59 @@
+main
+---
+title: "Operator CLI Flags"
+description: "Lists of possible arguments passed to operator executable."
+date: 2021-06-18T14:12:33-00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "operator"
+weight: 1000
+toc: false
+---
+
+Operator CLI Flags
+=================
+This article lists arguments of operator executable.
+> Note this document is automatically generated from the `cmd/operator/main.go` file and shouldn't be edited directly.
+
+| Argument | Description | Default Value |
+| -------- | ----------- | ------------- |
+| web.listen-address | Address on which to expose metrics and web interface. | :8080 |
+| web.enable-tls | Activate prometheus operator web server TLS.   This is useful for example when using the rule validation webhook. | false |
+| web.cert-file | Cert file to be used for operator web server endpoints. | /etc/tls/private/tls.crt |
+| web.key-file | Private key matching the cert file to be used for operator web server endpoints. | /etc/tls/private/tls.key |
+| web.client-ca-file | Client CA certificate file to be used for operator web server endpoints. | /etc/tls/private/tls-ca.crt |
+| web.tls-reload-interval | The interval at which to watch for TLS certificate changes, by default set to 1 minute. (default 1m0s). | Minute |
+| web.tls-min-version | Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. | VersionTLS13 |
+| web.tls-cipher-suites | Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).If omitted, the default Go cipher suites will be used.Note that TLS 1.3 ciphersuites are not configurable. | "" |
+| apiserver | API Server addr, e.g. ' - NOT RECOMMENDED FOR PRODUCTION - http://127.0.0.1:8080'. Omit parameter to run in on-cluster mode and utilize the service account token. | "" |
+| cert-file |  - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file. | "" |
+| key-file | - NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file. | "" |
+| ca-file | - NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file. | "" |
+| kubelet-service | Service/Endpoints object to write kubelets into in format \"namespace/name\" | "" |
+| tls-insecure | - NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate. | false |
+| prometheus-config-reloader | Prometheus config reloader image | "" |
+| config-reloader-cpu | Config Reloader CPU request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0. | 100m |
+| config-reloader-cpu-request | Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request | "" |
+| config-reloader-cpu-limit | Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit | "" |
+| config-reloader-memory | Config Reloader Memory request & limit. Value \"0\" disables it and causes no request/limit to be configured. Deprecated, it will be removed in v0.49.0. | 50Mi |
+| config-reloader-memory-request | Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request | "" |
+| config-reloader-memory-limit | Config Reloader Memory limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-memory` for the memory limit | "" |
+| alertmanager-default-base-image | Alertmanager default base image (path without tag/version) | "" |
+| prometheus-default-base-image | Prometheus default base image (path without tag/version) | "" |
+| thanos-default-base-image | Thanos default base image (path without tag/version) | "" |
+| namespaces | Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with --deny-namespaces. | N/A |
+| deny-namespaces | Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces. | N/A |
+| prometheus-instance-namespaces | Namespaces where Prometheus custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources. | N/A |
+| alertmanager-instance-namespaces | Namespaces where Alertmanager custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Alertmanager custom resources. | N/A |
+| thanos-ruler-instance-namespaces | Namespaces where ThanosRuler custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for ThanosRuler custom resources. | N/A |
+| labels | Labels to be add to all resources created by the operator | N/A |
+| localhost | EXPERIMENTAL (could be removed in future releases) - Host used to communicate between local services on a pod. Fixes issues where localhost resolves incorrectly. | localhost |
+| cluster-domain | The domain of the cluster. This is used to generate service FQDNs. If this is not specified, DNS search domain expansion is used instead. | "" |
+| log-level |  | info |
+| log-format |  | logfmt |
+| prometheus-instance-selector | Label selector to filter Prometheus Custom Resources to watch. | "" |
+| alertmanager-instance-selector | Label selector to filter AlertManager Custom Resources to watch. | "" |
+| thanos-ruler-instance-selector | Label selector to filter ThanosRuler Custom Resources to watch. | "" |
+| secret-field-selector | Field selector to filter Secrets to watch | "" |

--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,11 @@ $(RBAC_MANIFESTS): scripts/generate/vendor VERSION $(shell find jsonnet -type f)
 example/thanos/thanos.yaml: scripts/generate/vendor scripts/generate/thanos.jsonnet $(shell find jsonnet -type f)
 	scripts/generate/build-thanos-example.sh
 
-FULLY_GENERATED_DOCS = Documentation/api.md Documentation/compatibility.md
+FULLY_GENERATED_DOCS = Documentation/api.md Documentation/compatibility.md Documentation/operator.md
 TO_BE_EXTENDED_DOCS = $(filter-out $(FULLY_GENERATED_DOCS), $(shell find Documentation -type f))
+
+Documentation/operator.md: $(PO_DOCGEN_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET)
+	$(PO_DOCGEN_BINARY) operator cmd/operator/main.go > $@
 
 Documentation/api.md: $(PO_DOCGEN_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET)
 	$(PO_DOCGEN_BINARY) api $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET) > $@

--- a/cmd/po-docgen/main.go
+++ b/cmd/po-docgen/main.go
@@ -32,5 +32,7 @@ func main() {
 		printAPIDocs(os.Args[2:])
 	case "compatibility":
 		printCompatMatrixDocs()
+	case "operator":
+		printOperatorDocs(os.Args[2:])
 	}
 }

--- a/cmd/po-docgen/operator.go
+++ b/cmd/po-docgen/operator.go
@@ -1,0 +1,260 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+type FlagDoc struct {
+	name         string
+	defaultValue string
+	description  string
+}
+
+func fileToASTPackage(filePaths []string) *ast.Package {
+	fset := token.NewFileSet()
+	m := make(map[string]*ast.File)
+
+	for _, filePath := range filePaths {
+
+		f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+
+		m[filePath] = f
+	}
+	apkg, _ := ast.NewPackage(fset, m, nil, nil)
+
+	return apkg
+}
+
+func unquoteLiteral(value string) string {
+	if len(value) > 0 && value[0] == '"' {
+		value = value[1:]
+	}
+
+	if len(value) > 0 && value[len(value)-1] == '"' {
+		value = value[:len(value)-1]
+	}
+	return value
+}
+
+func resolveDurationExpr(expr ast.Expr) (string, error) {
+	var exprIdent *ast.Ident
+
+	switch exprCast := expr.(type) {
+	case *ast.SelectorExpr:
+		exprIdent = exprCast.Sel
+	case *ast.Ident:
+		exprIdent = exprCast
+	default:
+		return "", errors.New("No Identifier to Resolve")
+	}
+
+	if exprIdent.Obj == nil {
+		return exprIdent.String(), nil
+	}
+
+	retValue := ""
+
+	if exprIdent.Obj.Kind == ast.Con {
+		valSpec := exprIdent.Obj.Decl.(*ast.ValueSpec)
+		for _, value := range valSpec.Values {
+			retValue += unquoteLiteral(value.(*ast.BasicLit).Value)
+		}
+	}
+	return retValue, nil
+
+}
+
+func resolveBoolExpr(expr ast.Expr) (string, error) {
+	exprIdent, ok := expr.(*ast.Ident)
+	if ok {
+		return exprIdent.Name, nil
+	}
+
+	return "", errors.New("No Identifier to Resolve")
+}
+
+func resolveConstStringExpr(expr ast.Expr) (string, error) {
+
+	switch exprCast := expr.(type) {
+	case *ast.BasicLit:
+		return unquoteLiteral(exprCast.Value), nil
+	case *ast.Ident:
+		retValue := ""
+		if exprCast.Obj.Kind == ast.Con {
+			valSpec := exprCast.Obj.Decl.(*ast.ValueSpec)
+			for _, value := range valSpec.Values {
+				retValue += unquoteLiteral(value.(*ast.BasicLit).Value)
+			}
+		}
+		return retValue, nil
+	case *ast.BinaryExpr:
+		operandX, err := resolveConstStringExpr(exprCast.X)
+		if err != nil {
+			return "", err
+		}
+		operandY, err := resolveConstStringExpr(exprCast.Y)
+		if err != nil {
+			return "", err
+		}
+		if exprCast.Op == token.ADD {
+			return operandX + operandY, nil
+		}
+		return "", errors.New(fmt.Sprint("unhandled OP", exprCast.Op))
+
+	}
+
+	return "", nil
+}
+
+func operatorCodeToDoc(paths []string) ([]FlagDoc, error) {
+	astPkg := fileToASTPackage(paths)
+	flagDocs := make([]FlagDoc, 0)
+
+	for _, file := range astPkg.Files {
+		fmt.Println(file.Name.Name)
+		for _, decl := range file.Decls {
+			funcdecl, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+
+			if funcdecl.Name.Name == "init" {
+				for _, statement := range funcdecl.Body.List {
+					exprStatement, ok := statement.(*ast.ExprStmt)
+					if !ok {
+						continue
+					}
+					exprCall, ok := exprStatement.X.(*ast.CallExpr)
+					if !ok {
+						continue
+					}
+
+					if exprCall.Fun.(*ast.SelectorExpr).X.(*ast.Ident).Name == "flagset" {
+						selectorExpr, ok := exprCall.Fun.(*ast.SelectorExpr)
+						if !ok {
+							continue
+						}
+
+						var argName, argDefaultValue, argDescription string
+						var err error
+						switch selectorExpr.Sel.Name {
+						case "StringVar":
+							argName = unquoteLiteral(exprCall.Args[1].(*ast.BasicLit).Value)
+							argDefaultValue, err = resolveConstStringExpr(exprCall.Args[2])
+							if err != nil {
+								return flagDocs, err
+							}
+							if len(argDefaultValue) == 0 {
+								argDefaultValue = "\"\""
+							}
+							argDescription, err = resolveConstStringExpr(exprCall.Args[3])
+							if err != nil {
+								return flagDocs, err
+							}
+						case "Var":
+							argName = unquoteLiteral(exprCall.Args[1].(*ast.BasicLit).Value)
+							argDefaultValue = "N/A"
+							argDescription, err = resolveConstStringExpr(exprCall.Args[2])
+							if err != nil {
+								return flagDocs, err
+							}
+						case "DurationVar":
+							argName = unquoteLiteral(exprCall.Args[1].(*ast.BasicLit).Value)
+							argDefaultValue, err = resolveDurationExpr(exprCall.Args[2])
+							if err != nil {
+								return flagDocs, err
+							}
+							argDescription, err = resolveConstStringExpr(exprCall.Args[3])
+							if err != nil {
+								return flagDocs, err
+							}
+						case "BoolVar":
+							argName = unquoteLiteral(exprCall.Args[1].(*ast.BasicLit).Value)
+							argDefaultValue, err = resolveBoolExpr(exprCall.Args[2])
+							if err != nil {
+								return flagDocs, err
+							}
+							argDescription, err = resolveConstStringExpr(exprCall.Args[3])
+							if err != nil {
+								return flagDocs, err
+							}
+						default:
+							return flagDocs, errors.New(fmt.Sprint("Unhandled argument type ", selectorExpr.Sel.Name))
+						}
+
+						flagdoc := FlagDoc{
+							name:         argName,
+							defaultValue: argDefaultValue,
+							description:  argDescription,
+						}
+
+						flagDocs = append(flagDocs, flagdoc)
+
+					}
+
+				}
+			}
+
+		}
+	}
+	return flagDocs, nil
+
+}
+
+func printOperatorDocs(paths []string) {
+
+	flagdocs, err := operatorCodeToDoc(paths)
+	if err != nil {
+		fmt.Print("Error when generating documents! ", err)
+		return
+	}
+
+	fmt.Print(`---
+title: "Operator CLI Flags"
+description: "Lists of possible arguments passed to operator executable."
+date: 2021-06-18T14:12:33-00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "operator"
+weight: 1000
+toc: false
+---
+
+`)
+	fmt.Println("Operator CLI Flags")
+	fmt.Println("=================")
+	fmt.Println("This article lists arguments of operator executable.")
+	fmt.Println("> Note this document is automatically generated from the `cmd/operator/main.go` file and shouldn't be edited directly.")
+	fmt.Println("")
+	fmt.Println("| Argument | Description | Default Value |")
+	fmt.Println("| -------- | ----------- | ------------- |")
+
+	for _, flagdoc := range flagdocs {
+		fmt.Printf("| %s | %s | %s |\n",
+			flagdoc.name, flagdoc.description, flagdoc.defaultValue)
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

po-docgen and Makefile are updated to automatically generate Document/operator.md from cmd/operator/main.go, by parsing the definition of flagset in the init() function.

There is a limitation that constants imported from other packages are not resolved into its final literal value, runtime string contatenation using fmt.Sprintf is not evaluated by the doc generator. However, constants in the same file is resolved and constant expressions such as string concatenation is evaluated.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:enhancement
Automatically Generate Document for Operator Executable.
```
