### PR TITLE
jsonnet: Forbid write access to root filesystem

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -25879,6 +25879,7 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -41,6 +41,7 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -137,6 +137,7 @@ function(params) {
       resources: po.config.resources,
       securityContext: {
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
     };
     {


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This is part of the initiative to tighten security in kube-prometheus - https://github.com/prometheus-operator/kube-prometheus/issues/1595.

If a container, e.g. Prometheus-operator, needs to write to the filesystem, a strict volume mount should be used.
Following remediation docs from https://hub.armo.cloud/docs/c-0017


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Forbid write access to root filesystem of Prometheus-Operator
```
