### PR TITLE
Fix the shard number in the shards and replicas user guide

### DIFF
--- a/Documentation/user-guides/shards-and-replicas.md
+++ b/Documentation/user-guides/shards-and-replicas.md
@@ -31,7 +31,6 @@ metadata:
 spec:
   serviceAccountName: prometheus
   replicas: 2
-  shards: 2
   serviceMonitorSelector:
     matchLabels:
       team: frontend


### PR DESCRIPTION
Signed-off-by: Jiacheng Xu <xjcmaxwellcjx@gmail.com>

## Description

This PR removes the shard field in the `shards and replicas` user guide since the shard should not be configured at the beginning of the guide, and then be enabled later in the guide.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix the shard number in the shards and replicas user guide.
```
