### PR TITLE
.github/workflows: improve image publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,9 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows:
-      - "checks"
-      - "unit"
+      # "publish" workflow will start on ANY other workflow specified in this list.
+      # Specifying the one that is potentially longest running will delay publishing
+      # and allow checking status of other workflows in steps
       - "e2e"
     types: [completed]
     branches:
@@ -24,6 +25,25 @@ jobs:
         github.event.workflow_run.conclusion == 'success'
       }}
     steps:
+      - name: Wait for checks to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-checks
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: checks
+      - name: Wait for unit tests to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-unit
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: unit
+      - name: Exit if other workflows didn't succeeded
+        if: >
+          ${{
+            steps.wait-for-checks.outputs.conclusion != 'success' &&
+            steps.wait-for-unit.outputs.conclusion != 'success'
+          }}
+        run: exit 1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Go


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Follow-up to https://github.com/prometheus-operator/prometheus-operator/pull/4152

I tested the #4152 on a repository with only one depending workflow and GitHub docs are not great at explaining how `workflow_run.workflows` work. Turns out that list is ORed and not ANDed, so `publish` workflow would run after any other workflow specified in list is completed. This in turn causes publishing images 3 times in prometheus-operator.

This fix would cause to run `publish` workflow only after `e2e` workflow is completed and wait for `checks` and `unit` workflows to be successfully completed too. `e2e` workflow was chosen to be a trigger because it 
is running for an order of magnitude longer than the other 2 workflows.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:none
```
