### PR TITLE
Add timeout to the informers cache synchronization

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -325,26 +325,27 @@ func SanitizeSTS(sts *appsv1.StatefulSet) {
 	}
 }
 
-// WaitForNamedCacheSync synchronizes the informer's cache and will log a warning
-// every minute if the operation hasn't completed yet.
+// WaitForNamedCacheSync synchronizes the informer's cache and will log a
+// warning every minute if the operation hasn't completed yet, until it reaches
+// a timeout of 10 minutes.
 // Under normal circumstances, the cache sync should be fast. If it takes more
 // than 1 minute, it means that something is stuck and the message will
 // indicate to the admin which informer is the culprit.
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347.
 func WaitForNamedCacheSync(ctx context.Context, controllerName string, logger log.Logger, inf cache.SharedIndexInformer) bool {
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
 
-	done := make(chan struct{})
+	t := time.NewTicker(time.Minute)
+	defer t.Stop()
+
 	go func() {
-		t := time.NewTicker(time.Minute)
-		defer t.Stop()
-
 		for {
 			select {
 			case <-t.C:
 				level.Warn(logger).Log("msg", "cache sync not yet completed")
 			case <-ctx.Done():
-				close(done)
+				return
 			}
 		}
 	}()
@@ -355,10 +356,6 @@ func WaitForNamedCacheSync(ctx context.Context, controllerName string, logger lo
 	} else {
 		level.Debug(logger).Log("msg", "successfully synced cache")
 	}
-
-	// Stop the logging goroutine and wait for its exit.
-	cancel()
-	<-done
 
 	return ok
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

During heavy apiserver disruptions, the informers cache synchronization
done by the operator before running the informers might never return.
This results in the operator being stuck forever waiting for its
informers caches to be synchronized.
To prevent that, we introduce a timeout of 10 minutes in the context
passed to client-go to make sure that the sync will always return at
some point.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note**

```release-note:bug
Add a 10 minutes timeout to the informers cache synchronization
```

/cc @simonpasquier 