### PR TITLE
Fix validation pattern in alertmanagerconfig CRD

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -164,7 +164,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                               type: string
                             type: array
                           times:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -164,7 +164,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
                               type: string
                             type: array
                           times:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -170,7 +170,7 @@
                                 "description": "Months is a list of MonthRange",
                                 "items": {
                                   "description": "MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')",
-                                  "pattern": "^((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)",
+                                  "pattern": "^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)",
                                   "type": "string"
                                 },
                                 "type": "array"

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -892,7 +892,7 @@ type DayOfMonthRange struct {
 
 // MonthRange is an inclusive range of months of the year beginning in January
 // Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
-// +kubebuilder:validation:Pattern=`^((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|febuary|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)`
+// +kubebuilder:validation:Pattern=`^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)`
 type MonthRange string
 
 // YearRange is an inclusive range of years


### PR DESCRIPTION
## Description
There was a typo in the alertmanagerconfig CRD which could lead to a correct pattern not recognized. 

@simonpasquier let me know if you want me to target the v0.53.0 branch as well

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry


```release-note
Fix validation pattern for month in AlertManagerConfig CRD
```
