### PR TITLE
Documentation: use the correct version in Documentation files

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -27,7 +27,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: 0.52.0
+    app.kubernetes.io/version: 0.52.1
   name: prometheus-operator
 rules:
 - apiGroups:
@@ -174,7 +174,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: 0.52.0
+    app.kubernetes.io/version: 0.52.1
   name: prometheus-operator
   namespace: default
 ```
@@ -190,7 +190,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
-    app.kubernetes.io/version: 0.52.0
+    app.kubernetes.io/version: 0.52.1
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Description

Fixes the version label used in Kubernetes resources that are part of the documentation.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
