### PR TITLE
.github/stale.yml: exclude issues with 'help wanted'

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,6 +13,7 @@ onlyLabels: []
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - "kind/feature"
+  - "help wanted"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
the "help wanted" label means that at least one maintainer assumed that the issue is worthwhile so it's better not to close it.