### PR TITLE
Makefile: use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)


### PR DESCRIPTION
This allows invoking `make generate` from systems where bash is not in
/bin/bash (such as NixOS).

Instead, this will pick up `bash` from $PATH.

See https://www.reddit.com/r/linuxadmin/comments/975nok/binbash_vs_usrbinenv_bash/
## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
The `Makefile` will now pick up `bash` from `$PATH`, instead of hardcoding it to /bin/bash. This will fix running it on systems where bash is elsewhere.
```