### PR TITLE
Just add some comment to avoid misunderstanding joblabel

### DIFF
--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -490,7 +490,8 @@ spec:
                 type: array
               jobLabel:
                 description: "Chooses the label of the Kubernetes `Endpoints`. Its
-                  value will be used for the `job`-label's value of the created metrics.
+                  value which comes from the same name service's label will be used 
+                  for the `job`-label's value of the created metrics.
                   \n Default & fallback value: the name of the respective Kubernetes
                   `Endpoint`."
                 type: string

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -889,7 +889,7 @@ type ServiceMonitor struct {
 // +k8s:openapi-gen=true
 type ServiceMonitorSpec struct {
 	// Chooses the label of the Kubernetes `Endpoints`.
-	// Its value will be used for the `job`-label's value of the created metrics.
+	// Its value which comes from the same name service's label will be used for the `job`-label's value of the created metrics.
 	//
 	// Default & fallback value: the name of the respective Kubernetes `Endpoint`.
 	JobLabel string `json:"jobLabel,omitempty"`


### PR DESCRIPTION
https://github.com/prometheus-operator/prometheus-operator/issues/4470

## Description

Just add some comments to describe clearly about joblabel of  servicemonitor


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry




```release-note
Make joblabel of servicemonitor comment more clearly
```
