### PR TITLE
pkg/prometheus: Add validations for relabel configs

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9085,8 +9085,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -9235,8 +9244,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -9638,8 +9656,17 @@ spec:
                     of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                   properties:
                     action:
+                      default: replace
                       description: Action to perform based on regex matching. Default
                         is 'replace'
+                      enum:
+                      - replace
+                      - keep
+                      - drop
+                      - hashmod
+                      - labelmap
+                      - labeldrop
+                      - labelkeep
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -9824,8 +9851,17 @@ spec:
                             configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
+                              default: replace
                               description: Action to perform based on regex matching.
                                 Default is 'replace'
+                              enum:
+                              - replace
+                              - keep
+                              - drop
+                              - hashmod
+                              - labelmap
+                              - labeldrop
+                              - labelkeep
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -9926,8 +9962,17 @@ spec:
                             configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
+                              default: replace
                               description: Action to perform based on regex matching.
                                 Default is 'replace'
+                              enum:
+                              - replace
+                              - keep
+                              - drop
+                              - hashmod
+                              - labelmap
+                              - labeldrop
+                              - labelkeep
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -15164,8 +15209,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -18660,8 +18714,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -18810,8 +18873,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -190,8 +190,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -340,8 +349,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -160,8 +160,17 @@ spec:
                     of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                   properties:
                     action:
+                      default: replace
                       description: Action to perform based on regex matching. Default
                         is 'replace'
+                      enum:
+                      - replace
+                      - keep
+                      - drop
+                      - hashmod
+                      - labelmap
+                      - labeldrop
+                      - labelkeep
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -346,8 +355,17 @@ spec:
                             configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
+                              default: replace
                               description: Action to perform based on regex matching.
                                 Default is 'replace'
+                              enum:
+                              - replace
+                              - keep
+                              - drop
+                              - hashmod
+                              - labelmap
+                              - labeldrop
+                              - labelkeep
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -448,8 +466,17 @@ spec:
                             configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
+                              default: replace
                               description: Action to perform based on regex matching.
                                 Default is 'replace'
+                              enum:
+                              - replace
+                              - keep
+                              - drop
+                              - hashmod
+                              - labelmap
+                              - labeldrop
+                              - labelkeep
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5073,8 +5073,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -159,8 +159,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -309,8 +318,17 @@ spec:
                           configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
+                            default: replace
                             description: Action to perform based on regex matching.
                               Default is 'replace'
+                            enum:
+                            - replace
+                            - keep
+                            - drop
+                            - hashmod
+                            - labelmap
+                            - labeldrop
+                            - labelkeep
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -200,7 +200,17 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                             "properties": {
                               "action": {
+                                "default": "replace",
                                 "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "enum": [
+                                  "replace",
+                                  "keep",
+                                  "drop",
+                                  "hashmod",
+                                  "labelmap",
+                                  "labeldrop",
+                                  "labelkeep"
+                                ],
                                 "type": "string"
                               },
                               "modulus": {
@@ -363,7 +373,17 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                             "properties": {
                               "action": {
+                                "default": "replace",
                                 "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "enum": [
+                                  "replace",
+                                  "keep",
+                                  "drop",
+                                  "hashmod",
+                                  "labelmap",
+                                  "labeldrop",
+                                  "labelkeep"
+                                ],
                                 "type": "string"
                               },
                               "modulus": {

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -170,7 +170,17 @@
                       "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                       "properties": {
                         "action": {
+                          "default": "replace",
                           "description": "Action to perform based on regex matching. Default is 'replace'",
+                          "enum": [
+                            "replace",
+                            "keep",
+                            "drop",
+                            "hashmod",
+                            "labelmap",
+                            "labeldrop",
+                            "labelkeep"
+                          ],
                           "type": "string"
                         },
                         "modulus": {
@@ -377,7 +387,17 @@
                               "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                               "properties": {
                                 "action": {
+                                  "default": "replace",
                                   "description": "Action to perform based on regex matching. Default is 'replace'",
+                                  "enum": [
+                                    "replace",
+                                    "keep",
+                                    "drop",
+                                    "hashmod",
+                                    "labelmap",
+                                    "labeldrop",
+                                    "labelkeep"
+                                  ],
                                   "type": "string"
                                 },
                                 "modulus": {
@@ -474,7 +494,17 @@
                               "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                               "properties": {
                                 "action": {
+                                  "default": "replace",
                                   "description": "Action to perform based on regex matching. Default is 'replace'",
+                                  "enum": [
+                                    "replace",
+                                    "keep",
+                                    "drop",
+                                    "hashmod",
+                                    "labelmap",
+                                    "labeldrop",
+                                    "labelkeep"
+                                  ],
                                   "type": "string"
                                 },
                                 "modulus": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4768,7 +4768,17 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                             "properties": {
                               "action": {
+                                "default": "replace",
                                 "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "enum": [
+                                  "replace",
+                                  "keep",
+                                  "drop",
+                                  "hashmod",
+                                  "labelmap",
+                                  "labeldrop",
+                                  "labelkeep"
+                                ],
                                 "type": "string"
                               },
                               "modulus": {

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -168,7 +168,17 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                             "properties": {
                               "action": {
+                                "default": "replace",
                                 "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "enum": [
+                                  "replace",
+                                  "keep",
+                                  "drop",
+                                  "hashmod",
+                                  "labelmap",
+                                  "labeldrop",
+                                  "labelkeep"
+                                ],
                                 "type": "string"
                               },
                               "modulus": {
@@ -331,7 +341,17 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs",
                             "properties": {
                               "action": {
+                                "default": "replace",
                                 "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "enum": [
+                                  "replace",
+                                  "keep",
+                                  "drop",
+                                  "hashmod",
+                                  "labelmap",
+                                  "labeldrop",
+                                  "labelkeep"
+                                ],
                                 "type": "string"
                               },
                               "modulus": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -823,6 +823,8 @@ type RelabelConfig struct {
 	//regular expression matches. Regex capture groups are available. Default is '$1'
 	Replacement string `json:"replacement,omitempty"`
 	// Action to perform based on regex matching. Default is 'replace'
+	//+kubebuilder:validation:Enum=replace;keep;drop;hashmod;labelmap;labeldrop;labelkeep
+	//+kubebuilder:default=replace
 	Action string `json:"action,omitempty"`
 }
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2128,7 +2128,7 @@ func validateRelabelConfig(rc monitoringv1.RelabelConfig) error {
 	relabelTarget := regexp.MustCompile(`^(?:(?:[a-zA-Z_]|\$(?:\{\w+\}|\w+))+\w*)+$`)
 
 	if _, err := relabel.NewRegexp(rc.Regex); err != nil {
-		return errors.Errorf("regex for relabel configuration %s doesn't compile", rc.Regex)
+		return errors.Wrapf(err, "invalid regex %s for relabel configuration", rc.Regex)
 	}
 	if rc.Modulus == 0 && rc.Action == string(relabel.HashMod) {
 		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -29,6 +29,8 @@ import (
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1795,6 +1797,22 @@ func (c *Operator) selectServiceMonitors(ctx context.Context, p *monitoringv1.Pr
 			if err = store.AddSafeAuthorizationCredentials(ctx, sm.GetNamespace(), endpoint.Authorization, smAuthKey); err != nil {
 				break
 			}
+
+			for _, rl := range endpoint.RelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
+
+			for _, rl := range endpoint.MetricRelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
 		}
 
 		if err != nil {
@@ -1894,6 +1912,22 @@ func (c *Operator) selectPodMonitors(ctx context.Context, p *monitoringv1.Promet
 			pmAuthKey := fmt.Sprintf("podMonitor/auth/%s/%s/%d", pm.GetNamespace(), pm.GetName(), i)
 			if err = store.AddSafeAuthorizationCredentials(ctx, pm.GetNamespace(), endpoint.Authorization, pmAuthKey); err != nil {
 				break
+			}
+
+			for _, rl := range endpoint.RelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
+
+			for _, rl := range endpoint.MetricRelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
 			}
 		}
 
@@ -2010,6 +2044,14 @@ func (c *Operator) selectProbes(ctx context.Context, p *monitoringv1.Prometheus,
 			continue
 		}
 
+		for _, rl := range probe.Spec.MetricRelabelConfigs {
+			if rl.Action != "" {
+				if err = validateRelabelConfig(*rl); err != nil {
+					rejectFn(probe, err)
+					continue
+				}
+			}
+		}
 		res[probeName] = probe
 	}
 
@@ -2079,5 +2121,39 @@ func validateRemoteWriteSpec(spec monitoringv1.RemoteWriteSpec) error {
 		return errors.Errorf("%s can't be set at the same time, at most one of them must be defined", strings.Join(nonNilFields, " and "))
 	}
 
+	return nil
+}
+
+func validateRelabelConfig(rc monitoringv1.RelabelConfig) error {
+	relabelTarget := regexp.MustCompile(`^(?:(?:[a-zA-Z_]|\$(?:\{\w+\}|\w+))+\w*)+$`)
+
+	if _, err := relabel.NewRegexp(rc.Regex); err != nil {
+		return errors.Errorf("regex for relabel configuration %s doesn't compile", rc.Regex)
+	}
+	if rc.Modulus == 0 && rc.Action == string(relabel.HashMod) {
+		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
+	}
+	if (rc.Action == string(relabel.Replace) || rc.Action == string(relabel.HashMod)) && rc.TargetLabel == "" {
+		return errors.Errorf("relabel configuration for %s action needs targetLabel value", rc.Action)
+	}
+	if rc.Action == string(relabel.Replace) && !relabelTarget.MatchString(rc.TargetLabel) {
+		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+	}
+	if rc.Action == string(relabel.LabelMap) && !relabelTarget.MatchString(rc.Replacement) {
+		return errors.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
+	}
+	if rc.Action == string(relabel.HashMod) && !model.LabelName(rc.TargetLabel).IsValid() {
+		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+	}
+
+	if rc.Action == string(relabel.LabelDrop) || rc.Action == string(relabel.LabelKeep) {
+		if len(rc.SourceLabels) != 0 ||
+			rc.TargetLabel != "" ||
+			rc.Modulus != uint64(0) ||
+			rc.Separator != "" ||
+			rc.Replacement != "" {
+			return errors.Errorf("%s action requires only 'regex', and no other fields", rc.Action)
+		}
+	}
 	return nil
 }

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -266,44 +266,127 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 	}
 }
 
-func TestRelabelConfig(t *testing.T) {
+func TestValidateRelabelConfig(t *testing.T) {
 	for _, tc := range []struct {
+		scenario      string
 		relabelConfig monitoringv1.RelabelConfig
 		expectedErr   bool
 	}{
+		// Test invalid regex expression
 		{
+			scenario: "Invalid regex",
 			relabelConfig: monitoringv1.RelabelConfig{
-				Regex:       "invalid regex)",
-				Action:      "replace",
-				TargetLabel: "test_invalid_regex",
+				Regex: "invalid regex)",
 			},
 			expectedErr: true,
 		},
+		// Test invalid target label
 		{
+			scenario: "invalid target label",
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "replace",
 				TargetLabel: "l\\${3}",
 			},
 			expectedErr: true,
 		},
+		// Test empty target label for action replace
 		{
+			scenario: "empty target label for replace action",
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "replace",
 				TargetLabel: "",
 			},
 			expectedErr: true,
 		},
+		// Test empty target label for action hashmod
 		{
+			scenario: "empty target label for hashmod action",
 			relabelConfig: monitoringv1.RelabelConfig{
-				Action:      "replace",
-				TargetLabel: "test_valid_action_with_target_label",
+				Action:      "hashmod",
+				TargetLabel: "",
+			},
+			expectedErr: true,
+		},
+		// Test invalid hashmod relabel config
+		{
+			scenario: "invalid hashmod config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "hashmod",
+				Modulus:      0,
+				TargetLabel:  "__tmp_hashmod",
+			},
+			expectedErr: true,
+		},
+		// Test invalid labelmap relabel config
+		{
+			scenario: "invalid labelmap config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labelmap",
+				Regex:  "__meta_kubernetes_service_label_(.+)",
+			},
+			expectedErr: true,
+		},
+		// Test valid labelmap relabel config
+		{
+			scenario: "valid labelmap config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "labelmap",
+				Regex:       "__meta_kubernetes_service_label_(.+)",
+				Replacement: "k8s_$1",
+			},
+		},
+		// Test invalid labelkeep relabel config
+		{
+			scenario: "invalid labelkeep config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "labelkeep",
+				TargetLabel:  "__tmp_labelkeep",
+			},
+			expectedErr: true,
+		},
+		// Test valid labelkeep relabel config
+		{
+			scenario: "valid labelkeep config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labelkeep",
+			},
+		},
+		// Test valid labeldrop relabel config
+		{
+			scenario: "valid labeldrop config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labeldrop",
+				Regex:  "replica",
+			},
+		},
+		// Test valid relabel config
+		{
+			scenario: "valid hashmod config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "hashmod",
+				Modulus:      10,
+				TargetLabel:  "__tmp_hashmod",
+			},
+		},
+		// Test valid relabel config
+		{
+			scenario: "valid replace config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"__address__"},
+				Action:       "replace",
+				Regex:        "([^:]+)(?::\\d+)?",
+				Replacement:  "$1:80",
+				TargetLabel:  "__address__",
 			},
 		},
 	} {
-		t.Run(fmt.Sprintf("%s Action(%s)", tc.relabelConfig.Action, tc.relabelConfig.TargetLabel), func(t *testing.T) {
+		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
 			err := validateRelabelConfig(tc.relabelConfig)
 			if err != nil && !tc.expectedErr {
-				t.Fatalf("unexpected error occurred: %v", err)
+				t.Fatalf("expected no error, got: %v", err)
 			}
 			if err == nil && tc.expectedErr {
 				t.Fatalf("expected an error, got nil")


### PR DESCRIPTION
Fixes #2503, #3942

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This PR is to add validation for relabelling configs

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added validations for relabel configs
```
