### PR TITLE
fix loading clusterConfig from KUBECONFIG env

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -66,11 +66,12 @@ func NewClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientCo
 	var cfg *rest.Config
 	var err error
 
-	kubeconfigFile := os.Getenv(KubeConfigEnv)
-	if kubeconfigFile != "" {
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigFile)
+	kubeconfigPath := os.Getenv(KubeConfigEnv)
+	if kubeconfigPath != "" {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 		if err != nil {
-			return nil, fmt.Errorf("error creating config from %s: %w", kubeconfigFile, err)
+			return nil, fmt.Errorf("error creating config from %s: %w", kubeconfigPath, err)
 		}
 	} else {
 		if len(host) == 0 {


### PR DESCRIPTION
- fix loading ClusterConfig from KUBECONFIG env

Currently, prometheus-operator support loading Kubeconfig from `KUBECONFIG` env, which is a recommended way setting kubeconfig in k8s' [official doc](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable). The code below is able to load kubeconfig if one's `KUBECONFIG` env points to a specific file, like we do in `kubectl --kubeconfig /path/to/config`. But in my case my `KUBECONFIG` env is not a path to a single file but concatenated with other path together like it's done in the [official doc](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#append-home-kube-config-to-your-kubeconfig-environment-variable) too here, this way we will run into an error using `clientcmd.BuildConfigFromFlags("", kubeconfigFile)`.

https://github.com/prometheus-operator/prometheus-operator/blob/2388bfa557c9836d5ff01e620a129d33852670ff/pkg/k8sutil/k8sutil.go#L69-L74

FYI, I've test with the new way to load ClusterConfig, it's okay for both situation mentioned above.

**Release Note Template (will be copied)**

```release-note:enhancement
support loading ClusterConfig from concatenated KUBECONFIG env.
```
