### PR TITLE
readme: Change the kubectl command to create resources from bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ but have already applied the `bundle.yaml`, delete the bundle first (`kubectl de
 To quickly try out *just* the Prometheus Operator inside a cluster, **choose a release** and run the following command:
 
 ```sh
-kubectl apply -f bundle.yaml
+kubectl create -f bundle.yaml
 ```
 
 > Note: make sure to adapt the namespace in the ClusterRoleBinding if deploying in a namespace other than the default namespace.


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

The problem with too long annotation can be solved by changing the `kubectl create` command.

Fixes #4348

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Change the quickstart guideline
```
