### PR TITLE
e2e tests: Use prometheus as remote receiver for testPromRemoteWriteWithTLS

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -116,6 +116,10 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 		[]string{"key.pem", "cert.pem"}, [][]byte{serverKey, serverCert})
 	secrets = append(secrets, s)
 
+	s = testFramework.MakeSecretWithCert(ns, "server-tls-ca",
+		[]string{"ca.pem"}, [][]byte{serverCert})
+	secrets = append(secrets, s)
+
 	if cKey.Filename != "" && cCert.Filename != "" {
 		s = testFramework.MakeSecretWithCert(ns, cKey.SecretName,
 			[]string{"key.pem"}, [][]byte{clientKey})
@@ -141,7 +145,7 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 	if ca.Filename != "" {
 		if ca.ResourceType == testFramework.SECRET {
 			if ca.ResourceName == cKey.SecretName {
-				secrets[2].Data["ca.pem"] = caCert
+				secrets[3].Data["ca.pem"] = caCert
 			} else if ca.ResourceName == cCert.ResourceName {
 				s.Data["ca.pem"] = caCert
 			} else {
@@ -616,44 +620,44 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
-		//{
-		//	Name: "variant-17",
-		//	ClientKey: testFramework.Key{
-		//		Filename:   "",
-		//		SecretName: "",
-		//	},
-		//	ClientCert: testFramework.Cert{
-		//		Filename:     "",
-		//		ResourceName: "",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	CA: testFramework.Cert{
-		//		Filename:     "bad_ca.crt",
-		//		ResourceName: "client-tls-ca",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	InsecureSkipVerify: false,
-		//	ShouldSuccess:      false,
-		//},
-		//{
-		//	Name: "variant-18",
-		//	ClientKey: testFramework.Key{
-		//		Filename:   "",
-		//		SecretName: "",
-		//	},
-		//	ClientCert: testFramework.Cert{
-		//		Filename:     "",
-		//		ResourceName: "",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	CA: testFramework.Cert{
-		//		Filename:     "",
-		//		ResourceName: "",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	InsecureSkipVerify: false,
-		//	ShouldSuccess:      false,
-		//},
+		{
+			Name: "variant-17",
+			ClientKey: testFramework.Key{
+				Filename:   "",
+				SecretName: "",
+			},
+			ClientCert: testFramework.Cert{
+				Filename:     "",
+				ResourceName: "",
+				ResourceType: testFramework.SECRET,
+			},
+			CA: testFramework.Cert{
+				Filename:     "bad_ca.crt",
+				ResourceName: "client-tls-ca",
+				ResourceType: testFramework.SECRET,
+			},
+			InsecureSkipVerify: false,
+			ShouldSuccess:      false,
+		},
+		{
+			Name: "variant-18",
+			ClientKey: testFramework.Key{
+				Filename:   "",
+				SecretName: "",
+			},
+			ClientCert: testFramework.Cert{
+				Filename:     "",
+				ResourceName: "",
+				ResourceType: testFramework.SECRET,
+			},
+			CA: testFramework.Cert{
+				Filename:     "",
+				ResourceName: "",
+				ResourceType: testFramework.SECRET,
+			},
+			InsecureSkipVerify: false,
+			ShouldSuccess:      false,
+		},
 		{
 			Name: "variant-19",
 			ClientKey: testFramework.Key{
@@ -673,25 +677,25 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
-		//{
-		//	Name: "variant-20",
-		//	ClientKey: testFramework.Key{
-		//		Filename:   "",
-		//		SecretName: "",
-		//	},
-		//	ClientCert: testFramework.Cert{
-		//		Filename:     "",
-		//		ResourceName: "",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	CA: testFramework.Cert{
-		//		Filename:     "ca.crt",
-		//		ResourceName: "client-tls-ca",
-		//		ResourceType: testFramework.SECRET,
-		//	},
-		//	InsecureSkipVerify: false,
-		//	ShouldSuccess:      false,
-		//},
+		{
+			Name: "variant-20",
+			ClientKey: testFramework.Key{
+				Filename:   "",
+				SecretName: "",
+			},
+			ClientCert: testFramework.Cert{
+				Filename:     "",
+				ResourceName: "",
+				ResourceType: testFramework.SECRET,
+			},
+			CA: testFramework.Cert{
+				Filename:     "ca.crt",
+				ResourceName: "client-tls-ca",
+				ResourceType: testFramework.SECRET,
+			},
+			InsecureSkipVerify: false,
+			ShouldSuccess:      true,
+		},
 	}
 	for _, test := range tests {
 		test := test

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -236,7 +236,7 @@ func createK8sSampleApp(t *testing.T, name, ns string) {
 		t.Fatal(err)
 	}
 
-	svc, err = framework.KubeClient.CoreV1().Services(ns).Get(context.Background(), name, metav1.GetOptions{})
+	_, err = framework.KubeClient.CoreV1().Services(ns).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -677,6 +677,7 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
+		// Had to change the success flag to True, because prometheus receiver is running in VerifyClientCertIfGiven mode. Details here - https://github.com/prometheus-operator/prometheus-operator/pull/4337#discussion_r735064646
 		{
 			Name: "variant-20",
 			ClientKey: testFramework.Key{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -41,7 +41,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -56,12 +55,7 @@ import (
 )
 
 var (
-	certsDir       = "../../test/e2e/remote_write_certs/"
-	possibleErrors = map[string]string{
-		"bad_server_cert": "tls: bad certificate",
-		"bad_client_cert": "tls: failed to verify client's certificate: x509: certificate signed by unknown authority",
-		"no_client_cert":  "tls: client didn't provide a certificate",
-	}
+	certsDir = "../../test/e2e/remote_write_certs/"
 )
 
 func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Key, cCert, ca testFramework.Cert) {
@@ -183,7 +177,7 @@ func createK8sResources(t *testing.T, ns, certsDir string, cKey testFramework.Ke
 	}
 }
 
-func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
+func createK8sSampleApp(t *testing.T, name, ns string) {
 	simple, err := testFramework.MakeDeployment("../../test/framework/resources/basic-auth-app-deployment.yaml")
 	if err != nil {
 		t.Fatal(err)
@@ -246,16 +240,9 @@ func createK8sSampleApp(t *testing.T, name, ns string) (string, int32) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	return svc.Spec.ClusterIP, svc.Spec.Ports[1].Port
 }
 
-func createK8sAppMonitoring(
-	name, ns string,
-	prwtc testFramework.PromRemoteWriteTestConfig,
-	svcIP string,
-	svcTLSPort int32,
-) (*monitoringv1.Prometheus, error) {
+func createK8sAppMonitoring(name, ns string, prwtc testFramework.PromRemoteWriteTestConfig) (prometheus *monitoringv1.Prometheus, prometheusRecieverSvc string, err error) {
 
 	sm := framework.MakeBasicServiceMonitor(name)
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{
@@ -285,29 +272,43 @@ func createK8sAppMonitoring(
 		},
 	}
 
-	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
-		return nil, errors.Wrap(err, "creating ServiceMonitor failed")
+	if _, err = framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
+		return nil, prometheusRecieverSvc, errors.Wrap(err, "creating ServiceMonitor failed")
 	}
 
+	// Create prometheus receiver for remote writes
+	receiverName := fmt.Sprintf("%s-%s", name, "receiver")
+	prometheusReceiverCRD := framework.MakeBasicPrometheus(ns, receiverName, receiverName, 1)
+	framework.AddRemoteReceiveWithWebTLSToPrometheus(prometheusReceiverCRD, prwtc)
+
+	if _, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusReceiverCRD); err != nil {
+		return nil, "", err
+	}
+	prometheusReceiverSvc := framework.MakePrometheusService(receiverName, receiverName, v1.ServiceTypeClusterIP)
+	if _, err = framework.CreateServiceAndWaitUntilReady(context.Background(), ns, prometheusReceiverSvc); err != nil {
+		return nil, "", err
+	}
+	prometheusReceiverURL := "https://" + prometheusReceiverSvc.Name + ":9090/api/v1/write"
+
+	// Create prometheus for scraping app metrics with remote prometheus as write target
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
-	url := "https://" + svcIP + ":" + fmt.Sprint(svcTLSPort)
-	framework.AddRemoteWriteWithTLSToPrometheus(prometheusCRD, url, prwtc)
-	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
-		return nil, err
+	framework.AddRemoteWriteWithTLSToPrometheus(prometheusCRD, prometheusReceiverURL, prwtc)
+	if _, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
+		return nil, "", err
 	}
 
 	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
-		return nil, err
+	if _, err = framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
+		return nil, "", err
 	}
 
-	return prometheusCRD, nil
+	return prometheusCRD, prometheusReceiverSvc.Name, nil
 }
 
 func testPromRemoteWriteWithTLS(t *testing.T) {
 	t.Parallel()
 	// can't extend the names since ns cannot be created with more than 63 characters
-	tests := []testFramework.PromRemoteWriteTestConfig{
+	var tests = []testFramework.PromRemoteWriteTestConfig{
 		// working configurations
 		{
 			Name: "variant-1",
@@ -325,7 +326,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-cert-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -345,7 +345,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -365,7 +364,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -385,7 +383,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-cert-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -405,7 +402,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -425,7 +421,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-cert-ca",
 				ResourceType: testFramework.CONFIGMAP,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -445,7 +440,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.CONFIGMAP,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -465,7 +459,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.CONFIGMAP,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -485,7 +478,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.CONFIGMAP,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -505,7 +497,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -525,7 +516,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      true,
 		},
@@ -545,7 +535,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "",
 			InsecureSkipVerify: true,
 			ShouldSuccess:      true,
 		},
@@ -567,7 +556,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-cert-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "bad_server_cert",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
@@ -587,7 +575,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "bad_server_cert",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
@@ -607,7 +594,6 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-cert-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "bad_server_cert",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
@@ -627,50 +613,47 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "bad_server_cert",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
-		{
-			Name: "variant-17",
-			ClientKey: testFramework.Key{
-				Filename:   "",
-				SecretName: "",
-			},
-			ClientCert: testFramework.Cert{
-				Filename:     "",
-				ResourceName: "",
-				ResourceType: testFramework.SECRET,
-			},
-			CA: testFramework.Cert{
-				Filename:     "bad_ca.crt",
-				ResourceName: "client-tls-ca",
-				ResourceType: testFramework.SECRET,
-			},
-			ExpectedInLogs:     "bad_server_cert",
-			InsecureSkipVerify: false,
-			ShouldSuccess:      false,
-		},
-		{
-			Name: "variant-18",
-			ClientKey: testFramework.Key{
-				Filename:   "",
-				SecretName: "",
-			},
-			ClientCert: testFramework.Cert{
-				Filename:     "",
-				ResourceName: "",
-				ResourceType: testFramework.SECRET,
-			},
-			CA: testFramework.Cert{
-				Filename:     "",
-				ResourceName: "",
-				ResourceType: testFramework.SECRET,
-			},
-			ExpectedInLogs:     "bad_server_cert",
-			InsecureSkipVerify: false,
-			ShouldSuccess:      false,
-		},
+		//{
+		//	Name: "variant-17",
+		//	ClientKey: testFramework.Key{
+		//		Filename:   "",
+		//		SecretName: "",
+		//	},
+		//	ClientCert: testFramework.Cert{
+		//		Filename:     "",
+		//		ResourceName: "",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	CA: testFramework.Cert{
+		//		Filename:     "bad_ca.crt",
+		//		ResourceName: "client-tls-ca",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	InsecureSkipVerify: false,
+		//	ShouldSuccess:      false,
+		//},
+		//{
+		//	Name: "variant-18",
+		//	ClientKey: testFramework.Key{
+		//		Filename:   "",
+		//		SecretName: "",
+		//	},
+		//	ClientCert: testFramework.Cert{
+		//		Filename:     "",
+		//		ResourceName: "",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	CA: testFramework.Cert{
+		//		Filename:     "",
+		//		ResourceName: "",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	InsecureSkipVerify: false,
+		//	ShouldSuccess:      false,
+		//},
 		{
 			Name: "variant-19",
 			ClientKey: testFramework.Key{
@@ -687,32 +670,29 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 				ResourceName: "client-tls-key-cert-ca",
 				ResourceType: testFramework.SECRET,
 			},
-			ExpectedInLogs:     "bad_client_cert",
 			InsecureSkipVerify: false,
 			ShouldSuccess:      false,
 		},
-		{
-			Name: "variant-20",
-			ClientKey: testFramework.Key{
-				Filename:   "",
-				SecretName: "",
-			},
-			ClientCert: testFramework.Cert{
-				Filename:     "",
-				ResourceName: "",
-				ResourceType: testFramework.SECRET,
-			},
-			CA: testFramework.Cert{
-				Filename:     "ca.crt",
-				ResourceName: "client-tls-ca",
-				ResourceType: testFramework.SECRET,
-			},
-			ExpectedInLogs:     "no_client_cert",
-			InsecureSkipVerify: false,
-			ShouldSuccess:      false,
-		},
+		//{
+		//	Name: "variant-20",
+		//	ClientKey: testFramework.Key{
+		//		Filename:   "",
+		//		SecretName: "",
+		//	},
+		//	ClientCert: testFramework.Cert{
+		//		Filename:     "",
+		//		ResourceName: "",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	CA: testFramework.Cert{
+		//		Filename:     "ca.crt",
+		//		ResourceName: "client-tls-ca",
+		//		ResourceType: testFramework.SECRET,
+		//	},
+		//	InsecureSkipVerify: false,
+		//	ShouldSuccess:      false,
+		//},
 	}
-
 	for _, test := range tests {
 		test := test
 
@@ -732,10 +712,10 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			// Setup a sample-app which supports mTLS therefore will play 2 roles:
 			// 	1. app scraped by prometheus
 			// 	2. TLS receiver for prometheus remoteWrite
-			svcIP, svcTLSPort := createK8sSampleApp(t, name, ns)
+			createK8sSampleApp(t, name, ns)
 
 			// Setup monitoring.
-			prometheusCRD, err := createK8sAppMonitoring(name, ns, test, svcIP, svcTLSPort)
+			prometheusCRD, prometheusRecieverSvc, err := createK8sAppMonitoring(name, ns, test)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -751,37 +731,27 @@ func testPromRemoteWriteWithTLS(t *testing.T) {
 			// use wait.Poll() in k8s.io/apimachinery@v0.18.3/pkg/util/wait/wait.go
 			time.Sleep(45 * time.Second)
 
-			appOpts := metav1.ListOptions{
-				LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-					"group": name,
-				})).String(),
-			}
-
-			appPodList, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), appOpts)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			appLogs, err := framework.GetLogs(context.Background(), ns, appPodList.Items[0].ObjectMeta.Name, "")
-			if err != nil {
-				t.Fatal(err)
-			}
-
+			response, err := framework.PrometheusQuery(ns, prometheusRecieverSvc, "https", "up{container = 'example-app'}")
 			if test.ShouldSuccess {
-				for _, v := range possibleErrors {
-					if strings.Contains(appLogs, v) {
-						framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
-
-						t.Fatalf("test with (%s, %s, %s) failed\nscraped app logs shouldn't contain '%s' but it does",
-							test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, v)
-					}
+				if err != nil {
+					t.Logf("test with (%s, %s, %s) failed with error %s", test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, err.Error())
 				}
-			} else if !strings.Contains(appLogs, possibleErrors[test.ExpectedInLogs]) {
-				framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
-
-				t.Fatalf("test with (%s, %s, %s) failed\nscraped app logs should contain '%s' but it doesn't",
-					test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, possibleErrors[test.ExpectedInLogs])
+				if response[0].Value[1] != "1" {
+					framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
+					t.Fatalf("test with (%s, %s, %s) failed\nReciever Prometheus does not have the instrumented app metrics",
+						test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename)
+				}
+			} else {
+				if err != nil {
+					framework.PrintPrometheusLogs(context.Background(), t, prometheusCRD)
+					t.Fatalf("test with (%s, %s, %s) failed with error %s", test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename, err.Error())
+				}
+				if len(response) != 0 {
+					t.Fatalf("test with (%s, %s, %s) failed\nExpeted reciever prometheus to not have the instrumented app metrics",
+						test.ClientKey.Filename, test.ClientCert.Filename, test.CA.Filename)
+				}
 			}
+
 		})
 	}
 }
@@ -1281,7 +1251,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	}
 
 	err = wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
-		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, svc.Name, "/api/v1/alertmanagers", map[string]string{})
+		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, svc.Name, "http", "/api/v1/alertmanagers", map[string]string{})
 		if err != nil {
 			return true, err
 		}
@@ -2459,7 +2429,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
 
-	resp, err := framework.PrometheusSVCGetRequest(context.Background(), prometheusNSName, svc.Name, "/api/v1/status/config", map[string]string{})
+	resp, err := framework.PrometheusSVCGetRequest(context.Background(), prometheusNSName, svc.Name, "http", "/api/v1/status/config", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3298,13 +3268,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 	// TODO: Do a poll instead, should speed up things.
 	time.Sleep(30 * time.Second)
 
-	response, err := framework.PrometheusSVCGetRequest(
-		context.Background(),
-		ns,
-		promSVC.Name,
-		"/api/v1/query",
-		map[string]string{"query": fmt.Sprintf(`up{job="%v",endpoint="%v"}`, name, sm.Spec.Endpoints[0].Port)},
-	)
+	response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, promSVC.Name, "http", "/api/v1/query", map[string]string{"query": fmt.Sprintf(`up{job="%v",endpoint="%v"}`, name, sm.Spec.Endpoints[0].Port)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3872,7 +3836,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 
 			err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
 				loopErr = nil
-				res, err := framework.PrometheusQuery(ns, svc.Name, "prometheus_build_info")
+				res, err := framework.PrometheusQuery(ns, svc.Name, "http", "prometheus_build_info")
 				if err != nil {
 					loopErr = errors.Wrap(err, "failed to query Prometheus")
 					return false, nil
@@ -3919,7 +3883,7 @@ func isAlertmanagerDiscoveryWorking(ctx context.Context, ns, promSVCName, alertm
 			expectedAlertmanagerTargets = append(expectedAlertmanagerTargets, fmt.Sprintf("http://%s:9093/api/v2/alerts", p.Status.PodIP))
 		}
 
-		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, promSVCName, "/api/v1/alertmanagers", map[string]string{})
+		response, err := framework.PrometheusSVCGetRequest(context.Background(), ns, promSVCName, "http", "/api/v1/alertmanagers", map[string]string{})
 		if err != nil {
 			return false, err
 		}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/pkg/errors"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
@@ -58,7 +59,6 @@ type PromRemoteWriteTestConfig struct {
 	ClientKey          Key
 	ClientCert         Cert
 	CA                 Cert
-	ExpectedInLogs     string
 	InsecureSkipVerify bool
 	ShouldSuccess      bool
 }
@@ -109,7 +109,7 @@ func (f *Framework) AddRemoteWriteWithTLSToPrometheus(p *monitoringv1.Prometheus
 
 		p.Spec.RemoteWrite[0].TLSConfig = &monitoringv1.TLSConfig{
 			SafeTLSConfig: monitoringv1.SafeTLSConfig{
-				ServerName: "caandserver.com",
+				ServerName: "PrometheusRemoteWriteClient",
 			},
 		}
 
@@ -160,7 +160,64 @@ func (f *Framework) AddRemoteWriteWithTLSToPrometheus(p *monitoringv1.Prometheus
 			p.Spec.RemoteWrite[0].TLSConfig.InsecureSkipVerify = true
 		}
 	}
+}
 
+func (f *Framework) AddRemoteReceiveWithWebTLSToPrometheus(p *monitoringv1.Prometheus, prwtc PromRemoteWriteTestConfig) {
+	p.Spec.EnableFeatures = []string{"remote-write-receiver"}
+
+	p.Spec.Web = &monitoringv1.WebSpec{
+		TLSConfig: &monitoringv1.WebTLSConfig{},
+	}
+
+	if (prwtc.ClientKey.SecretName != "" && prwtc.ClientCert.ResourceName != "") || prwtc.CA.ResourceName != "" {
+
+		if prwtc.ClientKey.SecretName != "" && prwtc.ClientCert.ResourceName != "" {
+			p.Spec.Web.TLSConfig.KeySecret = v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: prwtc.ClientKey.SecretName,
+				},
+				Key: "key.pem",
+			}
+			p.Spec.Web.TLSConfig.Cert = monitoringv1.SecretOrConfigMap{}
+
+			if prwtc.ClientCert.ResourceType == SECRET {
+				p.Spec.Web.TLSConfig.Cert.Secret = &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: prwtc.ClientCert.ResourceName,
+					},
+					Key: "cert.pem",
+				}
+			} else { //certType == CONFIGMAP
+				p.Spec.Web.TLSConfig.Cert.ConfigMap = &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: prwtc.ClientCert.ResourceName,
+					},
+					Key: "cert.pem",
+				}
+			}
+		}
+
+		if prwtc.CA.ResourceName != "" {
+			p.Spec.Web.TLSConfig.ClientCA = monitoringv1.SecretOrConfigMap{}
+			if prwtc.CA.ResourceType == SECRET {
+				p.Spec.Web.TLSConfig.ClientAuthType = "RequestClientCert"
+				p.Spec.Web.TLSConfig.ClientCA.Secret = &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: prwtc.CA.ResourceName,
+					},
+					Key: "ca.pem",
+				}
+			} else { //caType == CONFIGMAP
+				p.Spec.Web.TLSConfig.ClientAuthType = "RequestClientCert"
+				p.Spec.Web.TLSConfig.ClientCA.ConfigMap = &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: prwtc.CA.ResourceName,
+					},
+					Key: "ca.pem",
+				}
+			}
+		}
+	}
 }
 
 func (f *Framework) AddAlertingToPrometheus(p *monitoringv1.Prometheus, ns, name string) {
@@ -450,7 +507,7 @@ func (f *Framework) WaitForDiscoveryWorking(ctx context.Context, ns, svcName, pr
 }
 
 func (f *Framework) basicQueryWorking(ctx context.Context, ns, svcName string) (bool, error) {
-	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "/api/v1/query", map[string]string{"query": "up"})
+	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "http", "/api/v1/query", map[string]string{"query": "up"})
 	if err != nil {
 		return false, err
 	}
@@ -488,14 +545,14 @@ func assertExpectedTargets(targets []*Target, expectedTargets []string) error {
 	return nil
 }
 
-func (f *Framework) PrometheusSVCGetRequest(ctx context.Context, ns, svcName, endpoint string, query map[string]string) ([]byte, error) {
+func (f *Framework) PrometheusSVCGetRequest(ctx context.Context, ns, svcName, scheme, endpoint string, query map[string]string) ([]byte, error) {
 	ProxyGet := f.KubeClient.CoreV1().Services(ns).ProxyGet
-	request := ProxyGet("", svcName, "web", endpoint, query)
+	request := ProxyGet(scheme, svcName, "web", endpoint, query)
 	return request.DoRaw(ctx)
 }
 
 func (f *Framework) GetActiveTargets(ctx context.Context, ns, svcName string) ([]*Target, error) {
-	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "/api/v1/targets", map[string]string{})
+	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "http", "/api/v1/targets", map[string]string{})
 	if err != nil {
 		return nil, err
 	}
@@ -528,13 +585,7 @@ func (f *Framework) GetHealthyTargets(ctx context.Context, ns, svcName string) (
 }
 
 func (f *Framework) CheckPrometheusFiringAlert(ctx context.Context, ns, svcName, alertName string) (bool, error) {
-	response, err := f.PrometheusSVCGetRequest(
-		ctx,
-		ns,
-		svcName,
-		"/api/v1/query",
-		map[string]string{"query": fmt.Sprintf(`ALERTS{alertname="%v",alertstate="firing"}`, alertName)},
-	)
+	response, err := f.PrometheusSVCGetRequest(ctx, ns, svcName, "http", "/api/v1/query", map[string]string{"query": fmt.Sprintf(`ALERTS{alertname="%v",alertstate="firing"}`, alertName)})
 	if err != nil {
 		return false, err
 	}
@@ -551,14 +602,8 @@ func (f *Framework) CheckPrometheusFiringAlert(ctx context.Context, ns, svcName,
 	return true, nil
 }
 
-func (f *Framework) PrometheusQuery(ns, svcName, query string) ([]PrometheusQueryResult, error) {
-	response, err := f.PrometheusSVCGetRequest(
-		context.Background(),
-		ns,
-		svcName,
-		"/api/v1/query",
-		map[string]string{"query": query},
-	)
+func (f *Framework) PrometheusQuery(ns, svcName, scheme, query string) ([]PrometheusQueryResult, error) {
+	response, err := f.PrometheusSVCGetRequest(context.Background(), ns, svcName, scheme, "/api/v1/query", map[string]string{"query": query})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

## Description
e2e tests: Use prometheus as remote receiver for testPromRemoteWriteWithTLS

sample app is doubling up as a scrape target as well the receiver endpoint.
With this change, we would launch another prometheus with remote-write-receiver feature enabled and use it as receiver instead. We would run queries against receiver prometheus to validate if remote write was successful.

[fixes#4319](https://github.com/prometheus-operator/prometheus-operator/issues/4319)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry
_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._
<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
e2e tests: Use prometheus as remote receiver for testPromRemoteWriteWithTLS e2e test
```
