### PR TITLE
Propagate annotations set by kubectl when updating statefulsets

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -173,7 +173,7 @@ func UpdateStatefulSet(ctx context.Context, sstClient clientappsv1.StatefulSetIn
 	}
 
 	mergeMetadata(&sset.ObjectMeta, existingSset.ObjectMeta)
-	// Propagate annotations set by kubectl. e.g performing a rolling restart.
+	// Propagate annotations set by kubectl on spec.template.annotations. e.g performing a rolling restart.
 	mergeKubectlAnnotations(&sset.Spec.Template.ObjectMeta, existingSset.Spec.Template.ObjectMeta)
 
 	_, err = sstClient.Update(ctx, sset, metav1.UpdateOptions{})

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -173,6 +173,8 @@ func UpdateStatefulSet(ctx context.Context, sstClient clientappsv1.StatefulSetIn
 	}
 
 	mergeMetadata(&sset.ObjectMeta, existingSset.ObjectMeta)
+	// Propagate annotations set by kubectl. e.g performing a rolling restart.
+	mergeKubectlAnnotations(&sset.Spec.Template.ObjectMeta, existingSset.Spec.Template.ObjectMeta)
 
 	_, err = sstClient.Update(ctx, sset, metav1.UpdateOptions{})
 	if err != nil {
@@ -263,6 +265,22 @@ func mergeMaps(new map[string]string, old map[string]string) map[string]string {
 	}
 	for k, v := range new {
 		old[k] = v
+	}
+	return old
+}
+
+func mergeKubectlAnnotations(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
+	new.SetAnnotations(mergeMapsByPrefix(new.Annotations, old.Annotations, "kubectl.kubernetes.io/"))
+}
+
+func mergeMapsByPrefix(new map[string]string, old map[string]string, prefix string) map[string]string {
+	if old == nil {
+		old = make(map[string]string, len(new))
+	}
+	for k, v := range new {
+		if strings.HasPrefix(k, prefix) {
+			old[k] = v
+		}
 	}
 	return old
 }


### PR DESCRIPTION
## Description

There are some special annotations set by kubectl when performing actions like a rolling restart, that should be preserved in the statefulset, for the command to be executed successfully.

Relevant issue: #4155 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Preserve annotations set by kubectl
```
