### PR TITLE
Fixing spelling mistake that is causing lint failure

### DIFF
--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4474,7 +4474,7 @@ spec:
                         tells the scheduler to schedule the pod in any location,   but
                         giving higher precedence to topologies that would help reduce
                         the   skew. A constraint is considered "Unsatisfiable" for
-                        an incoming pod if and only if every possible node assigment
+                        an incoming pod if and only if every possible node assignment
                         for that pod would violate "MaxSkew" on some topology. For
                         example, in a 3-zone cluster, MaxSkew is set to 1, and pods
                         with the same labelSelector spread as 3/1/1: | zone1 | zone2


### PR DESCRIPTION
## Description

Fixing spelling mistake that is causing kube-prometheus-stack helm project lint check to fail


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Fixing spelling mistake in CRD which is causing lint check in kube-prometheus-stack helm project CI process to fail

```release-note
Fixing spelling mistake in CRD which is causing lint check in kube-prometheus-stack helm project CI process to fail
```
