### PR TITLE
Update networking information pertaining to istio

### DIFF
--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -49,7 +49,7 @@ spec:
 ...
 ```
 
-Note: If you're using Istio you may need to also set `ListenLocal` on the Thanos spec due to Istio's forwarding of traffic to localhost.
+Note: If you're using Istio prior to version 1.10, you may need to also set `ListenLocal` on the Thanos spec due to Istio's forwarding of traffic to localhost. This however isn't needed from Istio 1.10 onward due [networking changes](https://istio.io/latest/blog/2021/upcoming-networking-changes/) implemented in 1.10.
 
 ## Configuring Thanos Object Storage
 

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -2,7 +2,7 @@
 title: "Thanos"
 description: "Thanos and the Prometheus Operator."
 lead: "Thanos and the Prometheus Operator."
-date: 2021-03-08T08:49:31+00:00
+date: 2021-08-05T20:27:31+00:00
 draft: false
 images: []
 menu:
@@ -49,7 +49,7 @@ spec:
 ...
 ```
 
-Note: If you're using Istio prior to version 1.10, you may need to also set `ListenLocal` on the Thanos spec due to Istio's forwarding of traffic to localhost. This however isn't needed from Istio 1.10 onward due [networking changes](https://istio.io/latest/blog/2021/upcoming-networking-changes/) implemented in 1.10.
+Note: If you're using Istio prior to version 1.10, you may need to also set `ListenLocal` on the Thanos spec due to Istio's forwarding of traffic to localhost. This however isn't needed from Istio 1.10 onward due to [networking changes](https://istio.io/latest/blog/2021/upcoming-networking-changes/) implemented in 1.10.
 
 ## Configuring Thanos Object Storage
 


### PR DESCRIPTION
## Description
Istio 1.10 brought about some networking [changes](https://istio.io/latest/blog/2021/upcoming-networking-changes/) which essentially render `listenLocal` needless. 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update networking information pertaining to Istio in Thanos docs
```
