### PR TITLE
Add support for retry_on_http_429 in Prometheus Remote Write config

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -838,6 +838,7 @@ QueueConfig allows the tuning of remote_write queue_config parameters. This obje
 | maxRetries | MaxRetries is the maximum number of times to retry a batch on recoverable errors. | int | false |
 | minBackoff | MinBackoff is the initial retry delay. Gets doubled for every retry. | string | false |
 | maxBackoff | MaxBackoff is the maximum retry delay. | string | false |
+| retryOnRateLimit | Retry upon receiving a 429 status code from the remote-write storage. This is experimental feature and might change in the future. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14528,6 +14528,11 @@ spec:
                           description: MinShards is the minimum number of shards,
                             i.e. amount of concurrency.
                           type: integer
+                        retryOnRateLimit:
+                          description: Retry upon receiving a 429 status code from
+                            the remote-write storage. This is experimental feature
+                            and might change in the future.
+                          type: boolean
                       type: object
                     remoteTimeout:
                       description: Timeout for requests to the remote write endpoint.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4742,6 +4742,11 @@ spec:
                           description: MinShards is the minimum number of shards,
                             i.e. amount of concurrency.
                           type: integer
+                        retryOnRateLimit:
+                          description: Retry upon receiving a 429 status code from
+                            the remote-write storage. This is experimental feature
+                            and might change in the future.
+                          type: boolean
                       type: object
                     remoteTimeout:
                       description: Timeout for requests to the remote write endpoint.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4431,6 +4431,10 @@
                             "minShards": {
                               "description": "MinShards is the minimum number of shards, i.e. amount of concurrency.",
                               "type": "integer"
+                            },
+                            "retryOnRateLimit": {
+                              "description": "Retry upon receiving a 429 status code from the remote-write storage. This is experimental feature and might change in the future.",
+                              "type": "boolean"
                             }
                           },
                           "type": "object"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -743,6 +743,9 @@ type QueueConfig struct {
 	MinBackoff string `json:"minBackoff,omitempty"`
 	// MaxBackoff is the maximum retry delay.
 	MaxBackoff string `json:"maxBackoff,omitempty"`
+	// Retry upon receiving a 429 status code from the remote-write storage.
+	// This is experimental feature and might change in the future.
+	RetryOnRateLimit bool `json:"retryOnRateLimit,omitempty"`
 }
 
 // Sigv4 optionally configures AWS's Signature Verification 4 signing process to

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1857,6 +1857,12 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(
 				queueConfig = append(queueConfig, yaml.MapItem{Key: "max_backoff", Value: spec.QueueConfig.MaxBackoff})
 			}
 
+			if version.GTE(semver.MustParse("2.26.0")) {
+				if spec.QueueConfig.RetryOnRateLimit {
+					queueConfig = append(queueConfig, yaml.MapItem{Key: "retry_on_http_429", Value: spec.QueueConfig.RetryOnRateLimit})
+				}
+			}
+
 			cfg = append(cfg, yaml.MapItem{Key: "queue_config", Value: queueConfig})
 		}
 


### PR DESCRIPTION
## Description

Prometheus added a feature flag to enable/disable retries on HTTP 429 (too many requests) responses.
Feature got introduced with: prometheus/prometheus#8477. This feature is very useful if rate limiting got hit but the requests should be or not be retried later.

Closes #4192.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added support for RetryOnRateLimit in Prometheus Remote Write Config
```
