### PR TITLE
pkg/prometheus: Make CR compatible for agent mode

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -87,13 +87,7 @@ func TestGlobalSettings(t *testing.T) {
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -105,13 +99,7 @@ alerting:
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -133,13 +121,7 @@ alerting:
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -157,13 +139,7 @@ alerting:
     prometheus: /
     prometheus_replica: $(POD_NAME)
   scrape_timeout: 30s
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -185,13 +161,7 @@ alerting:
     key2: value2
     prometheus: /
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -204,13 +174,7 @@ alerting:
     prometheus: /
     prometheus_replica: $(POD_NAME)
   query_log_file: test.log
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 	}
@@ -482,7 +446,6 @@ func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -515,11 +478,6 @@ scrape_configs:
     replacement: bar
     action: replace
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -601,7 +559,6 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -636,11 +593,6 @@ scrape_configs:
     action: labeldrop
   - target_label: namespace
     replacement: default
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -712,7 +664,6 @@ func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -742,11 +693,6 @@ scrape_configs:
   - target_label: __address__
     replacement: blackbox.exporter.io
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -817,7 +763,6 @@ func TestProbeStaticTargetsConfigGenerationWithoutModule(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -844,11 +789,6 @@ scrape_configs:
   - target_label: __address__
     replacement: blackbox.exporter.io
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -930,7 +870,6 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -974,11 +913,6 @@ scrape_configs:
     replacement: bar
     action: replace
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -1061,7 +995,6 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -1109,11 +1042,6 @@ scrape_configs:
   metric_relabel_configs:
   - target_label: namespace
     replacement: default
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -1251,7 +1179,6 @@ func TestAlertmanagerBearerToken(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
 alerting:
   alert_relabel_configs:
@@ -1329,7 +1256,6 @@ func TestAlertmanagerAPIVersion(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
 alerting:
   alert_relabel_configs:
@@ -1408,7 +1334,6 @@ func TestAlertmanagerTimeoutConfig(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
 alerting:
   alert_relabel_configs:
@@ -1502,7 +1427,6 @@ func TestAdditionalScrapeConfigs(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 15s
@@ -1519,11 +1443,6 @@ scrape_configs:
     source_labels:
     - __meta_gce_label_app
     regex: my_app
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -1535,7 +1454,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 15s
@@ -1552,11 +1470,6 @@ scrape_configs:
     source_labels:
     - __meta_gce_label_app
     regex: my_app
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 		{
@@ -1568,7 +1481,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: prometheus
   scrape_interval: 15s
@@ -1604,11 +1516,6 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `,
 		},
 	}
@@ -1669,7 +1576,6 @@ func TestAdditionalAlertRelabelConfigs(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
 alerting:
   alert_relabel_configs:
@@ -1777,7 +1683,6 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/test/0
   honor_labels: true
@@ -1855,11 +1760,6 @@ scrape_configs:
     - __name__
     regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
     action: drop
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -1934,7 +1834,6 @@ func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: podMonitor/pod-monitor-ns/testpodmonitor1/0
   honor_labels: false
@@ -1999,11 +1898,6 @@ scrape_configs:
     action: drop
   - target_label: ns-key
     replacement: pod-monitor-ns
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2087,7 +1981,6 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/test/0
   honor_labels: false
@@ -2171,11 +2064,6 @@ scrape_configs:
     action: drop
   - target_label: ns-key
     replacement: default
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2227,7 +2115,6 @@ func TestAdditionalAlertmanagers(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
 alerting:
   alert_relabel_configs:
@@ -2319,7 +2206,6 @@ func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -2390,11 +2276,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2461,7 +2342,6 @@ func TestSettingHonorTimestampsInPodMonitor(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: podMonitor/default/testpodmonitor1/0
   honor_labels: false
@@ -2513,11 +2393,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2585,7 +2460,6 @@ func TestHonorTimestampsOverriding(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -2656,11 +2530,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2726,7 +2595,6 @@ func TestSettingHonorLabels(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: true
@@ -2796,11 +2664,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -2867,7 +2730,6 @@ func TestHonorLabelsOverriding(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -2937,11 +2799,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -3007,7 +2864,6 @@ func TestTargetLabels(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -3077,11 +2933,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -3354,7 +3205,6 @@ func TestPodTargetLabels(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -3424,11 +3274,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -3493,7 +3338,6 @@ func TestPodTargetLabelsFromPodMonitor(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: podMonitor/default/testpodmonitor1/0
   honor_labels: false
@@ -3544,11 +3388,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -3608,7 +3447,6 @@ func TestEmptyEndointPorts(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/test/0
   honor_labels: false
@@ -3666,11 +3504,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)
@@ -4148,7 +3981,6 @@ func TestSampleLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -4208,11 +4040,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -4221,7 +4048,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -4282,11 +4108,6 @@ scrape_configs:
     action: keep
   sample_limit: %d
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -4391,7 +4212,6 @@ func TestTargetLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -4451,11 +4271,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -4464,7 +4279,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -4525,11 +4339,6 @@ scrape_configs:
     action: keep
   target_limit: %d
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -4679,13 +4488,7 @@ func TestRemoteReadConfig(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_read:
 - url: http://example.com
   remote_timeout: 30s
@@ -4715,13 +4518,7 @@ remote_read:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_read:
 - url: http://example.com
   remote_timeout: 30s
@@ -4746,13 +4543,7 @@ remote_read:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_read:
 - url: http://example.com
   remote_timeout: 30s
@@ -4865,13 +4656,7 @@ func TestRemoteWriteConfig(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -4910,13 +4695,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -4957,13 +4736,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -5005,13 +4778,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -5042,13 +4809,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -5081,13 +4842,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -5138,13 +4893,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 30s
@@ -5179,13 +4928,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 1s
@@ -5204,13 +4947,7 @@ remote_write:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 remote_write:
 - url: http://example.com
   remote_timeout: 1s
@@ -5316,7 +5053,6 @@ func TestLabelLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -5376,11 +5112,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -5389,7 +5120,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -5450,11 +5180,6 @@ scrape_configs:
     action: keep
   label_limit: %d
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -5588,7 +5313,6 @@ func TestLabelNameLengthLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: podMonitor/default/testpodmonitor1/0
   honor_labels: false
@@ -5629,11 +5353,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -5642,7 +5361,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: podMonitor/default/testpodmonitor1/0
   honor_labels: false
@@ -5684,11 +5402,6 @@ scrape_configs:
     action: keep
   label_name_length_limit: %d
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -5822,7 +5535,6 @@ func TestLabelValueLengthLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -5852,11 +5564,6 @@ scrape_configs:
   - target_label: __address__
     replacement: blackbox.exporter.io
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -5865,7 +5572,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: probe/default/testprobe1
   honor_timestamps: true
@@ -5896,11 +5602,6 @@ scrape_configs:
   - target_label: __address__
     replacement: blackbox.exporter.io
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -6046,7 +5747,6 @@ func TestBodySizeLimits(t *testing.T) {
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -6106,11 +5806,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	expectLimit := `global:
@@ -6119,7 +5814,6 @@ alerting:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/testservicemonitor1/0
   honor_labels: false
@@ -6180,11 +5874,6 @@ scrape_configs:
     action: keep
   body_size_limit: %s
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	for _, tc := range []struct {
@@ -6351,7 +6040,6 @@ func TestMatchExpressionsServiceMonitor(t *testing.T) {
   external_labels:
     prometheus: ns-value/test
     prometheus_replica: $(POD_NAME)
-rule_files: []
 scrape_configs:
 - job_name: serviceMonitor/default/test/0
   honor_labels: false
@@ -6416,11 +6104,6 @@ scrape_configs:
     regex: $(SHARD)
     action: keep
   metric_relabel_configs: []
-alerting:
-  alert_relabel_configs:
-  - action: labeldrop
-    regex: prometheus_replica
-  alertmanagers: []
 `
 
 	result := string(cfg)


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Prometheus in agent mode fail-fast if alerting or rules_files is present in its configuration.
This commit removes those sections from the config if not necessary, aiming to make it possible to run Prometheus in agent mode with the Prometheus Custom Resouce.

I'll leave this PR as a draft until there is consensus if we really want to do this, or if we prefer to only support agent mode with a dedicated PrometheusAgent Custom Resource.

Changes were made based on this comment: https://github.com/prometheus-operator/prometheus-operator/issues/3989#issuecomment-974137486


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add possibility to run Prometheus in agent mode with the Prometheus Custom Resource
```
