### PR TITLE
use AlertmanagerConfigAllowList for alertmanager secret informer

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -19,6 +19,8 @@ This article lists arguments of operator executable.
 
 ```$ mdox-exec="./operator --help"
 Usage of ./operator:
+  -alertmanager-config-namespaces value
+    	Namespaces where AlertmanagerConfig custom resources and corresponding Secrets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for AlertmanagerConfig custom resources.
   -alertmanager-default-base-image string
     	Alertmanager default base image (path without tag/version) (default "quay.io/prometheus/alertmanager")
   -alertmanager-instance-namespaces value

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -63,11 +63,12 @@ const (
 )
 
 var (
-	ns             = namespaces{}
-	deniedNs       = namespaces{}
-	prometheusNs   = namespaces{}
-	alertmanagerNs = namespaces{}
-	thanosRulerNs  = namespaces{}
+	ns                   = namespaces{}
+	deniedNs             = namespaces{}
+	prometheusNs         = namespaces{}
+	alertmanagerNs       = namespaces{}
+	alertmanagerConfigNs = namespaces{}
+	thanosRulerNs        = namespaces{}
 )
 
 type namespaces map[string]struct{}
@@ -162,6 +163,7 @@ func init() {
 	flagset.Var(deniedNs, "deny-namespaces", "Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.")
 	flagset.Var(prometheusNs, "prometheus-instance-namespaces", "Namespaces where Prometheus custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.")
 	flagset.Var(alertmanagerNs, "alertmanager-instance-namespaces", "Namespaces where Alertmanager custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Alertmanager custom resources.")
+	flagset.Var(alertmanagerNs, "alertmanager-config-namespaces", "Namespaces where AlertmanagerConfig custom resources and corresponding Secrets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for AlertmanagerConfig custom resources.")
 	flagset.Var(thanosRulerNs, "thanos-ruler-instance-namespaces", "Namespaces where ThanosRuler custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for ThanosRuler custom resources.")
 	flagset.Var(&cfg.Labels, "labels", "Labels to be add to all resources created by the operator")
 	flagset.StringVar(&cfg.LocalHost, "localhost", "localhost", "EXPERIMENTAL (could be removed in future releases) - Host used to communicate between local services on a pod. Fixes issues where localhost resolves incorrectly.")
@@ -230,6 +232,7 @@ func Main() int {
 	cfg.Namespaces.DenyList = deniedNs
 	cfg.Namespaces.PrometheusAllowList = prometheusNs
 	cfg.Namespaces.AlertmanagerAllowList = alertmanagerNs
+	cfg.Namespaces.AlertmanagerConfigAllowList = alertmanagerConfigNs
 	cfg.Namespaces.ThanosRulerAllowList = thanosRulerNs
 
 	if len(cfg.Namespaces.PrometheusAllowList) == 0 {
@@ -238,6 +241,10 @@ func Main() int {
 
 	if len(cfg.Namespaces.AlertmanagerAllowList) == 0 {
 		cfg.Namespaces.AlertmanagerAllowList = cfg.Namespaces.AllowList
+	}
+
+	if len(cfg.Namespaces.AlertmanagerConfigAllowList) == 0 {
+		cfg.Namespaces.AlertmanagerConfigAllowList = cfg.Namespaces.AllowList
 	}
 
 	if len(cfg.Namespaces.ThanosRulerAllowList) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.54.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.54.0
 	github.com/prometheus/alertmanager v0.23.1-0.20210914172521-e35efbddb66a
-	github.com/prometheus/client_golang v1.12.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.32.1
 	github.com/prometheus/prometheus v1.8.2-0.20211214150951-52c693a63be1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1521,8 +1521,8 @@ github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
 github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.0 h1:C+UIj/QWtmqY13Arb8kwMt5j34/0Z2iKamrJ+ryC0Gg=
-github.com/prometheus/client_golang v1.12.0/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
+github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -188,7 +188,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 	}
 	c.secrInfs, err = informers.NewInformersForResource(
 		informers.NewKubeInformerFactories(
-			c.config.Namespaces.AllowList,
+			c.config.Namespaces.AlertmanagerConfigAllowList,
 			c.config.Namespaces.DenyList,
 			c.kclient,
 			resyncPeriod,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -170,7 +170,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 
 	c.alrtCfgInfs, err = informers.NewInformersForResource(
 		informers.NewMonitoringInformerFactories(
-			c.config.Namespaces.AllowList,
+			c.config.Namespaces.AlertmanagerConfigAllowList,
 			c.config.Namespaces.DenyList,
 			c.mclient,
 			resyncPeriod,
@@ -237,8 +237,8 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 
 		return nsInf
 	}
-	c.nsAlrtCfgInf = newNamespaceInformer(c, c.config.Namespaces.AllowList)
-	if listwatch.IdenticalNamespaces(c.config.Namespaces.AllowList, c.config.Namespaces.AlertmanagerAllowList) {
+	c.nsAlrtCfgInf = newNamespaceInformer(c, c.config.Namespaces.AlertmanagerConfigAllowList)
+	if listwatch.IdenticalNamespaces(c.config.Namespaces.AlertmanagerConfigAllowList, c.config.Namespaces.AlertmanagerAllowList) {
 		c.nsAlrtInf = c.nsAlrtCfgInf
 	} else {
 		c.nsAlrtInf = newNamespaceInformer(c, c.config.Namespaces.AlertmanagerAllowList)

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -95,5 +95,5 @@ type Namespaces struct {
 	// Allow list/deny list for common custom resources.
 	AllowList, DenyList map[string]struct{}
 	// Allow list for prometheus/alertmanager custom resources.
-	PrometheusAllowList, AlertmanagerAllowList, ThanosRulerAllowList map[string]struct{}
+	PrometheusAllowList, AlertmanagerAllowList, AlertmanagerConfigAllowList, ThanosRulerAllowList map[string]struct{}
 }


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

I want to use the operator to handle PrometheusRule CRDs in many namespaces but only handle Prometheus CRDs in one namespace.  I saw the default RBAC in the helm chart was far too broad and wrote my own, having secrets operations as Roles instead of ClusterRoles, attached only to the namespaces where I want to set up prometheus instances.  I noticed after setting `--namespaces` and `--prometheus-instance-selector` to different values, that list/watch of secrets was being attempted in the namespaces under `--namespaces`, with access denied.

Fixes #3544 (and #3298 in the case `--namespaces` is unset, which results in attempting to watch all secrets)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added `-alertmanager-config-namespaces` CLI flag to the operator. 
```
