### PR TITLE
pkg/prometheus: Add validation for ScrapeTimeout

### DIFF
--- a/pkg/operator/validations.go
+++ b/pkg/operator/validations.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"github.com/alecthomas/units"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -32,5 +33,29 @@ func ValidateDurationField(durationField string) error {
 	if _, err := model.ParseDuration(durationField); err != nil {
 		return err
 	}
+	return nil
+}
+
+// CompareScrapeTimeoutToScrapeInterval validates value of scrapeTimeout based on scrapeInterval
+func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval string) error {
+	var err error
+	var si, st model.Duration
+
+	// since default scrapeInterval set by operator is 30s
+	if scrapeInterval == "" {
+		scrapeInterval = "30s"
+	}
+
+	if si, err = model.ParseDuration(scrapeInterval); err != nil {
+		return errors.Wrapf(err, "invalid scrapeInterval %q", scrapeInterval)
+	}
+	if st, err = model.ParseDuration(scrapeTimeout); err != nil {
+		return errors.Wrapf(err, "invalid scrapeTimeout: %q", scrapeTimeout)
+	}
+
+	if st > si {
+		return errors.Errorf("scrapeTimeout %q greater than scrapeInterval %q", scrapeTimeout, scrapeInterval)
+	}
+
 	return nil
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -25,12 +25,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -251,6 +250,9 @@ func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.ScrapeTimeout != "" {
 		if err := operator.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
 			return errors.Wrap(err, "invalid scrapeTimeout value specified")
+		}
+		if err := operator.CompareScrapeTimeoutToScrapeInterval(p.Spec.ScrapeTimeout, p.Spec.ScrapeInterval); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
This change adds validation for scrapeTimeout to avoid specifying
higher value than scrapeInterval at prometheus, servicemonitor, podmonitor and probe levels

Fixes #4485

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added scrapeTimeout validation to avoid invalid value being accepted
```
