### PR TITLE
Include Shards count as a metric as mentioned in #4168

### DIFF
--- a/pkg/prometheus/collector.go
+++ b/pkg/prometheus/collector.go
@@ -29,6 +29,14 @@ var (
 			"name",
 		}, nil,
 	)
+	descPrometheusSpecShards = prometheus.NewDesc(
+		"prometheus_operator_spec_shards",
+		"Number of expected shards for the object.",
+		[]string{
+			"namespace",
+			"name",
+		}, nil,
+	)
 	descPrometheusEnforcedSampleLimit = prometheus.NewDesc(
 		"prometheus_operator_prometheus_enforced_sample_limit",
 		"Global limit on the number of scraped samples per scrape target.",
@@ -51,6 +59,7 @@ func newPrometheusCollectorForStores(s ...cache.Store) *prometheusCollector {
 func (c *prometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descPrometheusSpecReplicas
 	ch <- descPrometheusEnforcedSampleLimit
+	ch <- descPrometheusSpecShards
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -71,5 +80,8 @@ func (c *prometheusCollector) collectPrometheus(ch chan<- prometheus.Metric, p *
 	// Include EnforcedSampleLimit in metrics if set in Prometheus object.
 	if p.Spec.EnforcedSampleLimit != nil {
 		ch <- prometheus.MustNewConstMetric(descPrometheusEnforcedSampleLimit, prometheus.GaugeValue, float64(*p.Spec.EnforcedSampleLimit), p.Namespace, p.Name)
+	}
+	if p.Spec.Shards != nil {
+		ch <- prometheus.MustNewConstMetric(descPrometheusSpecShards, prometheus.GaugeValue, float64(*p.Spec.Shards), p.Namespace, p.Name)
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Include Shards count as a metric as mentioned in #4168

Closes #4168


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

- release-note:feature
```
Adds prometheus_operator_spec_shards metric for exposing the number of shards set on prometheus operator spec
```
