### PR TITLE
Add tls-assets secret sharding

### DIFF
--- a/pkg/operator/sharded-secret.go
+++ b/pkg/operator/sharded-secret.go
@@ -1,0 +1,162 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// MaxSecretDataSizeBytes is the maximum data size that a single secret shard
+// may use. This is lower than v1.MaxSecretSize in order to reserve space for
+// metadata and the rest of the secret k8s object.
+const MaxSecretDataSizeBytes = v1.MaxSecretSize - 50_000
+
+// ShardedSecret is k8s secret data that is sharded across multiple enumerated
+// k8s secrets. This is used to circumvent the size limitation of k8s secrets.
+type ShardedSecret struct {
+	namePrefix   string
+	template     *v1.Secret
+	data         map[string][]byte
+	secretShards []*v1.Secret
+}
+
+// NewShardedSecret takes a v1.Secret as template and a secret name prefix and
+// returns a new ShardedSecret.
+func NewShardedSecret(template *v1.Secret, namePrefix string) *ShardedSecret {
+	return &ShardedSecret{
+		namePrefix: namePrefix,
+		template:   template,
+		data:       make(map[string][]byte),
+	}
+}
+
+// AppendData adds data to the secrets data portion. Already existing keys get
+// overwritten.
+func (s *ShardedSecret) AppendData(key string, data []byte) {
+	if s == nil {
+		return
+	}
+	s.data[key] = data
+}
+
+// StoreSecrets creates the individual secret shards and stores it via sClient.
+func (s *ShardedSecret) StoreSecrets(ctx context.Context, sClient corev1.SecretInterface) error {
+	if s == nil {
+		return nil
+	}
+	secrets := s.shard()
+	for _, secret := range secrets {
+		err := k8sutil.CreateOrUpdateSecret(ctx, sClient, secret)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create secret shard %q", secret.Name)
+		}
+	}
+	return s.cleanupExcessSecretShards(ctx, sClient, len(secrets)-1, s.namePrefix)
+}
+
+// shard does the in-memory sharding of the secret data.
+func (s *ShardedSecret) shard() []*v1.Secret {
+	// we need to iterate over the data in a stable order to avoid multiple
+	// re-shardings followed by secret updates just because the order of data
+	// items in the map changed and would now end up in another secret shard.
+	var keys []string
+	for k := range s.data {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	// reset s.secretShards to ensure it's empty in case shard() is called multiple times
+	s.secretShards = []*v1.Secret{}
+	curSecretIndex := 0
+	curSecretSize := 0
+	curSecret := s.newSecretShard(curSecretIndex)
+
+	for _, key := range keys {
+		v := s.data[key]
+		vSize := len(key) + len(v)
+		if curSecretSize+vSize > MaxSecretDataSizeBytes {
+			s.secretShards = append(s.secretShards, curSecret)
+			curSecretIndex++
+			curSecretSize = 0
+			curSecret = s.newSecretShard(curSecretIndex)
+		}
+		curSecretSize += vSize
+		curSecret.Data[key] = v
+	}
+	s.secretShards = append(s.secretShards, curSecret)
+	return s.secretShards
+}
+
+// newSecretShard allocates a new secret shard according to the secret template
+// suffixed by index.
+func (s *ShardedSecret) newSecretShard(index int) *v1.Secret {
+	newShardSecret := s.template.DeepCopy()
+	newShardSecret.Data = make(map[string][]byte)
+	newShardSecret.Name = makeShardSecretName(newShardSecret.Name, index)
+	return newShardSecret
+}
+
+// cleanupExcessSecretShards removes excess secret shards that are no longer in use.
+// It also tries to remove a non-sharded secret that exactly matches the name
+// prefix in order to make sure that operator version upgrades run smoothly.
+func (s *ShardedSecret) cleanupExcessSecretShards(ctx context.Context, sClient corev1.SecretInterface, lastSecretIndex int, sNamePrefix string) error {
+	for i := lastSecretIndex + 1; ; i++ {
+		secretName := makeShardSecretName(sNamePrefix, i)
+		err := sClient.Delete(ctx, secretName, metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// we reached the end of existing secrets
+			break
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete excess secret shard %q", secretName)
+		}
+	}
+	// Cleanup possibly existing secret of older non-sharded secret versions.
+	// TODO: remove this in future versions to save the unnecessary API calls.
+	err := sClient.Delete(ctx, sNamePrefix, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete non-sharded secret %q from older controller version", sNamePrefix)
+	}
+	return nil
+}
+
+func makeShardSecretName(prefix string, index int) string {
+	return fmt.Sprintf("%s-%d", prefix, index)
+}
+
+// ShardNames returns the names of the secret shards. This only returns
+// something after StoreSecrets was called and the actual sharding took place.
+func (s *ShardedSecret) ShardNames() []string {
+	if s == nil {
+		return []string{}
+	}
+	var names []string
+	for i := 0; i < len(s.secretShards); i++ {
+		names = append(names, makeShardSecretName(s.namePrefix, i))
+	}
+	return names
+}

--- a/pkg/operator/sharded-secret.go
+++ b/pkg/operator/sharded-secret.go
@@ -84,7 +84,7 @@ func (s *ShardedSecret) shard() []*v1.Secret {
 	for k := range s.data {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	sort.Strings(keys)
 
 	// reset s.secretShards to ensure it's empty in case shard() is called multiple times
 	s.secretShards = []*v1.Secret{}

--- a/pkg/operator/sharded-secret_test.go
+++ b/pkg/operator/sharded-secret_test.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestShardedSecret(t *testing.T) {
+	const namePrefix = "secret"
+
+	tt := []struct {
+		desc             string
+		input            map[string][]byte
+		expectShards     int
+		expectShardNames []string
+	}{
+		{
+			desc:             "empty data",
+			input:            make(map[string][]byte),
+			expectShards:     1,
+			expectShardNames: []string{namePrefix + "-0"},
+		},
+		{
+			desc: "one shard",
+			input: map[string][]byte{
+				"key": []byte("data"),
+			},
+			expectShards:     1,
+			expectShardNames: []string{namePrefix + "-0"},
+		},
+		{
+			desc: "exactly the size limit",
+			input: map[string][]byte{
+				"key": make([]byte, MaxSecretDataSizeBytes-3), // -3 because of the key size
+			},
+			expectShards:     1,
+			expectShardNames: []string{namePrefix + "-0"},
+		},
+		{
+			desc: "slightly over the size limit",
+			input: map[string][]byte{
+				"key": make([]byte, MaxSecretDataSizeBytes), // max size will push us over the limit because of the key size
+			},
+			expectShards:     2,
+			expectShardNames: []string{namePrefix + "-0", namePrefix + "-1"},
+		},
+		{
+			desc: "three shards",
+			input: map[string][]byte{
+				"one":   make([]byte, MaxSecretDataSizeBytes-3), // -3 because of the key size
+				"two":   make([]byte, MaxSecretDataSizeBytes-3), // -3 because of the key size
+				"three": []byte("data"),
+			},
+			expectShards:     3,
+			expectShardNames: []string{namePrefix + "-0", namePrefix + "-1", namePrefix + "-2"},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			template := &v1.Secret{}
+			s := NewShardedSecret(template, namePrefix)
+			for k, v := range tc.input {
+				s.AppendData(k, v)
+			}
+			secrets := s.shard()
+			if len(secrets) != tc.expectShards {
+				t.Errorf("sharding failed: got %d shards; want %d", len(secrets), tc.expectShards)
+			}
+			if diff := cmp.Diff(tc.expectShardNames, s.ShardNames()); diff != "" {
+				t.Errorf("ShardNames() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -39,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -1229,7 +1227,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return errors.Wrap(err, "creating config failed")
 	}
 
-	assetShards, err := c.createOrUpdateTLSAssetSecrets(ctx, p, assetStore)
+	tlsAssets, err := c.createOrUpdateTLSAssetSecrets(ctx, p, assetStore)
 	if err != nil {
 		return errors.Wrap(err, "creating tls asset secret failed")
 	}
@@ -1263,12 +1261,12 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			ss := obj.(*appsv1.StatefulSet)
 			spec = ss.Spec
 		}
-		newSSetInputHash, err := createSSetInputHash(*p, c.config, ruleConfigMapNames, assetShards, spec)
+		newSSetInputHash, err := createSSetInputHash(*p, c.config, ruleConfigMapNames, tlsAssets, spec)
 		if err != nil {
 			return err
 		}
 
-		sset, err := makeStatefulSet(ssetName, *p, &c.config, ruleConfigMapNames, newSSetInputHash, int32(shard), assetShards)
+		sset, err := makeStatefulSet(ssetName, *p, &c.config, ruleConfigMapNames, newSSetInputHash, int32(shard), tlsAssets.ShardNames())
 		if err != nil {
 			return errors.Wrap(err, "making statefulset failed")
 		}
@@ -1371,14 +1369,14 @@ func checkPrometheusSpecDeprecation(key string, p *monitoringv1.Prometheus, logg
 	}
 }
 
-func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfigMapNames []string, as int, ss interface{}) (string, error) {
+func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfigMapNames []string, tlsAssets *operator.ShardedSecret, ss interface{}) (string, error) {
 	hash, err := hashstructure.Hash(struct {
 		P monitoringv1.Prometheus
 		C operator.Config
 		S interface{}
 		R []string `hash:"set"`
-		A int
-	}{p, c, ss, ruleConfigMapNames, as},
+		A []string `hash:"set"`
+	}{p, c, ss, ruleConfigMapNames, tlsAssets.ShardNames()},
 		nil,
 	)
 	if err != nil {
@@ -1637,63 +1635,32 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	return k8sutil.CreateOrUpdateSecret(ctx, sClient, s)
 }
 
-func (c *Operator) createOrUpdateTLSAssetSecrets(ctx context.Context, p *monitoringv1.Prometheus, store *assets.Store) (assetShards int, err error) {
-	// k8s/etcd has an object limit of 1048576 bytes
-	// We use an upper limit of 950k for the data part to leave enough room for
-	// metadata and the rest of the object.
-	const maxSecretSizeBytes = 950_000
-
+func (c *Operator) createOrUpdateTLSAssetSecrets(ctx context.Context, p *monitoringv1.Prometheus, store *assets.Store) (*operator.ShardedSecret, error) {
 	labels := c.config.Labels.Merge(managedByOperatorLabels)
+	template := newTLSAssetSecret(p, labels)
 
-	var secrets []*v1.Secret
+	sSecret := operator.NewShardedSecret(template, tlsAssetsSecretName(p.Name))
 
-	curSecretIndex := 0
-	curSecretSize := 0
-	tlsAssetsSecret := newTLSAssetSecret(curSecretIndex, p, labels)
-
-	// we need to iterate over TLSAssets in a stable order to avoid multiple TLS
-	// asset secret updates just because the order of assets changed and would
-	// now end up in another secret shard.
-	var aKeys []assets.TLSAssetKey
-	for key := range store.TLSAssets {
-		aKeys = append(aKeys, key)
+	for k, v := range store.TLSAssets {
+		sSecret.AppendData(k.String(), []byte(v))
 	}
-	sort.Slice(aKeys, func(i, j int) bool { return aKeys[i].String() < aKeys[j].String() })
-
-	for _, key := range aKeys {
-		asset := store.TLSAssets[key]
-		assetSize := len(key.String()) + len(asset)
-		if curSecretSize+assetSize > maxSecretSizeBytes {
-			secrets = append(secrets, tlsAssetsSecret)
-			curSecretIndex++
-			curSecretSize = 0
-			tlsAssetsSecret = newTLSAssetSecret(curSecretIndex, p, labels)
-		}
-		curSecretSize += assetSize
-		tlsAssetsSecret.Data[key.String()] = []byte(asset)
-	}
-	secrets = append(secrets, tlsAssetsSecret)
-	lastSecretIndex := curSecretIndex
 
 	sClient := c.kclient.CoreV1().Secrets(p.Namespace)
 
-	for _, secret := range secrets {
-		err := k8sutil.CreateOrUpdateSecret(ctx, sClient, secret)
-		if err != nil {
-			return 0, errors.Wrapf(err, "failed to create TLS assets secret %q for Prometheus", secret.Name)
-		}
-		level.Debug(c.logger).Log("msg", fmt.Sprintf("tls-asset secret: stored %s/%s", secret.Namespace, secret.Name))
+	if err := sSecret.StoreSecrets(ctx, sClient); err != nil {
+		return nil, errors.Wrapf(err, "failed to create TLS assets secret for Prometheus")
 	}
 
-	// cleanup old secrets
-	return len(secrets), cleanupOldSecrets(ctx, sClient, lastSecretIndex, p.Name)
+	level.Debug(c.logger).Log("msg", "tls-asset secret: stored")
+
+	return sSecret, nil
 }
 
-func newTLSAssetSecret(index int, p *monitoringv1.Prometheus, labels map[string]string) *v1.Secret {
+func newTLSAssetSecret(p *monitoringv1.Prometheus, labels map[string]string) *v1.Secret {
 	boolTrue := true
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   tlsAssetsSecretNameWithIndex(p.Name, index),
+			Name:   tlsAssetsSecretName(p.Name),
 			Labels: labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -1708,33 +1675,6 @@ func newTLSAssetSecret(index int, p *monitoringv1.Prometheus, labels map[string]
 		},
 		Data: map[string][]byte{},
 	}
-}
-
-func cleanupOldSecrets(ctx context.Context, sClient corev1.SecretInterface, lastIndex int, pName string) error {
-	for i := lastIndex + 1; ; i++ {
-		secretName := tlsAssetsSecretNameWithIndex(pName, i)
-		err := sClient.Delete(ctx, secretName, metav1.DeleteOptions{})
-		if apierrors.IsNotFound(err) {
-			// we reached the end of existing secrets
-			break
-		}
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete old TLS assets secret %q for Prometheus", secretName)
-		}
-	}
-
-	// cleanup possibly existing secret of older operator versions
-	// TODO: remove this in future versions to save the unnecessary API call.
-	secretName := tlsAssetsSecretName(pName)
-	err := sClient.Delete(ctx, secretName, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Wrapf(err, "failed to delete old TLS assets secret %q for Prometheus", secretName)
-	}
-
-	return nil
 }
 
 func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitoringv1.Prometheus) error {

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -42,11 +42,11 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 	p2.Spec.Version = "v1.7.2"
 	c := operator.Config{}
 
-	p1Hash, err := createSSetInputHash(p1, c, []string{}, nil)
+	p1Hash, err := createSSetInputHash(p1, c, []string{}, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p2Hash, err := createSSetInputHash(p2, c, []string{}, nil)
+	p2Hash, err := createSSetInputHash(p2, c, []string{}, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -42,11 +42,11 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 	p2.Spec.Version = "v1.7.2"
 	c := operator.Config{}
 
-	p1Hash, err := createSSetInputHash(p1, c, []string{}, 0, nil)
+	p1Hash, err := createSSetInputHash(p1, c, []string{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p2Hash, err := createSSetInputHash(p2, c, []string{}, 0, nil)
+	p2Hash, err := createSSetInputHash(p2, c, []string{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -98,6 +98,7 @@ func makeStatefulSet(
 	ruleConfigMapNames []string,
 	inputHash string,
 	shard int32,
+	assetShards int,
 ) (*appsv1.StatefulSet, error) {
 	// p is passed in by value, not by reference. But p contains references like
 	// to annotation map, that do not get copied on function invocation. Ensure to
@@ -144,7 +145,7 @@ func makeStatefulSet(
 		}
 	}
 
-	spec, err := makeStatefulSetSpec(p, config, shard, ruleConfigMapNames, parsedVersion)
+	spec, err := makeStatefulSetSpec(p, config, shard, ruleConfigMapNames, assetShards, parsedVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "make StatefulSet spec")
 	}
@@ -321,7 +322,7 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config operator.Config) 
 }
 
 func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard int32, ruleConfigMapNames []string,
-	version semver.Version) (*appsv1.StatefulSetSpec, error) {
+	assetShards int, version semver.Version) (*appsv1.StatefulSetSpec, error) {
 	// Prometheus may take quite long to shut down to checkpoint existing data.
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
@@ -466,6 +467,23 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		promArgs[i] = "-" + a
 	}
 
+	assetsVolume := v1.Volume{
+		Name: "tls-assets",
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{},
+			},
+		},
+	}
+	for i := 0; i < assetShards; i++ {
+		assetsVolume.Projected.Sources = append(assetsVolume.Projected.Sources,
+			v1.VolumeProjection{
+				Secret: &v1.SecretProjection{
+					LocalObjectReference: v1.LocalObjectReference{Name: tlsAssetsSecretNameWithIndex(p.Name, i)},
+				},
+			})
+	}
+
 	volumes := []v1.Volume{
 		{
 			Name: "config",
@@ -475,14 +493,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				},
 			},
 		},
-		{
-			Name: "tls-assets",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: tlsAssetsSecretName(p.Name),
-				},
-			},
-		},
+		assetsVolume,
 		{
 			Name: "config-out",
 			VolumeSource: v1.VolumeSource{
@@ -925,6 +936,10 @@ func configSecretName(name string) string {
 
 func tlsAssetsSecretName(name string) string {
 	return fmt.Sprintf("%s-tls-assets", prefixedName(name))
+}
+
+func tlsAssetsSecretNameWithIndex(name string, index int) string {
+	return fmt.Sprintf("%s-%d", tlsAssetsSecretName(name), index)
 }
 
 func WebConfigSecretName(name string) string {

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -84,7 +84,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestPodLabelsAnnotations(t *testing.T) {
 				Labels:      labels,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	require.NoError(t, err)
 	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
 		t.Fatal("Pod labels are not properly propagated")
@@ -139,7 +139,7 @@ func TestPodLabelsShouldNotBeSelectorLabels(t *testing.T) {
 				Labels: labels,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 
@@ -178,7 +178,7 @@ func TestStatefulSetPVC(t *testing.T) {
 				VolumeClaimTemplate: pvc,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 	ssetPvc := sset.Spec.VolumeClaimTemplates[0]
@@ -210,7 +210,7 @@ func TestStatefulSetEmptyDir(t *testing.T) {
 				EmptyDir: &emptyDir,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -248,7 +248,7 @@ func TestStatefulSetEphemeral(t *testing.T) {
 				Ephemeral: &ephemeral,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -324,7 +324,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 										{
 											Secret: &v1.SecretProjection{
 												LocalObjectReference: v1.LocalObjectReference{
-													Name: tlsAssetsSecretNameWithIndex("volume-init-test", 0),
+													Name: tlsAssetsSecretName("volume-init-test") + "-0",
 												},
 											},
 										},
@@ -385,7 +385,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 				"test-secret1",
 			},
 		},
-	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, 1)
+	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test") + "-0"})
 
 	require.NoError(t, err)
 
@@ -405,7 +405,7 @@ func TestAdditionalConfigMap(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			ConfigMaps: []string{"test-cm1"},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -436,7 +436,7 @@ func TestListenLocal(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			ListenLocal: true,
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -512,7 +512,7 @@ func TestListenTLS(t *testing.T) {
 			},
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -581,7 +581,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:     "my-unrelated-tag",
 				Version: "v2.3.2",
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -599,7 +599,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:     "my-unrelated-tag",
 				Version: "v2.3.2",
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -620,7 +620,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -640,7 +640,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -658,7 +658,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -677,7 +677,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -694,7 +694,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 			Spec: monitoringv1.PrometheusSpec{
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -712,7 +712,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				SHA:   "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -730,7 +730,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:   "my-unrelated-tag",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -749,7 +749,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:   "my-unrelated-tag",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -786,7 +786,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, prometheusBaseImageConfig, nil, "", 0, 0)
+	}, prometheusBaseImageConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 
@@ -824,7 +824,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, thanosBaseImageConfig, nil, "", 0, 0)
+	}, thanosBaseImageConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 
@@ -846,7 +846,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -869,7 +869,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -894,7 +894,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Image:   &thanosImage,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -912,7 +912,7 @@ func TestThanosResourcesNotSet(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -940,7 +940,7 @@ func TestThanosResourcesSet(t *testing.T) {
 				Resources: expected,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -956,7 +956,7 @@ func TestThanosNoObjectStorage(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -999,7 +999,7 @@ func TestThanosObjectStorage(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1087,7 +1087,7 @@ func TestThanosObjectStorageFile(t *testing.T) {
 				ObjectStorageConfigFile: &testPath,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1175,7 +1175,7 @@ func TestThanosTracing(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1238,7 +1238,7 @@ func TestThanosSideCarVolumes(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1291,7 +1291,7 @@ func TestRetentionSize(t *testing.T) {
 				Version:       test.version,
 				RetentionSize: test.specRetentionSize,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1333,7 +1333,7 @@ func TestRetention(t *testing.T) {
 				Version:   test.version,
 				Retention: test.specRetention,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1372,7 +1372,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 			Replicas: &replicas,
 			Shards:   &shards,
 		},
-	}, testConfig, nil, "", 1, 0)
+	}, testConfig, nil, "", 1, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1410,7 +1410,7 @@ func TestSidecarsNoResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1440,7 +1440,7 @@ func TestSidecarsNoRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1473,7 +1473,7 @@ func TestSidecarsNoLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1506,7 +1506,7 @@ func TestSidecarsNoCPUResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1540,7 +1540,7 @@ func TestSidecarsNoCPURequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1575,7 +1575,7 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1610,7 +1610,7 @@ func TestSidecarsNoMemoryResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1644,7 +1644,7 @@ func TestSidecarsNoMemoryRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1679,7 +1679,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, 0)
+	}, testConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1702,7 +1702,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 
 func TestAdditionalContainers(t *testing.T) {
 	// The base to compare everything against
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0, 0)
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0, nil)
 	require.NoError(t, err)
 
 	// Add an extra container
@@ -1714,7 +1714,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers)+1 != len(addSset.Spec.Template.Spec.Containers) {
@@ -1733,7 +1733,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers) != len(modSset.Spec.Template.Spec.Containers) {
@@ -1776,7 +1776,7 @@ func TestWALCompression(t *testing.T) {
 				Version:        test.version,
 				WALCompression: test.enabled,
 			},
-		}, defaultTestConfig, nil, "", 0, 0)
+		}, defaultTestConfig, nil, "", 0, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1807,7 +1807,7 @@ func TestThanosListenLocal(t *testing.T) {
 				ListenLocal: true,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1828,7 +1828,7 @@ func TestThanosListenLocal(t *testing.T) {
 }
 
 func TestTerminationPolicy(t *testing.T) {
-	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0, 0)
+	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1845,7 +1845,7 @@ func TestEnableFeaturesWithOneFeature(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			EnableFeatures: []string{"exemplar-storage"},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1868,7 +1868,7 @@ func TestEnableFeaturesWithMultipleFeature(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			EnableFeatures: []string{"exemplar-storage1", "exemplar-storage2"},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1894,7 +1894,7 @@ func TestWebPageTitle(t *testing.T) {
 				PageTitle: &pageTitle,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1941,7 +1941,7 @@ func TestExpectedStatefulSetShardNames(t *testing.T) {
 func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 	statefulSet, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1956,7 +1956,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			MinReadySeconds: &expect,
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1969,7 +1969,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 
 func TestConfigReloader(t *testing.T) {
 	expectedShardNum := 0
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum), 0)
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum), nil)
 	require.NoError(t, err)
 
 	expectedArgsConfigReloader := []string{
@@ -2021,7 +2021,7 @@ func TestThanosReadyTimeout(t *testing.T) {
 				ReadyTimeout: "20m",
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, 0)
+	}, defaultTestConfig, nil, "", 0, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -84,7 +84,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestPodLabelsAnnotations(t *testing.T) {
 				Labels:      labels,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	require.NoError(t, err)
 	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
 		t.Fatal("Pod labels are not properly propagated")
@@ -139,7 +139,7 @@ func TestPodLabelsShouldNotBeSelectorLabels(t *testing.T) {
 				Labels: labels,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 
@@ -178,7 +178,7 @@ func TestStatefulSetPVC(t *testing.T) {
 				VolumeClaimTemplate: pvc,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 	ssetPvc := sset.Spec.VolumeClaimTemplates[0]
@@ -210,7 +210,7 @@ func TestStatefulSetEmptyDir(t *testing.T) {
 				EmptyDir: &emptyDir,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -248,7 +248,7 @@ func TestStatefulSetEphemeral(t *testing.T) {
 				Ephemeral: &ephemeral,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -319,8 +319,16 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 						{
 							Name: "tls-assets",
 							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
-									SecretName: tlsAssetsSecretName("volume-init-test"),
+								Projected: &v1.ProjectedVolumeSource{
+									Sources: []v1.VolumeProjection{
+										{
+											Secret: &v1.SecretProjection{
+												LocalObjectReference: v1.LocalObjectReference{
+													Name: tlsAssetsSecretNameWithIndex("volume-init-test", 0),
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -377,7 +385,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 				"test-secret1",
 			},
 		},
-	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0)
+	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, 1)
 
 	require.NoError(t, err)
 
@@ -397,7 +405,7 @@ func TestAdditionalConfigMap(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			ConfigMaps: []string{"test-cm1"},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -428,7 +436,7 @@ func TestListenLocal(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			ListenLocal: true,
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -504,7 +512,7 @@ func TestListenTLS(t *testing.T) {
 			},
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -573,7 +581,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:     "my-unrelated-tag",
 				Version: "v2.3.2",
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -591,7 +599,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:     "my-unrelated-tag",
 				Version: "v2.3.2",
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -612,7 +620,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -632,7 +640,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -650,7 +658,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -669,7 +677,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Version: "v2.3.2",
 				Image:   &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -686,7 +694,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 			Spec: monitoringv1.PrometheusSpec{
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -704,7 +712,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				SHA:   "7384a79f4b4991bf8269e7452390249b7c70bcdd10509c8c1c6c6e30e32fb324",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -722,7 +730,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:   "my-unrelated-tag",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -741,7 +749,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 				Tag:   "my-unrelated-tag",
 				Image: &image,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -778,7 +786,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, prometheusBaseImageConfig, nil, "", 0)
+	}, prometheusBaseImageConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 
@@ -816,7 +824,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, thanosBaseImageConfig, nil, "", 0)
+	}, thanosBaseImageConfig, nil, "", 0, 0)
 
 	require.NoError(t, err)
 
@@ -838,7 +846,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -861,7 +869,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -886,7 +894,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Image:   &thanosImage,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -904,7 +912,7 @@ func TestThanosResourcesNotSet(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -932,7 +940,7 @@ func TestThanosResourcesSet(t *testing.T) {
 				Resources: expected,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -948,7 +956,7 @@ func TestThanosNoObjectStorage(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -991,7 +999,7 @@ func TestThanosObjectStorage(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1079,7 +1087,7 @@ func TestThanosObjectStorageFile(t *testing.T) {
 				ObjectStorageConfigFile: &testPath,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1167,7 +1175,7 @@ func TestThanosTracing(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1230,7 +1238,7 @@ func TestThanosSideCarVolumes(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1283,7 +1291,7 @@ func TestRetentionSize(t *testing.T) {
 				Version:       test.version,
 				RetentionSize: test.specRetentionSize,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1325,7 +1333,7 @@ func TestRetention(t *testing.T) {
 				Version:   test.version,
 				Retention: test.specRetention,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1364,7 +1372,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 			Replicas: &replicas,
 			Shards:   &shards,
 		},
-	}, testConfig, nil, "", 1)
+	}, testConfig, nil, "", 1, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1402,7 +1410,7 @@ func TestSidecarsNoResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1432,7 +1440,7 @@ func TestSidecarsNoRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1465,7 +1473,7 @@ func TestSidecarsNoLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1498,7 +1506,7 @@ func TestSidecarsNoCPUResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1532,7 +1540,7 @@ func TestSidecarsNoCPURequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1567,7 +1575,7 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1602,7 +1610,7 @@ func TestSidecarsNoMemoryResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1636,7 +1644,7 @@ func TestSidecarsNoMemoryRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1671,7 +1679,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0)
+	}, testConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1694,7 +1702,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 
 func TestAdditionalContainers(t *testing.T) {
 	// The base to compare everything against
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0)
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0, 0)
 	require.NoError(t, err)
 
 	// Add an extra container
@@ -1706,7 +1714,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers)+1 != len(addSset.Spec.Template.Spec.Containers) {
@@ -1725,7 +1733,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers) != len(modSset.Spec.Template.Spec.Containers) {
@@ -1768,7 +1776,7 @@ func TestWALCompression(t *testing.T) {
 				Version:        test.version,
 				WALCompression: test.enabled,
 			},
-		}, defaultTestConfig, nil, "", 0)
+		}, defaultTestConfig, nil, "", 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1799,7 +1807,7 @@ func TestThanosListenLocal(t *testing.T) {
 				ListenLocal: true,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1820,7 +1828,7 @@ func TestThanosListenLocal(t *testing.T) {
 }
 
 func TestTerminationPolicy(t *testing.T) {
-	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0)
+	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1837,7 +1845,7 @@ func TestEnableFeaturesWithOneFeature(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			EnableFeatures: []string{"exemplar-storage"},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1860,7 +1868,7 @@ func TestEnableFeaturesWithMultipleFeature(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			EnableFeatures: []string{"exemplar-storage1", "exemplar-storage2"},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1886,7 +1894,7 @@ func TestWebPageTitle(t *testing.T) {
 				PageTitle: &pageTitle,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1933,7 +1941,7 @@ func TestExpectedStatefulSetShardNames(t *testing.T) {
 func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 	statefulSet, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1948,7 +1956,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			MinReadySeconds: &expect,
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1961,7 +1969,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 
 func TestConfigReloader(t *testing.T) {
 	expectedShardNum := 0
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum))
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum), 0)
 	require.NoError(t, err)
 
 	expectedArgsConfigReloader := []string{
@@ -2013,7 +2021,7 @@ func TestThanosReadyTimeout(t *testing.T) {
 				ReadyTimeout: "20m",
 			},
 		},
-	}, defaultTestConfig, nil, "", 0)
+	}, defaultTestConfig, nil, "", 0, 0)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1692,7 +1692,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					Secrets(ns).
-					Get(context.Background(), "prometheus-"+prometheusName+"-tls-assets", metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName+"-tls-assets-0", metav1.GetOptions{})
 			},
 			MaxExpectedChanges: 2,
 		},


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

k8s secrets have a default size limitation of 1048576 bytes. Once this
size gets exceeded the k8s API server will refuse to update the secret.
This introduces a sharding approach where all tls-assets are distributed
over shards of tls asset secrets and mounted into the prometheus pod
through volume projection.

Fixes #4353

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add tls-assets secret sharding to support a high amount of tls assets
```
