### PR TITLE
Add links to discussions and slack in "Create Issue"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false # Show or hide the Create a blank issue choice when users select New issue.
+contact_links:
+  - name: "Questions via prometheus-operator community support on kubernetes slack - #prometheus-operator"
+    url: https://kubernetes.slack.com/archives/CFFDS2Z7F
+    about: "Join us for questions, answers or prometheus-operator related chat. Please do create issues on Github for better collaboration. If you don't have an account, sign up at http://slack.k8s.io/"
+  - name: "Question via prometheus-operator discussions (similar to Stack Overflow)"
+    url: https://github.com/prometheus-operator/prometheus-operator/discussions
+    about: "Please ask and answer questions here for async response."


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should redirect some people to slack channel and discussions forum instead of creating support-type issues.

Shamelessly taken from thanos - https://github.com/thanos-io/thanos/blob/main/.github/ISSUE_TEMPLATE/config.yml :)

/cc @prometheus-operator/prometheus-operator-reviewers 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
