### PR TITLE
WIP: include operator version in CRD annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__
 .vscode/
 tmp
 
+example/prometheus-operator-crd/*.bak
+
 # These are empty target files, created on every docker build. Their sole
 # purpose is to track the last target execution time to evalualte, whether the
 # container needds to be rebuild

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,8 @@ generate: $(DEEPCOPY_TARGETS) generate-crds bundle.yaml example/mixin/alerts.yam
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET)
 	cd pkg/apis/monitoring/v1 && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1,preserveUnknownFields=false paths=. output:crd:dir=$(PWD)/example/prometheus-operator-crd
 	cd pkg/apis/monitoring/v1alpha1 && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1,preserveUnknownFields=false paths=. output:crd:dir=$(PWD)/example/prometheus-operator-crd
+	find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '/^    controller-gen.kubebuilder.io.version.*/a \    prometheus-operator.dev\/version: $(VERSION)' {} +
 	find example/prometheus-operator-crd/ -name '*.yaml' -print0 | xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
-
 
 .PHONY: generate-remote-write-certs
 generate-remote-write-certs:

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,8 @@ generate: $(DEEPCOPY_TARGETS) generate-crds bundle.yaml example/mixin/alerts.yam
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET)
 	cd pkg/apis/monitoring/v1 && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1,preserveUnknownFields=false paths=. output:crd:dir=$(PWD)/example/prometheus-operator-crd
 	cd pkg/apis/monitoring/v1alpha1 && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1,preserveUnknownFields=false paths=. output:crd:dir=$(PWD)/example/prometheus-operator-crd
-	find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '/^    controller-gen.kubebuilder.io.version.*/a \    prometheus-operator.dev\/version: $(VERSION)' {} +
+	find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -E -i.bak '/^    controller-gen.kubebuilder.io.version.*/a \
+	    prometheus-operator.dev\/version: $(VERSION)' {} +
 	find example/prometheus-operator-crd/ -name '*.yaml' -print0 | xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
 
 .PHONY: generate-remote-write-certs

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
@@ -3196,6 +3197,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:
@@ -9242,6 +9244,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:
@@ -9843,6 +9846,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:
@@ -10483,6 +10487,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
@@ -18799,6 +18804,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:
@@ -18902,6 +18908,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
@@ -19530,6 +19537,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
+    prometheus-operator.dev/version: 0.53.1
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "alertmanagerconfigs.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "alertmanagers.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "podmonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "probes.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "prometheuses.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheusrules-crd.json
+++ b/jsonnet/prometheus-operator/prometheusrules-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "prometheusrules.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "servicemonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.6.2"
+      "controller-gen.kubebuilder.io/version": "v0.6.2",
+      "prometheus-operator.dev/version": "0.53.1"
     },
     "creationTimestamp": null,
     "name": "thanosrulers.monitoring.coreos.com"


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Resurrecting and fixing #4344.

Since CRDs are global and there can be more than one operator working in a cluster it would be good to have a way to verify if CRD in a cluster is compatible with the operator and vice versa. To do this I propose to include the operator version in CRD annotation.

Sadly controller-gen does not support injecting custom annotations in CRD metadata, hence the proposed solution includes post-generation CRD modification using `sed` (there might be a way to do this with `jq`, but I didn't manage to make this work).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Include operator version in CRD annotations
```
