### PR TITLE
docs: Improve docs and error message for "smarthost" field

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1228,7 +1228,7 @@ func checkEmailConfigs(ctx context.Context, configs []monitoringv1alpha1.EmailCo
 		if config.Smarthost != "" {
 			_, _, err := net.SplitHostPort(config.Smarthost)
 			if err != nil {
-				return errors.New("invalid email field SMARTHOST")
+				return errors.New("failed to extract host and port from SMARTHOST")
 			}
 		}
 		if config.AuthPassword != nil {

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -560,7 +560,7 @@ type EmailConfig struct {
 	// The hostname to identify to the SMTP server.
 	// +optional
 	Hello string `json:"hello,omitempty"`
-	// The SMTP host through which emails are sent.
+	// The SMTP host and port through which emails are sent. E.g. example.com:25
 	// +optional
 	Smarthost string `json:"smarthost,omitempty"`
 	// The username to use for authentication.


### PR DESCRIPTION
## Description

The name of the "smarthost" field suggested to me that it was only a hostname, but it's actually a hostname:port combination. I made that mistake initially, and had to go check the source code to find out what "invalid email field SMARTHOST" really meant :)

This PR clears up that confusion by copying the error message from `amcfg.go` and adding an example to the docs.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Improve docs and error message for "smarthost" field
```
