### PR TITLE
pkg/operator: fix logging in WaitForNamedCacheSync()

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -339,11 +339,13 @@ func WaitForNamedCacheSync(ctx context.Context, controllerName string, logger lo
 		t := time.NewTicker(time.Minute)
 		defer t.Stop()
 
-		select {
-		case <-t.C:
-			level.Warn(logger).Log("msg", "cache sync not yet completed")
-		case <-ctx.Done():
-			close(done)
+		for {
+			select {
+			case <-t.C:
+				level.Warn(logger).Log("msg", "cache sync not yet completed")
+			case <-ctx.Done():
+				close(done)
+			}
 		}
 	}()
 


### PR DESCRIPTION
When the cache sync operation takes more than a minute, the
WaitForNamedCacheSync() function would log "cache sync not yet
completed" only once. This change ensures that the message is logged
every minute until the operation completes.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:bug
fix logging when cache sync is stuck.
```
