### PR TITLE
Support updated matching syntax for inhibit rules in AlertManagerConfig CRD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1406,7 +1406,8 @@ Matcher defines how to match on alert's labels.
 | ----- | ----------- | ------ | -------- |
 | name | Label to match. | string | true |
 | value | Label value to match. | string | true |
-| regex | Whether to match on equality (false) or regular-expression (true). | bool | false |
+| matchType | Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty. | MatchType | false |
+| regex | Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -62,13 +62,24 @@ spec:
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
+                          matchType:
+                            description: Match operation available with AlertManager
+                              >= v0.22.0 and takes precedence over Regex (deprecated)
+                              if non-empty.
+                            enum:
+                            - '!='
+                            - =
+                            - =~
+                            - '!~'
+                            type: string
                           name:
                             description: Label to match.
                             minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression
-                              (true).
+                              (true). Deprecated as of AlertManager >= v0.22.0 where
+                              a user should use MatchType instead.
                             type: boolean
                           value:
                             description: Label value to match.
@@ -84,13 +95,24 @@ spec:
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
+                          matchType:
+                            description: Match operation available with AlertManager
+                              >= v0.22.0 and takes precedence over Regex (deprecated)
+                              if non-empty.
+                            enum:
+                            - '!='
+                            - =
+                            - =~
+                            - '!~'
+                            type: string
                           name:
                             description: Label to match.
                             minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression
-                              (true).
+                              (true). Deprecated as of AlertManager >= v0.22.0 where
+                              a user should use MatchType instead.
                             type: boolean
                           value:
                             description: Label value to match.
@@ -2635,13 +2657,24 @@ spec:
                     items:
                       description: Matcher defines how to match on alert's labels.
                       properties:
+                        matchType:
+                          description: Match operation available with AlertManager
+                            >= v0.22.0 and takes precedence over Regex (deprecated)
+                            if non-empty.
+                          enum:
+                          - '!='
+                          - =
+                          - =~
+                          - '!~'
+                          type: string
                         name:
                           description: Label to match.
                           minLength: 1
                           type: string
                         regex:
                           description: Whether to match on equality (false) or regular-expression
-                            (true).
+                            (true). Deprecated as of AlertManager >= v0.22.0 where
+                            a user should use MatchType instead.
                           type: boolean
                         value:
                           description: Label value to match.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -62,13 +62,24 @@ spec:
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
+                          matchType:
+                            description: Match operation available with AlertManager
+                              >= v0.22.0 and takes precedence over Regex (deprecated)
+                              if non-empty.
+                            enum:
+                            - '!='
+                            - =
+                            - =~
+                            - '!~'
+                            type: string
                           name:
                             description: Label to match.
                             minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression
-                              (true).
+                              (true). Deprecated as of AlertManager >= v0.22.0 where
+                              a user should use MatchType instead.
                             type: boolean
                           value:
                             description: Label value to match.
@@ -84,13 +95,24 @@ spec:
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
+                          matchType:
+                            description: Match operation available with AlertManager
+                              >= v0.22.0 and takes precedence over Regex (deprecated)
+                              if non-empty.
+                            enum:
+                            - '!='
+                            - =
+                            - =~
+                            - '!~'
+                            type: string
                           name:
                             description: Label to match.
                             minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression
-                              (true).
+                              (true). Deprecated as of AlertManager >= v0.22.0 where
+                              a user should use MatchType instead.
                             type: boolean
                           value:
                             description: Label value to match.
@@ -2635,13 +2657,24 @@ spec:
                     items:
                       description: Matcher defines how to match on alert's labels.
                       properties:
+                        matchType:
+                          description: Match operation available with AlertManager
+                            >= v0.22.0 and takes precedence over Regex (deprecated)
+                            if non-empty.
+                          enum:
+                          - '!='
+                          - =
+                          - =~
+                          - '!~'
+                          type: string
                         name:
                           description: Label to match.
                           minLength: 1
                           type: string
                         regex:
                           description: Whether to match on equality (false) or regular-expression
-                            (true).
+                            (true). Deprecated as of AlertManager >= v0.22.0 where
+                            a user should use MatchType instead.
                           type: boolean
                         value:
                           description: Label value to match.

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -58,13 +58,23 @@
                           "items": {
                             "description": "Matcher defines how to match on alert's labels.",
                             "properties": {
+                              "matchType": {
+                                "description": "Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.",
+                                "enum": [
+                                  "!=",
+                                  "=",
+                                  "=~",
+                                  "!~"
+                                ],
+                                "type": "string"
+                              },
                               "name": {
                                 "description": "Label to match.",
                                 "minLength": 1,
                                 "type": "string"
                               },
                               "regex": {
-                                "description": "Whether to match on equality (false) or regular-expression (true).",
+                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
                                 "type": "boolean"
                               },
                               "value": {
@@ -84,13 +94,23 @@
                           "items": {
                             "description": "Matcher defines how to match on alert's labels.",
                             "properties": {
+                              "matchType": {
+                                "description": "Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.",
+                                "enum": [
+                                  "!=",
+                                  "=",
+                                  "=~",
+                                  "!~"
+                                ],
+                                "type": "string"
+                              },
                               "name": {
                                 "description": "Label to match.",
                                 "minLength": 1,
                                 "type": "string"
                               },
                               "regex": {
-                                "description": "Whether to match on equality (false) or regular-expression (true).",
+                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
                                 "type": "boolean"
                               },
                               "value": {
@@ -2767,13 +2787,23 @@
                         "items": {
                           "description": "Matcher defines how to match on alert's labels.",
                           "properties": {
+                            "matchType": {
+                              "description": "Match operation available with AlertManager >= v0.22.0 and takes precedence over Regex (deprecated) if non-empty.",
+                              "enum": [
+                                "!=",
+                                "=",
+                                "=~",
+                                "!~"
+                              ],
+                              "type": "string"
+                            },
                             "name": {
                               "description": "Label to match.",
                               "minLength": 1,
                               "type": "string"
                             },
                             "regex": {
-                              "description": "Whether to match on equality (false) or regular-expression (true).",
+                              "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
                               "type": "boolean"
                             },
                             "value": {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +39,11 @@ func strPtr(str string) *string {
 }
 
 func TestCheckAlertmanagerConfig(t *testing.T) {
+	version, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	c := fake.NewSimpleClientset(
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -801,7 +807,7 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 	} {
 		t.Run(tc.amConfig.Name, func(t *testing.T) {
 			store := assets.NewStore(c.CoreV1(), c.CoreV1())
-			err := checkAlertmanagerConfig(context.Background(), tc.amConfig, store)
+			err := checkAlertmanagerConfig(context.Background(), tc.amConfig, version, store)
 			if tc.ok {
 				if err != nil {
 					t.Fatalf("expecting no error but got %q", err)

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -713,9 +714,49 @@ type Matcher struct {
 	// Label value to match.
 	// +optional
 	Value string `json:"value"`
+	// Match operation available with AlertManager >= v0.22.0 and
+	// takes precedence over Regex (deprecated) if non-empty.
+	// +kubebuilder:validation:Enum=!=;=;=~;!~
+	// +optional
+	MatchType MatchType `json:"matchType,omitempty"`
 	// Whether to match on equality (false) or regular-expression (true).
+	// Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
 	// +optional
 	Regex bool `json:"regex,omitempty"`
+}
+
+// String returns Matcher as a string
+// Use only for MatchType Matcher
+func (in Matcher) String() string {
+	return fmt.Sprintf(`%s%s"%s"`, in.Name, in.MatchType, openMetricsEscape(in.Value))
+}
+
+// Validate the Matcher returns an error if the matcher is invalid
+// Validates only non-deprecated matching fields
+func (in Matcher) Validate() error {
+	// nothing to do
+	if in.MatchType == "" {
+		return nil
+	}
+
+	if !in.MatchType.Valid() {
+		return fmt.Errorf("invalid 'matchType' '%s' provided'", in.MatchType)
+	}
+
+	if strings.TrimSpace(in.Name) == "" {
+		return errors.New("matcher 'name' is required")
+	}
+
+	return nil
+}
+
+// MatchType is a comparison operator on a Matcher
+type MatchType string
+
+// Valid MatchType returns true if the operator is acceptable
+func (mt MatchType) Valid() bool {
+	_, ok := validMatchTypes[mt]
+	return ok
 }
 
 // DeepCopyObject implements the runtime.Object interface.
@@ -726,4 +767,18 @@ func (l *AlertmanagerConfig) DeepCopyObject() runtime.Object {
 // DeepCopyObject implements the runtime.Object interface.
 func (l *AlertmanagerConfigList) DeepCopyObject() runtime.Object {
 	return l.DeepCopy()
+}
+
+const (
+	MatchEqual     MatchType = "="
+	MatchNotEqual  MatchType = "!="
+	MatchRegexp    MatchType = "=~"
+	MatchNotRegexp MatchType = "!~"
+)
+
+var validMatchTypes = map[MatchType]bool{
+	MatchEqual:     true,
+	MatchNotEqual:  true,
+	MatchRegexp:    true,
+	MatchNotRegexp: true,
 }

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -782,3 +782,17 @@ var validMatchTypes = map[MatchType]bool{
 	MatchRegexp:    true,
 	MatchNotRegexp: true,
 }
+
+// openMetricsEscape is similar to the usual string escaping, but more
+// restricted. It merely replaces a new-line character with '\n', a double-quote
+// character with '\"', and a backslash with '\\', which is the escaping used by
+// OpenMetrics.
+// * Copied from alertmanager codebase pkg/labels *
+func openMetricsEscape(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		"\n", `\n`,
+		`"`, `\"`,
+	)
+	return r.Replace(s)
+}


### PR DESCRIPTION
## Description

Fixes #4087 



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support updated matching syntax for inhibit rules in AlertManagerConfig CRD
```
