### PR TITLE
WIP: .github: enable checking if PR description contains valid release note

### DIFF
--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -1,0 +1,16 @@
+name: validate-pr
+on:
+  pull_request:
+jobs:
+  validate-pr-description:
+    runs-on: ubuntu-latest
+    name: notes
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        # Make sure `release-note` is present
+        cat "$GITHUB_EVENT_PATH" | jq -r '.pull_request.body' | grep -c 'release-note'
+        # Make sure `release-note` is changed
+        cat "$GITHUB_EVENT_PATH" | jq -r '.pull_request.body' | grep -vz 'release-note:REPLACEME'
+
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is adding CI job which will fail if release note string in PR description wasn't modified.

The idea is to simplify automation of changelog generation during release process.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
