### PR TITLE
Fix syntax errors after merge

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -643,7 +643,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 	}
 
 	livenessProbe := &v1.Probe{
-		Handler:          probeHandler("/-/healthy"),
+		ProbeHandler:     probeHandler("/-/healthy"),
 		TimeoutSeconds:   probeTimeoutSeconds,
 		PeriodSeconds:    5,
 		FailureThreshold: 6,

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -477,7 +477,7 @@ func TestListenLocal(t *testing.T) {
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
 	expectedLivenessProbe := &v1.Probe{
-		Handler:          expectedProbeHandler("/-/healthy"),
+		ProbeHandler:     expectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
 		FailureThreshold: 6,
@@ -551,7 +551,7 @@ func TestListenTLS(t *testing.T) {
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
 	expectedLivenessProbe := &v1.Probe{
-		Handler:          expectedProbeHandler("/-/healthy"),
+		ProbeHandler:     expectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
 		FailureThreshold: 6,


### PR DESCRIPTION
## Description

Merging #4387 introduced syntax errors because the Handler field of the
HTTPProbe was changed to ProbeHandler.
    
This commit fixes the errors and makes sure the compilation succeeds again.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
