### PR TITLE
Validate prometheus rules when generating rule file content

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2002,6 +2002,7 @@ google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaE
 google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08 h1:pc16UedxnxXXtGxHCSUhafAoVHQZ0yXl8ZelMH4EETc=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -2034,6 +2035,7 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -22,6 +22,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	thanostypes "github.com/thanos-io/thanos/pkg/store/storepb"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	namespacelabeler "github.com/prometheus-operator/prometheus-operator/pkg/namespace-labeler"
 
@@ -29,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ghodss/yaml"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 )
@@ -186,7 +190,7 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 				return
 			}
 
-			content, err := generateContent(promRule.Spec)
+			content, err := GenerateContent(promRule.Spec, c.logger)
 			if err != nil {
 				marshalErr = err
 				return
@@ -219,14 +223,6 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 	}
 
 	return rules, nil
-}
-
-func generateContent(promRule monitoringv1.PrometheusRuleSpec) (string, error) {
-	content, err := yaml.Marshal(promRule)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal content")
-	}
-	return string(content), nil
 }
 
 // makeRulesConfigMaps takes a Prometheus configuration and rule files and
@@ -318,4 +314,45 @@ func makeRulesConfigMap(p *monitoringv1.Prometheus, ruleFiles map[string]string)
 
 func prometheusRuleConfigMapName(prometheusName string) string {
 	return "prometheus-" + prometheusName + "-rulefiles"
+}
+
+// GenerateContent takes a PrometheusRuleSpec and generates the rule content
+func GenerateContent(promRule monitoringv1.PrometheusRuleSpec, logger log.Logger) (string, error) {
+	content, err := yaml.Marshal(promRule)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal content")
+	}
+	errs := ValidateRule(promRule)
+	if len(errs) != 0 {
+		const m = "Invalid rule"
+		level.Debug(logger).Log("msg", m, "content", content)
+		for _, err := range errs {
+			level.Info(logger).Log("msg", m, "err", err)
+		}
+		return "", errors.New(m)
+	}
+	return string(content), nil
+}
+
+// ValidateRule takes PrometheusRuleSpec and validates it using the upstream prometheus rule validator
+func ValidateRule(promRule monitoringv1.PrometheusRuleSpec) []error {
+	for i, group := range promRule.Groups {
+		if group.PartialResponseStrategy == "" {
+			continue
+		}
+		if _, ok := thanostypes.PartialResponseStrategy_value[strings.ToUpper(group.PartialResponseStrategy)]; !ok {
+			return []error{
+				fmt.Errorf("invalid partial_response_strategy %s value", group.PartialResponseStrategy),
+			}
+		}
+		// reset this as the upstream prometheus rule validator
+		// is not aware of the partial_response_strategy field
+		promRule.Groups[i].PartialResponseStrategy = ""
+	}
+	content, err := yaml.Marshal(promRule)
+	if err != nil {
+		return []error{errors.Wrap(err, "failed to marshal content")}
+	}
+	_, errs := rulefmt.Parse(content)
+	return errs
 }

--- a/pkg/prometheus/rules_test.go
+++ b/pkg/prometheus/rules_test.go
@@ -41,7 +41,7 @@ func TestMakeRulesConfigMaps(t *testing.T) {
 func shouldAcceptValidRule(t *testing.T) {
 	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
 		{
-			Name:                    "group",
+			Name: "group",
 			Rules: []monitoringv1.Rule{
 				{
 					Alert: "alert",

--- a/pkg/prometheus/rules_test.go
+++ b/pkg/prometheus/rules_test.go
@@ -15,8 +15,12 @@
 package prometheus
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/go-kit/log"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +30,113 @@ func TestMakeRulesConfigMaps(t *testing.T) {
 	t.Run("ShouldReturnAtLeastOneConfigMap", shouldReturnAtLeastOneConfigMap)
 	t.Run("ShouldErrorOnTooLargeRuleFile", shouldErrorOnTooLargeRuleFile)
 	t.Run("ShouldSplitUpLargeSmallIntoTwo", shouldSplitUpLargeSmallIntoTwo)
+	t.Run("ShouldAcceptValidRule", shouldAcceptValidRule)
+	t.Run("shouldAcceptRuleWithValidPartialResponseStrategyValue", shouldAcceptRuleWithValidPartialResponseStrategyValue)
+	t.Run("shouldRejectRuleWithInvalidLabels", shouldRejectRuleWithInvalidLabels)
+	t.Run("shouldRejectRuleWithInvalidExpression", shouldRejectRuleWithInvalidExpression)
+	t.Run("shouldRejectRuleWithInvalidPartialResponseStrategyValue", shouldRejectRuleWithInvalidPartialResponseStrategyValue)
+
+}
+
+func shouldAcceptValidRule(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name:                    "group",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+					Labels: map[string]string{
+						"valid_label": "valid_value",
+					},
+				},
+			},
+		},
+	}}
+	_, err := GenerateContent(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err != nil {
+		t.Fatalf("expected no errors when parsing valid rule")
+	}
+}
+
+func shouldAcceptRuleWithValidPartialResponseStrategyValue(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name:                    "group",
+			PartialResponseStrategy: "abort",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+					Labels: map[string]string{
+						"valid_label": "valid_value",
+					},
+				},
+			},
+		},
+	}}
+	_, err := GenerateContent(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err != nil {
+		t.Fatalf("expected no errors when parsing rule with valid thanos partial_response_strategy value")
+	}
+}
+
+func shouldRejectRuleWithInvalidLabels(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name: "group2",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+					Labels: map[string]string{
+						"invalid/label": "value",
+					},
+				},
+			},
+		},
+	}}
+	_, err := GenerateContent(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err == nil {
+		t.Fatalf("expected errors when parsing rule with invalid labels")
+	}
+}
+
+func shouldRejectRuleWithInvalidExpression(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name: "group2",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("invalidfn(1)"),
+				},
+			},
+		},
+	}}
+	_, err := GenerateContent(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err == nil {
+		t.Fatalf("expected errors when parsing rule with invalid expression")
+	}
+}
+
+func shouldRejectRuleWithInvalidPartialResponseStrategyValue(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name:                    "group2",
+			PartialResponseStrategy: "invalid",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+				},
+			},
+		},
+	}}
+	_, err := GenerateContent(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err == nil {
+		t.Fatalf("expected errors when parsing rule with invalid partial_response_strategy value")
+	}
 }
 
 // makeRulesConfigMaps should return at least one ConfigMap even if it is empty

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -24,11 +24,11 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	namespacelabeler "github.com/prometheus-operator/prometheus-operator/pkg/namespace-labeler"
+	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ghodss/yaml"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 )
@@ -186,7 +186,7 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 				return
 			}
 
-			content, err := generateContent(promRule.Spec)
+			content, err := prometheus.GenerateContent(promRule.Spec, o.logger)
 			if err != nil {
 				marshalErr = err
 				return
@@ -218,15 +218,6 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 		o.metrics.SetRejectedResources(tKey, monitoringv1.PrometheusRuleKind, 0)
 	}
 	return rules, nil
-}
-
-func generateContent(promRule monitoringv1.PrometheusRuleSpec) (string, error) {
-
-	content, err := yaml.Marshal(promRule)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal content")
-	}
-	return string(content), nil
 }
 
 // makeRulesConfigMaps takes a ThanosRuler configuration and rule files and


### PR DESCRIPTION
## Description

This functionality is available in the custom validation admission webhook
but for environments where the webhooks cannot be enabled this patch enables
in-band validation of prometheus rules as well.

Fixes #4181 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Validate prometheus rules when generating rule file content_

