### PR TITLE
Address race condition in recreate flow for statefulset

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -321,6 +321,10 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 	podLabels := map[string]string{
 		"app.kubernetes.io/version": version.String(),
 	}
+	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
+	// We should try to avoid removing such immutable fields whenever possible since doing
+	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
+	// The requirement to make a change here should be carefully evaluated.
 	podSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "alertmanager",
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -655,6 +655,10 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	podLabels := map[string]string{
 		"app.kubernetes.io/version": version.String(),
 	}
+	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
+	// We should try to avoid removing such immutable fields whenever possible since doing
+	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
+	// The requirement to make a change here should be carefully evaluated.
 	podSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/managed-by": "prometheus-operator",

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -380,6 +380,10 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			}
 		}
 	}
+	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
+	// We should try to avoid removing such immutable fields whenever possible since doing
+	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
+	// The requirement to make a change here should be carefully evaluated.
 	podLabels["app.kubernetes.io/name"] = thanosRulerLabel
 	podLabels["app.kubernetes.io/managed-by"] = "prometheus-operator"
 	podLabels["app.kubernetes.io/instance"] = tr.Name


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._
```
We have observed an issue where the operator fails to update
a sts and must delete, recreate, a race can occur.

The delete is a foreground cascading delete which causes
the sts to remain visible via the API server for an unknown
amount of time.

We have observed for all resources, the operator is receiving a
multitude of update requests before the delete is finalized.

This is causing a hot-loop of delete, recreate cycles which in
some cases appear never to resolve without manual intervention
i.e. (deleting the sts in the background).

Since the foreground delete will add a deletionTimestamp to the
existing spec, we can check its existence to determine we should
not continue processing the update.

While this change does not guarantee zero downtime of the pods
owned by the sts, it should at least minimize it and not cause
the problem to exacerbate.
```

This bug was reported to us downstream and thanks @simonpasquier who did the initial investigation of the problem. 

I carried out an upgrade on kube v1.22 -> 1.23 taking the operator from 0.49.0 to 0.53.1 with no apparent ill effects.

It should be noted that this change will not guarantee zero downtime, it just prevents the problem from growing and keeps potential downtime to a minimum. I observed the following on the above upgrade in Thanos:

<img width="1913" alt="Screenshot 2022-01-21 at 14 36 02" src="https://user-images.githubusercontent.com/5781491/150818272-e7eee264-49ab-4766-a29a-3879f7a410d6.png">

Fixes #4519 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Avoid race during recreation of StatefulSet(s)
```
