### PR TITLE
pkg/prometheus: use /-/ready for the startup probe

### DIFF
--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -458,7 +458,7 @@ func TestListenLocal(t *testing.T) {
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
 	expectedStartupProbe := &v1.Probe{
-		Handler:          expectedProbeHandler("/-/healthy"),
+		Handler:          expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
 		FailureThreshold: 60,
@@ -521,7 +521,7 @@ func TestListenTLS(t *testing.T) {
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
 	expectedStartupProbe := &v1.Probe{
-		Handler:          expectedProbeHandler("/-/healthy"),
+		Handler:          expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
 		FailureThreshold: 60,


### PR DESCRIPTION
## Description

The /-/ready handler returns OK only after the TSDB initialization has
completed. The WAL replay can take a significant time for large setups
hence we enable the startup probe with a generous failure threshold (15
minutes) to ensure that the readiness probe only comes into effect once
Prometheus is effectively ready. We don't want to use the /-/healthy
handler here because it returns OK as soon as the web server is started
(irrespective of the WAL replay).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
use /-/ready endpoint for the startup probe
```
