### PR TITLE
Rework Prometheus StatefulSet probes

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -25,7 +25,7 @@ Details (optional):
 
 This document tracks people and use cases for the Prometheus Operator in production. By creating a list of production use cases we hope to build a community of advisors that we can reach out to with experience using various the Prometheus Operator applications, operation environments, and cluster sizes. The Prometheus Operator development team may reach out periodically to check-in on how the Prometheus Operator is working in the field and update this list.
 
-Go ahead and [add your organization](https://github.com/prometheus-operator/prometheus-operator/edit/master/ADOPTERS.md) to the list.
+Go ahead and [add your organization](https://github.com/prometheus-operator/prometheus-operator/edit/main/ADOPTERS.md) to the list.
 
 ## Clyso
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -630,7 +630,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		Handler:          probeHandler("/-/ready"),
 		TimeoutSeconds:   probeTimeoutSeconds,
 		PeriodSeconds:    5,
-		FailureThreshold: 120, // Allow up to 10m on startup for data recovery
+		FailureThreshold: 3,
 	}
 
 	podAnnotations := map[string]string{}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -456,6 +456,17 @@ func TestListenLocal(t *testing.T) {
 		}
 	}
 
+	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
+	expectedStartupProbe := &v1.Probe{
+		Handler:          expectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+	if !reflect.DeepEqual(actualStartupProbe, expectedStartupProbe) {
+		t.Fatalf("Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
+	}
+
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
 	expectedReadinessProbe := &v1.Probe{
 		Handler:          expectedProbeHandler("/-/ready"),
@@ -506,6 +517,17 @@ func TestListenTLS(t *testing.T) {
 				Scheme: "HTTPS",
 			},
 		}
+	}
+
+	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
+	expectedStartupProbe := &v1.Probe{
+		Handler:          expectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+	if !reflect.DeepEqual(actualStartupProbe, expectedStartupProbe) {
+		t.Fatalf("Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
 	}
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -472,7 +472,7 @@ func TestListenLocal(t *testing.T) {
 		Handler:          expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
-		FailureThreshold: 120,
+		FailureThreshold: 3,
 	}
 	if !reflect.DeepEqual(actualReadinessProbe, expectedReadinessProbe) {
 		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)
@@ -535,7 +535,7 @@ func TestListenTLS(t *testing.T) {
 		Handler:          expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
-		FailureThreshold: 120,
+		FailureThreshold: 3,
 	}
 	if !reflect.DeepEqual(actualReadinessProbe, expectedReadinessProbe) {
 		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)


### PR DESCRIPTION
## Description

This PR modifies the Prometheus StatefulSet to:
- add a startup probe (fixes https://github.com/prometheus-operator/prometheus-operator/issues/3211),
- restore the liveness probe (follow-up of https://github.com/prometheus-operator/prometheus-operator/pull/3502),
- decrease the failure threshold of the readiness probe (fixes https://github.com/prometheus-operator/prometheus-operator/issues/3671).

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

(I’m not sure if this is only a bugfix.)

## Changelog entry

```release-note
Rework Prometheus StatefulSet probes so that failures are detected early while still tolerating slow startups due to WAL recovery.
```