### PR TITLE
Upload bundle.yaml when a release is created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  upload-assets:
+    runs-on: ubuntu-latest
+    name: Upload release assets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: bundle.yaml
+          asset_name: bundle.yaml
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
## Description

This commit adds a Github workflow which uploads the manifests in
bundle.yaml to a release once it is created.

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/4457

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
