### PR TITLE
Document ruleNamespaceSelector

### DIFF
--- a/example/user-guides/alerting/prometheus-example-rule-namespace-selector.yaml
+++ b/example/user-guides/alerting/prometheus-example-rule-namespace-selector.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: example
+spec:
+  replicas: 2
+  alerting:
+    alertmanagers:
+    - namespace: default
+      name: alertmanager-example
+      port: web
+  serviceMonitorSelector:
+    matchLabels:
+      team: frontend
+  ruleSelector:
+    matchLabels:
+      role: alert-rules
+      prometheus: example
+  ruleNamespaceSelector:
+    matchLabels:
+      team: frontend


### PR DESCRIPTION
As raised in https://github.com/prometheus-operator/prometheus-operator/issues/4412,
there's no example or docs on how to use `metav1.LabelSelector` to
select namespaces.

This is even more confusing, as the
prometheus.spec.{rule,podMonitor,probe}NamespaceSelector fields (and
some others) use the `NamespaceSelector` type.

It might make sense to move those to `metav1.LabelSelector` as well
(https://github.com/prometheus-operator/prometheus-operator/issues/4412#issuecomment-971892883),
but let's start documenting how to use the ones we already have.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Add some more documentation and an example for the ruleNamespaceSelector field.
```
