### PR TITLE
pkg/k8sutil: set User-Agent for k8s client

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
-
 	"github.com/hashicorp/go-version"
+	promversion "github.com/prometheus/common/version"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -95,6 +95,8 @@ func NewClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientCo
 
 	cfg.QPS = 100
 	cfg.Burst = 100
+
+	cfg.UserAgent = fmt.Sprintf("PrometheusOperator/%s", promversion.Version)
 
 	return cfg, nil
 }

--- a/pkg/versionutil/cli.go
+++ b/pkg/versionutil/cli.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/prometheus/common/version"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (


### PR DESCRIPTION
The operator sets the User-Agent value to
"PrometheusOperator/<operator's version>".

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Set User-Agent for the kubernetes client.
```
