### PR TITLE
Specify SA token automounting on pod-level

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -169,6 +169,7 @@ Say the Prometheus Operator shall be deployed in the `default` namespace. First 
 
 ```yaml mdox-exec="cat example/rbac/prometheus-operator/prometheus-operator-service-account.yaml"
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -25860,6 +25860,7 @@ spec:
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/version: 0.53.1
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
@@ -25886,6 +25887,7 @@ spec:
       serviceAccountName: prometheus-operator
 ---
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/version: 0.53.1
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet

--- a/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -168,6 +168,7 @@ function(params) {
               runAsUser: 65534,
             },
             serviceAccountName: po.config.name,
+            automountServiceAccountToken: true,
           },
         },
       },
@@ -181,6 +182,7 @@ function(params) {
       namespace: po.config.namespace,
       labels: po.config.commonLabels,
     },
+    automountServiceAccountToken: false,
   },
 
   service: {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -902,6 +902,8 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to merge containers spec")
 	}
+
+	boolTrue := true
 	// PodManagementPolicy is set to Parallel to mitigate issues in kubernetes: https://github.com/kubernetes/kubernetes/issues/60164
 	// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 	return &appsv1.StatefulSetSpec{
@@ -925,6 +927,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				InitContainers:                initContainers,
 				SecurityContext:               p.Spec.SecurityContext,
 				ServiceAccountName:            p.Spec.ServiceAccountName,
+				AutomountServiceAccountToken:  &boolTrue,
 				NodeSelector:                  p.Spec.NodeSelector,
 				PriorityClassName:             p.Spec.PriorityClassName,
 				TerminationGracePeriodSeconds: &terminationGracePeriod,


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This is part of initiative to tighten security in kube-prometheus - https://github.com/prometheus-operator/kube-prometheus/issues/1589

This takes care of jsonnet deployment manifests for the operator itself (preventing token automount on SA level and specifying it directly on pod-level in Deployment object). Additionally, it explicitly specifies token automount for prometheus server, as without this kubernetes SD cannot work. Latter option allows to unset token automount on SA-level for prometheus server.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Specify SA token automounting on pod-level for operator and prometheus operand
```
