### PR TITLE
.github: publish images without looking at other jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,13 +1,7 @@
 name: publish
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      # "publish" workflow will start on ANY other workflow specified in this list.
-      # Specifying the one that is potentially longest running will delay publishing
-      # and allow checking status of other workflows in steps
-      - "e2e"
-    types: [completed]
+  push:
     branches:
       - 'release-*'
       - 'master'
@@ -19,31 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish container images
-    if: > 
-      ${{ 
-        github.event.workflow_run.event == 'push' && 
-        github.event.workflow_run.conclusion == 'success'
-      }}
     steps:
-      - name: Wait for checks to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-checks
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: checks
-      - name: Wait for unit tests to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-unit
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: unit
-      - name: Exit if other workflows didn't succeeded
-        if: >
-          ${{
-            steps.wait-for-checks.outputs.conclusion != 'success' &&
-            steps.wait-for-unit.outputs.conclusion != 'success'
-          }}
-        run: exit 1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Go


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Image publishing is still broken and images for 0.50 had to be created manually. To make publishing work again I am removing all job dependencies and simplifying it to push images regardless of other CI jobs. This means we should get images even if there are flaky tests (like https://github.com/prometheus-operator/prometheus-operator/issues/4070) and we should get them faster. It also means if `master` is broken, published images also may be broken, which in turn should allow easier debugging. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
