### PR TITLE
pkg/alertmanager: wrap errors from store.GetSecretKey()

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -270,12 +270,12 @@ func (cg *configGenerator) enforceNamespaceForRoute(r *route, namespace string) 
 func (cg *configGenerator) getValidURLFromSecret(ctx context.Context, namespace string, selector v1.SecretKeySelector) (string, error) {
 	url, err := cg.store.GetSecretKey(ctx, namespace, selector)
 	if err != nil {
-		return "", errors.Errorf("failed to get key %q from secret %q", selector.Key, selector.Name)
+		return "", errors.Wrap(err, "failed to get URL")
 	}
 
 	url = strings.TrimSpace(url)
 	if _, err := ValidateURL(url); err != nil {
-		return url, errors.Wrapf(err, "invalid url %s in secret %s config", url, selector.Name)
+		return url, errors.Wrapf(err, "invalid URL %q in key %q from secret %q", url, selector.Key, selector.Name)
 	}
 	return url, nil
 }
@@ -587,7 +587,7 @@ func (cg *configGenerator) convertPagerdutyConfig(ctx context.Context, in monito
 	if in.RoutingKey != nil {
 		routingKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.RoutingKey)
 		if err != nil {
-			return nil, errors.Errorf("failed to get routing key %q from secret %q", in.RoutingKey.Key, in.RoutingKey.Name)
+			return nil, errors.Wrap(err, "failed to get routing key")
 		}
 		out.RoutingKey = routingKey
 	}
@@ -595,7 +595,7 @@ func (cg *configGenerator) convertPagerdutyConfig(ctx context.Context, in monito
 	if in.ServiceKey != nil {
 		serviceKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.ServiceKey)
 		if err != nil {
-			return nil, errors.Errorf("failed to get service key %q from secret %q", in.ServiceKey.Key, in.ServiceKey.Name)
+			return nil, errors.Wrap(err, "failed to get service key")
 		}
 		out.ServiceKey = serviceKey
 	}
@@ -660,7 +660,7 @@ func (cg *configGenerator) convertOpsgenieConfig(ctx context.Context, in monitor
 	if in.APIKey != nil {
 		apiKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.APIKey)
 		if err != nil {
-			return nil, errors.Errorf("failed to get api key %q from secret %q", in.APIKey.Key, in.APIKey.Name)
+			return nil, errors.Wrap(err, "failed to get API key")
 		}
 		out.APIKey = apiKey
 	}
@@ -717,7 +717,7 @@ func (cg *configGenerator) convertWeChatConfig(ctx context.Context, in monitorin
 	if in.APISecret != nil {
 		apiSecret, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.APISecret)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.APISecret)
+			return nil, errors.Wrap(err, "failed to get API secret")
 		}
 		out.APISecret = apiSecret
 	}
@@ -753,7 +753,7 @@ func (cg *configGenerator) convertEmailConfig(ctx context.Context, in monitoring
 	if in.AuthPassword != nil {
 		authPassword, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.AuthPassword)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.AuthPassword)
+			return nil, errors.Wrap(err, "failed to get auth password")
 		}
 		out.AuthPassword = authPassword
 	}
@@ -761,7 +761,7 @@ func (cg *configGenerator) convertEmailConfig(ctx context.Context, in monitoring
 	if in.AuthSecret != nil {
 		authSecret, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.AuthSecret)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.AuthSecret)
+			return nil, errors.Wrap(err, "failed to get auth secret")
 		}
 		out.AuthSecret = authSecret
 	}
@@ -795,7 +795,7 @@ func (cg *configGenerator) convertVictorOpsConfig(ctx context.Context, in monito
 	if in.APIKey != nil {
 		apiKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.APIKey)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.APIKey)
+			return nil, errors.Wrap(err, "failed to get API key")
 		}
 		out.APIKey = apiKey
 	}
@@ -846,7 +846,7 @@ func (cg *configGenerator) convertPushoverConfig(ctx context.Context, in monitor
 	{
 		userKey, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.UserKey)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.UserKey)
+			return nil, errors.Wrap(err, "failed to get user key")
 		}
 		if userKey == "" {
 			return nil, errors.Errorf("mandatory field %q is empty", "userKey")
@@ -857,7 +857,7 @@ func (cg *configGenerator) convertPushoverConfig(ctx context.Context, in monitor
 	{
 		token, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.Token)
 		if err != nil {
-			return nil, errors.Errorf("failed to get secret %q", in.Token)
+			return nil, errors.Wrap(err, "failed to get token")
 		}
 		if token == "" {
 			return nil, errors.Errorf("mandatory field %q is empty", "token")
@@ -1044,12 +1044,12 @@ func (cg *configGenerator) convertHTTPConfig(ctx context.Context, in monitoringv
 	if in.BasicAuth != nil {
 		username, err := cg.store.GetSecretKey(ctx, crKey.Namespace, in.BasicAuth.Username)
 		if err != nil {
-			return nil, errors.Errorf("failed to get BasicAuth username key %q from secret %q", in.BasicAuth.Username.Key, in.BasicAuth.Username.Name)
+			return nil, errors.Wrap(err, "failed to get BasicAuth username")
 		}
 
 		password, err := cg.store.GetSecretKey(ctx, crKey.Namespace, in.BasicAuth.Password)
 		if err != nil {
-			return nil, errors.Errorf("failed to get BasicAuth password key %q from secret %q", in.BasicAuth.Password.Key, in.BasicAuth.Password.Name)
+			return nil, errors.Wrap(err, "failed to get BasicAuth password")
 		}
 
 		if username != "" || password != "" {
@@ -1060,7 +1060,7 @@ func (cg *configGenerator) convertHTTPConfig(ctx context.Context, in monitoringv
 	if in.Authorization != nil {
 		credentials, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.Authorization.Credentials)
 		if err != nil {
-			return nil, errors.Errorf("failed to get Authorization credentials key %q from secret %q", in.Authorization.Credentials.Key, in.Authorization.Credentials.Name)
+			return nil, errors.Wrap(err, "failed to get Authorization credentials")
 		}
 
 		if credentials != "" {
@@ -1079,7 +1079,7 @@ func (cg *configGenerator) convertHTTPConfig(ctx context.Context, in monitoringv
 	if in.BearerTokenSecret != nil {
 		bearerToken, err := cg.store.GetSecretKey(ctx, crKey.Namespace, *in.BearerTokenSecret)
 		if err != nil {
-			return nil, errors.Errorf("failed to get bearer token key %q from secret %q", in.BearerTokenSecret.Key, in.BearerTokenSecret.Name)
+			return nil, errors.Wrap(err, "failed to get bearer token")
 		}
 		out.BearerToken = bearerToken
 	}


### PR DESCRIPTION
Following my comment on #4468 that wrapping the returned error would be better.

cc @PhilipGough 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
