### PR TITLE
alertmanager: enable empty basic auth username

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -814,7 +814,7 @@ func (cg *configGenerator) convertHTTPConfig(ctx context.Context, in monitoringv
 			return nil, errors.Errorf("failed to get BasicAuth password key %q from secret %q", in.BasicAuth.Password.Key, in.BasicAuth.Password.Name)
 		}
 
-		if username != "" && password != "" {
+		if username != "" || password != "" {
 			out.BasicAuth = &basicAuth{Username: username, Password: password}
 		}
 	} else if in.Authorization != nil {


### PR DESCRIPTION
## Description

Some services apparently don't have username in auth basic authentication. Enable specifying empty username so the webhook receiver can work with them.

Sample usecase: sending monitoring alert heartbeat to OpsGenie via webhook.

* [OpsGenie authentication](https://docs.opsgenie.com/docs/authentication)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Allow empty username for HTTP Auth Basic
```
