### PR TITLE
Remove context field from framework struct in tests

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -44,7 +44,6 @@ func TestGenerateConfig(t *testing.T) {
 		expected   string
 	}
 
-	ctx := context.Background()
 	globalSlackAPIURL, err := url.Parse("http://slack.example.com")
 	if err != nil {
 		t.Fatal("Could not parse slack API URL")
@@ -715,7 +714,7 @@ templates: []
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewStore(tc.kclient.CoreV1(), tc.kclient.CoreV1())
 			cg := newConfigGenerator(nil, version, store)
-			cfgBytes, err := cg.generateConfig(ctx, tc.baseConfig, tc.amConfigs)
+			cfgBytes, err := cg.generateConfig(context.Background(), tc.baseConfig, tc.amConfigs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -140,7 +140,6 @@ func TestPropagateKubectlTemplateAnnotations(t *testing.T) {
 }
 
 func TestMergeMetadata(t *testing.T) {
-	ctx := context.Background()
 	testCases := []struct {
 		name                string
 		expectedLabels      map[string]string
@@ -216,17 +215,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSvc.Annotations[a] = v
 				}
-				_, err := svcClient.Update(ctx, modifiedSvc, metav1.UpdateOptions{})
+				_, err := svcClient.Update(context.Background(), modifiedSvc, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateService(ctx, svcClient, service)
+				err = CreateOrUpdateService(context.Background(), svcClient, service)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSvc, err := svcClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
+				updatedSvc, err := svcClient.Get(context.Background(), "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -262,17 +261,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedEndpoints.Annotations[a] = v
 				}
-				_, err := endpointsClient.Update(ctx, modifiedEndpoints, metav1.UpdateOptions{})
+				_, err := endpointsClient.Update(context.Background(), modifiedEndpoints, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateEndpoints(ctx, endpointsClient, endpoints)
+				err = CreateOrUpdateEndpoints(context.Background(), endpointsClient, endpoints)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedEndpoints, err := endpointsClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
+				updatedEndpoints, err := endpointsClient.Get(context.Background(), "prometheus-operated", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -308,17 +307,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSset.Annotations[a] = v
 				}
-				_, err := ssetClient.Update(ctx, modifiedSset, metav1.UpdateOptions{})
+				_, err := ssetClient.Update(context.Background(), modifiedSset, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = UpdateStatefulSet(ctx, ssetClient, sset)
+				err = UpdateStatefulSet(context.Background(), ssetClient, sset)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSset, err := ssetClient.Get(ctx, "prometheus", metav1.GetOptions{})
+				updatedSset, err := ssetClient.Get(context.Background(), "prometheus", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -354,17 +353,17 @@ func TestMergeMetadata(t *testing.T) {
 				for a, v := range tc.modifiedAnnotations {
 					modifiedSecret.Annotations[a] = v
 				}
-				_, err := sClient.Update(ctx, modifiedSecret, metav1.UpdateOptions{})
+				_, err := sClient.Update(context.Background(), modifiedSecret, metav1.UpdateOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				err = CreateOrUpdateSecret(ctx, sClient, secret)
+				err = CreateOrUpdateSecret(context.Background(), sClient, secret)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				updatedSecret, err := sClient.Get(ctx, "prometheus-tls-assets", metav1.GetOptions{})
+				updatedSecret, err := sClient.Get(context.Background(), "prometheus-tls-assets", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -41,37 +40,36 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 	//
 	// 3. "nonInstance" ns:
 	//   - hosts an Alertmanager CR which must not be reconciled
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	nonInstanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	nonInstanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, nil, nil, nil, []string{instanceNs}, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, nil, nil, []string{instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am := framework.MakeBasicAlertmanager("non-instance", 3)
 	am.Namespace = nonInstanceNs
-	_, err = framework.MonClientV1.Alertmanagers(nonInstanceNs).Create(ctx, am, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(nonInstanceNs).Create(context.Background(), am, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am = framework.MakeBasicAlertmanager("instance", 3)
 	am.Namespace = instanceNs
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, instanceNs, am); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), instanceNs, am); err != nil {
 		t.Fatal(err)
 	}
 
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(ctx, "alertmanager-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.Background(), "alertmanager-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 }
 
 func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -84,24 +82,23 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 	//   - will be configured on prometheus operator as --alertmanager-instance-namespaces="instance"
 	//   - will additionally be configured on prometheus operator as --deny-namespaces="instance"
 	//   - hosts an alertmanager CR which must be reconciled.
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, nil, []string{instanceNs}, nil, []string{instanceNs}, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, []string{instanceNs}, nil, []string{instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am := framework.MakeBasicAlertmanager("instance", 3)
 	am.Namespace = instanceNs
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, instanceNs, am); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), instanceNs, am); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -119,13 +116,13 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts an AlertmanagerConfig CR which must be reconciled
 	//   - hosts an Alertmanager CR which must not reconciled.
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := framework.AddLabelsToNamespace(ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(context.Background(), ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -134,7 +131,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	}
 
 	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, []string{"notfound", allowedNs}, nil, nil, []string{"notfound", instanceNs}, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{"notfound", allowedNs}, nil, nil, []string{"notfound", instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,18 +152,18 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	}
 
 	// Create an Alertmanager resource in the "allowedNs" namespace which must *not* be reconciled.
-	_, err = framework.MonClientV1.Alertmanagers(allowedNs).Create(ctx, am.DeepCopy(), metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(allowedNs).Create(context.Background(), am.DeepCopy(), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Create an Alertmanager resource in the "instance" namespace which must be reconciled.
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, instanceNs, am); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), instanceNs, am); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check that the Alertmanager resource created in the "allowed" namespace hasn't been reconciled.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(ctx, "alertmanager-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.Background(), "alertmanager-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
@@ -189,16 +186,16 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 		},
 	}
 
-	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(instanceNs).Create(ctx, amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(instanceNs).Create(context.Background(), amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(allowedNs).Create(ctx, amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err = framework.MonClientV1alpha1.AlertmanagerConfigs(allowedNs).Create(context.Background(), amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check that the AlertmanagerConfig resource in the "allowed" namespace is reconciled but not the one in "instance".
-	err = framework.PollAlertmanagerConfiguration(ctx, instanceNs, "instance",
+	err = framework.PollAlertmanagerConfiguration(context.Background(), instanceNs, "instance",
 		func(config string) error {
 			if !strings.Contains(config, "void") {
 				return fmt.Errorf("expected generated configuration to contain %q but got %q", "void", config)

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -43,20 +43,18 @@ import (
 func testAMCreateDeleteCluster(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx, ns, name); err != nil {
+	if err := framework.DeleteAlertmanagerAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -64,28 +62,26 @@ func testAMCreateDeleteCluster(t *testing.T) {
 func testAMScaling(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
-	a, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, framework.MakeBasicAlertmanager(name, 3))
+	a, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, framework.MakeBasicAlertmanager(name, 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	a.Spec.Replicas = proto.Int32(5)
-	a, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, a)
+	a, err = framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, a)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	a.Spec.Replicas = proto.Int32(3)
-	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, a); err != nil {
+	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, a); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,29 +89,28 @@ func testAMScaling(t *testing.T) {
 func testAMVersionMigration(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
 	am.Spec.Version = "v0.16.2"
-	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, am)
+	am, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.17.0"
-	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, am)
+	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.16.2"
-	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, am)
+	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,16 +119,15 @@ func testAMVersionMigration(t *testing.T) {
 func testAMStorageUpdate(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
 
-	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, am)
+	am, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,13 +145,13 @@ func testAMStorageUpdate(t *testing.T) {
 		},
 	}
 
-	_, err = framework.MonClientV1.Alertmanagers(ns).Update(ctx, am, metav1.UpdateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(ns).Update(context.Background(), am, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, alertmanager.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), alertmanager.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -183,27 +177,25 @@ func testAMStorageUpdate(t *testing.T) {
 func testAMExposingWithKubernetesAPI(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	proxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
-	_, err := request.DoRaw(ctx)
+	_, err := request.DoRaw(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,12 +204,10 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 func testAMClusterInitialization(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
@@ -230,24 +220,24 @@ func testAMClusterInitialization(t *testing.T) {
 		}
 
 		for i := 0; i < amClusterSize; i++ {
-			err := framework.PrintPodLogs(ctx, ns, fmt.Sprintf("alertmanager-test-%v", strconv.Itoa(i)))
+			err := framework.PrintPodLogs(context.Background(), ns, fmt.Sprintf("alertmanager-test-%v", strconv.Itoa(i)))
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
 	}()
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(context.Background(), ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -262,21 +252,21 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
+
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	amClusterSize := 3
 
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
 
-	if alertmanager, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if alertmanager, err = framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(context.Background(), ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -285,13 +275,13 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 	// line flags via the Retention.
 	alertmanager.Spec.Retention = "1h"
 
-	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(context.Background(), ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -300,34 +290,33 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 func testAMClusterGossipSilences(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(context.Background(), ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	silID, err := framework.CreateSilence(ctx, ns, "alertmanager-test-0")
+	silID, err := framework.CreateSilence(context.Background(), ns, "alertmanager-test-0")
 	if err != nil {
 		t.Fatalf("failed to create silence: %v", err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		err = wait.Poll(time.Second, framework.DefaultTimeout, func() (bool, error) {
-			silences, err := framework.GetSilences(ctx, ns, "alertmanager-"+alertmanager.Name+"-"+strconv.Itoa(i))
+			silences, err := framework.GetSilences(context.Background(), ns, "alertmanager-"+alertmanager.Name+"-"+strconv.Itoa(i))
 			if err != nil {
 				return false, err
 			}
@@ -350,11 +339,10 @@ func testAMClusterGossipSilences(t *testing.T) {
 func testAMReloadConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
 	templateResourceName := fmt.Sprintf("alertmanager-templates-%s", alertmanager.Name)
@@ -448,55 +436,55 @@ An Alert test
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, templateCfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.Background(), templateCfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, templateSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), templateSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.Background(), cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	firstExpectedString := "firstConfigWebHook"
-	if err := framework.WaitForAlertmanagerConfigToContainString(ctx, ns, alertmanager.Name, firstExpectedString); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(context.Background(), ns, alertmanager.Name, firstExpectedString); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for first expected config"))
 	}
 	cfg.Data["alertmanager.yaml"] = []byte(secondConfig)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.Background(), cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	secondExpectedString := "secondConfigWebHook"
 
-	if err := framework.WaitForAlertmanagerConfigToContainString(ctx, ns, alertmanager.Name, secondExpectedString); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(context.Background(), ns, alertmanager.Name, secondExpectedString); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for second expected config"))
 	}
 
 	priorToReloadTime := time.Now()
 	templateCfg.Data[templateFileKey] = secondTemplate
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(ctx, templateCfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(context.Background(), templateCfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ctx, ns, alertmanager.Name, priorToReloadTime); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToBeReloaded(context.Background(), ns, alertmanager.Name, priorToReloadTime); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for additional configMaps reload"))
 	}
 
 	priorToReloadTime = time.Now()
 	templateSecret.Data[templateSecretFileKey] = []byte(secondTemplate)
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, templateSecret, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.Background(), templateSecret, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ctx, ns, alertmanager.Name, priorToReloadTime); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToBeReloaded(context.Background(), ns, alertmanager.Name, priorToReloadTime); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for additional secrets reload"))
 	}
 }
@@ -504,11 +492,10 @@ An Alert test
 func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	whReplicas := int32(1)
 	whdpl := &appsv1.Deployment{
@@ -563,13 +550,13 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			},
 		},
 	}
-	if err := framework.CreateDeployment(ctx, ns, whdpl); err != nil {
+	if err := framework.CreateDeployment(context.Background(), ns, whdpl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, whsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, whsvc); err != nil {
 		t.Fatal(err)
 	}
-	err := framework.WaitForPodsReady(ctx, ns, time.Minute*5, 1,
+	err := framework.WaitForPodsReady(context.Background(), ns, time.Minute*5, 1,
 		metav1.ListOptions{
 			LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
 				"app.kubernetes.io/name": "alertmanager-webhook",
@@ -611,20 +598,20 @@ inhibit_rules:
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, amcfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), amcfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(ctx, alertmanager, metav1.CreateOptions{})
+	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(context.Background(), alertmanager, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerReady(ctx, ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
+	if err := framework.WaitForAlertmanagerReady(context.Background(), ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, amsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -651,7 +638,7 @@ inhibit_rules:
 				select {
 				case <-ticker.C:
 					err := framework.SendAlertToAlertmanager(
-						ctx,
+						context.Background(),
 						ns,
 						"alertmanager-rolling-deploy-"+strconv.Itoa(replica),
 					)
@@ -679,7 +666,7 @@ inhibit_rules:
 			"app.kubernetes.io/name": "alertmanager-webhook",
 		})).String(),
 	}
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -689,7 +676,7 @@ inhibit_rules:
 	}
 
 	podName := pl.Items[0].Name
-	logs, err := framework.GetLogs(ctx, ns, podName, "webhook-server")
+	logs, err := framework.GetLogs(context.Background(), ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -702,19 +689,19 @@ inhibit_rules:
 	// We need to force a rolling update, e.g. by changing one of the command
 	// line flags via the Retention.
 	alertmanager.Spec.Retention = "1h"
-	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(ctx, alertmanager, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(context.Background(), alertmanager, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Wait for the change above to take effect.
 	time.Sleep(time.Minute)
 
-	if err := framework.WaitForAlertmanagerReady(ctx, ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
+	if err := framework.WaitForAlertmanagerReady(context.Background(), ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(time.Minute)
 
-	logs, err = framework.GetLogs(ctx, ns, podName, "webhook-server")
+	logs, err = framework.GetLogs(context.Background(), ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,25 +715,23 @@ inhibit_rules:
 func testAlertmanagerConfigCRD(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	configNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	configNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("amconfig-crd", 1)
 	alertmanager.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
 	alertmanager.Spec.AlertmanagerConfigNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"monitored": "true"},
 	}
-	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager)
+	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.AddLabelsToNamespace(ctx, configNs, map[string]string{"monitored": "true"}); err != nil {
+	if err := framework.AddLabelsToNamespace(context.Background(), configNs, map[string]string{"monitored": "true"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -761,7 +746,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			testingSecretKey: []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, testingKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), testingKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -773,7 +758,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-key": []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, apiKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), apiKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -785,7 +770,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-url": []byte("http://slack.example.com"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -905,7 +890,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.Background(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -967,7 +952,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.Background(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -996,7 +981,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.Background(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1028,7 +1013,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.Background(), configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1036,7 +1021,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	var lastErr error
 	amConfigSecretName := fmt.Sprintf("alertmanager-%s-generated", alertmanager.Name)
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1141,12 +1126,12 @@ templates: []
 	// AlertmanagerConfig resources and wait until the Alertmanager
 	// configuration gets regenerated.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := framework.RemoveLabelsFromNamespace(ctx, configNs, "monitored"); err != nil {
+	if err := framework.RemoveLabelsFromNamespace(context.Background(), configNs, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1189,12 +1174,10 @@ templates: []
 func testUserDefinedAlertmanagerConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	yamlConfig := `route:
   receiver: "void"
@@ -1210,20 +1193,20 @@ receivers:
 			"template1.tmpl":    []byte(`template1`),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	alertmanager := framework.MakeBasicAlertmanager("user-amconfig", 1)
 	alertmanager.Spec.ConfigSecret = "amconfig"
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for the change above to take effect.
 	var lastErr error
 	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, "alertmanager-user-amconfig-generated", metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), "alertmanager-user-amconfig-generated", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			lastErr = err
 			return false, nil
@@ -1256,19 +1239,17 @@ receivers:
 
 func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	alertManager := framework.MakeBasicAlertmanager(name, 3)
 	alertManager.Namespace = ns
 
-	alertManager, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertManager)
+	alertManager, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertManager)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1292,28 +1273,28 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "alertmanager-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(ctx, "alertmanager-operated", metav1.GetOptions{})
+				return svcClient.Get(context.Background(), "alertmanager-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(ctx, asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(context.Background(), asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(ctx, "alertmanager-test", metav1.GetOptions{})
+				return ssetClient.Get(context.Background(), "alertmanager-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(context.Background(), asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager secret",
 			get: func() (metav1.Object, error) {
-				return secretClient.Get(ctx, "alertmanager-test-generated", metav1.GetOptions{})
+				return secretClient.Get(context.Background(), "alertmanager-test-generated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return secretClient.Update(ctx, asSecret(t, object), metav1.UpdateOptions{})
+				return secretClient.Update(context.Background(), asSecret(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}
@@ -1335,7 +1316,7 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 
 	// Ensure resource reconciles
 	alertManager.Spec.Replicas = proto.Int32(2)
-	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, alertManager)
+	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertManager)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1358,7 +1339,7 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx, ns, name); err != nil {
+	if err := framework.DeleteAlertmanagerAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -44,18 +44,19 @@ func testAMCreateDeleteCluster(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	name := "test"
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, framework.MakeBasicAlertmanager(name, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ns, name); err != nil {
+	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx, ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -64,26 +65,27 @@ func testAMScaling(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	name := "test"
 
-	a, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, framework.MakeBasicAlertmanager(name, 3))
+	a, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, framework.MakeBasicAlertmanager(name, 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	a.Spec.Replicas = proto.Int32(5)
-	a, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, a)
+	a, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, a)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	a.Spec.Replicas = proto.Int32(3)
-	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, a); err != nil {
+	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, a); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -91,29 +93,29 @@ func testAMScaling(t *testing.T) {
 func testAMVersionMigration(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
 	am.Spec.Version = "v0.16.2"
-	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am)
+	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.17.0"
-	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am)
+	am, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	am.Spec.Version = "v0.16.2"
-	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am)
+	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,16 +124,16 @@ func testAMVersionMigration(t *testing.T) {
 func testAMStorageUpdate(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
 
 	name := "test"
 
 	am := framework.MakeBasicAlertmanager(name, 1)
 
-	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am)
+	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, am)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,13 +151,13 @@ func testAMStorageUpdate(t *testing.T) {
 		},
 	}
 
-	_, err = framework.MonClientV1.Alertmanagers(ns).Update(framework.Ctx, am, metav1.UpdateOptions{})
+	_, err = framework.MonClientV1.Alertmanagers(ns).Update(ctx, am, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, alertmanager.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, alertmanager.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -182,25 +184,26 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("test-alertmanager", 1)
 	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	proxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := proxyGet("", alertmanagerService.Name, "web", "/", make(map[string]string))
-	_, err := request.DoRaw(framework.Ctx)
+	_, err := request.DoRaw(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,10 +213,11 @@ func testAMClusterInitialization(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
@@ -226,24 +230,24 @@ func testAMClusterInitialization(t *testing.T) {
 		}
 
 		for i := 0; i < amClusterSize; i++ {
-			err := framework.PrintPodLogs(ns, fmt.Sprintf("alertmanager-test-%v", strconv.Itoa(i)))
+			err := framework.PrintPodLogs(ctx, ns, fmt.Sprintf("alertmanager-test-%v", strconv.Itoa(i)))
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
 	}()
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -258,20 +262,21 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
 	amClusterSize := 3
 
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
 
-	if alertmanager, err = framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if alertmanager, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -280,13 +285,13 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 	// line flags via the Retention.
 	alertmanager.Spec.Retention = "1h"
 
-	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -295,33 +300,34 @@ func testAMClusterAfterRollingUpdate(t *testing.T) {
 func testAMClusterGossipSilences(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager("test", int32(amClusterSize))
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		name := "alertmanager-" + alertmanager.Name + "-" + strconv.Itoa(i)
-		if err := framework.WaitForAlertmanagerInitialized(ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
+		if err := framework.WaitForAlertmanagerInitialized(ctx, ns, name, amClusterSize, alertmanager.Spec.ForceEnableClusterMode); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	silID, err := framework.CreateSilence(ns, "alertmanager-test-0")
+	silID, err := framework.CreateSilence(ctx, ns, "alertmanager-test-0")
 	if err != nil {
 		t.Fatalf("failed to create silence: %v", err)
 	}
 
 	for i := 0; i < amClusterSize; i++ {
 		err = wait.Poll(time.Second, framework.DefaultTimeout, func() (bool, error) {
-			silences, err := framework.GetSilences(ns, "alertmanager-"+alertmanager.Name+"-"+strconv.Itoa(i))
+			silences, err := framework.GetSilences(ctx, ns, "alertmanager-"+alertmanager.Name+"-"+strconv.Itoa(i))
 			if err != nil {
 				return false, err
 			}
@@ -344,11 +350,11 @@ func testAMClusterGossipSilences(t *testing.T) {
 func testAMReloadConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("reload-config", 1)
 	templateResourceName := fmt.Sprintf("alertmanager-templates-%s", alertmanager.Name)
@@ -442,55 +448,55 @@ An Alert test
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(framework.Ctx, templateCfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, templateCfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, templateSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, templateSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	firstExpectedString := "firstConfigWebHook"
-	if err := framework.WaitForAlertmanagerConfigToContainString(ns, alertmanager.Name, firstExpectedString); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(ctx, ns, alertmanager.Name, firstExpectedString); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for first expected config"))
 	}
 	cfg.Data["alertmanager.yaml"] = []byte(secondConfig)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	secondExpectedString := "secondConfigWebHook"
 
-	if err := framework.WaitForAlertmanagerConfigToContainString(ns, alertmanager.Name, secondExpectedString); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToContainString(ctx, ns, alertmanager.Name, secondExpectedString); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for second expected config"))
 	}
 
 	priorToReloadTime := time.Now()
 	templateCfg.Data[templateFileKey] = secondTemplate
-	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(framework.Ctx, templateCfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Update(ctx, templateCfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ns, alertmanager.Name, priorToReloadTime); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ctx, ns, alertmanager.Name, priorToReloadTime); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for additional configMaps reload"))
 	}
 
 	priorToReloadTime = time.Now()
 	templateSecret.Data[templateSecretFileKey] = []byte(secondTemplate)
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(framework.Ctx, templateSecret, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, templateSecret, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ns, alertmanager.Name, priorToReloadTime); err != nil {
+	if err := framework.WaitForAlertmanagerConfigToBeReloaded(ctx, ns, alertmanager.Name, priorToReloadTime); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to wait for additional secrets reload"))
 	}
 }
@@ -498,11 +504,11 @@ An Alert test
 func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
-
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	whReplicas := int32(1)
 	whdpl := &appsv1.Deployment{
@@ -557,13 +563,13 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			},
 		},
 	}
-	if err := framework.CreateDeployment(ns, whdpl); err != nil {
+	if err := framework.CreateDeployment(ctx, ns, whdpl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := framework.CreateServiceAndWaitUntilReady(ns, whsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, whsvc); err != nil {
 		t.Fatal(err)
 	}
-	err := framework.WaitForPodsReady(ns, time.Minute*5, 1,
+	err := framework.WaitForPodsReady(ctx, ns, time.Minute*5, 1,
 		metav1.ListOptions{
 			LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
 				"app.kubernetes.io/name": "alertmanager-webhook",
@@ -605,20 +611,20 @@ inhibit_rules:
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, amcfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, amcfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(framework.Ctx, alertmanager, metav1.CreateOptions{})
+	alertmanager, err = framework.MonClientV1.Alertmanagers(ns).Create(ctx, alertmanager, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
+	if err := framework.WaitForAlertmanagerReady(ctx, ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ns, amsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, amsvc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -645,6 +651,7 @@ inhibit_rules:
 				select {
 				case <-ticker.C:
 					err := framework.SendAlertToAlertmanager(
+						ctx,
 						ns,
 						"alertmanager-rolling-deploy-"+strconv.Itoa(replica),
 					)
@@ -672,7 +679,7 @@ inhibit_rules:
 			"app.kubernetes.io/name": "alertmanager-webhook",
 		})).String(),
 	}
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -682,7 +689,7 @@ inhibit_rules:
 	}
 
 	podName := pl.Items[0].Name
-	logs, err := framework.GetLogs(ns, podName, "webhook-server")
+	logs, err := framework.GetLogs(ctx, ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -695,19 +702,19 @@ inhibit_rules:
 	// We need to force a rolling update, e.g. by changing one of the command
 	// line flags via the Retention.
 	alertmanager.Spec.Retention = "1h"
-	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(framework.Ctx, alertmanager, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.Alertmanagers(ns).Update(ctx, alertmanager, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Wait for the change above to take effect.
 	time.Sleep(time.Minute)
 
-	if err := framework.WaitForAlertmanagerReady(ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
+	if err := framework.WaitForAlertmanagerReady(ctx, ns, alertmanager.Name, int(*alertmanager.Spec.Replicas), alertmanager.Spec.ForceEnableClusterMode); err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(time.Minute)
 
-	logs, err = framework.GetLogs(ns, podName, "webhook-server")
+	logs, err = framework.GetLogs(ctx, ns, podName, "webhook-server")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -722,23 +729,24 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	configNs := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	configNs := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager("amconfig-crd", 1)
 	alertmanager.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{}
 	alertmanager.Spec.AlertmanagerConfigNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"monitored": "true"},
 	}
-	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager)
+	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.AddLabelsToNamespace(configNs, map[string]string{"monitored": "true"}); err != nil {
+	if err := framework.AddLabelsToNamespace(ctx, configNs, map[string]string{"monitored": "true"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -753,7 +761,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			testingSecretKey: []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, testingKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, testingKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -765,7 +773,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-key": []byte("1234abc"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, apiKeySecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, apiKeySecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -777,7 +785,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			"api-url": []byte("http://slack.example.com"),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(framework.Ctx, slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(configNs).Create(ctx, slackAPIURLSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -897,7 +905,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -959,7 +967,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -988,7 +996,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1020,7 +1028,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(framework.Ctx, configCR, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(ctx, configCR, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1028,7 +1036,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	var lastErr error
 	amConfigSecretName := fmt.Sprintf("alertmanager-%s-generated", alertmanager.Name)
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1133,12 +1141,12 @@ templates: []
 	// AlertmanagerConfig resources and wait until the Alertmanager
 	// configuration gets regenerated.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := framework.RemoveLabelsFromNamespace(configNs, "monitored"); err != nil {
+	if err := framework.RemoveLabelsFromNamespace(ctx, configNs, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, amConfigSecretName, metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
 			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
 			return false, nil
@@ -1182,10 +1190,11 @@ func testUserDefinedAlertmanagerConfig(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	yamlConfig := `route:
   receiver: "void"
@@ -1201,20 +1210,20 @@ receivers:
 			"template1.tmpl":    []byte(`template1`),
 		},
 	}
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(framework.Ctx, amConfig, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, amConfig, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
 	alertmanager := framework.MakeBasicAlertmanager("user-amconfig", 1)
 	alertmanager.Spec.ConfigSecret = "amconfig"
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertmanager); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertmanager); err != nil {
 		t.Fatal(err)
 	}
 
 	// Wait for the change above to take effect.
 	var lastErr error
 	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(framework.Ctx, "alertmanager-user-amconfig-generated", metav1.GetOptions{})
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, "alertmanager-user-amconfig-generated", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			lastErr = err
 			return false, nil
@@ -1248,17 +1257,18 @@ receivers:
 func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
 
 	name := "test"
 
 	alertManager := framework.MakeBasicAlertmanager(name, 3)
 	alertManager.Namespace = ns
 
-	alertManager, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertManager)
+	alertManager, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, alertManager)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1282,28 +1292,28 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "alertmanager-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(framework.Ctx, "alertmanager-operated", metav1.GetOptions{})
+				return svcClient.Get(ctx, "alertmanager-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(framework.Ctx, asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(ctx, asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(framework.Ctx, "alertmanager-test", metav1.GetOptions{})
+				return ssetClient.Get(ctx, "alertmanager-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(framework.Ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "alertmanager secret",
 			get: func() (metav1.Object, error) {
-				return secretClient.Get(framework.Ctx, "alertmanager-test-generated", metav1.GetOptions{})
+				return secretClient.Get(ctx, "alertmanager-test-generated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return secretClient.Update(framework.Ctx, asSecret(t, object), metav1.UpdateOptions{})
+				return secretClient.Update(ctx, asSecret(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}
@@ -1325,7 +1335,7 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 
 	// Ensure resource reconciles
 	alertManager.Spec.Replicas = proto.Int32(2)
-	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, alertManager)
+	_, err = framework.UpdateAlertmanagerAndWaitUntilReady(ctx, ns, alertManager)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1348,7 +1358,7 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ns, name); err != nil {
+	if err := framework.DeleteAlertmanagerAndWaitUntilGone(ctx, ns, name); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1347,14 +1347,14 @@ func testAMPreserveUserAddedMetadata(t *testing.T) {
 func testAMRollbackManualChanges(t *testing.T) {
 	t.Parallel()
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	alertManager := framework.MakeBasicAlertmanager(name, 3)
-	_, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, alertManager)
+	_, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertManager)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1371,11 +1371,11 @@ func testAMRollbackManualChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerReady(ns, name, 0, false); err != nil {
+	if err := framework.WaitForAlertmanagerReady(context.Background(), ns, name, 0, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForAlertmanagerReady(ns, name, 3, false); err != nil {
+	if err := framework.WaitForAlertmanagerReady(context.Background(), ns, name, 3, false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1385,15 +1385,15 @@ func testAlertManagerMinReadySeconds(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 	runFeatureGatedTests(t)
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	var setMinReadySecondsInitial uint32 = 5
 	am := framework.MakeBasicAlertmanager("basic-am", 3)
 	am.Spec.MinReadySeconds = &setMinReadySecondsInitial
-	am, err := framework.CreateAlertmanagerAndWaitUntilReady(ns, am)
+	am, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, am)
 	if err != nil {
 		t.Fatal("Creating AlertManager failed: ", err)
 	}
@@ -1409,7 +1409,7 @@ func testAlertManagerMinReadySeconds(t *testing.T) {
 
 	var updated uint32 = 10
 	am.Spec.MinReadySeconds = &updated
-	if _, err = framework.UpdateAlertmanagerAndWaitUntilReady(ns, am); err != nil {
+	if _, err = framework.UpdateAlertmanagerAndWaitUntilReady(context.Background(), ns, am); err != nil {
 		t.Fatal("Updating AlertManager failed: ", err)
 	}
 

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -28,34 +28,33 @@ import (
 )
 
 func testDenyPrometheus(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	operatorNamespace := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
-	deniedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
+	operatorNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
+	deniedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
 
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, operatorNamespace)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, denied := range deniedNamespaces {
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, denied)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, denied)
 		p := framework.MakeBasicPrometheus(denied, "denied", "denied", 1)
-		_, err = framework.MonClientV1.Prometheuses(denied).Create(ctx, p, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.Prometheuses(denied).Create(context.Background(), p, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 		}
 	}
 
 	for _, allowed := range allowedNamespaces {
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, allowed)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, allowed)
 		p := framework.MakeBasicPrometheus(allowed, "allowed", "allowed", 1)
-		_, err = framework.CreatePrometheusAndWaitUntilReady(ctx, allowed, p)
+		_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), allowed, p)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,14 +63,14 @@ func testDenyPrometheus(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(ctx, "prometheus-denied", metav1.GetOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.Background(), "prometheus-denied", metav1.GetOptions{})
 		if !api_errors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}
 	}
 
 	for _, allowed := range allowedNamespaces {
-		err := framework.DeletePrometheusAndWaitUntilGone(ctx, allowed, "allowed")
+		err := framework.DeletePrometheusAndWaitUntilGone(context.Background(), allowed, "allowed")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -79,17 +78,16 @@ func testDenyPrometheus(t *testing.T) {
 }
 
 func testDenyServiceMonitor(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	operatorNamespace := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
-	deniedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
+	operatorNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
+	deniedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
 
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, operatorNamespace)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,12 +128,12 @@ func testDenyServiceMonitor(t *testing.T) {
 			},
 		}
 
-		if err := framework.CreateDeployment(ctx, denied, echo); err != nil {
+		if err := framework.CreateDeployment(context.Background(), denied, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, denied, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), denied, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -143,39 +141,39 @@ func testDenyServiceMonitor(t *testing.T) {
 
 		// create the service monitor in a way, that it matches the label selector used in the allowed namespace.
 		s := framework.MakeBasicServiceMonitor("allowed")
-		if _, err := framework.MonClientV1.ServiceMonitors(denied).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(denied).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
 
 	for _, allowed := range allowedNamespaces {
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, allowed)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, allowed)
 		p := framework.MakeBasicPrometheus(allowed, "allowed", "allowed", 1)
-		_, err = framework.CreatePrometheusAndWaitUntilReady(ctx, allowed, p)
+		_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), allowed, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService("allowed", "allowed", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, allowed, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowed, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
 		s := framework.MakeBasicServiceMonitor("allowed")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowed).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowed).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForActiveTargets(ctx, allowed, svc.Name, 1); err != nil {
+		if err := framework.WaitForActiveTargets(context.Background(), allowed, svc.Name, 1); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// just iterate again, so we have a chance to catch a faulty reconciliation of denied namespaces.
 	for _, allowed := range allowedNamespaces {
-		targets, err := framework.GetActiveTargets(ctx, allowed, "prometheus-allowed")
+		targets, err := framework.GetActiveTargets(context.Background(), allowed, "prometheus-allowed")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -186,44 +184,43 @@ func testDenyServiceMonitor(t *testing.T) {
 	}
 
 	for _, allowed := range allowedNamespaces {
-		if err := framework.MonClientV1.ServiceMonitors(allowed).Delete(ctx, "allowed", metav1.DeleteOptions{}); err != nil {
+		if err := framework.MonClientV1.ServiceMonitors(allowed).Delete(context.Background(), "allowed", metav1.DeleteOptions{}); err != nil {
 			t.Fatal("Deleting ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForActiveTargets(ctx, allowed, "prometheus-allowed", 0); err != nil {
+		if err := framework.WaitForActiveTargets(context.Background(), allowed, "prometheus-allowed", 0); err != nil {
 			t.Fatal(err)
 		}
 	}
 }
 
 func testDenyThanosRuler(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	operatorNamespace := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
-	deniedNamespaces := []string{framework.CreateNamespace(ctx, t, testCtx), framework.CreateNamespace(ctx, t, testCtx)}
+	operatorNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
+	deniedNamespaces := []string{framework.CreateNamespace(context.Background(), t, testCtx), framework.CreateNamespace(context.Background(), t, testCtx)}
 
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, operatorNamespace)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, denied := range deniedNamespaces {
 		tr := framework.MakeBasicThanosRuler("denied", 1, "http://test.example.com")
-		_, err = framework.MonClientV1.ThanosRulers(denied).Create(ctx, tr, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.ThanosRulers(denied).Create(context.Background(), tr, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", tr.Spec.Replicas, tr.Name, err)
 		}
 	}
 
 	for _, allowed := range allowedNamespaces {
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, allowed)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, allowed)
 
-		if _, err := framework.CreateThanosRulerAndWaitUntilReady(ctx, allowed, framework.MakeBasicThanosRuler("allowed", 1, "http://test.example.com")); err != nil {
+		if _, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(), allowed, framework.MakeBasicThanosRuler("allowed", 1, "http://test.example.com")); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -231,14 +228,14 @@ func testDenyThanosRuler(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied thanos ruler.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(ctx, "thanosruler-denied", metav1.GetOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.Background(), "thanosruler-denied", metav1.GetOptions{})
 		if !api_errors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}
 	}
 
 	for _, allowed := range allowedNamespaces {
-		err := framework.DeleteThanosRulerAndWaitUntilGone(ctx, allowed, "allowed")
+		err := framework.DeleteThanosRulerAndWaitUntilGone(context.Background(), allowed, "allowed")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -87,21 +88,22 @@ func TestMain(m *testing.M) {
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
 
-	ns := framework.CreateNamespace(t, ctx)
+	ns := framework.CreateNamespace(ctx, t, testCtx)
 
-	finalizers, err := framework.CreatePrometheusOperator(ns, *opImage, nil, nil, nil, nil, true, true)
+	finalizers, err := framework.CreatePrometheusOperator(ctx, ns, *opImage, nil, nil, nil, nil, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, f := range finalizers {
-		ctx.AddFinalizerFn(f)
+		testCtx.AddFinalizerFn(f)
 	}
 
-	t.Run("TestServerTLS", testServerTLS(t, ns))
+	t.Run("TestServerTLS", testServerTLS(ctx, t, ns))
 
 	// t.Run blocks until the function passed as the second argument (f) returns or
 	// calls t.Parallel to become a parallel test. Run reports whether f succeeded
@@ -118,14 +120,14 @@ func TestAllNS(t *testing.T) {
 		"app.kubernetes.io/name": "prometheus-operator",
 	})).String()}
 
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(framework.Ctx, opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if expected := 1; len(pl.Items) != expected {
 		t.Fatalf("expected %v Prometheus Operator pods, but got %v", expected, len(pl.Items))
 	}
-	restarts, err := framework.GetPodRestartCount(ns, pl.Items[0].GetName())
+	restarts, err := framework.GetPodRestartCount(ctx, ns, pl.Items[0].GetName())
 	if err != nil {
 		t.Fatalf("failed to retrieve restart count of Prometheus Operator pod: %v", err)
 	}
@@ -286,16 +288,16 @@ const (
 	prometheusOperatorServiceName = "prometheus-operator"
 )
 
-func testServerTLS(t *testing.T, namespace string) func(t *testing.T) {
+func testServerTLS(ctx context.Context, t *testing.T, namespace string) func(t *testing.T) {
 
 	return func(t *testing.T) {
-		if err := framework.WaitForServiceReady(namespace, prometheusOperatorServiceName); err != nil {
+		if err := framework.WaitForServiceReady(ctx, namespace, prometheusOperatorServiceName); err != nil {
 			t.Fatal("waiting for prometheus operator service: ", err)
 		}
 
 		operatorService := framework.KubeClient.CoreV1().Services(namespace)
 		request := operatorService.ProxyGet("https", prometheusOperatorServiceName, "https", "/healthz", make(map[string]string))
-		_, err := request.DoRaw(framework.Ctx)
+		_, err := request.DoRaw(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -88,13 +88,12 @@ func TestMain(m *testing.M) {
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	ns := framework.CreateNamespace(ctx, t, testCtx)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 
-	finalizers, err := framework.CreatePrometheusOperator(ctx, ns, *opImage, nil, nil, nil, nil, true, true)
+	finalizers, err := framework.CreatePrometheusOperator(context.Background(), ns, *opImage, nil, nil, nil, nil, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func TestAllNS(t *testing.T) {
 		testCtx.AddFinalizerFn(f)
 	}
 
-	t.Run("TestServerTLS", testServerTLS(ctx, t, ns))
+	t.Run("TestServerTLS", testServerTLS(context.Background(), t, ns))
 
 	// t.Run blocks until the function passed as the second argument (f) returns or
 	// calls t.Parallel to become a parallel test. Run reports whether f succeeded
@@ -120,14 +119,14 @@ func TestAllNS(t *testing.T) {
 		"app.kubernetes.io/name": "prometheus-operator",
 	})).String()}
 
-	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, opts)
+	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if expected := 1; len(pl.Items) != expected {
 		t.Fatalf("expected %v Prometheus Operator pods, but got %v", expected, len(pl.Items))
 	}
-	restarts, err := framework.GetPodRestartCount(ctx, ns, pl.Items[0].GetName())
+	restarts, err := framework.GetPodRestartCount(context.Background(), ns, pl.Items[0].GetName())
 	if err != nil {
 		t.Fatalf("failed to retrieve restart count of Prometheus Operator pod: %v", err)
 	}
@@ -291,7 +290,7 @@ const (
 func testServerTLS(ctx context.Context, t *testing.T, namespace string) func(t *testing.T) {
 
 	return func(t *testing.T) {
-		if err := framework.WaitForServiceReady(ctx, namespace, prometheusOperatorServiceName); err != nil {
+		if err := framework.WaitForServiceReady(context.Background(), namespace, prometheusOperatorServiceName); err != nil {
 			t.Fatal("waiting for prometheus operator service: ", err)
 		}
 

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -25,41 +25,39 @@ import (
 )
 
 func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	nonInstanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	nonInstanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, nil, nil, []string{instanceNs}, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, nil, []string{instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p := framework.MakeBasicPrometheus(nonInstanceNs, "non-instance", "non-instance", 1)
-	_, err = framework.MonClientV1.Prometheuses(nonInstanceNs).Create(ctx, p, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(nonInstanceNs).Create(context.Background(), p, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
 	p = framework.MakeBasicPrometheus(instanceNs, "instance", "instance", 1)
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, instanceNs, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), instanceNs, p); err != nil {
 		t.Fatal(err)
 	}
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(ctx, "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 }
 
 func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -80,13 +78,13 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 	//   - will be configured on prometheus operator as --deny-namespaces="denied"
 	//   - hosts a service monitor CR which must NOT be reconciled
 	//   - hosts a prometheus CR which must NOT be reconciled
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	deniedNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	deniedNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
 	for _, ns := range []string{deniedNs, instanceNs} {
-		err := framework.AddLabelsToNamespace(ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(context.Background(), ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -94,7 +92,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +101,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		// create Prometheus custom resources in "denied" namespaces.
 		// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
 		p := framework.MakeBasicPrometheus(deniedNs, "denied", "denied", 1)
-		_, err = framework.MonClientV1.Prometheuses(deniedNs).Create(ctx, p, metav1.CreateOptions{})
+		_, err = framework.MonClientV1.Prometheuses(deniedNs).Create(context.Background(), p, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 		}
@@ -114,19 +112,19 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("denied")
 
-		if err := framework.CreateDeployment(ctx, deniedNs, echo); err != nil {
+		if err := framework.CreateDeployment(context.Background(), deniedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, deniedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), deniedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(deniedNs).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(deniedNs).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
@@ -153,18 +151,18 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
 		// create the prometheus service and wait until it is ready
-		_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, instanceNs, p)
+		_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), instanceNs, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -173,18 +171,17 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get(ctx, "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 
-	if err := framework.WaitForActiveTargets(ctx, instanceNs, "prometheus-instance", 0); err != nil {
+	if err := framework.WaitForActiveTargets(context.Background(), instanceNs, "prometheus-instance", 0); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -204,13 +201,13 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts a service monitor CR which must be reconciled
 	//   - hosts a prometheus CR which must NOT be reconciled
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := framework.AddLabelsToNamespace(ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(context.Background(), ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -218,7 +215,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, []string{allowedNs}, nil, []string{instanceNs}, nil, false, false)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{allowedNs}, nil, []string{instanceNs}, nil, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +223,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	// create Prometheus custom resources in "allowed" namespaces.
 	// This must NOT be reconciled as the prometheus-instance-namespaces option points to somewhere else.
 	p := framework.MakeBasicPrometheus(allowedNs, "allowed", "allowed", 1)
-	_, err = framework.MonClientV1.Prometheuses(allowedNs).Create(ctx, p, metav1.CreateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(allowedNs).Create(context.Background(), p, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
@@ -253,20 +250,20 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		// create the prometheus service and wait until it is ready
-		_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, instanceNs, p)
+		_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), instanceNs, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(instanceNs).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 	}
@@ -278,23 +275,23 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("allowed")
 
-		if err := framework.CreateDeployment(ctx, allowedNs, echo); err != nil {
+		if err := framework.CreateDeployment(context.Background(), allowedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForActiveTargets(ctx, instanceNs, "prometheus-instance", 1); err != nil {
+		if err := framework.WaitForActiveTargets(context.Background(), instanceNs, "prometheus-instance", 1); err != nil {
 			t.Fatal(err)
 		}
 
@@ -316,13 +313,13 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
-	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(ctx, "prometheus-instance", metav1.GetOptions{})
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
 	if !api_errors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 
 	// assert that no prometheus target points to the "instance" namespace
-	targets, err := framework.GetActiveTargets(ctx, instanceNs, "prometheus-instance")
+	targets, err := framework.GetActiveTargets(context.Background(), instanceNs, "prometheus-instance")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +337,6 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 // it's configured to watch namespaces that don't exist.
 // See https://github.com/prometheus-operator/prometheus-operator/issues/3347
 func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -358,13 +354,13 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	// 3. "allowed" ns:
 	//   - will be configured on prometheus operator as --namespaces="allowed"
 	//   - hosts a service monitor CR which must be reconciled
-	operatorNs := framework.CreateNamespace(ctx, t, testCtx)
-	allowedNs := framework.CreateNamespace(ctx, t, testCtx)
-	instanceNs := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, instanceNs)
+	operatorNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	allowedNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
 	for _, ns := range []string{allowedNs, instanceNs} {
-		err := framework.AddLabelsToNamespace(ctx, ns, map[string]string{
+		err := framework.AddLabelsToNamespace(context.Background(), ns, map[string]string{
 			"monitored": "true",
 		})
 		if err != nil {
@@ -373,7 +369,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	}
 
 	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
-	_, err := framework.CreatePrometheusOperator(ctx, operatorNs, *opImage, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true)
+	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,13 +394,13 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		// Create the prometheus service and wait until it is ready.
-		_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, instanceNs, p)
+		_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), instanceNs, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -418,23 +414,23 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		// Wait, until that service appears as a target in the "instance" Prometheus.
 		echo := framework.MakeEchoDeployment("allowed")
 
-		if err := framework.CreateDeployment(ctx, allowedNs, echo); err != nil {
+		if err := framework.CreateDeployment(context.Background(), allowedNs, echo); err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
 		s := framework.MakeBasicServiceMonitor("monitored")
-		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if _, err := framework.MonClientV1.ServiceMonitors(allowedNs).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 			t.Fatal("Creating ServiceMonitor failed: ", err)
 		}
 
-		if err := framework.WaitForActiveTargets(ctx, instanceNs, "prometheus-instance", 1); err != nil {
+		if err := framework.WaitForActiveTargets(context.Background(), instanceNs, "prometheus-instance", 1); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -65,7 +65,6 @@ var (
 )
 
 func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Key, cCert, ca testFramework.Cert) {
-	ctx := context.Background()
 	var clientKey, clientCert, serverKey, serverCert, caCert []byte
 	var err error
 
@@ -170,14 +169,14 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 	}
 
 	for _, s = range secrets {
-		_, err := framework.KubeClient.CoreV1().Secrets(s.ObjectMeta.Namespace).Create(ctx, s, metav1.CreateOptions{})
+		_, err := framework.KubeClient.CoreV1().Secrets(s.ObjectMeta.Namespace).Create(context.Background(), s, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	for _, cm = range configMaps {
-		_, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+		_, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.Background(), cm, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,7 +184,6 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 }
 
 func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
-	ctx := context.Background()
 	simple, err := testFramework.MakeDeployment("../../test/framework/resources/basic-auth-app-deployment.yaml")
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +209,7 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 		},
 	}
 
-	if err := framework.CreateDeployment(ctx, ns, simple); err != nil {
+	if err := framework.CreateDeployment(context.Background(), ns, simple); err != nil {
 		t.Fatal("Creating simple basic auth app failed: ", err)
 	}
 
@@ -240,11 +238,11 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 		},
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	}
 
-	svc, err = framework.KubeClient.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+	svc, err = framework.KubeClient.CoreV1().Services(ns).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +256,7 @@ func createK8sAppMonitoring(
 	svcIP string,
 	svcTLSPort int32,
 ) (*monitoringv1.Prometheus, error) {
-	ctx := context.Background()
+	
 	sm := framework.MakeBasicServiceMonitor(name)
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{
 		{
@@ -287,19 +285,19 @@ func createK8sAppMonitoring(
 		},
 	}
 
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "creating ServiceMonitor failed")
 	}
 
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 	url := "https://" + svcIP + ":" + fmt.Sprint(svcTLSPort)
 	framework.AddRemoteWriteWithTLSToPrometheus(prometheusCRD, url, prwtc)
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
 		return nil, err
 	}
 
 	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, promSVC); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
 		return nil, err
 	}
 
@@ -307,7 +305,6 @@ func createK8sAppMonitoring(
 }
 
 func testPromRemoteWriteWithTLS(t *testing.T) {
-	ctx := context.Background()
 	// can't extend the names since ns cannot be created with more than 63 characters
 	tests := []testFramework.PromRemoteWriteTestConfig{
 		// working configurations
@@ -724,8 +721,8 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			testCtx := framework.NewTestCtx(t)
 			defer testCtx.Cleanup(t)
 
-			ns := framework.CreateNamespace(ctx, t, testCtx)
-			framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+			ns := framework.CreateNamespace(context.Background(), t, testCtx)
+			framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 			name := "test"
 
 			// apply authorized certificate and key to k8s as a Secret
@@ -744,8 +741,8 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 
 			// Check for proper scraping.
 			promSVC := framework.MakePrometheusService(name, name, v1.ServiceTypeClusterIP)
-			if err := framework.WaitForHealthyTargets(ctx, ns, promSVC.Name, 1); err != nil {
-				framework.PrintPrometheusLogs(ctx, t, prometheusCRD)
+			if err := framework.WaitForHealthyTargets(context.Background(), ns, promSVC.Name, 1); err != nil {
+				framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
 				t.Fatal(err)
 			}
 
@@ -759,12 +756,12 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				})).String(),
 			}
 
-			appPodList, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, appOpts)
+			appPodList, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), appOpts)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			appLogs, err := framework.GetLogs(ctx, ns, appPodList.Items[0].ObjectMeta.Name, "")
+			appLogs, err := framework.GetLogs(context.Background(), ns, appPodList.Items[0].ObjectMeta.Name, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -772,14 +769,14 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			if test.ShouldSuccess {
 				for _, v := range possibleErrors {
 					if strings.Contains(appLogs, v) {
-						framework.PrintPrometheusLogs(ctx, t, prometheusCRD)
+						framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
 
 						t.Fatalf("test with (%s, %s, %s) failed\nscraped app logs shouldn't contain '%s' but it does",
 							test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, v)
 					}
 				}
 			} else if !strings.Contains(appLogs, possibleErrors[test.ExpectedInLogs]) {
-				framework.PrintPrometheusLogs(ctx, t, prometheusCRD)
+				framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
 
 				t.Fatalf("test with (%s, %s, %s) failed\nscraped app logs should contain '%s' but it doesn't",
 					test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, possibleErrors[test.ExpectedInLogs])
@@ -790,50 +787,47 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 
 func testPromCreateDeleteCluster(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 	prometheusCRD.Namespace = ns
 
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name); err != nil {
+	if err := framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testPromScaleUpDownCluster(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, framework.MakeBasicPrometheus(ns, name, name, 1))
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, framework.MakeBasicPrometheus(ns, name, name, 1))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p.Spec.Replicas = proto.Int32(3)
-	p, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p.Spec.Replicas = proto.Int32(2)
-	_, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, p)
+	_, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -841,29 +835,25 @@ func testPromScaleUpDownCluster(t *testing.T) {
 
 func testPromNoServiceMonitorSelector(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.ServiceMonitorSelector = nil
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testPromVersionMigration(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	startVersion := operator.PrometheusCompatibilityMatrix[0]
@@ -871,18 +861,18 @@ func testPromVersionMigration(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.Version = startVersion
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, v := range compatibilityMatrix {
 		p.Spec.Version = v
-		p, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, p)
+		p, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := framework.WaitForPrometheusRunImageAndReady(ctx, ns, p); err != nil {
+		if err := framework.WaitForPrometheusRunImageAndReady(context.Background(), ns, p); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -890,12 +880,10 @@ func testPromVersionMigration(t *testing.T) {
 
 func testPromResourceUpdate(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
@@ -906,12 +894,12 @@ func testPromResourceUpdate(t *testing.T) {
 			v1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, prometheus.ListOptions(name))
+	pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), prometheus.ListOptions(name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -926,13 +914,13 @@ func testPromResourceUpdate(t *testing.T) {
 			v1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
-	p, err = framework.MonClientV1.Prometheuses(ns).Update(ctx, p, metav1.UpdateOptions{})
+	p, err = framework.MonClientV1.Prometheuses(ns).Update(context.Background(), p, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -956,12 +944,10 @@ func testPromResourceUpdate(t *testing.T) {
 
 func testPromStorageLabelsAnnotations(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
@@ -988,7 +974,7 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 		},
 	}
 
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1001,7 +987,7 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{})
+		sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1032,18 +1018,16 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 
 func testPromStorageUpdate(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1060,13 +1044,13 @@ func testPromStorageUpdate(t *testing.T) {
 			},
 		},
 	}
-	_, err = framework.MonClientV1.Prometheuses(ns).Update(ctx, p, metav1.UpdateOptions{})
+	_, err = framework.MonClientV1.Prometheuses(ns).Update(context.Background(), p, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, prometheus.ListOptions(name))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), prometheus.ListOptions(name))
 		if err != nil {
 			return false, err
 		}
@@ -1091,12 +1075,10 @@ func testPromStorageUpdate(t *testing.T) {
 
 func testPromReloadConfig(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
@@ -1132,21 +1114,21 @@ scrape_configs:
 
 	svc := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, cfg, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), cfg, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 1); err != nil {
+	if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1168,36 +1150,34 @@ scrape_configs:
 	}
 	secondConfigCompressed := bufTwo.Bytes()
 
-	cfg, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, cfg.Name, metav1.GetOptions{})
+	cfg, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), cfg.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "could not retrieve previous secret"))
 	}
 
 	cfg.Data["prometheus.yaml.gz"] = secondConfigCompressed
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(ctx, cfg, metav1.UpdateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Update(context.Background(), cfg, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 2); err != nil {
+	if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 2); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testPromAdditionalScrapeConfig(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "additional-config-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -1214,7 +1194,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 			"prometheus-additional.yaml": []byte(additionalConfig),
 		},
 	}
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), &secret, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1226,37 +1206,35 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 		},
 		Key: "prometheus-additional.yaml",
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	// Wait for ServiceMonitor target, as well as additional-config target
-	if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 2); err != nil {
+	if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 2); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "additional-alert-config-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -1274,7 +1252,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 			"prometheus-additional.yaml": []byte(additionalConfig),
 		},
 	}
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), &secret, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1286,23 +1264,23 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 		},
 		Key: "prometheus-additional.yaml",
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	// Wait for ServiceMonitor target
-	if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 1); err != nil {
+	if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
-		response, err := framework.PrometheusSVCGetRequest(ctx, ns, svc.Name, "/api/v1/alertmanagers", map[string]string{})
+		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, svc.Name, "/api/v1/alertmanagers", map[string]string{})
 		if err != nil {
 			return true, err
 		}
@@ -1326,37 +1304,35 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 
 func testPromReloadRules(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	firtAlertName := "firstAlert"
 	secondAlertName := "secondAlert"
 
-	ruleFile, err := framework.MakeAndCreateFiringRule(ctx, ns, name, firtAlertName)
+	ruleFile, err := framework.MakeAndCreateFiringRule(context.Background(), ns, name, firtAlertName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.EvaluationInterval = "1s"
-	p, err = framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	err = framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, firtAlertName)
+	err = framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, firtAlertName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1372,12 +1348,12 @@ func testPromReloadRules(t *testing.T) {
 			},
 		},
 	}
-	_, err = framework.UpdateRule(ctx, ns, ruleFile)
+	_, err = framework.UpdateRule(context.Background(), ns, ruleFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, secondAlertName)
+	err = framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, secondAlertName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1385,18 +1361,16 @@ func testPromReloadRules(t *testing.T) {
 
 func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	alertNames := []string{"first-alert", "second-alert"}
 
 	for _, alertName := range alertNames {
-		_, err := framework.MakeAndCreateFiringRule(ctx, ns, alertName, alertName)
+		_, err := framework.MakeAndCreateFiringRule(context.Background(), ns, alertName, alertName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1404,20 +1378,20 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.EvaluationInterval = "1s"
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	for _, alertName := range alertNames {
-		err := framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, alertName)
+		err := framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, alertName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1426,14 +1400,12 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 
 func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	rootNS := framework.CreateNamespace(ctx, t, testCtx)
-	alertNSOne := framework.CreateNamespace(ctx, t, testCtx)
-	alertNSTwo := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, rootNS)
+	rootNS := framework.CreateNamespace(context.Background(), t, testCtx)
+	alertNSOne := framework.CreateNamespace(context.Background(), t, testCtx)
+	alertNSTwo := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, rootNS)
 
 	name := "test"
 	ruleFiles := []struct {
@@ -1444,14 +1416,14 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	ruleFilesNamespaceSelector := map[string]string{"monitored": "true"}
 
 	for _, file := range ruleFiles {
-		err := framework.AddLabelsToNamespace(ctx, file.ns, ruleFilesNamespaceSelector)
+		err := framework.AddLabelsToNamespace(context.Background(), file.ns, ruleFilesNamespaceSelector)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	for _, file := range ruleFiles {
-		_, err := framework.MakeAndCreateFiringRule(ctx, file.ns, file.alertName, file.alertName)
+		_, err := framework.MakeAndCreateFiringRule(context.Background(), file.ns, file.alertName, file.alertName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1462,20 +1434,20 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	p.Spec.RuleNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: ruleFilesNamespaceSelector,
 	}
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, rootNS, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), rootNS, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, rootNS, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), rootNS, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	for _, file := range ruleFiles {
-		err := framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, file.alertName)
+		err := framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, file.alertName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1485,7 +1457,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	// and wait until the rules are removed from Prometheus.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
 	for _, file := range ruleFiles {
-		if err := framework.RemoveLabelsFromNamespace(ctx, file.ns, "monitored"); err != nil {
+		if err := framework.RemoveLabelsFromNamespace(context.Background(), file.ns, "monitored"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1494,7 +1466,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 		var loopError error
 		err = wait.Poll(time.Second, 5*framework.DefaultTimeout, func() (bool, error) {
 			var firing bool
-			firing, loopError = framework.CheckPrometheusFiringAlert(ctx, file.ns, pSVC.Name, file.alertName)
+			firing, loopError = framework.CheckPrometheusFiringAlert(context.Background(), file.ns, pSVC.Name, file.alertName)
 			return !firing, nil
 		})
 
@@ -1506,17 +1478,15 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 
 func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusRules := []*monitoringv1.PrometheusRule{}
 	for i := 0; i < 2; i++ {
 		rule := generateHugePrometheusRule(ns, strconv.Itoa(i))
-		rule, err := framework.CreateRule(ctx, ns, rule)
+		rule, err := framework.CreateRule(context.Background(), ns, rule)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1527,28 +1497,28 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 	p.Spec.EvaluationInterval = "1s"
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
 		if t.Failed() {
-			if err := framework.PrintPodLogs(ctx, ns, "prometheus-"+p.Name+"-0"); err != nil {
+			if err := framework.PrintPodLogs(context.Background(), ns, "prometheus-"+p.Name+"-0"); err != nil {
 				t.Fatal(err)
 			}
 		}
 	}()
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	for i := range prometheusRules {
-		_, err := framework.WaitForConfigMapExist(ctx, ns, "prometheus-"+p.Name+"-rulefiles-"+strconv.Itoa(i))
+		_, err := framework.WaitForConfigMapExist(context.Background(), ns, "prometheus-"+p.Name+"-rulefiles-"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1556,27 +1526,27 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 
 	// Make sure both rule files ended up in the Prometheus Pod
 	for i := range prometheusRules {
-		err := framework.WaitForPrometheusFiringAlert(ctx, ns, pSVC.Name, "my-alert-"+strconv.Itoa(i))
+		err := framework.WaitForPrometheusFiringAlert(context.Background(), ns, pSVC.Name, "my-alert-"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	err = framework.DeleteRule(ctx, ns, prometheusRules[1].Name)
+	err = framework.DeleteRule(context.Background(), ns, prometheusRules[1].Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.WaitForConfigMapExist(ctx, ns, "prometheus-"+p.Name+"-rulefiles-0")
+	_, err = framework.WaitForConfigMapExist(context.Background(), ns, "prometheus-"+p.Name+"-rulefiles-0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = framework.WaitForConfigMapNotExist(ctx, ns, "prometheus-"+p.Name+"-rulefiles-1")
+	err = framework.WaitForConfigMapNotExist(context.Background(), ns, "prometheus-"+p.Name+"-rulefiles-1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForPrometheusFiringAlert(ctx, ns, pSVC.Name, "my-alert-0")
+	err = framework.WaitForPrometheusFiringAlert(context.Background(), ns, pSVC.Name, "my-alert-0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1584,22 +1554,20 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 
 func testPromRulesMustBeAnnotated(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "admission"
 	admissionAlert := "admissionAlert"
 
-	_, err := framework.MakeAndCreateFiringRule(ctx, ns, name, admissionAlert)
+	_, err := framework.MakeAndCreateFiringRule(context.Background(), ns, name, admissionAlert)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rule, err := framework.GetRule(ctx, ns, name)
+	rule, err := framework.GetRule(context.Background(), ns, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1615,17 +1583,15 @@ func testPromRulesMustBeAnnotated(t *testing.T) {
 
 func testInvalidRulesAreRejected(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "admission"
 	admissionAlert := "admissionAlert"
 
-	_, err := framework.MakeAndCreateInvalidRule(ctx, ns, name, admissionAlert)
+	_, err := framework.MakeAndCreateInvalidRule(context.Background(), ns, name, admissionAlert)
 	if err == nil {
 		t.Fatal("Expected invalid prometheusrule to be rejected")
 	}
@@ -1657,12 +1623,10 @@ func generateHugePrometheusRule(ns, identifier string) *monitoringv1.PrometheusR
 // and the Prometheus rules configmap on relevant changes
 func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 	prometheus := framework.MakeBasicPrometheus(ns, name, name, 1)
@@ -1673,7 +1637,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	// prevent a regression.
 	prometheus.Annotations["test-annotation"] = "test-value"
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 
 	type versionedResource interface {
 		GetResourceVersion() string
@@ -1691,7 +1655,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 				return framework.
 					MonClientV1.
 					Prometheuses(ns).
-					Get(ctx, prometheusName, metav1.GetOptions{})
+					Get(context.Background(), prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1702,7 +1666,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					ConfigMaps(ns).
-					Get(ctx, "prometheus-"+prometheusName+"-rulefiles-0", metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName+"-rulefiles-0", metav1.GetOptions{})
 			},
 			// The Prometheus Operator first creates the ConfigMap for the
 			// given Prometheus stateful set and then updates it with the matching
@@ -1716,7 +1680,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Secrets(ns).
-					Get(ctx, "prometheus-"+prometheusName, metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 2,
 		},
@@ -1727,7 +1691,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Secrets(ns).
-					Get(ctx, "prometheus-"+prometheusName+"-tls-assets", metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName+"-tls-assets", metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 2,
 		},
@@ -1738,7 +1702,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					AppsV1().
 					StatefulSets(ns).
-					Get(ctx, "prometheus-"+prometheusName, metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName, metav1.GetOptions{})
 			},
 			// First is the creation of the StatefulSet itself, following is the
 			// update of e.g. the ReadyReplicas status field
@@ -1751,7 +1715,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Services(ns).
-					Get(ctx, "prometheus-operated", metav1.GetOptions{})
+					Get(context.Background(), "prometheus-operated", metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1761,7 +1725,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 				return framework.
 					MonClientV1.
 					ServiceMonitors(ns).
-					Get(ctx, prometheusName, metav1.GetOptions{})
+					Get(context.Background(), prometheusName, metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 1,
 		},
@@ -1799,38 +1763,38 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	}()
 
 	alertName := "my-alert"
-	if _, err := framework.MakeAndCreateFiringRule(ctx, ns, "my-prometheus-rule", alertName); err != nil {
+	if _, err := framework.MakeAndCreateFiringRule(context.Background(), ns, "my-prometheus-rule", alertName); err != nil {
 		t.Fatal(err)
 	}
 
-	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheus)
+	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheus)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	pSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	s := framework.MakeBasicServiceMonitor(name)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
-	err = framework.WaitForPrometheusFiringAlert(ctx, prometheus.Namespace, pSVC.Name, alertName)
+	err = framework.WaitForPrometheusFiringAlert(context.Background(), prometheus.Namespace, pSVC.Name, alertName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForDiscoveryWorking(ctx, ns, pSVC.Name, prometheus.Name)
+	err = framework.WaitForDiscoveryWorking(context.Background(), ns, pSVC.Name, prometheus.Name)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
 	}
 
-	if err := framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name); err != nil {
+	if err := framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1866,19 +1830,17 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 
 func testPromPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 	prometheusCRD.Namespace = ns
 
-	prometheusCRD, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD)
+	prometheusCRD, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1903,37 +1865,37 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "prometheus-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
+				return svcClient.Get(context.Background(), "prometheus-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(ctx, asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(context.Background(), asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(ctx, "prometheus-test", metav1.GetOptions{})
+				return ssetClient.Get(context.Background(), "prometheus-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(ctx, asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(context.Background(), asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus-operated endpoints",
 			get: func() (metav1.Object, error) {
-				return endpointsClient.Get(ctx, "prometheus-operated", metav1.GetOptions{})
+				return endpointsClient.Get(context.Background(), "prometheus-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return endpointsClient.Update(ctx, asEndpoints(t, object), metav1.UpdateOptions{})
+				return endpointsClient.Update(context.Background(), asEndpoints(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "prometheus secret",
 			get: func() (metav1.Object, error) {
-				return secretClient.Get(ctx, "prometheus-test", metav1.GetOptions{})
+				return secretClient.Get(context.Background(), "prometheus-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return secretClient.Update(ctx, asSecret(t, object), metav1.UpdateOptions{})
+				return secretClient.Update(context.Background(), asSecret(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}
@@ -1955,7 +1917,7 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 
 	// Ensure resource reconciles
 	prometheusCRD.Spec.Replicas = proto.Int32(2)
-	_, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD)
+	_, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1979,7 +1941,7 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 	}
 
 	// Cleanup
-	if err := framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name); err != nil {
+	if err := framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2049,35 +2011,33 @@ func mergeMap(a, b map[string]string) map[string]string {
 
 func testPromWhenDeleteCRDCleanUpViaOwnerRef(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	configMapName := fmt.Sprintf("prometheus-%v-rulefiles-0", p.Name)
 
-	_, err = framework.WaitForConfigMapExist(ctx, ns, configMapName)
+	_, err = framework.WaitForConfigMapExist(context.Background(), ns, configMapName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Waits for Prometheus pods to vanish
-	err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, p.Name)
+	err = framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, p.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = framework.WaitForConfigMapNotExist(ctx, ns, configMapName)
+	err = framework.WaitForConfigMapNotExist(context.Background(), ns, configMapName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2085,40 +2045,38 @@ func testPromWhenDeleteCRDCleanUpViaOwnerRef(t *testing.T) {
 
 func testPromDiscovery(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Generated Secret could not be retrieved: ", err)
 	}
 
-	err = framework.WaitForDiscoveryWorking(ctx, ns, svc.Name, prometheusName)
+	err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
 	}
@@ -2126,45 +2084,43 @@ func testPromDiscovery(t *testing.T) {
 
 func testPromSharedResourcesReconciliation(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	s := framework.MakeBasicServiceMonitor("reconcile-test")
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Creating ServiceMonitor failed: %v", err)
 	}
 
 	// Create 2 Prometheus different Prometheus instances that watch the service monitor created above.
 	for _, prometheusName := range []string{"test", "test2"} {
 		p := framework.MakeBasicPrometheus(ns, prometheusName, "reconcile-test", 1)
-		_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+		_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 			t.Fatal(err)
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
-		_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+		_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Generated Secret could not be retrieved for %s: %v", prometheusName, err)
 		}
 
-		err = framework.WaitForActiveTargets(ctx, ns, svc.Name, 1)
+		err = framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 1)
 		if err != nil {
 			t.Fatalf("Validating Prometheus active targets failed for %s: %v", prometheusName, err)
 		}
 	}
 
-	if err := framework.MonClientV1.ServiceMonitors(ns).Delete(ctx, "reconcile-test", metav1.DeleteOptions{}); err != nil {
+	if err := framework.MonClientV1.ServiceMonitors(ns).Delete(context.Background(), "reconcile-test", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Deleting ServiceMonitor failed: %v", err)
 	}
 
@@ -2172,7 +2128,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 	for _, prometheusName := range []string{"test", "test2"} {
 		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), v1.ServiceTypeClusterIP)
 
-		if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 0); err != nil {
+		if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 0); err != nil {
 			t.Fatalf("Validating Prometheus active targets failed for %s: %v", prometheusName, err)
 		}
 	}
@@ -2180,31 +2136,29 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 
 func testShardingProvisioning(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
 	shards := int32(2)
 	p.Spec.Shards = &shards
-	_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2255,28 +2209,28 @@ func testShardingProvisioning(t *testing.T) {
 func testResharding(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
 	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2284,35 +2238,35 @@ func testResharding(t *testing.T) {
 
 	shards := int32(2)
 	p.Spec.Shards = &shards
-	p, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	shards = int32(1)
 	p.Spec.Shards = &shards
-	p, err = framework.UpdatePrometheusAndWaitUntilReady(ctx, ns, p)
+	p, err = framework.UpdatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
+	_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", p.Name), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = wait.Poll(time.Second, 1*time.Minute, func() (bool, error) {
-		_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
+		_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s-shard-1", p.Name), metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
 		}
@@ -2327,12 +2281,10 @@ func testResharding(t *testing.T) {
 
 func testPromAlertmanagerDiscovery(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	alertmanagerName := "test"
@@ -2342,36 +2294,36 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
 	framework.AddAlertingToPrometheus(p, ns, alertmanagerName)
-	_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
 	s := framework.MakeBasicServiceMonitor(group)
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Creating ServiceMonitor failed: %v", err)
 	}
 
-	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Generated Secret could not be retrieved: %v", err)
 	}
 
-	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, ns, framework.MakeBasicAlertmanager(alertmanagerName, 3)); err != nil {
+	if _, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, framework.MakeBasicAlertmanager(alertmanagerName, 3)); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, amsvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Alertmanager service failed"))
 	}
 
-	err = wait.Poll(time.Second, 18*time.Minute, isAlertmanagerDiscoveryWorking(ctx, ns, svc.Name, alertmanagerName))
+	err = wait.Poll(time.Second, 18*time.Minute, isAlertmanagerDiscoveryWorking(context.Background(), ns, svc.Name, alertmanagerName))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus Alertmanager discovery failed"))
 	}
@@ -2379,27 +2331,25 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 
 func testPromExposingWithKubernetesAPI(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	basicPrometheus := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
 	service := framework.MakePrometheusService(basicPrometheus.Name, "test-group", v1.ServiceTypeClusterIP)
 
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, basicPrometheus); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, basicPrometheus); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, service); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, service); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	}
 
 	ProxyGet := framework.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", service.Name, "web", "/metrics", make(map[string]string))
-	_, err := request.DoRaw(ctx)
+	_, err := request.DoRaw(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2407,12 +2357,10 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 
 func testPromDiscoverTargetPort(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
@@ -2440,27 +2388,27 @@ func testPromDiscoverTargetPort(t *testing.T) {
 			},
 		},
 	}
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Generated Secret could not be retrieved: ", err)
 	}
 
-	err = framework.WaitForDiscoveryWorking(ctx, ns, svc.Name, prometheusName)
+	err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
 	}
@@ -2468,16 +2416,14 @@ func testPromDiscoverTargetPort(t *testing.T) {
 
 func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	prometheusNSName := framework.CreateNamespace(ctx, t, testCtx)
-	serviceMonitorNSName := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, prometheusNSName)
+	prometheusNSName := framework.CreateNamespace(context.Background(), t, testCtx)
+	serviceMonitorNSName := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, prometheusNSName)
 
 	if err := framework.AddLabelsToNamespace(
-		ctx,
+		context.Background(),
 		serviceMonitorNSName,
 		map[string]string{"team": "frontend"},
 	); err != nil {
@@ -2493,7 +2439,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 
 	s := framework.MakeBasicServiceMonitor(group)
 
-	if _, err := framework.MonClientV1.ServiceMonitors(serviceMonitorNSName).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(serviceMonitorNSName).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2503,17 +2449,17 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 			"team": "frontend",
 		},
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, prometheusNSName, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), prometheusNSName, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, prometheusNSName, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), prometheusNSName, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	resp, err := framework.PrometheusSVCGetRequest(ctx, prometheusNSName, svc.Name, "/api/v1/status/config", map[string]string{})
+	resp, err := framework.PrometheusSVCGetRequest(context.Background(), prometheusNSName, svc.Name, "/api/v1/status/config", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2525,12 +2471,10 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 
 func testThanos(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	version := operator.DefaultThanosVersion
 
@@ -2539,17 +2483,17 @@ func testThanos(t *testing.T) {
 	prom.Spec.Thanos = &monitoringv1.ThanosSpec{
 		Version: &version,
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prom); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
 	promSvc := framework.MakePrometheusService(prom.Name, "test-group", v1.ServiceTypeClusterIP)
-	if _, err := framework.KubeClient.CoreV1().Services(ns).Create(ctx, promSvc, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Services(ns).Create(context.Background(), promSvc, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	}
 
 	svcMon := framework.MakeBasicServiceMonitor("test-group")
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, svcMon, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), svcMon, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating ServiceMonitor failed: ", err)
 	}
 
@@ -2570,12 +2514,12 @@ func testThanos(t *testing.T) {
 	}
 	t.Log("setting up query with args: ", qryArgs)
 	qryDep.Spec.Template.Spec.Containers[0].Args = qryArgs
-	if err := framework.CreateDeployment(ctx, ns, qryDep); err != nil {
+	if err := framework.CreateDeployment(context.Background(), ns, qryDep); err != nil {
 		t.Fatal("Creating Thanos query deployment failed: ", err)
 	}
 
 	qrySvc := framework.MakeThanosQuerierService(qryDep.Name)
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, qrySvc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, qrySvc); err != nil {
 		t.Fatal("Creating Thanos query service failed: ", err)
 	}
 
@@ -2585,7 +2529,7 @@ func testThanos(t *testing.T) {
 			"query": "prometheus_build_info",
 			"dedup": "false",
 		})
-		b, err := request.DoRaw(ctx)
+		b, err := request.DoRaw(context.Background())
 		if err != nil {
 			t.Logf("Error performing request against Thanos query: %v\n\nretrying...", err)
 			return false, nil
@@ -2687,11 +2631,11 @@ func testPromGetAuthSecret(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			
 			testCtx := framework.NewTestCtx(t)
 			defer testCtx.Cleanup(t)
-			ns := framework.CreateNamespace(ctx, t, testCtx)
-			framework.SetupPrometheusRBACGlobal(ctx, t, testCtx, ns)
+			ns := framework.CreateNamespace(context.Background(), t, testCtx)
+			framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, ns)
 
 			maptest := make(map[string]string)
 			maptest["tc"] = ns
@@ -2701,12 +2645,12 @@ func testPromGetAuthSecret(t *testing.T) {
 			}
 			prometheusCRD.Spec.ScrapeInterval = "1s"
 
-			if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD); err != nil {
+			if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
 				t.Fatal(err)
 			}
-			testNamespace := framework.CreateNamespace(ctx, t, testCtx)
+			testNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
 
-			err := framework.AddLabelsToNamespace(ctx, testNamespace, maptest)
+			err := framework.AddLabelsToNamespace(context.Background(), testNamespace, maptest)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2716,12 +2660,12 @@ func testPromGetAuthSecret(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := framework.CreateDeployment(ctx, testNamespace, simple); err != nil {
+			if err := framework.CreateDeployment(context.Background(), testNamespace, simple); err != nil {
 				t.Fatal("Creating simple basic auth app failed: ", err)
 			}
 
 			authSecret := test.secret
-			if _, err := framework.KubeClient.CoreV1().Secrets(testNamespace).Create(ctx, authSecret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(testNamespace).Create(context.Background(), authSecret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -2747,17 +2691,17 @@ func testPromGetAuthSecret(t *testing.T) {
 			}
 
 			sm := test.serviceMonitor()
-			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, testNamespace, svc); err != nil {
+			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), testNamespace, svc); err != nil {
 				t.Fatal(err)
 			} else {
 				testCtx.AddFinalizerFn(finalizerFn)
 			}
 
-			if _, err := framework.MonClientV1.ServiceMonitors(testNamespace).Create(ctx, sm, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.ServiceMonitors(testNamespace).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
 				t.Fatal("Creating ServiceMonitor failed: ", err)
 			}
 
-			if err := framework.WaitForHealthyTargets(ctx, ns, "prometheus-operated", 1); err != nil {
+			if err := framework.WaitForHealthyTargets(context.Background(), ns, "prometheus-operated", 1); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -2775,28 +2719,28 @@ func testOperatorNSScope(t *testing.T) {
 	secondAlertName := "secondAlert"
 
 	t.Run("SingleNS", func(t *testing.T) {
-		ctx := context.Background()
+		
 		testCtx := framework.NewTestCtx(t)
 		defer testCtx.Cleanup(t)
 
-		operatorNS := framework.CreateNamespace(ctx, t, testCtx)
-		mainNS := framework.CreateNamespace(ctx, t, testCtx)
-		arbitraryNS := framework.CreateNamespace(ctx, t, testCtx)
+		operatorNS := framework.CreateNamespace(context.Background(), t, testCtx)
+		mainNS := framework.CreateNamespace(context.Background(), t, testCtx)
+		arbitraryNS := framework.CreateNamespace(context.Background(), t, testCtx)
 
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, mainNS)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, mainNS)
 
 		prometheusNamespaceSelector := map[string]string{"prometheus": mainNS}
 
 		// Add labels to namespaces for Prometheus RuleNamespaceSelector.
 		for _, ns := range []string{mainNS, arbitraryNS} {
-			err := framework.AddLabelsToNamespace(ctx, ns, prometheusNamespaceSelector)
+			err := framework.AddLabelsToNamespace(context.Background(), ns, prometheusNamespaceSelector)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
 
 		// Prometheus Operator only watches single namespace mainNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(ctx, operatorNS, *opImage, []string{mainNS}, nil, nil, nil, false, true)
+		_, err := framework.CreatePrometheusOperator(context.Background(), operatorNS, *opImage, []string{mainNS}, nil, nil, nil, false, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2807,7 +2751,7 @@ func testOperatorNSScope(t *testing.T) {
 		}{{arbitraryNS, secondAlertName}, {mainNS, firtAlertName}}
 
 		for _, r := range ruleDef {
-			_, err := framework.MakeAndCreateFiringRule(ctx, r.NSName, name, r.AlertName)
+			_, err := framework.MakeAndCreateFiringRule(context.Background(), r.NSName, name, r.AlertName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2818,24 +2762,24 @@ func testOperatorNSScope(t *testing.T) {
 			MatchLabels: prometheusNamespaceSelector,
 		}
 		p.Spec.EvaluationInterval = "1s"
-		p, err = framework.CreatePrometheusAndWaitUntilReady(ctx, mainNS, p)
+		p, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), mainNS, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, mainNS, pSVC); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), mainNS, pSVC); err != nil {
 			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
-		err = framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, firtAlertName)
+		err = framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, firtAlertName)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		firing, err := framework.CheckPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, secondAlertName)
+		firing, err := framework.CheckPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, secondAlertName)
 		if err != nil && !strings.Contains(err.Error(), "expected 1 query result but got 0") {
 			t.Fatal(err)
 		}
@@ -2846,28 +2790,28 @@ func testOperatorNSScope(t *testing.T) {
 	})
 
 	t.Run("MultiNS", func(t *testing.T) {
-		ctx := context.Background()
+		
 		testCtx := framework.NewTestCtx(t)
 		defer testCtx.Cleanup(t)
 
-		operatorNS := framework.CreateNamespace(ctx, t, testCtx)
-		prometheusNS := framework.CreateNamespace(ctx, t, testCtx)
-		ruleNS := framework.CreateNamespace(ctx, t, testCtx)
-		arbitraryNS := framework.CreateNamespace(ctx, t, testCtx)
+		operatorNS := framework.CreateNamespace(context.Background(), t, testCtx)
+		prometheusNS := framework.CreateNamespace(context.Background(), t, testCtx)
+		ruleNS := framework.CreateNamespace(context.Background(), t, testCtx)
+		arbitraryNS := framework.CreateNamespace(context.Background(), t, testCtx)
 
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, prometheusNS)
+		framework.SetupPrometheusRBAC(context.Background(), t, testCtx, prometheusNS)
 
 		prometheusNamespaceSelector := map[string]string{"prometheus": prometheusNS}
 
 		for _, ns := range []string{ruleNS, arbitraryNS} {
-			err := framework.AddLabelsToNamespace(ctx, ns, prometheusNamespaceSelector)
+			err := framework.AddLabelsToNamespace(context.Background(), ns, prometheusNamespaceSelector)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}
 
 		// Prometheus Operator only watches prometheusNS and ruleNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(ctx, operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, nil, nil, false, true)
+		_, err := framework.CreatePrometheusOperator(context.Background(), operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, nil, nil, false, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2878,7 +2822,7 @@ func testOperatorNSScope(t *testing.T) {
 		}{{arbitraryNS, secondAlertName}, {ruleNS, firtAlertName}}
 
 		for _, r := range ruleDef {
-			_, err := framework.MakeAndCreateFiringRule(ctx, r.NSName, name, r.AlertName)
+			_, err := framework.MakeAndCreateFiringRule(context.Background(), r.NSName, name, r.AlertName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2889,24 +2833,24 @@ func testOperatorNSScope(t *testing.T) {
 			MatchLabels: prometheusNamespaceSelector,
 		}
 		p.Spec.EvaluationInterval = "1s"
-		p, err = framework.CreatePrometheusAndWaitUntilReady(ctx, prometheusNS, p)
+		p, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), prometheusNS, p)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, prometheusNS, pSVC); err != nil {
+		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), prometheusNS, pSVC); err != nil {
 			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
 
-		err = framework.WaitForPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, firtAlertName)
+		err = framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, firtAlertName)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		firing, err := framework.CheckPrometheusFiringAlert(ctx, p.Namespace, pSVC.Name, secondAlertName)
+		firing, err := framework.CheckPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, secondAlertName)
 		if err != nil && !strings.Contains(err.Error(), "expected 1 query result but got 0") {
 			t.Fatal(err)
 		}
@@ -2922,7 +2866,6 @@ func testOperatorNSScope(t *testing.T) {
 // configuration with the service monitor bearer token and tls assets option.
 func testPromArbitraryFSAcc(t *testing.T) {
 	t.Parallel()
-
 	name := "test"
 
 	tests := []struct {
@@ -3086,13 +3029,11 @@ func testPromArbitraryFSAcc(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-
-			ctx := context.Background()
 			testCtx := framework.NewTestCtx(t)
 			defer testCtx.Cleanup(t)
 
-			ns := framework.CreateNamespace(ctx, t, testCtx)
-			framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+			ns := framework.CreateNamespace(context.Background(), t, testCtx)
+			framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 			// Create secret either used by bearer token secret key ref, tls
 			// asset key ref or tls configmap key ref.
@@ -3117,7 +3058,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, tlsCertsSecret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), tlsCertsSecret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3130,13 +3071,13 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.Background(), tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			s := framework.MakeBasicServiceMonitor(name)
 			s.Spec.Endpoints[0] = test.endpoint
-			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
 				t.Fatal("creating ServiceMonitor failed: ", err)
 			}
 
@@ -3148,17 +3089,17 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				mountTLSFiles(prometheusCRD, name)
 			}
 
-			if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD); err != nil {
+			if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
 				t.Fatal(err)
 			}
 
 			svc := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
-			if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+			if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 				t.Fatal(err)
 			}
 
 			if test.expectTargets {
-				if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 1); err != nil {
+				if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 1); err != nil {
 					t.Fatal(err)
 				}
 
@@ -3167,7 +3108,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 
 			// Make sure Prometheus has enough time to reload.
 			time.Sleep(2 * time.Minute)
-			if err := framework.WaitForActiveTargets(ctx, ns, svc.Name, 0); err != nil {
+			if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 0); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -3205,13 +3146,11 @@ func mountTLSFiles(p *monitoringv1.Prometheus, secretName string) {
 // certificate assets via Kubernetes secrets into the Prometheus container.
 func testPromTLSConfigViaSecret(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 	name := "test"
 
 	//
@@ -3238,7 +3177,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, tlsCertsSecret, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), tlsCertsSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3267,7 +3206,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if err := framework.CreateDeployment(ctx, ns, simple); err != nil {
+	if err := framework.CreateDeployment(context.Background(), ns, simple); err != nil {
 		t.Fatal("Creating simple basic auth app failed: ", err)
 	}
 
@@ -3296,7 +3235,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3332,19 +3271,19 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
 		t.Fatal("creating ServiceMonitor failed: ", err)
 	}
 
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prometheusCRD); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
 		t.Fatal(err)
 	}
 
 	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, promSVC); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3352,7 +3291,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	// Check for proper scraping.
 	//
 
-	if err := framework.WaitForHealthyTargets(ctx, ns, promSVC.Name, 1); err != nil {
+	if err := framework.WaitForHealthyTargets(context.Background(), ns, promSVC.Name, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3360,7 +3299,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	time.Sleep(30 * time.Second)
 
 	response, err := framework.PrometheusSVCGetRequest(
-		ctx,
+		context.Background(),
 		ns,
 		promSVC.Name,
 		"/api/v1/query",
@@ -3386,20 +3325,18 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 
 func testPromStaticProbe(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	blackboxExporterName := "blackbox-exporter"
-	if err := framework.CreateBlackBoxExporterAndWaitUntilReady(ctx, ns, blackboxExporterName); err != nil {
+	if err := framework.CreateBlackBoxExporterAndWaitUntilReady(context.Background(), ns, blackboxExporterName); err != nil {
 		t.Fatal("Creating blackbox exporter failed: ", err)
 	}
 
 	blackboxSvc := framework.MakeBlackBoxExporterService(ns, blackboxExporterName)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, blackboxSvc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, blackboxSvc); err != nil {
 		t.Fatal("creating blackbox exporter service failed ", err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -3413,7 +3350,7 @@ func testPromStaticProbe(t *testing.T) {
 	targets := []string{svc.Name + ":9090"}
 
 	probe := framework.MakeBasicStaticProbe(group, proberURL, targets)
-	if _, err := framework.MonClientV1.Probes(ns).Create(ctx, probe, metav1.CreateOptions{}); err != nil {
+	if _, err := framework.MonClientV1.Probes(ns).Create(context.Background(), probe, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Creating Probe failed: ", err)
 	}
 
@@ -3423,11 +3360,11 @@ func testPromStaticProbe(t *testing.T) {
 			"group": group,
 		},
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(ctx, ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -3440,7 +3377,7 @@ func testPromStaticProbe(t *testing.T) {
 	expectedURL.RawQuery = q.Encode()
 
 	if err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		activeTargets, err := framework.GetActiveTargets(ctx, ns, svc.Name)
+		activeTargets, err := framework.GetActiveTargets(context.Background(), ns, svc.Name)
 		if err != nil {
 			return false, err
 		}
@@ -3466,7 +3403,6 @@ func testPromStaticProbe(t *testing.T) {
 
 func testPromSecurePodMonitor(t *testing.T) {
 	t.Parallel()
-
 	name := "test"
 
 	tests := []struct {
@@ -3592,12 +3528,10 @@ func testPromSecurePodMonitor(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-
-			ctx := context.Background()
 			testCtx := framework.NewTestCtx(t)
 			defer testCtx.Cleanup(t)
-			ns := framework.CreateNamespace(ctx, t, testCtx)
-			framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+			ns := framework.CreateNamespace(context.Background(), t, testCtx)
+			framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 			// Create secret either used by bearer token secret key ref, tls
 			// asset key ref or tls configmap key ref.
@@ -3624,7 +3558,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3637,14 +3571,14 @@ func testPromSecurePodMonitor(t *testing.T) {
 				},
 			}
 
-			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.Background(), tlsCertsConfigMap, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
 			prom := framework.MakeBasicPrometheus(ns, name, name, 1)
 			prom.Namespace = ns
 
-			if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prom); err != nil {
+			if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3675,18 +3609,18 @@ func testPromSecurePodMonitor(t *testing.T) {
 				simple.Spec.Template.Spec.Containers[0].Args = []string{"--cert-path=/etc/ca-certificates"}
 			}
 
-			if err := framework.CreateDeployment(ctx, ns, simple); err != nil {
+			if err := framework.CreateDeployment(context.Background(), ns, simple); err != nil {
 				t.Fatal("failed to create simple basic auth app: ", err)
 			}
 
 			pm := framework.MakeBasicPodMonitor(name)
 			pm.Spec.PodMetricsEndpoints[0] = test.endpoint
 
-			if _, err := framework.MonClientV1.PodMonitors(ns).Create(ctx, pm, metav1.CreateOptions{}); err != nil {
+			if _, err := framework.MonClientV1.PodMonitors(ns).Create(context.Background(), pm, metav1.CreateOptions{}); err != nil {
 				t.Fatal("failed to create PodMonitor: ", err)
 			}
 
-			if err := framework.WaitForHealthyTargets(ctx, ns, "prometheus-operated", 1); err != nil {
+			if err := framework.WaitForHealthyTargets(context.Background(), ns, "prometheus-operated", 1); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -3695,12 +3629,10 @@ func testPromSecurePodMonitor(t *testing.T) {
 
 func testPromWebTLS(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	host := fmt.Sprintf("%s.%s.svc", "basic-prometheus", ns)
 	certBytes, keyBytes, err := certutil.GenerateSelfSignedCertKey(host, nil, nil)
@@ -3709,7 +3641,7 @@ func testPromWebTLS(t *testing.T) {
 	}
 
 	kubeClient := framework.KubeClient
-	if err := framework.CreateSecretWithCert(ctx, certBytes, keyBytes, ns, "web-tls"); err != nil {
+	if err := framework.CreateSecretWithCert(context.Background(), certBytes, keyBytes, ns, "web-tls"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3732,11 +3664,11 @@ func testPromWebTLS(t *testing.T) {
 			},
 		},
 	}
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, prom); err != nil {
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	promPods, err := kubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	promPods, err := kubeClient.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3967,7 +3899,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 
 func isAlertmanagerDiscoveryWorking(ctx context.Context, ns, promSVCName, alertmanagerName string) func() (bool, error) {
 	return func() (bool, error) {
-		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, alertmanager.ListOptions(alertmanagerName))
+		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), alertmanager.ListOptions(alertmanagerName))
 		if err != nil {
 			return false, err
 		}
@@ -3979,7 +3911,7 @@ func isAlertmanagerDiscoveryWorking(ctx context.Context, ns, promSVCName, alertm
 			expectedAlertmanagerTargets = append(expectedAlertmanagerTargets, fmt.Sprintf("http://%s:9093/api/v2/alerts", p.Status.PodIP))
 		}
 
-		response, err := framework.PrometheusSVCGetRequest(ctx, ns, promSVCName, "/api/v1/alertmanagers", map[string]string{})
+		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, promSVCName, "/api/v1/alertmanagers", map[string]string{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -256,7 +256,7 @@ func createK8sAppMonitoring(
 	svcIP string,
 	svcTLSPort int32,
 ) (*monitoringv1.Prometheus, error) {
-	
+
 	sm := framework.MakeBasicServiceMonitor(name)
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{
 		{
@@ -2209,7 +2209,6 @@ func testShardingProvisioning(t *testing.T) {
 func testResharding(t *testing.T) {
 	t.Parallel()
 
-	
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
@@ -2631,7 +2630,7 @@ func testPromGetAuthSecret(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			testCtx := framework.NewTestCtx(t)
 			defer testCtx.Cleanup(t)
 			ns := framework.CreateNamespace(context.Background(), t, testCtx)
@@ -2719,7 +2718,7 @@ func testOperatorNSScope(t *testing.T) {
 	secondAlertName := "secondAlert"
 
 	t.Run("SingleNS", func(t *testing.T) {
-		
+
 		testCtx := framework.NewTestCtx(t)
 		defer testCtx.Cleanup(t)
 
@@ -2790,7 +2789,7 @@ func testOperatorNSScope(t *testing.T) {
 	})
 
 	t.Run("MultiNS", func(t *testing.T) {
-		
+
 		testCtx := framework.NewTestCtx(t)
 		defer testCtx.Cleanup(t)
 

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -219,22 +219,22 @@ func testTRMinReadySeconds(t *testing.T) {
 	runFeatureGatedTests(t)
 	t.Parallel()
 
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	ns := framework.CreateNamespace(t, ctx)
-	framework.SetupPrometheusRBAC(t, ctx, ns)
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	kubeClient := framework.KubeClient
 
 	var setMinReadySecondsInitial uint32 = 5
 	thanosRuler := framework.MakeBasicThanosRuler("test-thanos", 1, "http://test.example.com")
 	thanosRuler.Spec.MinReadySeconds = &setMinReadySecondsInitial
-	thanosRuler, err := framework.CreateThanosRulerAndWaitUntilReady(ns, thanosRuler)
+	thanosRuler, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanosRuler)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	trSS, err := kubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, "thanos-ruler-test-thanos", metav1.GetOptions{})
+	trSS, err := kubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), "thanos-ruler-test-thanos", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,11 +245,11 @@ func testTRMinReadySeconds(t *testing.T) {
 
 	var updated uint32 = 10
 	thanosRuler.Spec.MinReadySeconds = &updated
-	if _, err = framework.UpdateThanosRulerAndWaitUntilReady(ns, thanosRuler); err != nil {
+	if _, err = framework.UpdateThanosRulerAndWaitUntilReady(context.Background(), ns, thanosRuler); err != nil {
 		t.Fatal("Updating ThanosRuler failed: ", err)
 	}
 
-	trSS, err = kubeClient.AppsV1().StatefulSets(ns).Get(framework.Ctx, "thanos-ruler-test-thanos", metav1.GetOptions{})
+	trSS, err = kubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), "thanos-ruler-test-thanos", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -30,16 +30,16 @@ func testThanosRulerCreateDeleteCluster(t *testing.T) {
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	ns := framework.CreateNamespace(context.Background(),t, testCtx)
-	framework.SetupPrometheusRBAC(context.Background(),t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
-	if _, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(),ns, framework.MakeBasicThanosRuler(name, 1, "http://test.example.com")); err != nil {
+	if _, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, framework.MakeBasicThanosRuler(name, 1, "http://test.example.com")); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := framework.DeleteThanosRulerAndWaitUntilGone(context.Background(),ns, name); err != nil {
+	if err := framework.DeleteThanosRulerAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -48,19 +48,19 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
-	thanosNamespace := framework.CreateNamespace(context.Background(),t, testCtx)
-	framework.SetupPrometheusRBAC(context.Background(),t, testCtx, thanosNamespace)
+	thanosNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, thanosNamespace)
 
 	name := "test"
 
 	// Create a Prometheus resource because Thanos ruler needs a query API.
-	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(),thanosNamespace, framework.MakeBasicPrometheus(thanosNamespace, name, name, 1))
+	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), thanosNamespace, framework.MakeBasicPrometheus(thanosNamespace, name, name, 1))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	svc := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(),thanosNamespace, svc); err != nil {
+	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), thanosNamespace, svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,45 +73,45 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	}
 	thanos.Spec.EvaluationInterval = "1s"
 
-	if _, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(),thanosNamespace, thanos); err != nil {
+	if _, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(), thanosNamespace, thanos); err != nil {
 		t.Fatal(err)
 	}
 
-	ruleNamespace := framework.CreateNamespace(context.Background(),t, testCtx)
-	if err := framework.AddLabelsToNamespace(context.Background(),ruleNamespace, map[string]string{
+	ruleNamespace := framework.CreateNamespace(context.Background(), t, testCtx)
+	if err := framework.AddLabelsToNamespace(context.Background(), ruleNamespace, map[string]string{
 		"monitored": "true",
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	const testAlert = "alert1"
-	_, err = framework.MakeAndCreateFiringRule(context.Background(),ruleNamespace, "rule1", testAlert)
+	_, err = framework.MakeAndCreateFiringRule(context.Background(), ruleNamespace, "rule1", testAlert)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	thanosService := framework.MakeThanosRulerService(thanos.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(),thanosNamespace, thanosService); err != nil {
+	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), thanosNamespace, thanosService); err != nil {
 		t.Fatalf("creating Thanos ruler service failed: %v", err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	if err := framework.WaitForThanosFiringAlert(context.Background(),thanosNamespace, thanosService.Name, testAlert); err != nil {
+	if err := framework.WaitForThanosFiringAlert(context.Background(), thanosNamespace, thanosService.Name, testAlert); err != nil {
 		t.Fatal(err)
 	}
 
 	// Remove the selecting label from ruleNamespace and wait until the rule is
 	// removed from the Thanos ruler.
 	// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-	if err := framework.RemoveLabelsFromNamespace(context.Background(),ruleNamespace, "monitored"); err != nil {
+	if err := framework.RemoveLabelsFromNamespace(context.Background(), ruleNamespace, "monitored"); err != nil {
 		t.Fatal(err)
 	}
 
 	var loopError error
 	err = wait.Poll(time.Second, 5*framework.DefaultTimeout, func() (bool, error) {
 		var firing bool
-		firing, loopError = framework.CheckThanosFiringAlert(context.Background(),thanosNamespace, thanosService.Name, testAlert)
+		firing, loopError = framework.CheckThanosFiringAlert(context.Background(), thanosNamespace, thanosService.Name, testAlert)
 		return !firing, nil
 	})
 
@@ -124,13 +124,13 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
-	ns := framework.CreateNamespace(context.Background(),t, testCtx)
-	framework.SetupPrometheusRBAC(context.Background(),t, testCtx, ns)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	name := "test"
 
 	thanosRuler := framework.MakeBasicThanosRuler(name, 1, "http://test.example.com")
-	thanosRuler, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(),ns, thanosRuler)
+	thanosRuler, err := framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanosRuler)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,19 +153,19 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 		{
 			name: "thanos-ruler-operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(context.Background(),"thanos-ruler-operated", metav1.GetOptions{})
+				return svcClient.Get(context.Background(), "thanos-ruler-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return svcClient.Update(context.Background(),asService(t, object), metav1.UpdateOptions{})
+				return svcClient.Update(context.Background(), asService(t, object), metav1.UpdateOptions{})
 			},
 		},
 		{
 			name: "thanos-ruler stateful set",
 			get: func() (metav1.Object, error) {
-				return ssetClient.Get(context.Background(),"thanos-ruler-test", metav1.GetOptions{})
+				return ssetClient.Get(context.Background(), "thanos-ruler-test", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
-				return ssetClient.Update(context.Background(),asStatefulSet(t, object), metav1.UpdateOptions{})
+				return ssetClient.Update(context.Background(), asStatefulSet(t, object), metav1.UpdateOptions{})
 			},
 		},
 	}
@@ -187,7 +187,7 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 
 	// Ensure resource reconciles
 	thanosRuler.Spec.Replicas = proto.Int32(2)
-	_, err = framework.UpdateThanosRulerAndWaitUntilReady(context.Background(),ns, thanosRuler)
+	_, err = framework.UpdateThanosRulerAndWaitUntilReady(context.Background(), ns, thanosRuler)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 		}
 	}
 
-	if err := framework.DeleteThanosRulerAndWaitUntilGone(context.Background(),ns, name); err != nil {
+	if err := framework.DeleteThanosRulerAndWaitUntilGone(context.Background(), ns, name); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/test/framework/admission-webhooks.go
+++ b/test/framework/admission-webhooks.go
@@ -15,13 +15,14 @@
 package framework
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) createMutatingHook(certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
+func (f *Framework) createMutatingHook(ctx context.Context, certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
 	h, err := parseMutatingHookYaml(yamlPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed parsing mutating webhook")
@@ -30,17 +31,17 @@ func (f *Framework) createMutatingHook(certBytes []byte, namespace, yamlPath str
 	h.Webhooks[0].ClientConfig.Service.Namespace = namespace
 	h.Webhooks[0].ClientConfig.CABundle = certBytes
 
-	_, err = f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(f.Ctx, h, metav1.CreateOptions{})
+	_, err = f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, h, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create mutating webhook %s", h.Name)
 	}
 
-	finalizerFn := func() error { return f.deleteMutatingWebhook(h.Name) }
+	finalizerFn := func() error { return f.deleteMutatingWebhook(ctx, h.Name) }
 
 	return finalizerFn, nil
 }
 
-func (f *Framework) createValidatingHook(certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
+func (f *Framework) createValidatingHook(ctx context.Context, certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
 	h, err := parseValidatingHookYaml(yamlPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed parsing mutating webhook")
@@ -49,22 +50,22 @@ func (f *Framework) createValidatingHook(certBytes []byte, namespace, yamlPath s
 	h.Webhooks[0].ClientConfig.Service.Namespace = namespace
 	h.Webhooks[0].ClientConfig.CABundle = certBytes
 
-	_, err = f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(f.Ctx, h, metav1.CreateOptions{})
+	_, err = f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, h, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create validating webhook %s", h.Name)
 	}
 
-	finalizerFn := func() error { return f.deleteValidatingWebhook(h.Name) }
+	finalizerFn := func() error { return f.deleteValidatingWebhook(ctx, h.Name) }
 
 	return finalizerFn, nil
 }
 
-func (f *Framework) deleteMutatingWebhook(name string) error {
-	return f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(f.Ctx, name, metav1.DeleteOptions{})
+func (f *Framework) deleteMutatingWebhook(ctx context.Context, name string) error {
+	return f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-func (f *Framework) deleteValidatingWebhook(name string) error {
-	return f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(f.Ctx, name, metav1.DeleteOptions{})
+func (f *Framework) deleteValidatingWebhook(ctx context.Context, name string) error {
+	return f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func parseValidatingHookYaml(pathToYaml string) (*v1.ValidatingWebhookConfiguration, error) {

--- a/test/framework/cluster_role.go
+++ b/test/framework/cluster_role.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -43,24 +44,24 @@ var (
 	}
 )
 
-func (f *Framework) CreateClusterRole(relativePath string) (*rbacv1.ClusterRole, error) {
+func (f *Framework) CreateClusterRole(ctx context.Context, relativePath string) (*rbacv1.ClusterRole, error) {
 	clusterRole, err := parseClusterRoleYaml(relativePath)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = f.KubeClient.RbacV1().ClusterRoles().Get(f.Ctx, clusterRole.Name, metav1.GetOptions{})
+	_, err = f.KubeClient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
 
 	if err == nil {
 		// ClusterRole already exists -> Update
-		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Update(f.Ctx, clusterRole, metav1.UpdateOptions{})
+		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}
 
 	} else {
 		// ClusterRole doesn't exists -> Create
-		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Create(f.Ctx, clusterRole, metav1.CreateOptions{})
+		clusterRole, err = f.KubeClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -69,17 +70,17 @@ func (f *Framework) CreateClusterRole(relativePath string) (*rbacv1.ClusterRole,
 	return clusterRole, nil
 }
 
-func (f *Framework) DeleteClusterRole(relativePath string) error {
+func (f *Framework) DeleteClusterRole(ctx context.Context, relativePath string) error {
 	clusterRole, err := parseClusterRoleYaml(relativePath)
 	if err != nil {
 		return err
 	}
 
-	return f.KubeClient.RbacV1().ClusterRoles().Delete(f.Ctx, clusterRole.Name, metav1.DeleteOptions{})
+	return f.KubeClient.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.DeleteOptions{})
 }
 
-func (f *Framework) UpdateClusterRole(clusterRole *rbacv1.ClusterRole) error {
-	_, err := f.KubeClient.RbacV1().ClusterRoles().Update(f.Ctx, clusterRole, metav1.UpdateOptions{})
+func (f *Framework) UpdateClusterRole(ctx context.Context, clusterRole *rbacv1.ClusterRole) error {
+	_, err := f.KubeClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/framework/config_map.go
+++ b/test/framework/config_map.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ func MakeConfigMapWithCert(kubeClient kubernetes.Interface, ns, name, keyKey, ce
 	return cm
 }
 
-func (f *Framework) WaitForConfigMapExist(ns, name string) (*v1.ConfigMap, error) {
+func (f *Framework) WaitForConfigMapExist(ctx context.Context, ns, name string) (*v1.ConfigMap, error) {
 	var configMap *v1.ConfigMap
 	err := wait.Poll(2*time.Second, f.DefaultTimeout, func() (bool, error) {
 		var err error
@@ -57,7 +58,7 @@ func (f *Framework) WaitForConfigMapExist(ns, name string) (*v1.ConfigMap, error
 			KubeClient.
 			CoreV1().
 			ConfigMaps(ns).
-			Get(f.Ctx, name, metav1.GetOptions{})
+			Get(ctx, name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
 			return false, nil
@@ -71,14 +72,14 @@ func (f *Framework) WaitForConfigMapExist(ns, name string) (*v1.ConfigMap, error
 	return configMap, errors.Wrapf(err, "waiting for ConfigMap '%v' in namespace '%v'", name, ns)
 }
 
-func (f *Framework) WaitForConfigMapNotExist(ns, name string) error {
+func (f *Framework) WaitForConfigMapNotExist(ctx context.Context, ns, name string) error {
 	err := wait.Poll(2*time.Second, f.DefaultTimeout, func() (bool, error) {
 		var err error
 		_, err = f.
 			KubeClient.
 			CoreV1().
 			ConfigMaps(ns).
-			Get(f.Ctx, name, metav1.GetOptions{})
+			Get(ctx, name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
 			return true, nil

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -31,8 +32,8 @@ import (
 )
 
 // GetCRD gets a custom resource definition from the apiserver.
-func (f *Framework) GetCRD(name string) (*v1.CustomResourceDefinition, error) {
-	crd, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(f.Ctx, name, metav1.GetOptions{})
+func (f *Framework) GetCRD(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
+	crd, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get CRD with name %v", name)
 	}
@@ -40,8 +41,8 @@ func (f *Framework) GetCRD(name string) (*v1.CustomResourceDefinition, error) {
 }
 
 // ListCRDs gets a list of custom resource definitions from the apiserver.
-func (f *Framework) ListCRDs() (*v1.CustomResourceDefinitionList, error) {
-	crds, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().List(f.Ctx, metav1.ListOptions{})
+func (f *Framework) ListCRDs(ctx context.Context) (*v1.CustomResourceDefinitionList, error) {
+	crds, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list CRDs")
 	}
@@ -49,14 +50,14 @@ func (f *Framework) ListCRDs() (*v1.CustomResourceDefinitionList, error) {
 }
 
 // CreateCRD creates a custom resource definition on the apiserver.
-func (f *Framework) CreateCRD(crd *v1.CustomResourceDefinition) error {
-	_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(f.Ctx, crd.Name, metav1.GetOptions{})
+func (f *Framework) CreateCRD(ctx context.Context, crd *v1.CustomResourceDefinition) error {
+	_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "getting CRD: %s", crd.Spec.Names.Kind)
 	}
 
 	if apierrors.IsNotFound(err) {
-		_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(f.Ctx, crd, metav1.CreateOptions{})
+		_, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "create CRD: %s", crd.Spec.Names.Kind)
 		}
@@ -100,7 +101,7 @@ func WaitForCRDReady(listFunc func(opts metav1.ListOptions) (runtime.Object, err
 
 // CreateCRDAndWaitUntilReady creates a Custom Resource Definition from yaml
 // manifest on the apiserver and wait until it is available for use.
-func (f *Framework) CreateCRDAndWaitUntilReady(crdName string, listFunc func(opts metav1.ListOptions) (runtime.Object, error)) error {
+func (f *Framework) CreateCRDAndWaitUntilReady(ctx context.Context, crdName string, listFunc func(opts metav1.ListOptions) (runtime.Object, error)) error {
 	crdName = strings.ToLower(crdName)
 	group := monitoring.GroupName
 	assetPath := "../../example/prometheus-operator-crd/" + group + "_" + crdName + ".yaml"
@@ -113,7 +114,7 @@ func (f *Framework) CreateCRDAndWaitUntilReady(crdName string, listFunc func(opt
 	crd.ObjectMeta.Name = crd.Spec.Names.Plural + "." + group
 	crd.Spec.Group = group
 
-	err = f.CreateCRD(crd)
+	err = f.CreateCRD(ctx, crd)
 	if err != nil {
 		return errors.Wrapf(err, "create CRD %s on the apiserver", crdName)
 	}

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -15,14 +15,15 @@
 package framework
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PrintEvents prints the Kubernetes events to standard out.
-func (f *Framework) PrintEvents() error {
-	events, err := f.KubeClient.CoreV1().Events("").List(f.Ctx, metav1.ListOptions{})
+func (f *Framework) PrintEvents(ctx context.Context) error {
+	events, err := f.KubeClient.CoreV1().Events("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -172,11 +172,10 @@ func (f *Framework) MakeEchoDeployment(group string) *appsv1.Deployment {
 // inside the specified namespace using the specified operator image. In addition
 // one can specify the namespaces to watch, which defaults to all namespaces.
 // Returns the CA, which can bs used to access the operator over TLS
-func (f *Framework) CreatePrometheusOperator(ns, opImage string, namespaceAllowlist,
+func (f *Framework) CreatePrometheusOperator(ctx context.Context, ns, opImage string, namespaceAllowlist,
 	namespaceDenylist, prometheusInstanceNamespaces, alertmanagerInstanceNamespaces []string,
 	createRuleAdmissionHooks, createClusterRoleBindings bool) ([]FinalizerFn, error) {
 
-	ctx := context.Background()
 	var finalizers []FinalizerFn
 
 	_, err := f.createServiceAccount(

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -46,9 +47,9 @@ func PathToOSFile(relativePath string) (*os.File, error) {
 
 // WaitForPodsReady waits for a selection of Pods to be running and each
 // container to pass its readiness check.
-func (f *Framework) WaitForPodsReady(namespace string, timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
+func (f *Framework) WaitForPodsReady(ctx context.Context, namespace string, timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
-		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(f.Ctx, opts)
+		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, opts)
 		if err != nil {
 			return false, err
 		}
@@ -72,9 +73,9 @@ func (f *Framework) WaitForPodsReady(namespace string, timeout time.Duration, ex
 	})
 }
 
-func (f *Framework) WaitForPodsRunImage(namespace string, expectedReplicas int, image string, opts metav1.ListOptions) error {
+func (f *Framework) WaitForPodsRunImage(ctx context.Context, namespace string, expectedReplicas int, image string, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
-		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(f.Ctx, opts)
+		pl, err := f.KubeClient.CoreV1().Pods(namespace).List(ctx, opts)
 		if err != nil {
 			return false, err
 		}
@@ -121,13 +122,13 @@ func podRunsImage(p v1.Pod, image string) bool {
 	return false
 }
 
-func (f *Framework) GetLogs(namespace string, podName, containerName string) (string, error) {
+func (f *Framework) GetLogs(ctx context.Context, namespace string, podName, containerName string) (string, error) {
 	logs, err := f.KubeClient.CoreV1().RESTClient().Get().
 		Resource("pods").
 		Namespace(namespace).
 		Name(podName).SubResource("log").
 		Param("container", containerName).
-		Do(f.Ctx).
+		Do(ctx).
 		Raw()
 	if err != nil {
 		return "", err

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -25,10 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (f *Framework) CreateNamespace(t *testing.T, ctx *TestCtx) string {
-	name := ctx.GetObjID()
+func (f *Framework) CreateNamespace(ctx context.Context, t *testing.T, testCtx *TestCtx) string {
+	name := testCtx.GetObjID()
 
-	_, err := f.KubeClient.CoreV1().Namespaces().Create(f.Ctx, &v1.Namespace{
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -39,20 +40,20 @@ func (f *Framework) CreateNamespace(t *testing.T, ctx *TestCtx) string {
 	}
 
 	namespaceFinalizerFn := func() error {
-		return f.DeleteNamespace(name)
+		return f.DeleteNamespace(ctx, name)
 	}
 
-	ctx.AddFinalizerFn(namespaceFinalizerFn)
+	testCtx.AddFinalizerFn(namespaceFinalizerFn)
 
 	return name
 }
 
-func (f *Framework) DeleteNamespace(name string) error {
-	return f.KubeClient.CoreV1().Namespaces().Delete(f.Ctx, name, metav1.DeleteOptions{})
+func (f *Framework) DeleteNamespace(ctx context.Context, name string) error {
+	return f.KubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-func (f *Framework) AddLabelsToNamespace(name string, additionalLabels map[string]string) error {
-	ns, err := f.KubeClient.CoreV1().Namespaces().Get(f.Ctx, name, metav1.GetOptions{})
+func (f *Framework) AddLabelsToNamespace(ctx context.Context, name string, additionalLabels map[string]string) error {
+	ns, err := f.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -65,7 +66,7 @@ func (f *Framework) AddLabelsToNamespace(name string, additionalLabels map[strin
 		ns.Labels[k] = v
 	}
 
-	_, err = f.KubeClient.CoreV1().Namespaces().Update(f.Ctx, ns, metav1.UpdateOptions{})
+	_, err = f.KubeClient.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -73,8 +74,8 @@ func (f *Framework) AddLabelsToNamespace(name string, additionalLabels map[strin
 	return nil
 }
 
-func (f *Framework) RemoveLabelsFromNamespace(name string, labels ...string) error {
-	ns, err := f.KubeClient.CoreV1().Namespaces().Get(f.Ctx, name, metav1.GetOptions{})
+func (f *Framework) RemoveLabelsFromNamespace(ctx context.Context, name string, labels ...string) error {
+	ns, err := f.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +98,7 @@ func (f *Framework) RemoveLabelsFromNamespace(name string, labels ...string) err
 		return err
 	}
 
-	_, err = f.KubeClient.CoreV1().Namespaces().Patch(f.Ctx, name, types.JSONPatchType, b, metav1.PatchOptions{})
+	_, err = f.KubeClient.CoreV1().Namespaces().Patch(ctx, name, types.JSONPatchType, b, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"k8s.io/client-go/tools/portforward"
@@ -34,15 +35,15 @@ import (
 )
 
 // PrintPodLogs prints the logs of a specified Pod
-func (f *Framework) PrintPodLogs(ns, p string) error {
-	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(f.Ctx, p, metav1.GetOptions{})
+func (f *Framework) PrintPodLogs(ctx context.Context, ns, p string) error {
+	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(ctx, p, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to print logs of pod '%v': failed to get pod", p)
 	}
 
 	for _, c := range pod.Spec.Containers {
 		req := f.KubeClient.CoreV1().Pods(ns).GetLogs(p, &v1.PodLogOptions{Container: c.Name})
-		resp, err := req.DoRaw(f.Ctx)
+		resp, err := req.DoRaw(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve logs of pod '%v'", p)
 		}
@@ -56,8 +57,8 @@ func (f *Framework) PrintPodLogs(ns, p string) error {
 
 // GetPodRestartCount returns a map of container names and their restart counts for
 // a given pod.
-func (f *Framework) GetPodRestartCount(ns, podName string) (map[string]int32, error) {
-	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(f.Ctx, podName, metav1.GetOptions{})
+func (f *Framework) GetPodRestartCount(ctx context.Context, ns, podName string) (map[string]int32, error) {
+	pod, err := f.KubeClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrieve pod to get restart count")
 	}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -268,36 +269,36 @@ func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
 	return service
 }
 
-func (f *Framework) CreatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
-	result, err := f.MonClientV1.Prometheuses(ns).Create(f.Ctx, p, metav1.CreateOptions{})
+func (f *Framework) CreatePrometheusAndWaitUntilReady(ctx context.Context, ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
+	result, err := f.MonClientV1.Prometheuses(ns).Create(ctx, p, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("creating %v Prometheus instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
-	if err := f.WaitForPrometheusReady(result, 5*time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(ctx, result, 5*time.Minute); err != nil {
 		return nil, fmt.Errorf("waiting for %v Prometheus instances timed out (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
 	return result, nil
 }
 
-func (f *Framework) UpdatePrometheusAndWaitUntilReady(ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
-	result, err := f.MonClientV1.Prometheuses(ns).Update(f.Ctx, p, metav1.UpdateOptions{})
+func (f *Framework) UpdatePrometheusAndWaitUntilReady(ctx context.Context, ns string, p *monitoringv1.Prometheus) (*monitoringv1.Prometheus, error) {
+	result, err := f.MonClientV1.Prometheuses(ns).Update(ctx, p, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
-	if err := f.WaitForPrometheusReady(result, 5*time.Minute); err != nil {
+	if err := f.WaitForPrometheusReady(ctx, result, 5*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to update %d Prometheus instances (%v): %v", p.Spec.Replicas, p.Name, err)
 	}
 
 	return result, nil
 }
 
-func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout time.Duration) error {
+func (f *Framework) WaitForPrometheusReady(ctx context.Context, p *monitoringv1.Prometheus, timeout time.Duration) error {
 	var pollErr error
 
 	err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
-		st, _, pollErr := prometheus.Status(f.Ctx, f.KubeClient, p)
+		st, _, pollErr := prometheus.Status(ctx, f.KubeClient, p)
 
 		if pollErr != nil {
 			return false, nil
@@ -317,17 +318,18 @@ func (f *Framework) WaitForPrometheusReady(p *monitoringv1.Prometheus, timeout t
 	return errors.Wrapf(pollErr, "waiting for Prometheus %v/%v: %v", p.Namespace, p.Name, err)
 }
 
-func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
-	_, err := f.MonClientV1.Prometheuses(ns).Get(f.Ctx, name, metav1.GetOptions{})
+func (f *Framework) DeletePrometheusAndWaitUntilGone(ctx context.Context, ns, name string) error {
+	_, err := f.MonClientV1.Prometheuses(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("requesting Prometheus custom resource %v failed", name))
 	}
 
-	if err := f.MonClientV1.Prometheuses(ns).Delete(f.Ctx, name, metav1.DeleteOptions{}); err != nil {
+	if err := f.MonClientV1.Prometheuses(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("deleting Prometheus custom resource %v failed", name))
 	}
 
 	if err := f.WaitForPodsReady(
+		ctx,
 		ns,
 		f.DefaultTimeout,
 		0,
@@ -342,11 +344,12 @@ func (f *Framework) DeletePrometheusAndWaitUntilGone(ns, name string) error {
 	return nil
 }
 
-func (f *Framework) WaitForPrometheusRunImageAndReady(ns string, p *monitoringv1.Prometheus) error {
-	if err := f.WaitForPodsRunImage(ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
+func (f *Framework) WaitForPrometheusRunImageAndReady(ctx context.Context, ns string, p *monitoringv1.Prometheus) error {
+	if err := f.WaitForPodsRunImage(ctx, ns, int(*p.Spec.Replicas), promImage(p.Spec.Version), prometheus.ListOptions(p.Name)); err != nil {
 		return err
 	}
 	return f.WaitForPodsReady(
+		ctx,
 		ns,
 		f.DefaultTimeout,
 		int(*p.Spec.Replicas),
@@ -359,12 +362,12 @@ func promImage(version string) string {
 }
 
 // WaitForActiveTargets waits for a number of targets to be configured.
-func (f *Framework) WaitForActiveTargets(ns, svcName string, amount int) error {
+func (f *Framework) WaitForActiveTargets(ctx context.Context, ns, svcName string, amount int) error {
 	var targets []*Target
 
 	if err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		var err error
-		targets, err = f.GetActiveTargets(ns, svcName)
+		targets, err = f.GetActiveTargets(ctx, ns, svcName)
 		if err != nil {
 			return false, err
 		}
@@ -383,12 +386,12 @@ func (f *Framework) WaitForActiveTargets(ns, svcName string, amount int) error {
 
 // WaitForHealthyTargets waits for a number of targets to be configured and
 // healthy.
-func (f *Framework) WaitForHealthyTargets(ns, svcName string, amount int) error {
+func (f *Framework) WaitForHealthyTargets(ctx context.Context, ns, svcName string, amount int) error {
 	var targets []*Target
 
 	if err := wait.Poll(time.Second, time.Minute*5, func() (bool, error) {
 		var err error
-		targets, err = f.GetHealthyTargets(ns, svcName)
+		targets, err = f.GetHealthyTargets(ctx, ns, svcName)
 		if err != nil {
 			return false, err
 		}
@@ -405,11 +408,11 @@ func (f *Framework) WaitForHealthyTargets(ns, svcName string, amount int) error 
 	return nil
 }
 
-func (f *Framework) WaitForDiscoveryWorking(ns, svcName, prometheusName string) error {
+func (f *Framework) WaitForDiscoveryWorking(ctx context.Context, ns, svcName, prometheusName string) error {
 	var loopErr error
 
 	err := wait.Poll(time.Second, 5*f.DefaultTimeout, func() (bool, error) {
-		pods, loopErr := f.KubeClient.CoreV1().Pods(ns).List(f.Ctx, prometheus.ListOptions(prometheusName))
+		pods, loopErr := f.KubeClient.CoreV1().Pods(ns).List(ctx, prometheus.ListOptions(prometheusName))
 		if loopErr != nil {
 			return false, loopErr
 		}
@@ -419,7 +422,7 @@ func (f *Framework) WaitForDiscoveryWorking(ns, svcName, prometheusName string) 
 		podIP := pods.Items[0].Status.PodIP
 		expectedTargets := []string{fmt.Sprintf("http://%s:9090/metrics", podIP)}
 
-		activeTargets, loopErr := f.GetActiveTargets(ns, svcName)
+		activeTargets, loopErr := f.GetActiveTargets(ctx, ns, svcName)
 		if loopErr != nil {
 			return false, loopErr
 		}
@@ -428,7 +431,7 @@ func (f *Framework) WaitForDiscoveryWorking(ns, svcName, prometheusName string) 
 			return false, nil
 		}
 
-		working, loopErr := f.basicQueryWorking(ns, svcName)
+		working, loopErr := f.basicQueryWorking(ctx, ns, svcName)
 		if loopErr != nil {
 			return false, loopErr
 		}
@@ -446,8 +449,8 @@ func (f *Framework) WaitForDiscoveryWorking(ns, svcName, prometheusName string) 
 	return nil
 }
 
-func (f *Framework) basicQueryWorking(ns, svcName string) (bool, error) {
-	response, err := f.PrometheusSVCGetRequest(ns, svcName, "/api/v1/query", map[string]string{"query": "up"})
+func (f *Framework) basicQueryWorking(ctx context.Context, ns, svcName string) (bool, error) {
+	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "/api/v1/query", map[string]string{"query": "up"})
 	if err != nil {
 		return false, err
 	}
@@ -485,14 +488,14 @@ func assertExpectedTargets(targets []*Target, expectedTargets []string) error {
 	return nil
 }
 
-func (f *Framework) PrometheusSVCGetRequest(ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
+func (f *Framework) PrometheusSVCGetRequest(ctx context.Context, ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
 	ProxyGet := f.KubeClient.CoreV1().Services(ns).ProxyGet
 	request := ProxyGet("", svcName, "web", endpoint, query)
-	return request.DoRaw(f.Ctx)
+	return request.DoRaw(ctx)
 }
 
-func (f *Framework) GetActiveTargets(ns, svcName string) ([]*Target, error) {
-	response, err := f.PrometheusSVCGetRequest(ns, svcName, "/api/v1/targets", map[string]string{})
+func (f *Framework) GetActiveTargets(ctx context.Context, ns, svcName string) ([]*Target, error) {
+	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "/api/v1/targets", map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -505,8 +508,8 @@ func (f *Framework) GetActiveTargets(ns, svcName string) ([]*Target, error) {
 	return rt.Data.ActiveTargets, nil
 }
 
-func (f *Framework) GetHealthyTargets(ns, svcName string) ([]*Target, error) {
-	targets, err := f.GetActiveTargets(ns, svcName)
+func (f *Framework) GetHealthyTargets(ctx context.Context, ns, svcName string) ([]*Target, error) {
+	targets, err := f.GetActiveTargets(ctx, ns, svcName)
 	if err != nil {
 		return nil, err
 	}
@@ -524,8 +527,9 @@ func (f *Framework) GetHealthyTargets(ns, svcName string) ([]*Target, error) {
 	return healthyTargets, nil
 }
 
-func (f *Framework) CheckPrometheusFiringAlert(ns, svcName, alertName string) (bool, error) {
+func (f *Framework) CheckPrometheusFiringAlert(ctx context.Context, ns, svcName, alertName string) (bool, error) {
 	response, err := f.PrometheusSVCGetRequest(
+		ctx,
 		ns,
 		svcName,
 		"/api/v1/query",
@@ -571,14 +575,14 @@ func (f *Framework) PrometheusQuery(ns, svcName, query string) ([]PrometheusQuer
 }
 
 // PrintPrometheusLogs prints the logs for each Prometheus replica.
-func (f *Framework) PrintPrometheusLogs(t *testing.T, p *monitoringv1.Prometheus) {
+func (f *Framework) PrintPrometheusLogs(ctx context.Context, t *testing.T, p *monitoringv1.Prometheus) {
 	if p == nil {
 		return
 	}
 
 	replicas := int(*p.Spec.Replicas)
 	for i := 0; i < replicas; i++ {
-		l, err := f.GetLogs(p.Namespace, fmt.Sprintf("prometheus-%s-%d", p.Name, i), "prometheus")
+		l, err := f.GetLogs(ctx, p.Namespace, fmt.Sprintf("prometheus-%s-%d", p.Name, i), "prometheus")
 		if err != nil {
 			t.Logf("failed to retrieve logs for replica[%d]: %v", i, err)
 			continue
@@ -588,12 +592,12 @@ func (f *Framework) PrintPrometheusLogs(t *testing.T, p *monitoringv1.Prometheus
 	}
 }
 
-func (f *Framework) WaitForPrometheusFiringAlert(ns, svcName, alertName string) error {
+func (f *Framework) WaitForPrometheusFiringAlert(ctx context.Context, ns, svcName, alertName string) error {
 	var loopError error
 
 	err := wait.Poll(time.Second, 5*f.DefaultTimeout, func() (bool, error) {
 		var firing bool
-		firing, loopError = f.CheckPrometheusFiringAlert(ns, svcName, alertName)
+		firing, loopError = f.CheckPrometheusFiringAlert(ctx, ns, svcName, alertName)
 		return firing, nil
 	})
 

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -553,6 +553,7 @@ func (f *Framework) CheckPrometheusFiringAlert(ctx context.Context, ns, svcName,
 
 func (f *Framework) PrometheusQuery(ns, svcName, query string) ([]PrometheusQueryResult, error) {
 	response, err := f.PrometheusSVCGetRequest(
+		context.Background(),
 		ns,
 		svcName,
 		"/api/v1/query",

--- a/test/framework/prometheus_rule.go
+++ b/test/framework/prometheus_rule.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -40,8 +41,8 @@ func (f *Framework) MakeBasicRule(ns, name string, groups []monitoringv1.RuleGro
 	}
 }
 
-func (f *Framework) CreateRule(ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Create(f.Ctx, ar, metav1.CreateOptions{})
+func (f *Framework) CreateRule(ctx context.Context, ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
+	result, err := f.MonClientV1.PrometheusRules(ns).Create(ctx, ar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("creating %v RuleFile failed: %v", ar.Name, err)
 	}
@@ -49,8 +50,8 @@ func (f *Framework) CreateRule(ns string, ar *monitoringv1.PrometheusRule) (*mon
 	return result, nil
 }
 
-func (f *Framework) GetRule(ns, name string) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Get(f.Ctx, name, metav1.GetOptions{})
+func (f *Framework) GetRule(ctx context.Context, ns, name string) (*monitoringv1.PrometheusRule, error) {
+	result, err := f.MonClientV1.PrometheusRules(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("getting %v Rule failed: %v", name, err)
 	}
@@ -58,7 +59,7 @@ func (f *Framework) GetRule(ns, name string) (*monitoringv1.PrometheusRule, erro
 	return result, nil
 }
 
-func (f *Framework) MakeAndCreateFiringRule(ns, name, alertName string) (*monitoringv1.PrometheusRule, error) {
+func (f *Framework) MakeAndCreateFiringRule(ctx context.Context, ns, name, alertName string) (*monitoringv1.PrometheusRule, error) {
 	groups := []monitoringv1.RuleGroup{
 		{
 			Name: alertName,
@@ -72,7 +73,7 @@ func (f *Framework) MakeAndCreateFiringRule(ns, name, alertName string) (*monito
 	}
 	file := f.MakeBasicRule(ns, name, groups)
 
-	result, err := f.CreateRule(ns, file)
+	result, err := f.CreateRule(ctx, ns, file)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (f *Framework) MakeAndCreateFiringRule(ns, name, alertName string) (*monito
 	return result, nil
 }
 
-func (f *Framework) MakeAndCreateInvalidRule(ns, name, alertName string) (*monitoringv1.PrometheusRule, error) {
+func (f *Framework) MakeAndCreateInvalidRule(ctx context.Context, ns, name, alertName string) (*monitoringv1.PrometheusRule, error) {
 	groups := []monitoringv1.RuleGroup{
 		{
 			Name: alertName,
@@ -94,7 +95,7 @@ func (f *Framework) MakeAndCreateInvalidRule(ns, name, alertName string) (*monit
 	}
 	file := f.MakeBasicRule(ns, name, groups)
 
-	result, err := f.CreateRule(ns, file)
+	result, err := f.CreateRule(ctx, ns, file)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +105,9 @@ func (f *Framework) MakeAndCreateInvalidRule(ns, name, alertName string) (*monit
 
 // WaitForRule waits for a rule file with a given name to exist in a given
 // namespace.
-func (f *Framework) WaitForRule(ns, name string) error {
+func (f *Framework) WaitForRule(ctx context.Context, ns, name string) error {
 	return wait.Poll(time.Second, f.DefaultTimeout, func() (bool, error) {
-		_, err := f.MonClientV1.PrometheusRules(ns).Get(f.Ctx, name, metav1.GetOptions{})
+		_, err := f.MonClientV1.PrometheusRules(ns).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		} else if err != nil {
@@ -116,8 +117,8 @@ func (f *Framework) WaitForRule(ns, name string) error {
 	})
 }
 
-func (f *Framework) UpdateRule(ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
-	result, err := f.MonClientV1.PrometheusRules(ns).Update(f.Ctx, ar, metav1.UpdateOptions{})
+func (f *Framework) UpdateRule(ctx context.Context, ns string, ar *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
+	result, err := f.MonClientV1.PrometheusRules(ns).Update(ctx, ar, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("updating %v RuleFile failed: %v", ar.Name, err)
 	}
@@ -125,8 +126,8 @@ func (f *Framework) UpdateRule(ns string, ar *monitoringv1.PrometheusRule) (*mon
 	return result, nil
 }
 
-func (f *Framework) DeleteRule(ns string, r string) error {
-	err := f.MonClientV1.PrometheusRules(ns).Delete(f.Ctx, r, metav1.DeleteOptions{})
+func (f *Framework) DeleteRule(ctx context.Context, ns string, r string) error {
+	err := f.MonClientV1.PrometheusRules(ns).Delete(ctx, r, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("deleting %v Prometheus rule in namespace %v failed: %v", r, ns, err.Error())
 	}

--- a/test/framework/role-binding.go
+++ b/test/framework/role-binding.go
@@ -15,24 +15,25 @@
 package framework
 
 import (
+	"context"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) CreateRoleBinding(ns string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return f.DeleteRoleBinding(ns, relativePath) }
+func (f *Framework) CreateRoleBinding(ctx context.Context, ns string, relativePath string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteRoleBinding(ctx, ns, relativePath) }
 	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 	if err != nil {
 		return finalizerFn, err
 	}
 
-	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(f.Ctx, roleBinding, metav1.CreateOptions{})
+	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(ctx, roleBinding, metav1.CreateOptions{})
 	return finalizerFn, err
 }
 
-func (f *Framework) CreateRoleBindingForSubjectNamespace(ns, subjectNs string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return f.DeleteRoleBinding(ns, relativePath) }
+func (f *Framework) CreateRoleBindingForSubjectNamespace(ctx context.Context, ns, subjectNs string, relativePath string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteRoleBinding(ctx, ns, relativePath) }
 	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 
 	for i := range roleBinding.Subjects {
@@ -43,17 +44,17 @@ func (f *Framework) CreateRoleBindingForSubjectNamespace(ns, subjectNs string, r
 		return finalizerFn, err
 	}
 
-	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(f.Ctx, roleBinding, metav1.CreateOptions{})
+	_, err = f.KubeClient.RbacV1().RoleBindings(ns).Create(ctx, roleBinding, metav1.CreateOptions{})
 	return finalizerFn, err
 }
 
-func (f *Framework) DeleteRoleBinding(ns string, relativePath string) error {
+func (f *Framework) DeleteRoleBinding(ctx context.Context, ns string, relativePath string) error {
 	roleBinding, err := f.parseRoleBindingYaml(relativePath)
 	if err != nil {
 		return err
 	}
 
-	return f.KubeClient.RbacV1().RoleBindings(ns).Delete(f.Ctx, roleBinding.Name, metav1.DeleteOptions{})
+	return f.KubeClient.RbacV1().RoleBindings(ns).Delete(ctx, roleBinding.Name, metav1.DeleteOptions{})
 }
 
 func (f *Framework) parseRoleBindingYaml(relativePath string) (*rbacv1.RoleBinding, error) {

--- a/test/framework/secret.go
+++ b/test/framework/secret.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,10 +36,10 @@ func MakeSecretWithCert(ns, name string, keyList []string,
 	return secret
 }
 
-func (f *Framework) CreateSecretWithCert(certBytes, keyBytes []byte, ns, name string) error {
+func (f *Framework) CreateSecretWithCert(ctx context.Context, certBytes, keyBytes []byte, ns, name string) error {
 
 	secret := MakeSecretWithCert(ns, name, []string{"tls.key", "tls.crt"}, [][]byte{keyBytes, certBytes})
-	_, err := f.KubeClient.CoreV1().Secrets(ns).Create(f.Ctx, secret, metav1.CreateOptions{})
+	_, err := f.KubeClient.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
 
 	return err
 }

--- a/test/framework/service_account.go
+++ b/test/framework/service_account.go
@@ -15,20 +15,21 @@
 package framework
 
 import (
+	"context"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) createServiceAccount(namespace string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return f.DeleteServiceAccount(namespace, relativePath) }
+func (f *Framework) createServiceAccount(ctx context.Context, namespace string, relativePath string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteServiceAccount(ctx, namespace, relativePath) }
 
 	serviceAccount, err := parseServiceAccountYaml(relativePath)
 	if err != nil {
 		return finalizerFn, err
 	}
 	serviceAccount.Namespace = namespace
-	_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(f.Ctx, serviceAccount, metav1.CreateOptions{})
+	_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
 	if err != nil {
 		return finalizerFn, err
 	}
@@ -50,11 +51,11 @@ func parseServiceAccountYaml(relativePath string) (*v1.ServiceAccount, error) {
 	return &serviceAccount, nil
 }
 
-func (f *Framework) DeleteServiceAccount(namespace string, relativePath string) error {
+func (f *Framework) DeleteServiceAccount(ctx context.Context, namespace string, relativePath string) error {
 	serviceAccount, err := parseServiceAccountYaml(relativePath)
 	if err != nil {
 		return err
 	}
 
-	return f.KubeClient.CoreV1().ServiceAccounts(namespace).Delete(f.Ctx, serviceAccount.Name, metav1.DeleteOptions{})
+	return f.KubeClient.CoreV1().ServiceAccounts(namespace).Delete(ctx, serviceAccount.Name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
## Description

Remove the context field from framework struct and updating method signatures to pass context instead. Doing this change since its not recommended to have context as a field in struct


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove context field from framework struct and pass as an argument instead of methods
```

cc: @simonpasquier 