### PR TITLE
Make `mdox` less error-prone

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,4 +1,5 @@
 version: 1
+timeout: "1m"
 
 validators:
   # Cloudflare protection, so returns 503 if not in browser. Cannot curl as well.

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ check-golang: $(GOLANGCILINTER_BINARY)
 	$(GOLANGCILINTER_BINARY) run
 
 MDOX_VALIDATE_CONFIG?=.mdox.validate.yaml
-MD_FILES_TO_FORMAT=$(filter-out $(FULLY_GENERATED_DOCS), $(shell find Documentation -name "*.md")) $(shell ls *.md)
+MD_FILES_TO_FORMAT=$(filter-out $(FULLY_GENERATED_DOCS), $(shell find Documentation -name "*.md")) $(filter-out ADOPTERS.md, $(shell ls *.md))
 
 .PHONY: docs
 docs: $(MDOX_BINARY)


### PR DESCRIPTION
## Description

This PR tries to addresses the recent uptick of `mdox` CI failures (e.g, #4532, #4505) by increasing the request timeouts for `mdox` to one minute from the default 10s (as defined in [colly](https://github.com/gocolly/colly/blob/e63893d27834f749d7e2035c29ffe6c75c4c6ad4/colly.go#L980) which is the scraping framework used by mdox) and haven't come across the usual `net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)` error yet.
But other errors such as a TLS handshake timeout do happen from time to time.

Also, removes `ADOPTERS.md` from the list of checked files as content is not modified frequently, but is still error-prone.

Tested this a number of times locally and also on [GitHub Actions in my fork](https://github.com/saswatamcode/prometheus-operator/runs/4981220629?check_suite_focus=true).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Increase timeout for mdox
```
