### PR TITLE
Ensure group_by values are unique in alertmanager config

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1532,7 +1532,7 @@ Route defines a node in the routing tree.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | receiver | Name of the receiver for this route. If not empty, it should be listed in the `receivers` field. | string | true |
-| groupBy | List of labels to group by. | []string | false |
+| groupBy | List of labels to group by. Labels must not be repeated (unique list). Special label \"...\" (aggregate by all possible labels), if provided, must be the only element in the list. | []string | false |
 | groupWait | How long to wait before sending the initial notification. Must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | string | false |
 | groupInterval | How long to wait before sending an updated notification. Must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | string | false |
 | repeatInterval | How long to wait before repeating the last notification. Must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | string | false |

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -2635,7 +2635,9 @@ spec:
                       to true for the first-level route by the Prometheus operator.
                     type: boolean
                   groupBy:
-                    description: List of labels to group by.
+                    description: List of labels to group by. Labels must not be repeated
+                      (unique list). Special label "..." (aggregate by all possible
+                      labels), if provided, must be the only element in the list.
                     items:
                       type: string
                     type: array

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -2635,7 +2635,9 @@ spec:
                       to true for the first-level route by the Prometheus operator.
                     type: boolean
                   groupBy:
-                    description: List of labels to group by.
+                    description: List of labels to group by. Labels must not be repeated
+                      (unique list). Special label "..." (aggregate by all possible
+                      labels), if provided, must be the only element in the list.
                     items:
                       type: string
                     type: array

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -2768,7 +2768,7 @@
                         "type": "boolean"
                       },
                       "groupBy": {
-                        "description": "List of labels to group by.",
+                        "description": "List of labels to group by. Labels must not be repeated (unique list). Special label \"...\" (aggregate by all possible labels), if provided, must be the only element in the list.",
                         "items": {
                           "type": "string"
                         },

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -270,6 +270,7 @@ templates: []
 					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 						Route: &monitoringv1alpha1.Route{
 							Receiver: "test",
+							GroupBy:  []string{"job"},
 						},
 						Receivers: []monitoringv1alpha1.Receiver{{Name: "test"}},
 					},
@@ -279,6 +280,8 @@ templates: []
   receiver: "null"
   routes:
   - receiver: mynamespace-myamc-test
+    group_by:
+    - job
     matchers:
     - namespace="mynamespace"
     continue: true

--- a/pkg/alertmanager/validation.go
+++ b/pkg/alertmanager/validation.go
@@ -218,6 +218,19 @@ func validateAlertManagerRoutes(r *monitoringv1alpha1.Route, receivers map[strin
 		return errors.Errorf("receiver %q not found", r.Receiver)
 	}
 
+	if groupLen := len(r.GroupBy); groupLen > 0 {
+		groupedBy := make(map[string]struct{}, groupLen)
+		for _, str := range r.GroupBy {
+			if _, found := groupedBy[str]; found {
+				return errors.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
+			}
+			groupedBy[str] = struct{}{}
+		}
+		if _, found := groupedBy["..."]; found && groupLen > 1 {
+			return errors.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
+		}
+	}
+
 	children, err := r.ChildRoutes()
 	if err != nil {
 		return err

--- a/pkg/alertmanager/validation_test.go
+++ b/pkg/alertmanager/validation_test.go
@@ -332,6 +332,40 @@ func TestValidateConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "Test fail to validate routes with duplicate groupBy",
+			in: &monitoringv1alpha1.AlertmanagerConfig{
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{
+							Name: "same",
+						},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "same",
+						GroupBy:  []string{"job", "job"},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate routes with exclusive value and other in groupBy",
+			in: &monitoringv1alpha1.AlertmanagerConfig{
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{
+							Name: "same",
+						},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "same",
+						GroupBy:  []string{"job", "..."},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
 			name: "Test happy path",
 			in: &monitoringv1alpha1.AlertmanagerConfig{
 				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
@@ -419,6 +453,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "same",
+						GroupBy:  []string{"..."},
 					},
 				},
 			},

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -89,6 +89,8 @@ type Route struct {
 	// +optional
 	Receiver string `json:"receiver"`
 	// List of labels to group by.
+	// Labels must not be repeated (unique list).
+	// Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
 	// +optional
 	GroupBy []string `json:"groupBy,omitempty"`
 	// How long to wait before sending the initial notification. Must match the


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Elements in the routes `groupBy` list must be unique and furthermore, when the special value '...' is provided, there must be no other elements in the list.

Fixes #4402 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Ensure group_by values are unique in alertmanager config
```
