### PR TITLE
docs: Update link in adopters file which fixes ci failures

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -171,7 +171,7 @@ Opstrace installations use the Prometheus Operator internally to collect metrics
 
 ## Polar Signals
 
-[polarsignals.com](https://polarsignals.com/)
+[polarsignals.com](https://www.polarsignals.com/)
 
 Environment: Google Cloud
 


### PR DESCRIPTION
We are repeatedly failing link checking in `make check-docs`.

I believe we are being bitten by https://github.com/bwplotka/mdox/issues/22 since polarsignals.com redirects to www.polarsignals.com

Updated the link to avoid the redirect and circumvent bug in tooling.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


