### PR TITLE
test: Reduce runtime of e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ test/e2e/remote_write_certs/ca.key test/e2e/remote_write_certs/ca.crt test/e2e/r
 .PHONY: test-e2e
 test-e2e: KUBECONFIG?=$(HOME)/.kube/config
 test-e2e: test/instrumented-sample-app/certs/cert.pem test/instrumented-sample-app/certs/key.pem
-	go test -timeout 120m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(IMAGE_OPERATOR):$(TAG) -count=1
+	go test -timeout 120m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG) --operator-image=$(IMAGE_OPERATOR):$(TAG) -count=1 -parallel 4
 
 ############
 # Binaries #

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2383,7 +2383,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 			Endpoints: []monitoringv1.Endpoint{
 				{
 					TargetPort: &targetPort,
-					Interval:   "30s",
+					Interval:   "5s",
 				},
 			},
 		},


### PR DESCRIPTION

## Description

This commit reduces the runtime of Prometheus e2e tests from 40 minutes
to less than 30 minutes. It does so by implementing two changes:
* reducing the scraping time for the tlsRemoteWrite test from 30s to 5s
* increasing the parallelism for e2e tests from 2 to 4.

According to the docs[1], the Github runners have 2 CPUs and our tests
do not seem to be CPU bound. Since each Github Actions job runs on a
dedicated VM, doubling the parallelism should not be problematic for now.

[1] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
