### PR TITLE
Update ConfigReloader to add port name mapping

### DIFF
--- a/pkg/operator/config-reloader.go
+++ b/pkg/operator/config-reloader.go
@@ -148,6 +148,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 				},
 			},
 		}
+		ports []v1.ContainerPort
 	)
 
 	if configReloader.runOnce {
@@ -158,6 +159,14 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		args = append(args, fmt.Sprintf("--listen-address=%s:%d", configReloader.localHost, configReloaderPort))
 	} else {
 		args = append(args, fmt.Sprintf("--listen-address=:%d", configReloaderPort))
+		ports = append(
+			ports,
+			v1.ContainerPort{
+				Name:          "reloader-web",
+				ContainerPort: configReloaderPort,
+				Protocol:      v1.ProtocolTCP,
+			},
+		)
 	}
 
 	if len(configReloader.reloadURL.String()) > 0 {
@@ -218,6 +227,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		Env:                      envVars,
 		Command:                  []string{"/bin/prometheus-config-reloader"},
 		Args:                     args,
+		Ports:                    ports,
 		VolumeMounts:             configReloader.volumeMounts,
 		Resources:                resources,
 	}


### PR DESCRIPTION
## Description

Add mapping between the port name `reloader-web` and the actual port number, which was dropped in v. 0.49.0.
Fixes: #4162 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
  Add port name mapping to ConfigReloader to avoid reloader-web probe failure.
```
