### PR TITLE
*: specify all maintainers of prometheus-operator organisation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-## Core Maintainers of this repository
+## Maintainers of Prometheus Operator organization
 
 | Name                  | Email                       | Kubernetes Slack         | GitHub                                            | Company           |
 |-----------------------|-----------------------------|--------------------------|---------------------------------------------------|-------------------|
@@ -9,6 +9,9 @@
 | Sergiusz Urbaniak     | sergiusz.urbaniak@gmail.com | `@sur`                   | [@s-urbaniak](https://github.com/s-urbaniak)      | Red Hat           |
 | Simon Pasquier        | pasquier.simon@gmail.com    | `@SimonPasquier`         | [@simonpasquier](https://github.com/simonpasquier)| Red Hat           |
 | Vasily Sliouniaev     |                             | `@vas`                   | [@vsliouniaev](https://github.com/vsliouniaev)    |                   |
+| Kemal Akkoyun         | kakkoyun@gmail.com          | `@kakkoyun`              | [@kakkoyun](https://github.com/kakkoyun)          | Polar Signals     |
+| Damien Grisonnet      | dgrisonn@redhat.com         | `@dgrisonnet`            | [@dgrisonnet](https://github.com/dgrisonnet)      | Red Hat           |
+| Arthur Silva Sens     | arthursens2005@gmail.com    | `@Arthur Silva Sens`     | [@ArthurSens](https://github.com/ArthurSens)      | Gitpod            |
 
 Please reach any of the maintainer on slack (#prometheus-operator on https://slack.k8s.io/) or email if you want to help.
 
@@ -25,7 +28,7 @@ Full list of triage people is displayed below:
 
 ## How to be maintainer?
 
-Any contributor that shows effort, consistentcy and willingness in maintaining this repository will be invited to join the Maintainers team.
+Any contributor that shows effort, consistentcy and willingness in maintaining a repository will be invited to join the Maintainers team.
 
 Open Source is all about the trust, which is the key factor in decision to add write permissions.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As discussed internally. Let's unify who is a "maintainer" in prometheus-operator organization by joining @prometheus-operator/prometheus-operator-reviewers and @prometheus-operator/kube-prometheus-reviewers into one team :)

@kakkoyun @dgrisonnet @ArthurSens please verify if you agree with the data in this document.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none

```
