### PR TITLE
Handle Thanos rules partial_response_strategy field in validating admission webhook

### DIFF
--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -242,6 +242,7 @@ var goodRulesWithAnnotations = []byte(`
         "groups": [
           {
             "name": "test.rules",
+            "partial_response_strategy": "abort",
             "rules": [
               {
                 "alert": "Test",


### PR DESCRIPTION
Fixes #4199

## Description

Reuse the same logic used for synchronous rule validation
introduced in https://github.com/prometheus-operator/prometheus-operator/pull/4184

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Handle Thanos rules partial_response_strategy field in validating admission webhook
```
