### PR TITLE
Support updated matching syntax for routes in AlertManagerConfig CRD

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -279,8 +279,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -473,8 +473,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
   - receiver: "null"
 receivers:
@@ -530,8 +530,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test-pd
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -575,8 +575,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -633,8 +633,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -695,8 +695,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -757,8 +757,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -822,8 +822,8 @@ route:
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"
@@ -894,8 +894,8 @@ route:
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
-    match:
-      namespace: mynamespace
+    matchers:
+    - namespace="mynamespace"
     continue: true
 receivers:
 - name: "null"

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1041,13 +1041,14 @@ route:
   - job
   routes:
   - receiver: %s-e2e-test-amconfig-many-receivers-e2e
-    match:
-      namespace: %s
+    matchers:
+    - namespace="%s"
     continue: true
   - receiver: %s-e2e-test-amconfig-sub-routes-e2e
     match:
-      namespace: %s
       service: webapp
+    matchers:
+    - namespace="%s"
     continue: true
     routes:
     - receiver: %s-e2e-test-amconfig-sub-routes-e2e


### PR DESCRIPTION
## Description

Depends on #4309 
Related to #4087 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support updated matching syntax for routes in AlertManagerConfig CRD
```
