### PR TITLE
.github/workflows: publish untagged images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,17 +1,16 @@
 name: publish
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
-    - "checks"
-    - "unit"
-    - "e2e"
+      - "checks"
+      - "unit"
+      - "e2e"
     types: [completed]
     branches:
       - 'release-*'
       - 'master'
       - 'main'
-    tags:
-      - 'v*'
 
 env:
   golang-version: '1.16'
@@ -19,7 +18,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish container images
-    if: ${{ github.event_name == 'push' && github.event.workflow_run.conclusion == 'success' }}
+    if: > 
+      ${{ 
+        github.event.workflow_run.event == 'push' && 
+        github.event.workflow_run.conclusion == 'success'
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

* Allow manually triggering workflow by adding workflow_dispatch
* Remove 'tags' keyword as it is not supported for workflow_run
* Fix condition to better detect an event (used example from      https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Fixes #4150 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
