### PR TITLE
Add standalone admission webhook

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,6 +68,7 @@ jobs:
       run: |
         kind load docker-image quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)
         kind load docker-image quay.io/prometheus-operator/prometheus-config-reloader:$(git rev-parse --short HEAD)
+        kind load docker-image quay.io/prometheus-operator/prometheus-admission-webhook:$(git rev-parse --short HEAD)
         kubectl apply -f scripts/kind-rbac.yaml
     - name: Run tests
       run: >

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /operator
+/admission-webhook
 /po-lint
 /prometheus-config-reloader
 .build/

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ tidy:
 	cd scripts && go mod tidy -v -modfile=go.mod
 
 .PHONY: generate
-generate: $(DEEPCOPY_TARGETS) generate-crds bundle.yaml example/mixin/alerts.yaml example/thanos/thanos.yaml generate-docs
+generate: $(DEEPCOPY_TARGETS) generate-crds bundle.yaml example/mixin/alerts.yaml example/thanos/thanos.yaml example/admission-webhook generate-docs
 
 .PHONY: generate-crds
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET)
@@ -231,6 +231,9 @@ $(RBAC_MANIFESTS): scripts/generate/vendor VERSION $(shell find jsonnet -type f)
 
 example/thanos/thanos.yaml: scripts/generate/vendor scripts/generate/thanos.jsonnet $(shell find jsonnet -type f)
 	scripts/generate/build-thanos-example.sh
+
+example/admission-webhook: scripts/generate/vendor scripts/generate/admission-webhook.jsonnet $(shell find jsonnet -type f)
+	scripts/generate/build-admission-webhook-example.sh
 
 FULLY_GENERATED_DOCS = Documentation/api.md Documentation/compatibility.md Documentation/operator.md
 TO_BE_EXTENDED_DOCS = $(filter-out $(FULLY_GENERATED_DOCS), $(shell find Documentation -type f))

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ kubectl delete --ignore-not-found customresourcedefinitions \
 1. `kind create cluster --image=kindest/node:<latest>`. e.g `v1.16.2` version.
 2. `kubectl cluster-info --context kind-kind`. kind version >= 0.6.x
 3. `make image` - build Prometheus Operator docker image locally.
-4. `for n in "operator" "config-reloader"; do kind load docker-image "quay.io/prometheus-operator/prometheus-$n:$(git rev-parse --short HEAD)"; done` - publish
+4. `for n in "operator" "config-reloader" "admission-webhook"; do kind load docker-image "quay.io/prometheus-operator/prometheus-$n:$(git rev-parse --short HEAD)"; done` - publish
    built locally images to be accessible inside kind.
 5. `make test-e2e`
 

--- a/cmd/admission-webhook/Dockerfile
+++ b/cmd/admission-webhook/Dockerfile
@@ -1,0 +1,9 @@
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+
+ADD admission-webhook /bin/admission-webhook
+
+USER nobody
+
+ENTRYPOINT ["/bin/admission-webhook"]

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -1,0 +1,250 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	stdlog "log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	rbacproxytls "github.com/brancz/kube-rbac-proxy/pkg/tls"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
+	"golang.org/x/sync/errgroup"
+
+	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
+	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
+	"github.com/prometheus-operator/prometheus-operator/pkg/server"
+)
+
+const (
+	defaultTLSDir  = "/etc/tls/private"
+	defaultCrtFile = defaultTLSDir + "/tls.crt"
+	defaultKeyFile = defaultTLSDir + "/tls.key"
+	defaultCaCrt   = defaultTLSDir + "/tls-ca.crt"
+)
+
+var (
+	cfg     = config{}
+	flagset = flag.CommandLine
+
+	serverTLS          bool
+	rawTLSCipherSuites string
+)
+
+func main() {
+	flagset.StringVar(&cfg.ListenAddress, "web.listen-address", ":8443", "Address on which the admission webhook service listens")
+	flagset.BoolVar(&serverTLS, "web.enable-tls", true, "Enable TLS web server")
+
+	flagset.StringVar(&cfg.ServerTLSConfig.CertFile, "web.cert-file", defaultCrtFile, "Certificate file to be used for the web server.")
+	flagset.StringVar(&cfg.ServerTLSConfig.KeyFile, "web.key-file", defaultKeyFile, "Private key matching the certificate file to be used for the web server")
+	flagset.StringVar(&cfg.ServerTLSConfig.ClientCAFile, "web.client-ca-file", defaultCaCrt, "Client CA certificate file to be used for web server.")
+
+	flagset.DurationVar(&cfg.ServerTLSConfig.ReloadInterval, "web.tls-reload-interval", time.Minute, "The interval at which to watch for TLS certificate changes (default 1m).")
+	flagset.StringVar(&cfg.ServerTLSConfig.MinVersion, "web.tls-min-version", "VersionTLS13", fmt.Sprintf("Minimum TLS version supported. One of %s", validTLSVersions()))
+	flagset.StringVar(&rawTLSCipherSuites, "web.tls-cipher-suites", "", "Comma-separated list of cipher suites for the server."+
+		" Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants)."+
+		"If omitted, the default Go cipher suites will be used."+
+		"Note that TLS 1.3 ciphersuites are not configurable.")
+
+	flagset.StringVar(&cfg.LogLevel, "log-level", logging.LevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(logging.AvailableLogLevels, ", ")))
+	flagset.StringVar(&cfg.LogFormat, "log-format", logging.FormatLogFmt, fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(logging.AvailableLogFormats, ", ")))
+
+	_ = flagset.Parse(os.Args[1:])
+
+	logger, err := logging.NewLogger(cfg.LogLevel, cfg.LogFormat)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wg, ctx := errgroup.WithContext(ctx)
+
+	listener, err := net.Listen("tcp", cfg.ListenAddress)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to start required HTTP listener", "err", err)
+		os.Exit(1)
+	}
+
+	tlsConf, err := loadTLSConfigFromFlags(ctx, logger, wg)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build TLS config", "err", err)
+		os.Exit(1)
+	}
+
+	server := newSrv(logger, tlsConf)
+	wg.Go(func() error {
+		return server.run(listener)
+	})
+
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case sig := <-term:
+		level.Info(logger).Log("msg", "Received signal, exiting gracefully...", "signal", sig.String())
+	case <-ctx.Done():
+	}
+
+	if err := server.shutdown(ctx); err != nil {
+		level.Warn(logger).Log("msg", "Server shutdown error", "err", err)
+	}
+
+	cancel()
+	if err := wg.Wait(); err != nil {
+		level.Warn(logger).Log("msg", "Unhandled error received. Exiting...", "err", err)
+		os.Exit(1)
+	}
+}
+
+func (s *srv) run(listener net.Listener) error {
+	log := log.With(s.logger, "address", listener.Addr().String())
+
+	if s.s.TLSConfig != nil {
+		level.Info(log).Log("msg", "Starting TLS enabled server")
+		if err := s.s.ServeTLS(listener, "", ""); err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+
+	level.Info(log).Log("msg", "Starting insecure server")
+	if err := s.s.Serve(listener); err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (s *srv) shutdown(ctx context.Context) error {
+	return s.s.Shutdown(ctx)
+}
+
+func newSrv(logger log.Logger, tlsConf *tls.Config) *srv {
+	mux := http.NewServeMux()
+	admit := admission.New(log.With(logger, "component", "admissionwebhook"))
+	admit.Register(mux)
+
+	r := prometheus.NewRegistry()
+	r.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		version.NewCollector("prometheus_operator_admission_webhook"),
+	)
+	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
+
+	return &srv{
+		logger: logger,
+		s: &http.Server{
+			Handler:   mux,
+			TLSConfig: tlsConf,
+			// use flags on standard logger to align with base logger and get consistent parsed fields form adapter:
+			// use shortfile flag to get proper 'caller' field (avoid being wrongly parsed/extracted from message)
+			// and no datetime related flag to keep 'ts' field from base logger (with controlled format)
+			ErrorLog: stdlog.New(log.NewStdlibAdapter(logger), "", stdlog.Lshortfile),
+		},
+	}
+}
+
+// loadTLSConfigFromFlags creates a tls.Config if configured and starts a watch on the dir to reload certs
+func loadTLSConfigFromFlags(ctx context.Context, logger log.Logger, wg *errgroup.Group) (*tls.Config, error) {
+	var (
+		tlsConfig *tls.Config
+		err       error
+	)
+	if serverTLS {
+		if _, ok := allowedTLSVersions[cfg.ServerTLSConfig.MinVersion]; !ok {
+			return nil, fmt.Errorf("unsupported TLS version %s provided", cfg.ServerTLSConfig.MinVersion)
+		}
+
+		if rawTLSCipherSuites != "" {
+			cfg.ServerTLSConfig.CipherSuites = strings.Split(rawTLSCipherSuites, ",")
+		}
+		tlsConfig, err = server.NewTLSConfig(
+			logger,
+			cfg.ServerTLSConfig.CertFile,
+			cfg.ServerTLSConfig.KeyFile,
+			cfg.ServerTLSConfig.ClientCAFile,
+			cfg.ServerTLSConfig.MinVersion,
+			cfg.ServerTLSConfig.CipherSuites,
+		)
+		if tlsConfig == nil || err != nil {
+			return nil, fmt.Errorf("invalid TLS config: %w", err)
+		}
+	}
+
+	if tlsConfig != nil {
+		r, err := rbacproxytls.NewCertReloader(
+			cfg.ServerTLSConfig.CertFile,
+			cfg.ServerTLSConfig.KeyFile,
+			cfg.ServerTLSConfig.ReloadInterval,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize certificate reloader: %w", err)
+		}
+
+		tlsConfig.GetCertificate = r.GetCertificate
+		wg.Go(func() error {
+			for {
+				// r.Watch will wait ReloadInterval, so this is not
+				// a hot loop
+				if err := r.Watch(ctx); err != nil {
+					level.Warn(logger).Log("msg", "error watching certificate reloader", "err", err)
+				} else {
+					return nil
+				}
+			}
+		})
+	}
+	return tlsConfig, nil
+}
+
+type config struct {
+	ListenAddress   string
+	TLSInsecure     bool
+	ServerTLSConfig server.TLSServerConfig
+	LocalHost       string
+	LogLevel        string
+	LogFormat       string
+}
+
+type srv struct {
+	logger log.Logger
+	s      *http.Server
+}
+
+// any older versions won't allow a secure conn
+var allowedTLSVersions = map[string]bool{"VersionTLS13": true, "VersionTLS12": true}
+
+func validTLSVersions() string {
+	var out string
+	for validVersion := range allowedTLSVersions {
+		out += validVersion + ","
+	}
+	return strings.TrimRight(out, ",")
+}

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -158,6 +158,11 @@ func newSrv(logger log.Logger, tlsConf *tls.Config) *srv {
 	)
 	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
 
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"up"}`))
+		w.WriteHeader(http.StatusOK)
+	})
+
 	return &srv{
 		logger: logger,
 		s: &http.Server{

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prometheuscontroller "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+	"github.com/prometheus-operator/prometheus-operator/pkg/server"
 	thanoscontroller "github.com/prometheus-operator/prometheus-operator/pkg/thanos"
 	"github.com/prometheus-operator/prometheus-operator/pkg/versionutil"
 
@@ -294,7 +295,7 @@ func Main() int {
 		if rawTLSCipherSuites != "" {
 			cfg.ServerTLSConfig.CipherSuites = strings.Split(rawTLSCipherSuites, ",")
 		}
-		tlsConfig, err = operator.NewTLSConfig(logger, cfg.ServerTLSConfig.CertFile, cfg.ServerTLSConfig.KeyFile,
+		tlsConfig, err = server.NewTLSConfig(logger, cfg.ServerTLSConfig.CertFile, cfg.ServerTLSConfig.KeyFile,
 			cfg.ServerTLSConfig.ClientCAFile, cfg.ServerTLSConfig.MinVersion, cfg.ServerTLSConfig.CipherSuites)
 		if tlsConfig == nil || err != nil {
 			fmt.Fprint(os.Stderr, "invalid TLS config", err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -304,26 +304,24 @@ func Main() int {
 		}
 	}
 
-	// todo - I wonder can these go away because of
-	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhook-metrics
 	validationTriggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_triggered_total",
-		Help: "Number of times a prometheusRule object triggered validation",
+		Help: "DEPRECATED, removed in v0.57.0: Number of times a prometheusRule object triggered validation",
 	})
 
 	validationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_errors_total",
-		Help: "Number of errors that occurred while validating a prometheusRules object",
+		Help: "DEPRECATED, removed in v0.57.0: Number of errors that occurred while validating a prometheusRules object",
 	})
 
 	alertManagerConfigValidationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_alertmanager_config_validation_triggered_total",
-		Help: "Number of times an alertmanagerconfig object triggered validation",
+		Help: "DEPRECATED, removed in v0.57.0: Number of times an alertmanagerconfig object triggered validation",
 	})
 
 	alertManagerConfigValidationError := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_alertmanager_config_validation_errors_total",
-		Help: "Number of errors that occurred while validating a alertmanagerconfig object",
+		Help: "DEPRECATED, removed in v0.57.0: Number of errors that occurred while validating a alertmanagerconfig object",
 	})
 
 	r.MustRegister(

--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+  name: prometheus-operator-admission-webhook
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: admission-webhook
+      labels:
+        app.kubernetes.io/name: prometheus-operator-admission-webhook
+    spec:
+      containers:
+        - ## TODO - update prior to merge
+          image: quay.io/prometheus-operator/admission-webhook:main
+          name: admission-webhook
+          ports:
+            - containerPort: 8443
+              name: https
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: ""

--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.54.0
   name: prometheus-operator-admission-webhook
   namespace: default
 spec:
@@ -13,37 +14,30 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: admission-webhook
+        kubectl.kubernetes.io/default-container: prometheus-operator-admission-webhook
       labels:
         app.kubernetes.io/name: prometheus-operator-admission-webhook
+        app.kubernetes.io/version: 0.54.0
     spec:
+      automountServiceAccountToken: false
       containers:
-        - ## TODO - update prior to merge
-          image: quay.io/prometheus-operator/admission-webhook:main
-          name: admission-webhook
-          ports:
-            - containerPort: 8443
-              name: https
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 50m
-              memory: 50Mi
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8443
-              scheme: HTTPS
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          securityContext:
-            allowPrivilegeEscalation: false
-      nodeSelector:
-        kubernetes.io/os: linux
+      - image: quay.io/prometheus-operator/prometheus-admission-webhook:v0.54.0
+        name: prometheus-operator-admission-webhook
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      serviceAccountName: ""
+      serviceAccountName: prometheus-operator-admission-webhook

--- a/example/admission-webhook/service-account.yaml
+++ b/example/admission-webhook/service-account.yaml
@@ -1,16 +1,9 @@
 apiVersion: v1
-kind: Service
+automountServiceAccountToken: false
+kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
     app.kubernetes.io/version: 0.54.0
   name: prometheus-operator-admission-webhook
   namespace: default
-spec:
-  clusterIP: None
-  ports:
-  - name: https
-    port: 8443
-    targetPort: https
-  selector:
-    app.kubernetes.io/name: prometheus-operator-admission-webhook

--- a/example/admission-webhook/service-monitor.yaml
+++ b/example/admission-webhook/service-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.54.0
+  name: prometheus-operator-admission-webhook
+  namespace: default
+spec:
+  endpoints:
+  - honorLabels: true
+    port: https
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook
+      app.kubernetes.io/version: 0.54.0

--- a/example/admission-webhook/service.yaml
+++ b/example/admission-webhook/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+  name: prometheus-operator-admission-webhook
+spec:
+  clusterIP: None
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook

--- a/jsonnet/prometheus-operator/admission-webhook.libsonnet
+++ b/jsonnet/prometheus-operator/admission-webhook.libsonnet
@@ -1,0 +1,112 @@
+local defaults = {
+  local defaults = self,
+  name: 'prometheus-operator-admission-webhook',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide admission webhook image',
+  port: 8443,
+  replicas: 2,
+  resources: {
+    limits: { cpu: '200m', memory: '200Mi' },
+    requests: { cpu: '50m', memory: '50Mi' },
+  },
+  commonLabels:: {
+    'app.kubernetes.io/name': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+  },
+  selectorLabels:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if !std.setMember(labelName, ['app.kubernetes.io/version'])
+  },
+};
+
+
+function(params) {
+  local aw = self,
+  _config:: defaults + params,
+  _metadata:: {
+      name: aw._config.name,
+      namespace: aw._config.namespace,
+      labels: aw._config.commonLabels,
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: aw._metadata,
+    automountServiceAccountToken: false,
+  },
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: aw._metadata,
+    spec: {
+      ports: [
+        { name: 'https', targetPort: 'https', port: aw._config.port },
+      ],
+      selector: aw._config.selectorLabels,
+      clusterIP: 'None',
+    },
+  },
+
+  deployment:
+    local container = {
+      name: aw._config.name,
+      image: aw._config.image,
+      ports: [{
+        containerPort: aw._config.port,
+        name: 'https',
+      }],
+      resources: aw._config.resources,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+      securityContext: {
+        allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
+      },
+    };
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: aw._metadata,
+      spec: {
+        replicas: aw._config.replicas,
+        selector: { matchLabels: aw._config.selectorLabels },
+        template: {
+          metadata: {
+            labels: aw._config.commonLabels,
+            annotations: {
+              "kubectl.kubernetes.io/default-container": container.name,
+            }
+          },
+          spec: {
+            containers: [container],
+            securityContext: {
+              runAsNonRoot: true,
+              runAsUser: 65534,
+            },
+            serviceAccountName: aw._config.name,
+            automountServiceAccountToken: false,
+          },
+        },
+      },
+    },
+
+  serviceMonitor: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata: aw._metadata,
+    spec: {
+      endpoints: [
+        {
+          port: 'https',
+          honorLabels: true,
+        },
+      ],
+      selector: {
+        matchLabels: aw._config.commonLabels,
+      },
+    },
+  },
+}

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -216,20 +216,20 @@ func (a *Admission) mutatePrometheusRules(ar v1.AdmissionReview) *v1.AdmissionRe
 }
 
 func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	a.promRuleValidationTriggeredCounter.Inc()
+	a.incrementCounter(a.promRuleValidationTriggeredCounter)
 	level.Debug(a.logger).Log("msg", "Validating prometheusrules")
 
 	if ar.Request.Resource != prometheusRuleGVR {
 		err := fmt.Errorf("expected resource to be %v, but received %v", prometheusRuleResource, ar.Request.Resource)
 		level.Warn(a.logger).Log("err", err)
-		a.promRuleValidationErrorsCounter.Inc()
+		a.incrementCounter(a.promRuleValidationErrorsCounter)
 		return toAdmissionResponseFailure("Unexpected resource kind", prometheusRuleResource, []error{err})
 	}
 
 	promRule := &monitoringv1.PrometheusRule{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, promRule); err != nil {
 		level.Info(a.logger).Log("msg", errUnmarshalRules, "err", err)
-		a.promRuleValidationErrorsCounter.Inc()
+		a.incrementCounter(a.promRuleValidationErrorsCounter)
 		return toAdmissionResponseFailure(errUnmarshalRules, prometheusRuleResource, []error{err})
 	}
 
@@ -241,7 +241,7 @@ func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.Admission
 			level.Info(a.logger).Log("msg", m, "err", err)
 		}
 
-		a.promRuleValidationErrorsCounter.Inc()
+		a.incrementCounter(a.promRuleValidationErrorsCounter)
 		return toAdmissionResponseFailure("Rules are not valid", prometheusRuleResource, errors)
 	}
 
@@ -249,20 +249,20 @@ func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.Admission
 }
 
 func (a *Admission) validateAlertManagerConfig(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	a.amConfValidationTriggeredCounter.Inc()
+	a.incrementCounter(a.amConfValidationTriggeredCounter)
 	level.Debug(a.logger).Log("msg", "Validating alertmanagerconfigs")
 
 	if ar.Request.Resource != alertManagerConfigGVR {
 		err := fmt.Errorf("expected resource to be %v, but received %v", alertManagerConfigResource, ar.Request.Resource)
 		level.Warn(a.logger).Log("err", err)
-		a.amConfValidationErrorsCounter.Inc()
+		a.incrementCounter(a.amConfValidationErrorsCounter)
 		return toAdmissionResponseFailure("Unexpected resource kind", alertManagerConfigResource, []error{err})
 	}
 
 	amConf := &monitoringv1alpha1.AlertmanagerConfig{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, amConf); err != nil {
 		level.Info(a.logger).Log("msg", errUnmarshalConfig, "err", err)
-		a.amConfValidationErrorsCounter.Inc()
+		a.incrementCounter(a.amConfValidationErrorsCounter)
 		return toAdmissionResponseFailure(errUnmarshalConfig, alertManagerConfigResource, []error{err})
 	}
 
@@ -270,8 +270,19 @@ func (a *Admission) validateAlertManagerConfig(ar v1.AdmissionReview) *v1.Admiss
 		msg := "invalid config"
 		level.Debug(a.logger).Log("msg", msg, "content", amConf.Spec)
 		level.Info(a.logger).Log("msg", msg, "err", err)
-		a.amConfValidationErrorsCounter.Inc()
+		a.incrementCounter(a.amConfValidationErrorsCounter)
 		return toAdmissionResponseFailure("AlertManagerConfig is invalid", alertManagerConfigResource, []error{err})
 	}
 	return &v1.AdmissionResponse{Allowed: true}
+}
+
+// TODO (PhilipGough) - this can be removed when the following deprecated metrics are removed
+//  -  prometheus_operator_rule_validation_triggered_total
+//  -  prometheus_operator_rule_validation_errors_total
+//  -  prometheus_operator_alertmanager_config_validation_errors_total
+//  -  prometheus_operator_alertmanager_config_validation_triggered_total
+func (a *Admission) incrementCounter(counter prometheus.Counter) {
+	if counter != nil {
+		counter.Inc()
+	}
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"k8s.io/client-go/rest"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/server"
 )
 
 // Config defines configuration parameters for the Operator.
@@ -28,7 +30,7 @@ type Config struct {
 	ListenAddress                string
 	TLSInsecure                  bool
 	TLSConfig                    rest.TLSClientConfig
-	ServerTLSConfig              TLSServerConfig
+	ServerTLSConfig              server.TLSServerConfig
 	ReloaderConfig               ReloaderConfig
 	AlertmanagerDefaultBaseImage string
 	PrometheusDefaultBaseImage   string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package operator
+package server
 
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -43,15 +42,10 @@ type TLSServerConfig struct {
 func NewTLSConfig(logger log.Logger, certFile, keyFile, clientCAFile, minVersion string, cipherSuites []string) (*tls.Config, error) {
 	if certFile == "" && keyFile == "" {
 		if clientCAFile != "" {
-			return nil, errors.New("when a client CA is used a server key and certificate must also be provided")
+			return nil, fmt.Errorf("when a client CA is used a server key and certificate must also be provided")
 		}
-
-		level.Info(logger).Log("msg", "TLS disabled key and cert must be set to enable")
-
-		return nil, nil
+		return nil, fmt.Errorf("TLS disabled. key and cert must be set to enable")
 	}
-
-	level.Info(logger).Log("msg", "enabling server side TLS")
 
 	tlsCfg := &tls.Config{}
 
@@ -64,7 +58,7 @@ func NewTLSConfig(logger log.Logger, certFile, keyFile, clientCAFile, minVersion
 
 	cipherSuiteIDs, err := flag.TLSCipherSuites(cipherSuites)
 	if err != nil {
-		return nil, fmt.Errorf("TLS cipher suite name to ID conversion: %v", err)
+		return nil, fmt.Errorf("TLS cipher suite name to ID conversion: %w", err)
 	}
 
 	// A list of supported cipher suites for TLS versions up to TLS 1.2.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package operator
+package server
 
 import (
 	"testing"

--- a/scripts/generate/admission-webhook.jsonnet
+++ b/scripts/generate/admission-webhook.jsonnet
@@ -1,0 +1,12 @@
+local admissionWebhook = (import 'prometheus-operator/admission-webhook.libsonnet');
+local config = (import 'config.jsonnet');
+local aw = admissionWebhook(config {
+  image: 'quay.io/prometheus-operator/prometheus-admission-webhook:v' + config.version,
+});
+
+{
+  'service-account.yaml': aw.serviceAccount,
+  'deployment.yaml': aw.deployment,
+  'service.yaml': aw.service,
+  'service-monitor.yaml': aw.serviceMonitor,
+}

--- a/scripts/generate/build-admission-webhook-example.sh
+++ b/scripts/generate/build-admission-webhook-example.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+AW=$(jsonnet -J scripts/generate/vendor scripts/generate/admission-webhook.jsonnet)
+echo "$AW" | jq -r 'keys[]' | while read -r file
+do
+    echo "$AW" | jq -r ".[\"${file}\"]" | gojsontoyaml > "example/admission-webhook/${file}"
+done

--- a/test/framework/resources/alertmanager-config-validating-webhook.yaml
+++ b/test/framework/resources/alertmanager-config-validating-webhook.yaml
@@ -5,7 +5,7 @@ metadata:
 webhooks:
   - clientConfig:
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-alertmanagerconfigs/validate
     failurePolicy: Fail

--- a/test/framework/resources/prometheus-operator-mutatingwebhook.yaml
+++ b/test/framework/resources/prometheus-operator-mutatingwebhook.yaml
@@ -5,7 +5,7 @@ metadata:
 webhooks:
   - clientConfig:
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-prometheusrules/mutate
 

--- a/test/framework/resources/prometheus-operator-validatingwebhook.yaml
+++ b/test/framework/resources/prometheus-operator-validatingwebhook.yaml
@@ -5,7 +5,7 @@ metadata:
 webhooks:
   - clientConfig:
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-prometheusrules/validate
     failurePolicy: Fail


### PR DESCRIPTION
## Description

Decouples the admission webhook logic into a standalone binary with the view to enabling a HA setup.

I don't view this as fully completing #4437, see [comment](https://github.com/prometheus-operator/prometheus-operator/issues/4437#issuecomment-1012080661), but I feel it could be merged as is without breaking anything.


* ~I have marked the relevant flags in the existing operator binary as deprecated.~ - reverted based on [comment](https://github.com/prometheus-operator/prometheus-operator/pull/4494#issuecomment-1012162998)
* I have marked four existing metrics as deprecated since I believe we can extract that info natively from the `apiserver_admission_webhook_rejection_count` and based on [this comment](https://github.com/prometheus-operator/prometheus-operator/pull/4494#discussion_r794361803) 
  * `prometheus_operator_rule_validation_errors_total `
  *  `prometheus_operator_alertmanager_config_validation_errors_total `
  *  `prometheus_operator_rule_validation_triggered_total `
  *  `prometheus_operator_alertmanager_config_validation_triggered_total ` 



_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Related to #4182 
Partially addresses #4437

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
