### PR TITLE
fix: Add list/watch request verbs to services/endpoints in ClusterRole

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -20626,8 +20626,18 @@ rules:
   - ""
   resources:
   - services
-  - services/finalizers
   - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services/finalizers
   verbs:
   - get
   - create


### PR DESCRIPTION
Fixes #4114.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
Add list/watch request verbs to services/endpoints in ClusterRole
```
