### PR TITLE
test/e2e: check user metadata 3 times to reduce test flakiness

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1941,22 +1941,35 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Assert labels preserved
-	for _, rConf := range resourceConfigs {
-		res, err := rConf.get()
-		if err != nil {
-			t.Fatal(err)
-		}
+	failed := false
+	// Run check 3 times in loop to prevent test flakes caused by stale data
+	for i := 0; i < 3; i++ {
+		// Assert labels preserved
+		for _, rConf := range resourceConfigs {
+			res, err := rConf.get()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		labels := res.GetLabels()
-		if !containsValues(labels, updatedLabels) {
-			t.Errorf("%s: labels do not contain updated labels, found: %q, should contain: %q", rConf.name, labels, updatedLabels)
-		}
+			labels := res.GetLabels()
+			if !containsValues(labels, updatedLabels) {
+				t.Logf("%s: labels do not contain updated labels, found: %q, should contain: %q", rConf.name, labels, updatedLabels)
+				failed = true
+			}
 
-		annotations := res.GetAnnotations()
-		if !containsValues(annotations, updatedAnnotations) {
-			t.Fatalf("%s: annotations do not contain updated annotations, found: %q, should contain: %q", rConf.name, annotations, updatedAnnotations)
+			annotations := res.GetAnnotations()
+			if !containsValues(annotations, updatedAnnotations) {
+				t.Logf("%s: annotations do not contain updated annotations, found: %q, should contain: %q", rConf.name, annotations, updatedAnnotations)
+				failed = true
+			}
 		}
+		if !failed {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if failed {
+		t.Fatal()
 	}
 
 	// Cleanup


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Running flaky test 3 times as a workaround for #4070 issue.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
