### PR TITLE
.github: introduce a central place for storing CI env variables

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,3 @@
+golang-version=1.17
+kind-version=v0.11.1
+kind-image=kindest/node:v1.22.0

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,8 +8,6 @@ on:
       - 'main'
     tags:
       - 'v*'
-env:
-  golang-version: '1.17'
 jobs:
   generate:
     runs-on: ${{ matrix.os }}
@@ -21,18 +19,22 @@ jobs:
     name: Generate and format
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: make --always-make format generate && git diff --exit-code
   check-docs:
     runs-on: ubuntu-latest
     name: Check Documentation formatting and links
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: make check-docs
   check-golang:
     runs-on: ubuntu-latest
@@ -49,9 +51,11 @@ jobs:
     name: Check prometheus metrics
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: make check-metrics
   build:
     runs-on: ${{ matrix.os }}
@@ -63,17 +67,21 @@ jobs:
     name: Build operator binary
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: make operator
   po-rule-migration:
     runs-on: ubuntu-latest
     name: Build Prometheus Operator rule config map to rule file CRDs CLI tool
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: cd cmd/po-rule-migration && go install
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,10 +8,6 @@ on:
       - 'main'
     tags:
       - 'v*'
-env:
-  kind-version: 'v0.11.1'
-  kind-image: 'kindest/node:v1.22.0'  # Image defines which k8s version is used
-  golang-version: '1.17'
 jobs:
   e2e-tests:
     name: E2E tests
@@ -37,9 +33,12 @@ jobs:
             featureGated: "include"
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
+    - name: Install Go
+      uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - name: Build images
       run: |
         export SHELL=/bin/bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,6 @@ on:
       - 'v*'
       - '!pkg*'
 
-env:
-  golang-version: '1.17'
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,10 +17,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.golang-version }}
+          go-version: '${{ env.golang-version }}'
       - name: login to quay.io
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -8,23 +8,25 @@ on:
       - 'main'
     tags:
       - 'v*'
-env:
-  golang-version: '1.17'
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     name: Unit tests
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ env.golang-version }}
+        go-version: '${{ env.golang-version }}'
     - run: make test-unit
   extended-tests:
     runs-on: ubuntu-latest
     name: Extended tests
     steps:
     - uses: actions/checkout@v2
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.golang-version }}


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Reducing code duplication in CI by allowing to store all CI env variables in one place.

Mechanism was tested in https://github.com/thaum-xyz/ankhmorpork/pull/96

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
