### PR TITLE
pkg/alertmanager: refactor validation of AlertmanagerConfig resources

### DIFF
--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -266,7 +266,7 @@ func (a *Admission) validateAlertManagerConfig(ar v1.AdmissionReview) *v1.Admiss
 		return toAdmissionResponseFailure(errUnmarshalConfig, alertManagerConfigResource, []error{err})
 	}
 
-	if err := alertmanager.ValidateConfig(amConf); err != nil {
+	if err := alertmanager.ValidateAlertmanagerConfig(amConf); err != nil {
 		msg := "invalid config"
 		level.Debug(a.logger).Log("msg", msg, "content", amConf.Spec)
 		level.Info(a.logger).Log("msg", msg, "err", err)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1043,38 +1043,28 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 }
 
 // checkAlertmanagerConfigResource verifies that an AlertmanagerConfig object is valid
-// and has no missing references to other objects.
+// for the given Alertmanager version and has no missing references to other objects.
 func checkAlertmanagerConfigResource(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, amVersion semver.Version, store *assets.Store) error {
-	receiverNames, err := checkReceivers(ctx, amc, store)
-	if err != nil {
+	if err := ValidateAlertmanagerConfig(amc); err != nil {
 		return err
 	}
 
-	muteTimeIntervalNames, err := validateMuteTimeIntervals(amc.Spec.MuteTimeIntervals)
-	if err != nil {
+	if err := checkReceivers(ctx, amc, store); err != nil {
 		return err
 	}
 
-	if err := checkRoutes(ctx, amc.Spec.Route, receiverNames, muteTimeIntervalNames, amVersion); err != nil {
+	if err := checkRoute(ctx, amc.Spec.Route, amVersion); err != nil {
 		return err
 	}
 
 	return checkInhibitRules(ctx, amc, amVersion)
 }
 
-func checkRoutes(ctx context.Context, route *monitoringv1alpha1.Route, receiverNames, muteTimeIntervalNames map[string]struct{}, amVersion semver.Version) error {
+func checkRoute(ctx context.Context, route *monitoringv1alpha1.Route, amVersion semver.Version) error {
 	if route == nil {
 		return nil
 	}
 
-	if err := validateAlertManagerRoutes(route, receiverNames, muteTimeIntervalNames, true); err != nil {
-		return err
-	}
-
-	return checkRoute(ctx, *route, amVersion)
-}
-
-func checkRoute(ctx context.Context, route monitoringv1alpha1.Route, amVersion semver.Version) error {
 	matchersV2Allowed := amVersion.GTE(semver.MustParse("0.22.0"))
 	if !matchersV2Allowed && checkIsV2Matcher(route.Matchers) {
 		return fmt.Errorf(
@@ -1086,69 +1076,65 @@ func checkRoute(ctx context.Context, route monitoringv1alpha1.Route, amVersion s
 	if err != nil {
 		return err
 	}
+
 	for _, route := range childRoutes {
-		if err := checkRoute(ctx, route, amVersion); err != nil {
+		if err := checkRoute(ctx, &route, amVersion); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func checkReceivers(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, store *assets.Store) (map[string]struct{}, error) {
-	receiverNames, err := validateReceivers(amc.Spec.Receivers)
-	if err != nil {
-		return nil, errors.Wrap(err, "checkReceivers: failed to validateReceivers")
-	}
-
+func checkReceivers(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, store *assets.Store) error {
 	for i, receiver := range amc.Spec.Receivers {
 		amcKey := fmt.Sprintf("alertmanagerConfig/%s/%s/%d", amc.GetNamespace(), amc.GetName(), i)
 
-		err = checkPagerDutyConfigs(ctx, receiver.PagerDutyConfigs, amc.GetNamespace(), amcKey, store)
+		err := checkPagerDutyConfigs(ctx, receiver.PagerDutyConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkOpsGenieConfigs(ctx, receiver.OpsGenieConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		err = checkSlackConfigs(ctx, receiver.SlackConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkWebhookConfigs(ctx, receiver.WebhookConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkWechatConfigs(ctx, receiver.WeChatConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkEmailConfigs(ctx, receiver.EmailConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkVictorOpsConfigs(ctx, receiver.VictorOpsConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkPushoverConfigs(ctx, receiver.PushoverConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = checkSnsConfigs(ctx, receiver.SNSConfigs, amc.GetNamespace(), amcKey, store)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return receiverNames, nil
+	return nil
 }
 
 func checkPagerDutyConfigs(ctx context.Context, configs []monitoringv1alpha1.PagerDutyConfig, namespace string, key string, store *assets.Store) error {
@@ -1364,6 +1350,7 @@ func checkInhibitRules(ctx context.Context, amc *monitoringv1alpha1.Alertmanager
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/validation_test.go
+++ b/pkg/alertmanager/validation_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 )
 
-func TestValidateConfig(t *testing.T) {
+func TestValidateAlertmanagerConfig(t *testing.T) {
 	testCases := []struct {
 		name      string
 		in        *monitoringv1alpha1.AlertmanagerConfig
@@ -450,7 +450,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateConfig(tc.in)
+			err := ValidateAlertmanagerConfig(tc.in)
 			if tc.expectErr && err == nil {
 				t.Error("expected error but got none")
 			}


### PR DESCRIPTION
## Description

checkAlertmanagerConfigResource() now calls ValidateAlertmanagerConfig()
first which is easier to maintain (IMHO) than the individual check*()
functions invoking their respective validate*() functions.

cc @PhilipGough 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
