### PR TITLE
Don't propogate fluxcd labels to statefulset

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -155,7 +155,7 @@ func makeStatefulSet(
 	// pruned by kubectl
 	annotations := make(map[string]string)
 	for key, value := range p.ObjectMeta.Annotations {
-		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+		if !(strings.HasPrefix(key, "kubectl.kubernetes.io/") || strings.HasPrefix(key, "kustomize.toolkit.fluxcd.io")) {
 			annotations[key] = value
 		}
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -55,6 +55,9 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 		"testannotation": "testannotationvalue",
 		"kubectl.kubernetes.io/last-applied-configuration": "something",
 		"kubectl.kubernetes.io/something":                  "something",
+		"kustomize.toolkit.fluxcd.io/checksum":             "something",
+		"kustomize.toolkit.fluxcd.io/name":                 "something",
+		"kustomize.toolkit.fluxcd.io/namespace":            "something",
 	}
 	// kubectl annotations must not be on the statefulset so kubectl does
 	// not manage the generated object


### PR DESCRIPTION
## Description

We use [fluxcd](https://github.com/fluxcd/flux2) with a
[kustomization](https://fluxcd.io/docs/components/kustomize/kustomization/)
referring to manifests generated by
[kube-prometheus](https://github.com/prometheus-operator/kube-prometheus)

Flux sets these labels on objects
it manages. If an object it manages exists on the cluster, but does not
exist in the defined kustomization, fluxcd will purge the object. As the
operator manages the statefulset, this does not exist in the
kustomization and flux will delete the statefulset when it reconciles.
We currently work around this by disabling flux garbage collection on
Prometheus objects, but it would be good if the operator didnt propogate
this label and we didnt need this workaround.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Stop propogating fluxcd labels to prometheus statefulset to improve process of managing operator with fluxcd
```
