### PR TITLE
pkg/prometheus replace storage.tsdb command-line args for agent

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -344,10 +344,17 @@ func makeStatefulSetSpec(
 		retentionTimeFlagValue = defaultRetention
 	}
 
-	if retentionTimeFlagValue != "" {
+	for _, f := range p.Spec.EnableFeatures {
+		switch f {
+		case "agent":
+			prometheusAgentMode = true
+		}
+	}
+
+	if retentionTimeFlagValue != "" && !prometheusAgentMode {
 		promArgs = append(promArgs, monitoringv1.Argument{Name: retentionTimeFlagName, Value: retentionTimeFlagValue})
 	}
-	if p.Spec.RetentionSize != "" {
+	if p.Spec.RetentionSize != "" && !prometheusAgentMode {
 		retentionSizeFlag := monitoringv1.Argument{Name: "storage.tsdb.retention.size", Value: string(p.Spec.RetentionSize)}
 		promArgs = cg.WithMinimumVersion("2.7.0").AppendCommandlineArgument(promArgs, retentionSizeFlag)
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1387,11 +1387,13 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 }
 
 func TestAgentModeStorageArgs(t *testing.T) {
-	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
+	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
-			EnableFeatures: []string{"agent"},
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				EnableFeatures: []string{"agent"},
+			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	})
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -2486,8 +2488,8 @@ func TestPrometheusAdditionalArgsNoError(t *testing.T) {
 		"--web.console.libraries=/etc/prometheus/console_libraries",
 		"--storage.tsdb.retention.time=24h",
 		"--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
-		"--storage.tsdb.path=/prometheus",
 		"--web.enable-lifecycle",
+		"--storage.tsdb.path=/prometheus",
 		"--web.route-prefix=/",
 		"--web.config.file=/etc/prometheus/web_config/web-config.yaml",
 		"--scrape.discovery-reload-interval=30s",


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Generating statefulsets by prometheus-operator does contain `--storage.tsdb.path` and ` --storage.tsdb.retention.time` when pod is  expecting only `--storage.agent.path` or nothing instead when  enabled `--enable-feature=agent`. This put  Prometheus to error state, preventing boot.
This PR switches default storage command-line args when feature `agent` is enabled.

Related to #3989  [(comment)](https://github.com/prometheus-operator/prometheus-operator/issues/3989#issuecomment-974137486)

>The important bit is that the Prometheus arguments need to be overridden because the storage flags are different (TSDB path and retention in particular)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Set correct storage command-line args to Prometheus StatefulSet in Agent mode
```
