### PR TITLE
Remove context.TODO() from client_go function calls

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -39,6 +39,7 @@ func TestGenerateConfig(t *testing.T) {
 		baseConfig alertmanagerConfig
 		amConfigs  map[string]*monitoringv1alpha1.AlertmanagerConfig
 		expected   string
+		ctx        context.Context
 	}
 
 	globalSlackAPIURL, err := url.Parse("http://slack.example.com")
@@ -61,6 +62,7 @@ receivers:
 - name: "null"
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global send_revolved, no CRs",
@@ -81,6 +83,7 @@ receivers:
 - name: "null"
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to false, no CRs",
@@ -101,6 +104,7 @@ receivers:
 - name: "null"
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to true, no CRs",
@@ -121,6 +125,7 @@ receivers:
 - name: "null"
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "base with sub route, no CRs",
@@ -147,6 +152,7 @@ receivers:
 - name: custom
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -181,6 +187,7 @@ receivers:
 - name: mynamespace-myamc-test
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only",
@@ -231,6 +238,7 @@ receivers:
 - name: "null"
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "base with subroute, simple CR",
@@ -269,6 +277,7 @@ receivers:
 - name: mynamespace-myamc-test
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name: "CR with Pagerduty Receiver",
@@ -327,6 +336,7 @@ receivers:
   - routing_key: 1234abc
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name:    "CR with Webhook Receiver",
@@ -372,6 +382,7 @@ receivers:
   - url: http://test.url
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name: "CR with Opsgenie Receiver",
@@ -430,6 +441,7 @@ receivers:
   - api_key: 1234abc
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name: "CR with Opsgenie Team Responder",
@@ -495,6 +507,7 @@ receivers:
       type: team
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 			name: "CR with WeChat Receiver",
@@ -555,6 +568,7 @@ receivers:
     corp_id: wechatcorpid
 templates: []
 `,
+			ctx: context.Background(),
 		},
 		{
 
@@ -627,6 +641,7 @@ receivers:
         text: text
 templates: []
 `,
+			ctx: context.Background(),
 		},
 	}
 
@@ -634,7 +649,7 @@ templates: []
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewStore(tc.kclient.CoreV1(), tc.kclient.CoreV1())
 			cg := newConfigGenerator(nil, store)
-			cfgBytes, err := cg.generateConfig(context.TODO(), tc.baseConfig, tc.amConfigs)
+			cfgBytes, err := cg.generateConfig(tc.ctx, tc.baseConfig, tc.amConfigs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -39,9 +39,9 @@ func TestGenerateConfig(t *testing.T) {
 		baseConfig alertmanagerConfig
 		amConfigs  map[string]*monitoringv1alpha1.AlertmanagerConfig
 		expected   string
-		ctx        context.Context
 	}
 
+	ctx := context.Background()
 	globalSlackAPIURL, err := url.Parse("http://slack.example.com")
 	if err != nil {
 		t.Fatal("Could not parse slack API URL")
@@ -62,7 +62,6 @@ receivers:
 - name: "null"
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global send_revolved, no CRs",
@@ -83,7 +82,6 @@ receivers:
 - name: "null"
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to false, no CRs",
@@ -104,7 +102,6 @@ receivers:
 - name: "null"
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to true, no CRs",
@@ -125,7 +122,6 @@ receivers:
 - name: "null"
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "base with sub route, no CRs",
@@ -152,7 +148,6 @@ receivers:
 - name: custom
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -187,7 +182,6 @@ receivers:
 - name: mynamespace-myamc-test
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only",
@@ -238,7 +232,6 @@ receivers:
 - name: "null"
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "base with subroute, simple CR",
@@ -277,7 +270,6 @@ receivers:
 - name: mynamespace-myamc-test
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name: "CR with Pagerduty Receiver",
@@ -336,7 +328,6 @@ receivers:
   - routing_key: 1234abc
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name:    "CR with Webhook Receiver",
@@ -382,7 +373,6 @@ receivers:
   - url: http://test.url
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name: "CR with Opsgenie Receiver",
@@ -441,7 +431,6 @@ receivers:
   - api_key: 1234abc
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name: "CR with Opsgenie Team Responder",
@@ -507,7 +496,6 @@ receivers:
       type: team
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 			name: "CR with WeChat Receiver",
@@ -568,7 +556,6 @@ receivers:
     corp_id: wechatcorpid
 templates: []
 `,
-			ctx: context.Background(),
 		},
 		{
 
@@ -641,7 +628,6 @@ receivers:
         text: text
 templates: []
 `,
-			ctx: context.Background(),
 		},
 	}
 
@@ -649,7 +635,7 @@ templates: []
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewStore(tc.kclient.CoreV1(), tc.kclient.CoreV1())
 			cg := newConfigGenerator(nil, store)
-			cfgBytes, err := cg.generateConfig(tc.ctx, tc.baseConfig, tc.amConfigs)
+			cfgBytes, err := cg.generateConfig(ctx, tc.baseConfig, tc.amConfigs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -71,6 +71,7 @@ func Test_SanitizeVolumeName(t *testing.T) {
 func TestMergeMetadata(t *testing.T) {
 	testCases := []struct {
 		name                string
+		ctx                 context.Context
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
 		modifiedLabels      map[string]string
@@ -84,6 +85,7 @@ func TestMergeMetadata(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"app.kubernetes.io/name": "kube-state-metrics",
 			},
+			ctx: context.Background(),
 		},
 		{
 			name: "added label and annotation",
@@ -101,6 +103,7 @@ func TestMergeMetadata(t *testing.T) {
 			modifiedAnnotations: map[string]string{
 				"annotation": "value",
 			},
+			ctx: context.Background(),
 		},
 		{
 			name: "overridden label amd annotation",
@@ -116,6 +119,7 @@ func TestMergeMetadata(t *testing.T) {
 			modifiedAnnotations: map[string]string{
 				"app.kubernetes.io/name": "overridden-value",
 			},
+			ctx: context.Background(),
 		},
 	}
 
@@ -144,17 +148,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSvc.Annotations[a] = v
 				}
-				_, err := svcClient.Update(context.TODO(), modifiedSvc, metav1.UpdateOptions{})
+				_, err := svcClient.Update(tc.ctx, modifiedSvc, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateService(context.TODO(), svcClient, service)
+				err = CreateOrUpdateService(tc.ctx, svcClient, service)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSvc, err := svcClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				updatedSvc, err := svcClient.Get(tc.ctx, "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -190,17 +194,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedEndpoints.Annotations[a] = v
 				}
-				_, err := endpointsClient.Update(context.TODO(), modifiedEndpoints, metav1.UpdateOptions{})
+				_, err := endpointsClient.Update(tc.ctx, modifiedEndpoints, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateEndpoints(context.TODO(), endpointsClient, endpoints)
+				err = CreateOrUpdateEndpoints(tc.ctx, endpointsClient, endpoints)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedEndpoints, err := endpointsClient.Get(context.TODO(), "prometheus-operated", metav1.GetOptions{})
+				updatedEndpoints, err := endpointsClient.Get(tc.ctx, "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -236,17 +240,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSset.Annotations[a] = v
 				}
-				_, err := ssetClient.Update(context.TODO(), modifiedSset, metav1.UpdateOptions{})
+				_, err := ssetClient.Update(tc.ctx, modifiedSset, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = UpdateStatefulSet(context.TODO(), ssetClient, sset)
+				err = UpdateStatefulSet(tc.ctx, ssetClient, sset)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSset, err := ssetClient.Get(context.TODO(), "prometheus", metav1.GetOptions{})
+				updatedSset, err := ssetClient.Get(tc.ctx, "prometheus", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -282,17 +286,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSecret.Annotations[a] = v
 				}
-				_, err := sClient.Update(context.TODO(), modifiedSecret, metav1.UpdateOptions{})
+				_, err := sClient.Update(tc.ctx, modifiedSecret, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateSecret(context.TODO(), sClient, secret)
+				err = CreateOrUpdateSecret(tc.ctx, sClient, secret)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSecret, err := sClient.Get(context.TODO(), "prometheus-tls-assets", metav1.GetOptions{})
+				updatedSecret, err := sClient.Get(tc.ctx, "prometheus-tls-assets", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -69,9 +69,9 @@ func Test_SanitizeVolumeName(t *testing.T) {
 }
 
 func TestMergeMetadata(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		name                string
-		ctx                 context.Context
 		expectedLabels      map[string]string
 		expectedAnnotations map[string]string
 		modifiedLabels      map[string]string
@@ -85,7 +85,6 @@ func TestMergeMetadata(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"app.kubernetes.io/name": "kube-state-metrics",
 			},
-			ctx: context.Background(),
 		},
 		{
 			name: "added label and annotation",
@@ -103,7 +102,6 @@ func TestMergeMetadata(t *testing.T) {
 			modifiedAnnotations: map[string]string{
 				"annotation": "value",
 			},
-			ctx: context.Background(),
 		},
 		{
 			name: "overridden label amd annotation",
@@ -119,7 +117,6 @@ func TestMergeMetadata(t *testing.T) {
 			modifiedAnnotations: map[string]string{
 				"app.kubernetes.io/name": "overridden-value",
 			},
-			ctx: context.Background(),
 		},
 	}
 
@@ -148,17 +145,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSvc.Annotations[a] = v
 				}
-				_, err := svcClient.Update(tc.ctx, modifiedSvc, metav1.UpdateOptions{})
+				_, err := svcClient.Update(ctx, modifiedSvc, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateService(tc.ctx, svcClient, service)
+				err = CreateOrUpdateService(ctx, svcClient, service)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSvc, err := svcClient.Get(tc.ctx, "prometheus-operated", metav1.GetOptions{})
+				updatedSvc, err := svcClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -194,17 +191,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedEndpoints.Annotations[a] = v
 				}
-				_, err := endpointsClient.Update(tc.ctx, modifiedEndpoints, metav1.UpdateOptions{})
+				_, err := endpointsClient.Update(ctx, modifiedEndpoints, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateEndpoints(tc.ctx, endpointsClient, endpoints)
+				err = CreateOrUpdateEndpoints(ctx, endpointsClient, endpoints)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedEndpoints, err := endpointsClient.Get(tc.ctx, "prometheus-operated", metav1.GetOptions{})
+				updatedEndpoints, err := endpointsClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -240,17 +237,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSset.Annotations[a] = v
 				}
-				_, err := ssetClient.Update(tc.ctx, modifiedSset, metav1.UpdateOptions{})
+				_, err := ssetClient.Update(ctx, modifiedSset, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = UpdateStatefulSet(tc.ctx, ssetClient, sset)
+				err = UpdateStatefulSet(ctx, ssetClient, sset)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSset, err := ssetClient.Get(tc.ctx, "prometheus", metav1.GetOptions{})
+				updatedSset, err := ssetClient.Get(ctx, "prometheus", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -286,17 +283,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSecret.Annotations[a] = v
 				}
-				_, err := sClient.Update(tc.ctx, modifiedSecret, metav1.UpdateOptions{})
+				_, err := sClient.Update(ctx, modifiedSecret, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateSecret(tc.ctx, sClient, secret)
+				err = CreateOrUpdateSecret(ctx, sClient, secret)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSecret, err := sClient.Get(tc.ctx, "prometheus-tls-assets", metav1.GetOptions{})
+				updatedSecret, err := sClient.Get(ctx, "prometheus-tls-assets", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -28,7 +28,6 @@ import (
 
 func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:
@@ -72,7 +71,6 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 
 func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create two namespaces:
@@ -102,7 +100,6 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 
 func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:
@@ -40,10 +41,10 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 	//
 	// 3. "nonInstance" ns:
 	//   - hosts an Alertmanager CR which must not be reconciled
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	nonInstanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	nonInstanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, nil, nil, []string{instanceNs}, false, true)
 	if err != nil {
@@ -70,7 +71,8 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 }
 
 func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create two namespaces:
@@ -82,9 +84,9 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 	//   - will be configured on prometheus operator as --alertmanager-instance-namespaces="instance"
 	//   - will additionally be configured on prometheus operator as --deny-namespaces="instance"
 	//   - hosts an alertmanager CR which must be reconciled.
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, []string{instanceNs}, nil, []string{instanceNs}, false, true)
 	if err != nil {
@@ -99,7 +101,8 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 }
 
 func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:
@@ -116,13 +119,13 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts an AlertmanagerConfig CR which must be reconciled
 	//   - hosts an Alertmanager CR which must not reconciled.
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	allowedNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	allowedNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:
@@ -71,8 +71,8 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 }
 
 func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create two namespaces:
@@ -101,8 +101,8 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 }
 
 func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create 3 namespaces:

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
 func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
@@ -122,7 +121,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -223,7 +222,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	// Remove the selecting label on the "allowed" namespace and check that
 	// the alertmanager configuration is updated.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	//if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, allowedNs, "monitored"); err != nil {
+	//if err := framework.RemoveLabelsFromNamespace(allowedNs, "monitored"); err != nil {
 	//	t.Fatal(err)
 	//}
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -44,8 +44,7 @@ func testAMCreateDeleteCluster(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -66,8 +65,7 @@ func testAMScaling(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -96,8 +94,7 @@ func testAMVersionMigration(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -129,8 +126,8 @@ func testAMStorageUpdate(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 
@@ -189,8 +186,8 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -218,8 +215,7 @@ func testAMClusterInitialization(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -268,8 +264,8 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	amClusterSize := 3
@@ -306,8 +302,7 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 func testAMClusterGossipSilences(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -358,8 +353,7 @@ func testAMReloadConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -514,8 +508,7 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -739,8 +732,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -1201,8 +1193,7 @@ func testUserDefinedAlertmanagerConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
@@ -1269,8 +1260,7 @@ receivers:
 func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -45,7 +45,6 @@ func testAMCreateDeleteCluster(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -66,7 +65,6 @@ func testAMScaling(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -95,7 +93,6 @@ func testAMVersionMigration(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -127,7 +124,6 @@ func testAMStorageUpdate(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 
@@ -187,7 +183,6 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -216,7 +211,6 @@ func testAMClusterInitialization(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -265,7 +259,6 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	amClusterSize := 3
@@ -303,7 +296,6 @@ func testAMClusterGossipSilences(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -354,7 +346,6 @@ func testAMReloadConfig(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -509,7 +500,6 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -733,7 +723,6 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	configNs := framework.CreateNamespace(t, ctx)
@@ -1194,7 +1183,6 @@ func testUserDefinedAlertmanagerConfig(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1261,7 +1249,6 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -44,10 +44,12 @@ func testAMCreateDeleteCluster(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	name := "test"
 
@@ -64,10 +66,12 @@ func testAMScaling(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	name := "test"
 
@@ -92,10 +96,12 @@ func testAMVersionMigration(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	name := "test"
 
@@ -123,9 +129,10 @@ func testAMStorageUpdate(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
 
 	name := "test"
 
@@ -182,10 +189,11 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
@@ -194,7 +202,7 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,10 +218,12 @@ func testAMClusterInitialization(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
@@ -237,7 +247,7 @@ func testAMClusterInitialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
@@ -258,9 +268,10 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
 	amClusterSize := 3
 
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
@@ -295,10 +306,12 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 func testAMClusterGossipSilences(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
@@ -345,10 +358,12 @@ func testAMReloadConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
 	templateResourceName := fmt.Sprintf("alertmanager-templates-%s", alertmanager.Name)
@@ -499,10 +514,12 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	whReplicas := int32(1)
 	whdpl := &appsv1.Deployment{
@@ -557,13 +574,13 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			},
 		},
 	}
-	if err := testFramework.CreateDeployment(framework.KubeClient, ns, whdpl); err != nil {
+	if err := framework.CreateDeployment(ns, whdpl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, whsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ns, whsvc); err != nil {
 		t.Fatal(err)
 	}
-	err := testFramework.WaitForPodsReady(framework.KubeClient, ns, time.Minute*5, 1,
+	err := framework.WaitForPodsReady(ns, time.Minute*5, 1,
 		metav1.ListOptions{
 			LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
 				"app.kubernetes.io/name": "alertmanager-webhook",
@@ -618,7 +635,7 @@ inhibit_rules:
 		t.Fatal(err)
 	}
 
-	if _, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, ns, amsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ns, amsvc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -682,7 +699,7 @@ inhibit_rules:
 	}
 
 	podName := pl.Items[0].Name
-	logs, err := testFramework.GetLogs(framework.KubeClient, ns, podName, "webhook-server")
+	logs, err := framework.GetLogs(ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -707,7 +724,7 @@ inhibit_rules:
 
 	time.Sleep(time.Minute)
 
-	logs, err = testFramework.GetLogs(framework.KubeClient, ns, podName, "webhook-server")
+	logs, err = framework.GetLogs(ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -722,11 +739,13 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	configNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	configNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("amconfig-crd", 1)
 	alertmanager.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
@@ -738,7 +757,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.AddLabelsToNamespace(framework.KubeClient, configNs, map[string]string{"monitored": "true"}); err != nil {
+	if err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, configNs, map[string]string{"monitored": "true"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1133,7 +1152,7 @@ templates: []
 	// AlertmanagerConfig resources and wait until the Alertmanager
 	// configuration gets regenerated.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, configNs, "monitored"); err != nil {
+	if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, framework.Ctx, configNs, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1182,10 +1201,12 @@ func testUserDefinedAlertmanagerConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	yamlConfig := `route:
   receiver: "void"
@@ -1248,10 +1269,12 @@ receivers:
 func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
+
 	defer ctx.Cleanup(t)
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBAC(t, ns, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	name := "test"
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
 func testAMCreateDeleteCluster(t *testing.T) {
@@ -738,7 +737,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, configNs, map[string]string{"monitored": "true"}); err != nil {
+	if err := framework.AddLabelsToNamespace(configNs, map[string]string{"monitored": "true"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1133,7 +1132,7 @@ templates: []
 	// AlertmanagerConfig resources and wait until the Alertmanager
 	// configuration gets regenerated.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, framework.Ctx, configNs, "monitored"); err != nil {
+	if err := framework.RemoveLabelsFromNamespace(configNs, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -28,7 +28,6 @@ import (
 
 func testDenyPrometheus(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)
@@ -79,7 +78,6 @@ func testDenyPrometheus(t *testing.T) {
 
 func testDenyServiceMonitor(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)
@@ -197,7 +195,6 @@ func testDenyServiceMonitor(t *testing.T) {
 
 func testDenyThanosRuler(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func testDenyPrometheus(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)
@@ -78,8 +78,8 @@ func testDenyPrometheus(t *testing.T) {
 }
 
 func testDenyServiceMonitor(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)
@@ -134,7 +134,7 @@ func testDenyServiceMonitor(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( denied, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(denied, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -148,7 +148,7 @@ func testDenyServiceMonitor(t *testing.T) {
 	}
 
 	for _, allowed := range allowedNamespaces {
-		framework.SetupPrometheusRBAC(t,ctx,  allowed)
+		framework.SetupPrometheusRBAC(t, ctx, allowed)
 		p := framework.MakeBasicPrometheus(allowed, "allowed", "allowed", 1)
 		_, err = framework.CreatePrometheusAndWaitUntilReady(allowed, p)
 		if err != nil {
@@ -196,8 +196,8 @@ func testDenyServiceMonitor(t *testing.T) {
 }
 
 func testDenyThanosRuler(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	operatorNamespace := framework.CreateNamespace(t, ctx)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -16,10 +16,11 @@ package e2e
 
 import (
 	"flag"
-	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 	"log"
 	"os"
 	"testing"
+
+	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -79,8 +80,8 @@ func TestMain(m *testing.M) {
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -79,10 +79,11 @@ func TestMain(m *testing.M) {
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
-	ns := ctx.CreateNamespace(t, framework.KubeClient)
+	ns := framework.CreateNamespace(t, ctx)
 
 	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, nil, nil, nil, true, true)
 	if err != nil {
@@ -276,7 +277,7 @@ const (
 func testServerTLS(t *testing.T, namespace string) func(t *testing.T) {
 
 	return func(t *testing.T) {
-		if err := operatorFramework.WaitForServiceReady(framework.KubeClient, namespace, prometheusOperatorServiceName); err != nil {
+		if err := framework.WaitForServiceReady(namespace, prometheusOperatorServiceName); err != nil {
 			t.Fatal("waiting for prometheus operator service: ", err)
 		}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -81,7 +81,6 @@ func TestMain(m *testing.M) {
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -25,13 +25,14 @@ import (
 )
 
 func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	nonInstanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	nonInstanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	_, err := framework.CreatePrometheusOperator(operatorNs, *opImage, nil, nil, []string{instanceNs}, nil, false, true)
 	if err != nil {
@@ -58,7 +59,8 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 }
 
 func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -78,13 +80,13 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 	//   - will be configured on prometheus operator as --deny-namespaces="denied"
 	//   - hosts a service monitor CR which must NOT be reconciled
 	//   - hosts a prometheus CR which must NOT be reconciled
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	deniedNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	deniedNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{deniedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -112,12 +114,12 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("denied")
 
-		if err := testFramework.CreateDeployment(framework.KubeClient, deniedNs, echo); err != nil {
+		if err := framework.CreateDeployment(deniedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, deniedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( deniedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -162,7 +164,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -182,7 +184,8 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 }
 
 func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -201,13 +204,13 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts a service monitor CR which must be reconciled
 	//   - hosts a prometheus CR which must NOT be reconciled
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	allowedNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	allowedNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -256,7 +259,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -275,12 +278,12 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("allowed")
 
-		if err := testFramework.CreateDeployment(framework.KubeClient, allowedNs, echo); err != nil {
+		if err := framework.CreateDeployment(allowedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -337,7 +340,8 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 // it's configured to watch namespaces that don't exist.
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347
 func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	testCtx := framework.NewTestCtx(t)
+	ctx := &testCtx
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -354,13 +358,13 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	// 3. "allowed" ns:
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts a service monitor CR which must be reconciled
-	operatorNs := ctx.CreateNamespace(t, framework.KubeClient)
-	allowedNs := ctx.CreateNamespace(t, framework.KubeClient)
-	instanceNs := ctx.CreateNamespace(t, framework.KubeClient)
-	ctx.SetupPrometheusRBACGlobal(t, instanceNs, framework.KubeClient)
+	operatorNs := framework.CreateNamespace(t, ctx)
+	allowedNs := framework.CreateNamespace(t, ctx)
+	instanceNs := framework.CreateNamespace(t, ctx)
+	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, ns, map[string]string{
+		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -400,7 +404,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -414,12 +418,12 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("allowed")
 
-		if err := testFramework.CreateDeployment(framework.KubeClient, allowedNs, echo); err != nil {
+		if err := framework.CreateDeployment(allowedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := testFramework.CreateServiceAndWaitUntilReady(framework.KubeClient, allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	operatorNs := framework.CreateNamespace(t, ctx)
@@ -59,8 +59,8 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 }
 
 func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -119,7 +119,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( deniedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(deniedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -164,7 +164,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -184,8 +184,8 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 }
 
 func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -259,7 +259,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -283,7 +283,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)
@@ -340,8 +340,8 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 // it's configured to watch namespaces that don't exist.
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347
 func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -404,7 +404,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady( instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			ctx.AddFinalizerFn(finalizerFn)

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 	v1 "k8s.io/api/core/v1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +83,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{deniedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -207,7 +206,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -360,7 +359,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	framework.SetupPrometheusRBACGlobal(t, ctx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -26,7 +26,6 @@ import (
 
 func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	operatorNs := framework.CreateNamespace(t, ctx)
@@ -60,7 +59,6 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 
 func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -185,7 +183,6 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:
@@ -341,7 +338,6 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347
 func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	// create three namespaces:

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1430,7 +1430,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	ruleFilesNamespaceSelector := map[string]string{"monitored": "true"}
 
 	for _, file := range ruleFiles {
-		err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, file.ns, ruleFilesNamespaceSelector)
+		err := framework.AddLabelsToNamespace(file.ns, ruleFilesNamespaceSelector)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1471,7 +1471,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	// and wait until the rules are removed from Prometheus.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
 	for _, file := range ruleFiles {
-		if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, framework.Ctx, file.ns, "monitored"); err != nil {
+		if err := framework.RemoveLabelsFromNamespace(file.ns, "monitored"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2448,9 +2448,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	serviceMonitorNSName := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, prometheusNSName)
 
-	if err := testFramework.AddLabelsToNamespace(
-		framework.KubeClient,
-		framework.Ctx,
+	if err := framework.AddLabelsToNamespace(
 		serviceMonitorNSName,
 		map[string]string{"team": "frontend"},
 	); err != nil {
@@ -2677,7 +2675,7 @@ func testPromGetAuthSecret(t *testing.T) {
 			}
 			testNamespace := framework.CreateNamespace(t, ctx)
 
-			err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, testNamespace, maptest)
+			err := framework.AddLabelsToNamespace(testNamespace, maptest)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2759,7 +2757,7 @@ func testOperatorNSScope(t *testing.T) {
 
 		// Add labels to namespaces for Prometheus RuleNamespaceSelector.
 		for _, ns := range []string{mainNS, arbitraryNS} {
-			err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, prometheusNamespaceSelector)
+			err := framework.AddLabelsToNamespace(ns, prometheusNamespaceSelector)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2829,7 +2827,7 @@ func testOperatorNSScope(t *testing.T) {
 		prometheusNamespaceSelector := map[string]string{"prometheus": prometheusNS}
 
 		for _, ns := range []string{ruleNS, arbitraryNS} {
-			err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ns, prometheusNamespaceSelector)
+			err := framework.AddLabelsToNamespace(ns, prometheusNamespaceSelector)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -720,7 +720,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			t.Parallel()
 
 			ctx := framework.NewTestCtx(t)
-
 			defer ctx.Cleanup(t)
 
 			ns := framework.CreateNamespace(t, ctx)
@@ -791,7 +790,6 @@ func testPromCreateDeleteCluster(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -842,7 +840,6 @@ func testPromNoServiceMonitorSelector(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -859,7 +856,6 @@ func testPromVersionMigration(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -891,7 +887,6 @@ func testPromResourceUpdate(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -957,7 +952,6 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1033,7 +1027,6 @@ func testPromStorageUpdate(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1092,7 +1085,6 @@ func testPromReloadConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1186,7 +1178,6 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1245,7 +1236,6 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1327,7 +1317,6 @@ func testPromReloadRules(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1386,7 +1375,6 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1427,7 +1415,6 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	rootNS := framework.CreateNamespace(t, ctx)
 	alertNSOne := framework.CreateNamespace(t, ctx)
@@ -1507,7 +1494,6 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1585,7 +1571,6 @@ func testPromRulesMustBeAnnotated(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1616,7 +1601,6 @@ func testInvalidRulesAreRejected(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1866,7 +1850,6 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2049,7 +2032,6 @@ func testPromWhenDeleteCRDCleanUpViaOwnerRef(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2085,7 +2067,6 @@ func testPromDiscovery(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2126,7 +2107,6 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2180,7 +2160,6 @@ func testShardingProvisioning(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2254,7 +2233,6 @@ func testResharding(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2327,7 +2305,6 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2379,7 +2356,6 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2407,7 +2383,6 @@ func testPromDiscoverTargetPort(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2468,7 +2443,6 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	prometheusNSName := framework.CreateNamespace(t, ctx)
 	serviceMonitorNSName := framework.CreateNamespace(t, ctx)
@@ -2526,7 +2500,6 @@ func testThanos(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2687,7 +2660,6 @@ func testPromGetAuthSecret(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := framework.NewTestCtx(t)
-
 			defer ctx.Cleanup(t)
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBACGlobal(t, ctx, ns)
@@ -2775,7 +2747,6 @@ func testOperatorNSScope(t *testing.T) {
 
 	t.Run("SingleNS", func(t *testing.T) {
 		ctx := framework.NewTestCtx(t)
-
 		defer ctx.Cleanup(t)
 
 		operatorNS := framework.CreateNamespace(t, ctx)
@@ -2846,7 +2817,6 @@ func testOperatorNSScope(t *testing.T) {
 
 	t.Run("MultiNS", func(t *testing.T) {
 		ctx := framework.NewTestCtx(t)
-
 		defer ctx.Cleanup(t)
 
 		operatorNS := framework.CreateNamespace(t, ctx)
@@ -3087,8 +3057,8 @@ func testPromArbitraryFSAcc(t *testing.T) {
 			t.Parallel()
 
 			ctx := framework.NewTestCtx(t)
-
 			defer ctx.Cleanup(t)
+
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBAC(t, ctx, ns)
 
@@ -3205,7 +3175,6 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)
@@ -3385,7 +3354,6 @@ func testPromStaticProbe(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -3591,7 +3559,6 @@ func testPromSecurePodMonitor(t *testing.T) {
 			t.Parallel()
 
 			ctx := framework.NewTestCtx(t)
-
 			defer ctx.Cleanup(t)
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -3694,7 +3661,6 @@ func testPromWebTLS(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	certutil "k8s.io/client-go/util/cert"
 	"log"
 	"net/http"
 	"net/url"
@@ -32,6 +31,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	certutil "k8s.io/client-go/util/cert"
 
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -718,8 +719,8 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			testCtx := framework.NewTestCtx(t)
-			ctx := &testCtx
+			ctx := framework.NewTestCtx(t)
+
 			defer ctx.Cleanup(t)
 
 			ns := framework.CreateNamespace(t, ctx)
@@ -789,8 +790,8 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 func testPromCreateDeleteCluster(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -812,8 +813,7 @@ func testPromCreateDeleteCluster(t *testing.T) {
 func testPromScaleUpDownCluster(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx  := &testCtx
+	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -841,8 +841,8 @@ func testPromScaleUpDownCluster(t *testing.T) {
 func testPromNoServiceMonitorSelector(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -858,8 +858,8 @@ func testPromNoServiceMonitorSelector(t *testing.T) {
 func testPromVersionMigration(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -890,8 +890,8 @@ func testPromVersionMigration(t *testing.T) {
 func testPromResourceUpdate(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -956,10 +956,10 @@ func testPromResourceUpdate(t *testing.T) {
 func testPromStorageLabelsAnnotations(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t,ctx)
+	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
 
 	name := "test"
@@ -1032,8 +1032,8 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 func testPromStorageUpdate(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1091,8 +1091,8 @@ func testPromStorageUpdate(t *testing.T) {
 func testPromReloadConfig(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1185,8 +1185,8 @@ scrape_configs:
 func testPromAdditionalScrapeConfig(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1244,8 +1244,8 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1326,8 +1326,8 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 func testPromReloadRules(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1385,8 +1385,8 @@ func testPromReloadRules(t *testing.T) {
 func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1426,8 +1426,8 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	rootNS := framework.CreateNamespace(t, ctx)
 	alertNSOne := framework.CreateNamespace(t, ctx)
@@ -1506,8 +1506,8 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1584,8 +1584,8 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 func testPromRulesMustBeAnnotated(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1615,8 +1615,8 @@ func testPromRulesMustBeAnnotated(t *testing.T) {
 func testInvalidRulesAreRejected(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -1659,8 +1659,8 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(t, &testCtx)
-	framework.SetupPrometheusRBAC(t, &testCtx, ns)
+	ns := framework.CreateNamespace(t, testCtx)
+	framework.SetupPrometheusRBAC(t, testCtx, ns)
 
 	name := "test"
 	prometheus := framework.MakeBasicPrometheus(ns, name, name, 1)
@@ -1865,8 +1865,8 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 func testPromPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2048,8 +2048,8 @@ func mergeMap(a, b map[string]string) map[string]string {
 func testPromWhenDeleteCRDCleanUpViaOwnerRef(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2084,8 +2084,8 @@ func testPromWhenDeleteCRDCleanUpViaOwnerRef(t *testing.T) {
 func testPromDiscovery(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2125,8 +2125,8 @@ func testPromDiscovery(t *testing.T) {
 func testPromSharedResourcesReconciliation(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2179,8 +2179,8 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 func testShardingProvisioning(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2253,8 +2253,8 @@ func testShardingProvisioning(t *testing.T) {
 func testResharding(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2326,8 +2326,8 @@ func testResharding(t *testing.T) {
 func testPromAlertmanagerDiscovery(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2378,8 +2378,8 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 func testPromExposingWithKubernetesAPI(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2406,8 +2406,8 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 func testPromDiscoverTargetPort(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2467,8 +2467,8 @@ func testPromDiscoverTargetPort(t *testing.T) {
 func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	prometheusNSName := framework.CreateNamespace(t, ctx)
 	serviceMonitorNSName := framework.CreateNamespace(t, ctx)
@@ -2525,8 +2525,8 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 func testThanos(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -2686,8 +2686,8 @@ func testPromGetAuthSecret(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			testCtx := framework.NewTestCtx(t)
-			ctx := &testCtx
+			ctx := framework.NewTestCtx(t)
+
 			defer ctx.Cleanup(t)
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBACGlobal(t, ctx, ns)
@@ -2774,8 +2774,8 @@ func testOperatorNSScope(t *testing.T) {
 	secondAlertName := "secondAlert"
 
 	t.Run("SingleNS", func(t *testing.T) {
-		testCtx := framework.NewTestCtx(t)
-		ctx := &testCtx
+		ctx := framework.NewTestCtx(t)
+
 		defer ctx.Cleanup(t)
 
 		operatorNS := framework.CreateNamespace(t, ctx)
@@ -2845,8 +2845,8 @@ func testOperatorNSScope(t *testing.T) {
 	})
 
 	t.Run("MultiNS", func(t *testing.T) {
-		testCtx := framework.NewTestCtx(t)
-		ctx := &testCtx
+		ctx := framework.NewTestCtx(t)
+
 		defer ctx.Cleanup(t)
 
 		operatorNS := framework.CreateNamespace(t, ctx)
@@ -3086,8 +3086,8 @@ func testPromArbitraryFSAcc(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			testCtx := framework.NewTestCtx(t)
-			ctx := &testCtx
+			ctx := framework.NewTestCtx(t)
+
 			defer ctx.Cleanup(t)
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -3204,8 +3204,8 @@ func mountTLSFiles(p *monitoringv1.Prometheus, secretName string) {
 func testPromTLSConfigViaSecret(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)
@@ -3384,8 +3384,8 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 func testPromStaticProbe(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -3590,8 +3590,8 @@ func testPromSecurePodMonitor(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			testCtx := framework.NewTestCtx(t)
-			ctx := &testCtx
+			ctx := framework.NewTestCtx(t)
+
 			defer ctx.Cleanup(t)
 			ns := framework.CreateNamespace(t, ctx)
 			framework.SetupPrometheusRBAC(t, ctx, ns)
@@ -3693,8 +3693,8 @@ func testPromSecurePodMonitor(t *testing.T) {
 func testPromWebTLS(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func testThanosRulerCreateDeleteCluster(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)
@@ -46,8 +46,7 @@ func testThanosRulerCreateDeleteCluster(t *testing.T) {
 }
 
 func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
 
 	thanosNamespace := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, thanosNamespace)
@@ -124,8 +123,8 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 func testTRPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
-	testCtx := framework.NewTestCtx(t)
-	ctx := &testCtx
+	ctx := framework.NewTestCtx(t)
+
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -28,7 +28,6 @@ import (
 
 func testThanosRulerCreateDeleteCluster(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 
 	ns := framework.CreateNamespace(t, ctx)
@@ -47,6 +46,7 @@ func testThanosRulerCreateDeleteCluster(t *testing.T) {
 
 func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup(t)
 
 	thanosNamespace := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, thanosNamespace)
@@ -124,7 +124,6 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx := framework.NewTestCtx(t)
-
 	defer ctx.Cleanup(t)
 	ns := framework.CreateNamespace(t, ctx)
 	framework.SetupPrometheusRBAC(t, ctx, ns)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +77,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	}
 
 	ruleNamespace := framework.CreateNamespace(t, ctx)
-	if err := testFramework.AddLabelsToNamespace(framework.KubeClient, framework.Ctx, ruleNamespace, map[string]string{
+	if err := framework.AddLabelsToNamespace(ruleNamespace, map[string]string{
 		"monitored": "true",
 	}); err != nil {
 		t.Fatal(err)
@@ -104,7 +103,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	// Remove the selecting label from ruleNamespace and wait until the rule is
 	// removed from the Thanos ruler.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, framework.Ctx, ruleNamespace, "monitored"); err != nil {
+	if err := framework.RemoveLabelsFromNamespace(ruleNamespace, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/framework/cluster_role.go
+++ b/test/framework/cluster_role.go
@@ -15,12 +15,9 @@
 package framework
 
 import (
-	"context"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -46,24 +43,24 @@ var (
 	}
 )
 
-func CreateClusterRole(kubeClient kubernetes.Interface, relativePath string) (*rbacv1.ClusterRole, error) {
+func (f *Framework) CreateClusterRole(relativePath string) (*rbacv1.ClusterRole, error) {
 	clusterRole, err := parseClusterRoleYaml(relativePath)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = kubeClient.RbacV1().ClusterRoles().Get(context.TODO(), clusterRole.Name, metav1.GetOptions{})
+	_, err = f.KubeClient.RbacV1().ClusterRoles().Get(f.Ctx, clusterRole.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// ClusterRole already exists -> Update
-		clusterRole, err = kubeClient.RbacV1().ClusterRoles().Update(context.TODO(), clusterRole, metav1.UpdateOptions{})
+		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Update(f.Ctx, clusterRole, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}
 
 	} else {
 		// ClusterRole doesn't exists -> Create
-		clusterRole, err = kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
+		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Create(f.Ctx, clusterRole, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -72,17 +69,17 @@ func CreateClusterRole(kubeClient kubernetes.Interface, relativePath string) (*r
 	return clusterRole, nil
 }
 
-func DeleteClusterRole(kubeClient kubernetes.Interface, relativePath string) error {
+func (f *Framework) DeleteClusterRole(relativePath string) error {
 	clusterRole, err := parseClusterRoleYaml(relativePath)
 	if err != nil {
 		return err
 	}
 
-	return kubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), clusterRole.Name, metav1.DeleteOptions{})
+	return f.KubeClient.RbacV1().ClusterRoles().Delete(f.Ctx, clusterRole.Name, metav1.DeleteOptions{})
 }
 
-func UpdateClusterRole(kubeClient kubernetes.Interface, clusterRole *rbacv1.ClusterRole) error {
-	_, err := kubeClient.RbacV1().ClusterRoles().Update(context.TODO(), clusterRole, metav1.UpdateOptions{})
+func (f *Framework) UpdateClusterRole(clusterRole *rbacv1.ClusterRole) error {
+	_, err := f.KubeClient.RbacV1().ClusterRoles().Update(f.Ctx, clusterRole, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -30,7 +30,7 @@ type TestCtx struct {
 
 type FinalizerFn func() error
 
-func (f *Framework) NewTestCtx(t *testing.T) TestCtx {
+func (f *Framework) NewTestCtx(t *testing.T) *TestCtx {
 	// TestCtx is used among others for namespace names where '/' is forbidden
 	prefix := strings.TrimPrefix(
 		strings.Replace(
@@ -43,7 +43,7 @@ func (f *Framework) NewTestCtx(t *testing.T) TestCtx {
 	)
 
 	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 36)
-	return TestCtx{
+	return &TestCtx{
 		ID: id,
 	}
 }

--- a/test/framework/deployment.go
+++ b/test/framework/deployment.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -28,12 +27,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func GetDeployment(kubeCilent kubernetes.Interface, ns, name string) (*appsv1.Deployment, error) {
-	return kubeCilent.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *Framework) GetDeployment( ns, name string) (*appsv1.Deployment, error) {
+	return f.KubeClient.AppsV1().Deployments(ns).Get(f.Ctx, name, metav1.GetOptions{})
 }
 
-func UpdateDeployment(kubeCilent kubernetes.Interface, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-	return kubeCilent.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+func (f *Framework) UpdateDeployment(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	return f.KubeClient.AppsV1().Deployments(deployment.Namespace).Update(f.Ctx, deployment, metav1.UpdateOptions{})
 }
 
 func MakeDeployment(pathToYaml string) (*appsv1.Deployment, error) {
@@ -49,17 +48,17 @@ func MakeDeployment(pathToYaml string) (*appsv1.Deployment, error) {
 	return &deployment, nil
 }
 
-func CreateDeployment(kubeClient kubernetes.Interface, namespace string, d *appsv1.Deployment) error {
+func (f *Framework) CreateDeployment(namespace string, d *appsv1.Deployment) error {
 	d.Namespace = namespace
-	_, err := kubeClient.AppsV1().Deployments(namespace).Create(context.TODO(), d, metav1.CreateOptions{})
+	_, err := f.KubeClient.AppsV1().Deployments(namespace).Create(f.Ctx, d, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to create deployment %s", d.Name))
 	}
 	return nil
 }
 
-func DeleteDeployment(kubeClient kubernetes.Interface, namespace, name string) error {
-	d, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (f *Framework) DeleteDeployment(namespace, name string) error {
+	d, err := f.KubeClient.AppsV1().Deployments(namespace).Get(f.Ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -67,18 +66,18 @@ func DeleteDeployment(kubeClient kubernetes.Interface, namespace, name string) e
 	zero := int32(0)
 	d.Spec.Replicas = &zero
 
-	d, err = kubeClient.AppsV1().Deployments(namespace).Update(context.TODO(), d, metav1.UpdateOptions{})
+	d, err = f.KubeClient.AppsV1().Deployments(namespace).Update(f.Ctx, d, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
-	return kubeClient.AppsV1beta2().Deployments(namespace).Delete(context.TODO(), d.Name, metav1.DeleteOptions{})
+	return f.KubeClient.AppsV1beta2().Deployments(namespace).Delete(f.Ctx, d.Name, metav1.DeleteOptions{})
 }
 
-func WaitUntilDeploymentGone(kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+func (f *Framework) WaitUntilDeploymentGone(kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
-		_, err := kubeClient.
+		_, err := f.KubeClient.
 			AppsV1beta2().Deployments(namespace).
-			Get(context.TODO(), name, metav1.GetOptions{})
+			Get(f.Ctx, name, metav1.GetOptions{})
 
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/test/framework/deployment.go
+++ b/test/framework/deployment.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (f *Framework) GetDeployment( ns, name string) (*appsv1.Deployment, error) {
+func (f *Framework) GetDeployment(ns, name string) (*appsv1.Deployment, error) {
 	return f.KubeClient.AppsV1().Deployments(ns).Get(f.Ctx, name, metav1.GetOptions{})
 }
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -188,7 +188,7 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 		return nil, errors.Wrap(err, "failed to create prometheus operator service account")
 	}
 
-	clusterRole, err := f.CreateClusterRole( "../../example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml")
+	clusterRole, err := f.CreateClusterRole("../../example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml")
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.Wrap(err, "failed to create prometheus cluster role")
 	}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -180,8 +180,7 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 
 	var finalizers []FinalizerFn
 
-	_, err := createServiceAccount(
-		f.KubeClient,
+	_, err := f.createServiceAccount(
 		ns,
 		"../../example/rbac/prometheus-operator/prometheus-operator-service-account.yaml",
 	)
@@ -189,19 +188,19 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 		return nil, errors.Wrap(err, "failed to create prometheus operator service account")
 	}
 
-	clusterRole, err := CreateClusterRole(f.KubeClient, "../../example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml")
+	clusterRole, err := f.CreateClusterRole( "../../example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml")
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.Wrap(err, "failed to create prometheus cluster role")
 	}
 
 	// Add CRD rbac rules
 	clusterRole.Rules = append(clusterRole.Rules, CRDCreateRule, CRDMonitoringRule)
-	if err := UpdateClusterRole(f.KubeClient, clusterRole); err != nil {
+	if err := f.UpdateClusterRole(clusterRole); err != nil {
 		return nil, errors.Wrap(err, "failed to update prometheus cluster role")
 	}
 
 	if createClusterRoleBindings {
-		if _, err := createClusterRoleBinding(f.KubeClient, ns, "../../example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := f.createClusterRoleBinding(ns, "../../example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, errors.Wrap(err, "failed to create prometheus cluster role binding")
 		}
 	} else {
@@ -210,7 +209,7 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 		namespaces = append(namespaces, alertmanagerInstanceNamespaces...)
 
 		for _, n := range namespaces {
-			if _, err := CreateRoleBindingForSubjectNamespace(f.KubeClient, n, ns, "../framework/resources/prometheus-operator-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+			if _, err := f.CreateRoleBindingForSubjectNamespace(n, ns, "../framework/resources/prometheus-operator-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 				return nil, errors.Wrap(err, "failed to create prometheus operator role binding")
 			}
 		}
@@ -221,7 +220,7 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 		return nil, errors.Wrap(err, "failed to generate certificate and key")
 	}
 
-	if err := CreateSecretWithCert(f.KubeClient, certBytes, keyBytes, ns, admissionHookSecretName); err != nil {
+	if err := f.CreateSecretWithCert(certBytes, keyBytes, ns, admissionHookSecretName); err != nil {
 		return nil, errors.Wrap(err, "failed to create admission webhook secret")
 	}
 
@@ -359,13 +358,13 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 		)
 	}
 
-	err = CreateDeployment(f.KubeClient, ns, deploy)
+	err = f.CreateDeployment(ns, deploy)
 	if err != nil {
 		return nil, err
 	}
 
 	opts := metav1.ListOptions{LabelSelector: fields.SelectorFromSet(fields.Set(deploy.Spec.Template.ObjectMeta.Labels)).String()}
-	err = WaitForPodsReady(f.KubeClient, ns, f.DefaultTimeout, 1, opts)
+	err = f.WaitForPodsReady(ns, f.DefaultTimeout, 1, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to wait for prometheus operator to become ready")
 	}
@@ -379,18 +378,18 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 	service.Spec.ClusterIP = ""
 	service.Spec.Ports = []v1.ServicePort{{Name: "https", Port: 443, TargetPort: intstr.FromInt(8443)}}
 
-	if _, err := CreateServiceAndWaitUntilReady(f.KubeClient, ns, service); err != nil {
+	if _, err := f.CreateServiceAndWaitUntilReady(ns, service); err != nil {
 		return finalizers, errors.Wrap(err, "failed to create prometheus operator service")
 	}
 
 	if createRuleAdmissionHooks {
-		finalizer, err := createMutatingHook(f.KubeClient, certBytes, ns, "../../test/framework/resources/prometheus-operator-mutatingwebhook.yaml")
+		finalizer, err := f.createMutatingHook(certBytes, ns, "../../test/framework/resources/prometheus-operator-mutatingwebhook.yaml")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create mutating webhook")
 		}
 		finalizers = append(finalizers, finalizer)
 
-		finalizer, err = createValidatingHook(f.KubeClient, certBytes, ns, "../../test/framework/resources/prometheus-operator-validatingwebhook.yaml")
+		finalizer, err = f.createValidatingHook(certBytes, ns, "../../test/framework/resources/prometheus-operator-validatingwebhook.yaml")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create validating webhook")
 		}
@@ -400,34 +399,34 @@ func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowl
 	return finalizers, nil
 }
 
-func (ctx *TestCtx) SetupPrometheusRBAC(t *testing.T, ns string, kubeClient kubernetes.Interface) {
-	if _, err := CreateClusterRole(kubeClient, "../../example/rbac/prometheus/prometheus-cluster-role.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+func (f *Framework) SetupPrometheusRBAC(t *testing.T, ctx *TestCtx, ns string) {
+	if _, err := f.CreateClusterRole("../../example/rbac/prometheus/prometheus-cluster-role.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		t.Fatalf("failed to create prometheus cluster role: %v", err)
 	}
-	if finalizerFn, err := createServiceAccount(kubeClient, ns, "../../example/rbac/prometheus/prometheus-service-account.yaml"); err != nil {
+	if finalizerFn, err := f.createServiceAccount(ns, "../../example/rbac/prometheus/prometheus-service-account.yaml"); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to create prometheus service account"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	if finalizerFn, err := CreateRoleBinding(kubeClient, ns, "../framework/resources/prometheus-role-binding.yml"); err != nil {
+	if finalizerFn, err := f.CreateRoleBinding(ns, "../framework/resources/prometheus-role-binding.yml"); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to create prometheus role binding"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 }
 
-func (ctx *TestCtx) SetupPrometheusRBACGlobal(t *testing.T, ns string, kubeClient kubernetes.Interface) {
-	if _, err := CreateClusterRole(kubeClient, "../../example/rbac/prometheus/prometheus-cluster-role.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+func (f *Framework) SetupPrometheusRBACGlobal(t *testing.T, ctx *TestCtx, ns string) {
+	if _, err := f.CreateClusterRole("../../example/rbac/prometheus/prometheus-cluster-role.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		t.Fatalf("failed to create prometheus cluster role: %v", err)
 	}
-	if finalizerFn, err := createServiceAccount(kubeClient, ns, "../../example/rbac/prometheus/prometheus-service-account.yaml"); err != nil {
+	if finalizerFn, err := f.createServiceAccount(ns, "../../example/rbac/prometheus/prometheus-service-account.yaml"); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to create prometheus service account"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)
 	}
 
-	if finalizerFn, err := createClusterRoleBinding(kubeClient, ns, "../../example/rbac/prometheus/prometheus-cluster-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
+	if finalizerFn, err := f.createClusterRoleBinding(ns, "../../example/rbac/prometheus/prometheus-cluster-role-binding.yaml"); err != nil && !apierrors.IsAlreadyExists(err) {
 		t.Fatal(errors.Wrap(err, "failed to create prometheus cluster role binding"))
 	} else {
 		ctx.AddFinalizerFn(finalizerFn)

--- a/test/framework/ingress.go
+++ b/test/framework/ingress.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
@@ -27,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 )
 
 func MakeBasicIngress(serviceName string, servicePort int) *v1beta1.Ingress {
@@ -57,19 +55,19 @@ func MakeBasicIngress(serviceName string, servicePort int) *v1beta1.Ingress {
 	}
 }
 
-func CreateIngress(kubeClient kubernetes.Interface, namespace string, i *v1beta1.Ingress) error {
-	_, err := kubeClient.ExtensionsV1beta1().Ingresses(namespace).Create(context.TODO(), i, metav1.CreateOptions{})
+func (f *Framework) CreateIngress(namespace string, i *v1beta1.Ingress) error {
+	_, err := f.KubeClient.ExtensionsV1beta1().Ingresses(namespace).Create(f.Ctx, i, metav1.CreateOptions{})
 	return errors.Wrap(err, fmt.Sprintf("creating ingress %v failed", i.Name))
 }
 
-func SetupNginxIngressControllerIncDefaultBackend(kubeClient kubernetes.Interface, namespace string) error {
+func (f *Framework) SetupNginxIngressControllerIncDefaultBackend(namespace string) error {
 	// Create Nginx Ingress Replication Controller
-	if err := createReplicationControllerViaYml(kubeClient, namespace, "./framework/resources/nxginx-ingress-controller.yml"); err != nil {
+	if err := f.createReplicationControllerViaYml(namespace, "./framework/resources/nxginx-ingress-controller.yml"); err != nil {
 		return errors.Wrap(err, "creating nginx ingress replication controller failed")
 	}
 
 	// Create Default HTTP Backend Replication Controller
-	if err := createReplicationControllerViaYml(kubeClient, namespace, "./framework/resources/default-http-backend.yml"); err != nil {
+	if err := f.createReplicationControllerViaYml(namespace, "./framework/resources/default-http-backend.yml"); err != nil {
 		return errors.Wrap(err, "creating default http backend replication controller failed")
 	}
 
@@ -85,25 +83,25 @@ func SetupNginxIngressControllerIncDefaultBackend(kubeClient kubernetes.Interfac
 		return errors.Wrap(err, "decoding http backend service yaml failed")
 	}
 
-	_, err = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), &service, metav1.CreateOptions{})
+	_, err = f.KubeClient.CoreV1().Services(namespace).Create(f.Ctx, &service, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("creating http backend service %v failed", service.Name))
 	}
-	if err := WaitForServiceReady(kubeClient, namespace, service.Name); err != nil {
+	if err := f.WaitForServiceReady(namespace, service.Name); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("waiting for http backend service %v timed out", service.Name))
 	}
 
 	return nil
 }
 
-func DeleteNginxIngressControllerIncDefaultBackend(kubeClient kubernetes.Interface, namespace string) error {
+func (f *Framework) DeleteNginxIngressControllerIncDefaultBackend(namespace string) error {
 	// Delete Nginx Ingress Replication Controller
-	if err := deleteReplicationControllerViaYml(kubeClient, namespace, "./framework/resources/nxginx-ingress-controller.yml"); err != nil {
+	if err := f.deleteReplicationControllerViaYml(namespace, "./framework/resources/nxginx-ingress-controller.yml"); err != nil {
 		return errors.Wrap(err, "deleting nginx ingress replication controller failed")
 	}
 
 	// Delete Default HTTP Backend Replication Controller
-	if err := deleteReplicationControllerViaYml(kubeClient, namespace, "./framework/resources/default-http-backend.yml"); err != nil {
+	if err := f.deleteReplicationControllerViaYml(namespace, "./framework/resources/default-http-backend.yml"); err != nil {
 		return errors.Wrap(err, "deleting default http backend replication controller failed")
 	}
 
@@ -119,18 +117,18 @@ func DeleteNginxIngressControllerIncDefaultBackend(kubeClient kubernetes.Interfa
 		return errors.Wrap(err, "decoding http backend service yaml failed")
 	}
 
-	if err := kubeClient.CoreV1().Services(namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{}); err != nil {
+	if err := f.KubeClient.CoreV1().Services(namespace).Delete(f.Ctx, service.Name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting http backend service %v failed", service.Name))
 	}
 
 	return nil
 }
 
-func GetIngressIP(kubeClient kubernetes.Interface, namespace string, ingressName string) (*string, error) {
+func (f *Framework) GetIngressIP(namespace string, ingressName string) (*string, error) {
 	var ingress *v1beta1.Ingress
 	err := wait.Poll(time.Millisecond*500, time.Minute*5, func() (bool, error) {
 		var err error
-		ingress, err = kubeClient.ExtensionsV1beta1().Ingresses(namespace).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		ingress, err = f.KubeClient.ExtensionsV1beta1().Ingresses(namespace).Get(f.Ctx, ingressName, metav1.GetOptions{})
 		if err != nil {
 			return false, errors.Wrap(err, fmt.Sprintf("requesting the ingress %v failed", ingressName))
 		}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -327,8 +327,7 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus custom resource %v failed", name))
 	}
 
-	if err := WaitForPodsReady(
-		f.KubeClient,
+	if err := f.WaitForPodsReady(
 		ns,
 		f.DefaultTimeout,
 		0,
@@ -344,11 +343,10 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 }
 
 func (f *Framework) WaitForPrometheusRunImageAndReady(ns string, p *monitoringv1.Prometheus) error {
-	if err := WaitForPodsRunImage(f.KubeClient, ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
+	if err := f.WaitForPodsRunImage(ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
 		return err
 	}
-	return WaitForPodsReady(
-		f.KubeClient,
+	return f.WaitForPodsReady(
 		ns,
 		f.DefaultTimeout,
 		int(*p.Spec.Replicas),
@@ -557,7 +555,7 @@ func (f *Framework) PrintPrometheusLogs(t *testing.T, p *monitoringv1.Prometheus
 
 	replicas := int(*p.Spec.Replicas)
 	for i := 0; i < replicas; i++ {
-		l, err := GetLogs(f.KubeClient, p.Namespace, fmt.Sprintf("prometheus-%s-%d", p.Name, i), "prometheus")
+		l, err := f.GetLogs(p.Namespace, fmt.Sprintf("prometheus-%s-%d", p.Name, i), "prometheus")
 		if err != nil {
 			t.Logf("failed to retrieve logs for replica[%d]: %v", i, err)
 			continue

--- a/test/framework/replication-controller.go
+++ b/test/framework/replication-controller.go
@@ -15,7 +15,6 @@
 package framework
 
 import (
-	"context"
 	"os"
 	"time"
 
@@ -23,10 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 )
 
-func createReplicationControllerViaYml(kubeClient kubernetes.Interface, namespace string, filepath string) error {
+func (f *Framework) createReplicationControllerViaYml(namespace string, filepath string) error {
 	manifest, err := os.Open(filepath)
 	if err != nil {
 		return err
@@ -38,7 +36,7 @@ func createReplicationControllerViaYml(kubeClient kubernetes.Interface, namespac
 		return err
 	}
 
-	_, err = kubeClient.CoreV1().ReplicationControllers(namespace).Create(context.TODO(), &rC, metav1.CreateOptions{})
+	_, err = f.KubeClient.CoreV1().ReplicationControllers(namespace).Create(f.Ctx, &rC, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -46,7 +44,7 @@ func createReplicationControllerViaYml(kubeClient kubernetes.Interface, namespac
 	return nil
 }
 
-func deleteReplicationControllerViaYml(kubeClient kubernetes.Interface, namespace string, filepath string) error {
+func (f *Framework) deleteReplicationControllerViaYml(namespace string, filepath string) error {
 	manifest, err := os.Open(filepath)
 	if err != nil {
 		return err
@@ -58,24 +56,24 @@ func deleteReplicationControllerViaYml(kubeClient kubernetes.Interface, namespac
 		return err
 	}
 
-	if err := scaleDownReplicationController(kubeClient, namespace, rC); err != nil {
+	if err := f.scaleDownReplicationController(namespace, rC); err != nil {
 		return err
 	}
 
-	return kubeClient.CoreV1().ReplicationControllers(namespace).Delete(context.TODO(), rC.Name, metav1.DeleteOptions{})
+	return f.KubeClient.CoreV1().ReplicationControllers(namespace).Delete(f.Ctx, rC.Name, metav1.DeleteOptions{})
 }
 
-func scaleDownReplicationController(kubeClient kubernetes.Interface, namespace string, rC v1.ReplicationController) error {
+func (f *Framework) scaleDownReplicationController(namespace string, rC v1.ReplicationController) error {
 	*rC.Spec.Replicas = 0
-	rCAPI := kubeClient.CoreV1().ReplicationControllers(namespace)
+	rCAPI := f.KubeClient.CoreV1().ReplicationControllers(namespace)
 
-	_, err := kubeClient.CoreV1().ReplicationControllers(namespace).Update(context.TODO(), &rC, metav1.UpdateOptions{})
+	_, err := f.KubeClient.CoreV1().ReplicationControllers(namespace).Update(f.Ctx, &rC, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		currentRC, err := rCAPI.Get(context.TODO(), rC.Name, metav1.GetOptions{})
+		currentRC, err := rCAPI.Get(f.Ctx, rC.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/framework/role-binding.go
+++ b/test/framework/role-binding.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) CreateRoleBinding( ns string, relativePath string) (FinalizerFn, error) {
+func (f *Framework) CreateRoleBinding(ns string, relativePath string) (FinalizerFn, error) {
 	finalizerFn := func() error { return f.DeleteRoleBinding(ns, relativePath) }
 	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 	if err != nil {

--- a/test/framework/role-binding.go
+++ b/test/framework/role-binding.go
@@ -15,28 +15,25 @@
 package framework
 
 import (
-	"context"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 )
 
-func CreateRoleBinding(kubeClient kubernetes.Interface, ns string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return DeleteRoleBinding(kubeClient, ns, relativePath) }
-	roleBinding, err := parseRoleBindingYaml(relativePath)
+func (f *Framework) CreateRoleBinding( ns string, relativePath string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteRoleBinding(ns, relativePath) }
+	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 	if err != nil {
 		return finalizerFn, err
 	}
 
-	_, err = kubeClient.RbacV1().RoleBindings(ns).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(f.Ctx, roleBinding, metav1.CreateOptions{})
 	return finalizerFn, err
 }
 
-func CreateRoleBindingForSubjectNamespace(kubeClient kubernetes.Interface, ns, subjectNs string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return DeleteRoleBinding(kubeClient, ns, relativePath) }
-	roleBinding, err := parseRoleBindingYaml(relativePath)
+func (f *Framework) CreateRoleBindingForSubjectNamespace(ns, subjectNs string, relativePath string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteRoleBinding(ns, relativePath) }
+	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 
 	for i := range roleBinding.Subjects {
 		roleBinding.Subjects[i].Namespace = subjectNs
@@ -46,20 +43,20 @@ func CreateRoleBindingForSubjectNamespace(kubeClient kubernetes.Interface, ns, s
 		return finalizerFn, err
 	}
 
-	_, err = kubeClient.RbacV1().RoleBindings(ns).Create(context.TODO(), roleBinding, metav1.CreateOptions{})
+	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(f.Ctx, roleBinding, metav1.CreateOptions{})
 	return finalizerFn, err
 }
 
-func DeleteRoleBinding(kubeClient kubernetes.Interface, ns string, relativePath string) error {
-	roleBinding, err := parseRoleBindingYaml(relativePath)
+func (f *Framework) DeleteRoleBinding(ns string, relativePath string) error {
+	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 	if err != nil {
 		return err
 	}
 
-	return kubeClient.RbacV1().RoleBindings(ns).Delete(context.TODO(), roleBinding.Name, metav1.DeleteOptions{})
+	return f.KubeClient.RbacV1().RoleBindings(ns).Delete(f.Ctx, roleBinding.Name, metav1.DeleteOptions{})
 }
 
-func parseRoleBindingYaml(relativePath string) (*rbacv1.RoleBinding, error) {
+func (f *Framework) parseRoleBindingYaml(relativePath string) (*rbacv1.RoleBinding, error) {
 	manifest, err := PathToOSFile(relativePath)
 	if err != nil {
 		return nil, err

--- a/test/framework/secret.go
+++ b/test/framework/secret.go
@@ -15,14 +15,11 @@
 package framework
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
-func MakeSecretWithCert(kubeClient kubernetes.Interface, ns, name string, keyList []string,
+func MakeSecretWithCert(ns, name string, keyList []string,
 	dataList [][]byte) *corev1.Secret {
 
 	secret := &corev1.Secret{
@@ -38,10 +35,10 @@ func MakeSecretWithCert(kubeClient kubernetes.Interface, ns, name string, keyLis
 	return secret
 }
 
-func CreateSecretWithCert(kubeClient kubernetes.Interface, certBytes, keyBytes []byte, ns, name string) error {
+func (f *Framework) CreateSecretWithCert(certBytes, keyBytes []byte, ns, name string) error {
 
-	secret := MakeSecretWithCert(kubeClient, ns, name, []string{"tls.key", "tls.crt"}, [][]byte{keyBytes, certBytes})
-	_, err := kubeClient.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
+	secret := MakeSecretWithCert(ns, name, []string{"tls.key", "tls.crt"}, [][]byte{keyBytes, certBytes})
+	_, err := f.KubeClient.CoreV1().Secrets(ns).Create(f.Ctx, secret, metav1.CreateOptions{})
 
 	return err
 }

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -177,8 +177,7 @@ func (f *Framework) DeleteThanosRulerAndWaitUntilGone(ns, name string) error {
 		return errors.Wrap(err, fmt.Sprintf("deleting ThanosRuler custom resource %v failed", name))
 	}
 
-	if err := WaitForPodsReady(
-		f.KubeClient,
+	if err := f.WaitForPodsReady(
 		ns,
 		f.DefaultTimeout,
 		0,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes #3158 

context.TODO() now remains only with informers which cannot be updated since they are generated code

```bash
░▒▓    ~/gi/s/prometheus-operator  on   remove_context_todo  find . -name "*go" | xargs grep -l context.TODO                PIPE ✘  took 38s   3.9.5   1.16.4   2.7.3   at admin ⎈  at 15:52:10  ▓▒░
./pkg/client/informers/externalversions/monitoring/v1/podmonitor.go
./pkg/client/informers/externalversions/monitoring/v1/prometheusrule.go
./pkg/client/informers/externalversions/monitoring/v1/servicemonitor.go
./pkg/client/informers/externalversions/monitoring/v1/alertmanager.go
./pkg/client/informers/externalversions/monitoring/v1/probe.go
./pkg/client/informers/externalversions/monitoring/v1/prometheus.go
./pkg/client/informers/externalversions/monitoring/v1/thanosruler.go
./pkg/client/informers/externalversions/monitoring/v1alpha1/alertmanagerconfig.go

░▒▓    ~/gi/s/prometheus-operator  on   remove_context_todo      
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

Remove context.TODO() from framework, e2e tests, amcg_test and k8sutil_test
```
