### PR TITLE
Add validations for duration fields in alertmanager and thanos

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -30,7 +30,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
-	"github.com/prometheus-operator/prometheus-operator/pkg/common"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,19 +78,19 @@ func newConfigGenerator(logger log.Logger, amVersion semver.Version, store *asse
 // validateConfigInputs runs extra validation on the AlertManager fields which can't be done at the CRD schema validation level.
 func validateConfigInputs(am *monitoringv1.Alertmanager) error {
 	if am.Spec.ClusterGossipInterval != "" {
-		if err := common.ValidateDurationField(am.Spec.ClusterGossipInterval); err != nil {
+		if err := operator.ValidateDurationField(am.Spec.ClusterGossipInterval); err != nil {
 			return errors.Wrap(err, "invalid clusterGossipInterval value specified")
 		}
 	}
 
 	if am.Spec.ClusterPushpullInterval != "" {
-		if err := common.ValidateDurationField(am.Spec.ClusterPushpullInterval); err != nil {
+		if err := operator.ValidateDurationField(am.Spec.ClusterPushpullInterval); err != nil {
 			return errors.Wrap(err, "invalid clusterPushpullInterval value specified")
 		}
 	}
 
 	if am.Spec.ClusterPeerTimeout != "" {
-		if err := common.ValidateDurationField(am.Spec.ClusterPeerTimeout); err != nil {
+		if err := operator.ValidateDurationField(am.Spec.ClusterPeerTimeout); err != nil {
 			return errors.Wrap(err, "invalid clusterPeerTimeout value specified")
 		}
 	}

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -30,6 +30,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+	"github.com/prometheus-operator/prometheus-operator/pkg/common"
 	"github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/types"
@@ -72,6 +73,28 @@ func newConfigGenerator(logger log.Logger, amVersion semver.Version, store *asse
 		store:     store,
 	}
 	return cg
+}
+
+// validateConfigInputs runs extra validation on the AlertManager fields which can't be done at the CRD schema validation level.
+func validateConfigInputs(am *monitoringv1.Alertmanager) error {
+	if am.Spec.ClusterGossipInterval != "" {
+		if err := common.ValidateDurationField(am.Spec.ClusterGossipInterval); err != nil {
+			return errors.Wrap(err, "invalid clusterGossipInterval value specified")
+		}
+	}
+
+	if am.Spec.ClusterPushpullInterval != "" {
+		if err := common.ValidateDurationField(am.Spec.ClusterPushpullInterval); err != nil {
+			return errors.Wrap(err, "invalid clusterPushpullInterval value specified")
+		}
+	}
+
+	if am.Spec.ClusterPeerTimeout != "" {
+		if err := common.ValidateDurationField(am.Spec.ClusterPeerTimeout); err != nil {
+			return errors.Wrap(err, "invalid clusterPeerTimeout value specified")
+		}
+	}
+	return nil
 }
 
 func (cg *configGenerator) generateConfig(

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -77,6 +77,11 @@ func newConfigGenerator(logger log.Logger, amVersion semver.Version, store *asse
 
 // validateConfigInputs runs extra validation on the AlertManager fields which can't be done at the CRD schema validation level.
 func validateConfigInputs(am *monitoringv1.Alertmanager) error {
+	if am.Spec.Retention != "" {
+		if err := operator.ValidateDurationField(am.Spec.Retention); err != nil {
+			return errors.Wrap(err, "invalid retention value specified")
+		}
+	}
 	if am.Spec.ClusterGossipInterval != "" {
 		if err := operator.ValidateDurationField(am.Spec.ClusterGossipInterval); err != nil {
 			return errors.Wrap(err, "invalid clusterGossipInterval value specified")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -847,6 +847,11 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, s appsv1.Statefu
 func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.Store) error {
 	namespacedLogger := log.With(c.logger, "alertmanager", am.Name, "namespace", am.Namespace)
 
+	// Validate AlertManager Config Inputs at AlertManager CRD level
+	if err := validateConfigInputs(am); err != nil {
+		return err
+	}
+
 	secretName := defaultConfigSecretName(am.Name)
 	if am.Spec.ConfigSecret != "" {
 		secretName = am.Spec.ConfigSecret

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1024,6 +1024,30 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			ok:           true,
 			expectedKeys: []string{"key1"},
 		},
+		{
+			am: &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid cluster gossip interval",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					ClusterGossipInterval: "30k",
+				},
+			},
+			ok: false,
+		},
+		{
+			am: &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "correct cluster gossip interval",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					ClusterGossipInterval: "30s",
+				},
+			},
+			ok: true,
+		},
 	} {
 		t.Run(tc.am.Name, func(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.objects...)

--- a/pkg/common/validations.go
+++ b/pkg/common/validations.go
@@ -1,0 +1,36 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/alecthomas/units"
+	"github.com/prometheus/common/model"
+)
+
+func ValidateSizeField(sizeField string) error {
+	// To validate if given value is parsable for the acceptable size values
+	if _, err := units.ParseBase2Bytes(sizeField); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateDurationField(durationField string) error {
+	// To validate if given value is parsable for the acceptable duration values
+	if _, err := model.ParseDuration(durationField); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/operator/validations.go
+++ b/pkg/operator/validations.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package operator
 
 import (
 	"github.com/alecthomas/units"

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -30,7 +30,6 @@ import (
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
-	"github.com/prometheus-operator/prometheus-operator/pkg/common"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
@@ -219,56 +218,56 @@ func buildExternalLabels(p *v1.Prometheus) yaml.MapSlice {
 // validateConfigInputs runs extra validation on the Prometheus fields which can't be done at the CRD schema validation level.
 func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.EnforcedBodySizeLimit != "" {
-		if err := common.ValidateSizeField(p.Spec.EnforcedBodySizeLimit); err != nil {
+		if err := operator.ValidateSizeField(p.Spec.EnforcedBodySizeLimit); err != nil {
 			return errors.Wrap(err, "invalid enforcedBodySizeLimit value specified")
 		}
 	}
 
 	if p.Spec.RetentionSize != "" {
-		if err := common.ValidateSizeField(p.Spec.RetentionSize); err != nil {
+		if err := operator.ValidateSizeField(p.Spec.RetentionSize); err != nil {
 			return errors.Wrap(err, "invalid retentionSize value specified")
 		}
 	}
 
 	if p.Spec.Retention != "" {
-		if err := common.ValidateDurationField(p.Spec.Retention); err != nil {
+		if err := operator.ValidateDurationField(p.Spec.Retention); err != nil {
 			return errors.Wrap(err, "invalid retention value specified")
 		}
 	}
 
 	if p.Spec.ScrapeInterval != "" {
-		if err := common.ValidateDurationField(p.Spec.ScrapeInterval); err != nil {
+		if err := operator.ValidateDurationField(p.Spec.ScrapeInterval); err != nil {
 			return errors.Wrap(err, "invalid scrapeInterval value specified")
 		}
 	}
 
 	if p.Spec.ScrapeTimeout != "" {
-		if err := common.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
+		if err := operator.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
 			return errors.Wrap(err, "invalid scrapeTimeout value specified")
 		}
 	}
 
 	if p.Spec.EvaluationInterval != "" {
-		if err := common.ValidateDurationField(p.Spec.EvaluationInterval); err != nil {
+		if err := operator.ValidateDurationField(p.Spec.EvaluationInterval); err != nil {
 			return errors.Wrap(err, "invalid evaluationInterval value specified")
 		}
 	}
 
 	if p.Spec.Thanos != nil && p.Spec.Thanos.ReadyTimeout != "" {
-		if err := common.ValidateDurationField(p.Spec.Thanos.ReadyTimeout); err != nil {
+		if err := operator.ValidateDurationField(p.Spec.Thanos.ReadyTimeout); err != nil {
 			return errors.Wrap(err, "invalid thanos.readyTimeout value specified")
 		}
 	}
 
 	if p.Spec.Query != nil && p.Spec.Query.Timeout != nil && *p.Spec.Query.Timeout != "" {
-		if err := common.ValidateDurationField(*p.Spec.Query.Timeout); err != nil {
+		if err := operator.ValidateDurationField(*p.Spec.Query.Timeout); err != nil {
 			return errors.Wrap(err, "invalid query.timeout value specified")
 		}
 	}
 
 	for i, rr := range p.Spec.RemoteRead {
 		if rr.RemoteTimeout != "" {
-			if err := common.ValidateDurationField(rr.RemoteTimeout); err != nil {
+			if err := operator.ValidateDurationField(rr.RemoteTimeout); err != nil {
 				return errors.Wrapf(err, "invalid remoteRead[%d].remoteTimeout value specified", i)
 			}
 		}
@@ -276,13 +275,13 @@ func validateConfigInputs(p *v1.Prometheus) error {
 
 	for i, rw := range p.Spec.RemoteWrite {
 		if rw.RemoteTimeout != "" {
-			if err := common.ValidateDurationField(rw.RemoteTimeout); err != nil {
+			if err := operator.ValidateDurationField(rw.RemoteTimeout); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].remoteTimeout value specified", i)
 			}
 		}
 
 		if rw.MetadataConfig != nil && rw.MetadataConfig.SendInterval != "" {
-			if err := common.ValidateDurationField(rw.MetadataConfig.SendInterval); err != nil {
+			if err := operator.ValidateDurationField(rw.MetadataConfig.SendInterval); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].metadataConfig.sendInterval value specified", i)
 			}
 		}
@@ -291,7 +290,7 @@ func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.Alerting != nil {
 		for i, ap := range p.Spec.Alerting.Alertmanagers {
 			if ap.Timeout != nil && *ap.Timeout != "" {
-				if err := common.ValidateDurationField(*ap.Timeout); err != nil {
+				if err := operator.ValidateDurationField(*ap.Timeout); err != nil {
 					return errors.Wrapf(err, "invalid alertmanagers[%d].timeout value specified", i)
 				}
 			}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -21,18 +21,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/units"
-
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+	"github.com/prometheus-operator/prometheus-operator/pkg/common"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
@@ -221,56 +219,56 @@ func buildExternalLabels(p *v1.Prometheus) yaml.MapSlice {
 // validateConfigInputs runs extra validation on the Prometheus fields which can't be done at the CRD schema validation level.
 func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.EnforcedBodySizeLimit != "" {
-		if err := validateSizeField(p.Spec.EnforcedBodySizeLimit); err != nil {
+		if err := common.ValidateSizeField(p.Spec.EnforcedBodySizeLimit); err != nil {
 			return errors.Wrap(err, "invalid enforcedBodySizeLimit value specified")
 		}
 	}
 
 	if p.Spec.RetentionSize != "" {
-		if err := validateSizeField(p.Spec.RetentionSize); err != nil {
+		if err := common.ValidateSizeField(p.Spec.RetentionSize); err != nil {
 			return errors.Wrap(err, "invalid retentionSize value specified")
 		}
 	}
 
 	if p.Spec.Retention != "" {
-		if err := validateDurationField(p.Spec.Retention); err != nil {
+		if err := common.ValidateDurationField(p.Spec.Retention); err != nil {
 			return errors.Wrap(err, "invalid retention value specified")
 		}
 	}
 
 	if p.Spec.ScrapeInterval != "" {
-		if err := validateDurationField(p.Spec.ScrapeInterval); err != nil {
+		if err := common.ValidateDurationField(p.Spec.ScrapeInterval); err != nil {
 			return errors.Wrap(err, "invalid scrapeInterval value specified")
 		}
 	}
 
 	if p.Spec.ScrapeTimeout != "" {
-		if err := validateDurationField(p.Spec.ScrapeTimeout); err != nil {
+		if err := common.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
 			return errors.Wrap(err, "invalid scrapeTimeout value specified")
 		}
 	}
 
 	if p.Spec.EvaluationInterval != "" {
-		if err := validateDurationField(p.Spec.EvaluationInterval); err != nil {
+		if err := common.ValidateDurationField(p.Spec.EvaluationInterval); err != nil {
 			return errors.Wrap(err, "invalid evaluationInterval value specified")
 		}
 	}
 
 	if p.Spec.Thanos != nil && p.Spec.Thanos.ReadyTimeout != "" {
-		if err := validateDurationField(p.Spec.Thanos.ReadyTimeout); err != nil {
+		if err := common.ValidateDurationField(p.Spec.Thanos.ReadyTimeout); err != nil {
 			return errors.Wrap(err, "invalid thanos.readyTimeout value specified")
 		}
 	}
 
 	if p.Spec.Query != nil && p.Spec.Query.Timeout != nil && *p.Spec.Query.Timeout != "" {
-		if err := validateDurationField(*p.Spec.Query.Timeout); err != nil {
+		if err := common.ValidateDurationField(*p.Spec.Query.Timeout); err != nil {
 			return errors.Wrap(err, "invalid query.timeout value specified")
 		}
 	}
 
 	for i, rr := range p.Spec.RemoteRead {
 		if rr.RemoteTimeout != "" {
-			if err := validateDurationField(rr.RemoteTimeout); err != nil {
+			if err := common.ValidateDurationField(rr.RemoteTimeout); err != nil {
 				return errors.Wrapf(err, "invalid remoteRead[%d].remoteTimeout value specified", i)
 			}
 		}
@@ -278,13 +276,13 @@ func validateConfigInputs(p *v1.Prometheus) error {
 
 	for i, rw := range p.Spec.RemoteWrite {
 		if rw.RemoteTimeout != "" {
-			if err := validateDurationField(rw.RemoteTimeout); err != nil {
+			if err := common.ValidateDurationField(rw.RemoteTimeout); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].remoteTimeout value specified", i)
 			}
 		}
 
 		if rw.MetadataConfig != nil && rw.MetadataConfig.SendInterval != "" {
-			if err := validateDurationField(rw.MetadataConfig.SendInterval); err != nil {
+			if err := common.ValidateDurationField(rw.MetadataConfig.SendInterval); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].metadataConfig.sendInterval value specified", i)
 			}
 		}
@@ -293,29 +291,13 @@ func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.Alerting != nil {
 		for i, ap := range p.Spec.Alerting.Alertmanagers {
 			if ap.Timeout != nil && *ap.Timeout != "" {
-				if err := validateDurationField(*ap.Timeout); err != nil {
+				if err := common.ValidateDurationField(*ap.Timeout); err != nil {
 					return errors.Wrapf(err, "invalid alertmanagers[%d].timeout value specified", i)
 				}
 			}
 		}
 	}
 
-	return nil
-}
-
-func validateSizeField(sizeField string) error {
-	// To validate if given value is parsable for the acceptable size values
-	if _, err := units.ParseBase2Bytes(sizeField); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateDurationField(durationField string) error {
-	// To validate if given value is parsable for the acceptable duration values
-	if _, err := model.ParseDuration(durationField); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/prometheus-operator/prometheus-operator/pkg/common"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	appsv1 "k8s.io/api/apps/v1"
@@ -175,7 +174,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	if tr.Spec.EvaluationInterval != "" {
-		if err := common.ValidateDurationField(tr.Spec.EvaluationInterval); err != nil {
+		if err := operator.ValidateDurationField(tr.Spec.EvaluationInterval); err != nil {
 			return nil, errors.Wrap(err, "invalid evaluationInterval value specified")
 		}
 	}
@@ -185,7 +184,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	if tr.Spec.Retention != "" {
-		if err := common.ValidateDurationField(tr.Spec.Retention); err != nil {
+		if err := operator.ValidateDurationField(tr.Spec.Retention); err != nil {
 			return nil, errors.Wrap(err, "invalid retention value specified")
 		}
 	}

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/common"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	appsv1 "k8s.io/api/apps/v1"
@@ -172,8 +173,21 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	if tr.Spec.EvaluationInterval == "" {
 		tr.Spec.EvaluationInterval = defaultEvaluationInterval
 	}
+
+	if tr.Spec.EvaluationInterval != "" {
+		if err := common.ValidateDurationField(tr.Spec.EvaluationInterval); err != nil {
+			return nil, errors.Wrap(err, "invalid evaluationInterval value specified")
+		}
+	}
+
 	if tr.Spec.Retention == "" {
 		tr.Spec.Retention = defaultRetention
+	}
+
+	if tr.Spec.Retention != "" {
+		if err := common.ValidateDurationField(tr.Spec.Retention); err != nil {
+			return nil, errors.Wrap(err, "invalid retention value specified")
+		}
 	}
 
 	trCLIArgs := []string{


### PR DESCRIPTION
## Description

Add validations for duration fields in alertmanager and thanos

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->


```release-note
Added input validations for duration fields in alertmanager and thanos
```

cc: @simonpasquier 