### PR TITLE
*: volunteer as 0.50 release shepherd

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v0.47   | 2021-04-07                                 | Simon Pasquier (GitHub: @simonpasquier)     |
 | v0.48   | 2021-05-19                                 | Matthias Loibl (GitHub: @metalmatze)        |
 | v0.49   | 2021-06-30                                 | Pawel Krupa (GitHub: @paulfantom)           |
-| v0.50   | 2021-08-11                                 | **searching for volunteer**                 |
+| v0.50   | 2021-08-11                                 | Pawel Krupa (GitHub: @paulfantom)           |
 | v0.51   | 2021-09-08                                 | Simon Pasquier (GitHub: @simonpasquier)     |
 | v0.52   | 2021-10-20                                 | **searching for volunteer**                 |
 | v0.53   | 2021-12-15                                 | **searching for volunteer**                 |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I probably won't be able to do 0.52 nor 0.53 so volunteering for 0.50. Unless anyone from @prometheus-operator/prometheus-operator-reviewers wants to take this one ;)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
