### PR TITLE
add a flag to enable local prometheus compaction when sidecar upload …

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1146,6 +1146,7 @@ ThanosSpec defines parameters for a Prometheus server within a Thanos deployment
 | minTime | MinTime for Thanos sidecar to be configured with. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y. | string | false |
 | readyTimeout | ReadyTimeout is the maximum time Thanos sidecar will wait for Prometheus to start. Eg 10m | string | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition. VolumeMounts specified will be appended to other VolumeMounts in the thanos-sidecar container. | []v1.VolumeMount | false |
+| enableLocalCompaction | EnableLocalCompaction enables Prometheus local TSDB compaction even if object storage config is provided. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15712,6 +15712,10 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  enableLocalCompaction:
+                    description: EnableLocalCompaction enables Prometheus local TSDB
+                      compaction even if object storage config is provided.
+                    type: boolean
                   grpcServerTlsConfig:
                     description: 'GRPCServerTLSConfig configures the gRPC server from
                       which Thanos Querier reads recorded rule data. Note: Currently

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5961,6 +5961,10 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  enableLocalCompaction:
+                    description: EnableLocalCompaction enables Prometheus local TSDB
+                      compaction even if object storage config is provided.
+                    type: boolean
                   grpcServerTlsConfig:
                     description: 'GRPCServerTLSConfig configures the gRPC server from
                       which Thanos Querier reads recorded rule data. Note: Currently

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5563,6 +5563,10 @@
                         "description": "Thanos base image if other than default. Deprecated: use 'image' instead",
                         "type": "string"
                       },
+                      "enableLocalCompaction": {
+                        "description": "EnableLocalCompaction enables Prometheus local TSDB compaction even if object storage config is provided.",
+                        "type": "boolean"
+                      },
                       "grpcServerTlsConfig": {
                         "description": "GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads recorded rule data. Note: Currently only the CAFile, CertFile, and KeyFile fields are supported. Maps to the '--grpc-server-tls-*' CLI args.",
                         "properties": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -680,6 +680,8 @@ type ThanosSpec struct {
 	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
 	// VolumeMounts specified will be appended to other VolumeMounts in the thanos-sidecar container.
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	// EnableLocalCompaction enables Prometheus local TSDB compaction even if object storage config is provided.
+	EnableLocalCompaction bool `json:"enableLocalCompaction,omitempty"`
 }
 
 // RemoteWriteSpec defines the remote_write configuration for prometheus.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -752,9 +752,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				},
 			)
 
-			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
-			// to avoid races during upload, if the uploads are configured.
-			disableCompaction = true
+			// By default, Prometheus local TSDB compaction is disabled when uploads are configured.
+			disableCompaction = !p.Spec.Thanos.EnableLocalCompaction
 		}
 
 		if p.Spec.Thanos.TracingConfig != nil || len(p.Spec.Thanos.TracingConfigFile) > 0 {

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1126,6 +1126,93 @@ func TestThanosObjectStorageFile(t *testing.T) {
 	}
 }
 
+func TestThanosObjectStorageWithLocalCompaction(t *testing.T) {
+	testKey := "thanos-config-secret-test"
+
+	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			Thanos: &monitoringv1.ThanosSpec{
+				ObjectStorageConfig: &v1.SecretKeySelector{
+					Key: testKey,
+				},
+				EnableLocalCompaction: true,
+			},
+		},
+	}, defaultTestConfig, nil, "", 0)
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	if sset.Spec.Template.Spec.Containers[0].Name != "prometheus" {
+		t.Fatalf("expected 1st containers to be prometheus, got %s", sset.Spec.Template.Spec.Containers[0].Name)
+	}
+
+	if sset.Spec.Template.Spec.Containers[2].Name != "thanos-sidecar" {
+		t.Fatalf("expected 3rd containers to be thanos-sidecar, got %s", sset.Spec.Template.Spec.Containers[2].Name)
+	}
+
+	var containsEnvVar bool
+	for _, env := range sset.Spec.Template.Spec.Containers[2].Env {
+		if env.Name == "OBJSTORE_CONFIG" {
+			if env.ValueFrom.SecretKeyRef.Key == testKey {
+				containsEnvVar = true
+				break
+			}
+		}
+	}
+	if !containsEnvVar {
+		t.Fatalf("Thanos sidecar is missing expected OBJSTORE_CONFIG env var with correct value")
+	}
+
+	{
+		var containsArg bool
+		const expectedArg = "--objstore.config=$(OBJSTORE_CONFIG)"
+		for _, arg := range sset.Spec.Template.Spec.Containers[2].Args {
+			if arg == expectedArg {
+				containsArg = true
+				break
+			}
+		}
+		if !containsArg {
+			t.Fatalf("Thanos sidecar is missing expected argument: %s", expectedArg)
+		}
+	}
+	{
+		const unexpectedArg = "--storage.tsdb.max-block-duration=2h"
+		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
+			if arg == unexpectedArg {
+				t.Fatalf("Prometheus is haveing an unexpected argument: %s", unexpectedArg)
+			}
+		}
+	}
+
+	{
+		var found bool
+		for _, arg := range sset.Spec.Template.Spec.Containers[2].Args {
+			if strings.HasPrefix(arg, "--tsdb.path=") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("--tsdb.path argument should be given to the Thanos sidecar, got %q", strings.Join(sset.Spec.Template.Spec.Containers[3].Args, " "))
+		}
+	}
+
+	{
+		var found bool
+		for _, vol := range sset.Spec.Template.Spec.Containers[2].VolumeMounts {
+			if vol.MountPath == storageDir {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("Prometheus data volume should be mounted in the Thanos sidecar")
+		}
+	}
+}
+
 func TestThanosTracing(t *testing.T) {
 	testKey := "thanos-config-secret-test"
 


### PR DESCRIPTION
…is configured

Signed-off-by: Ben Ye <ben.ye@bytedance.com>

## Description

TSDB compaction is useful for improving Prometheus Query Performance. In the case of some edge sites with sidecar and Prometheus, we want to enable TSDB compaction for better query performance as well as uploading data to the object storage. For more detail, please check out https://github.com/thanos-io/thanos/issues/2620.

This pr provides a flag to enable local TSDB compaction for Prometheus for the use case described above.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
