### PR TITLE
Add securityContext to managed containers

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -538,6 +538,8 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 	var watchedDirectories []string
 	watchedDirectories = append(watchedDirectories, reloadWatchDirs...)
 
+	boolFalse := false
+	boolTrue := true
 	defaultContainers := []v1.Container{
 		{
 			Args:           amArgs,
@@ -548,6 +550,13 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 			LivenessProbe:  livenessProbe,
 			ReadinessProbe: readinessProbe,
 			Resources:      a.Spec.Resources,
+			SecurityContext: &v1.SecurityContext{
+				AllowPrivilegeEscalation: &boolFalse,
+				ReadOnlyRootFilesystem:   &boolTrue,
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
+			},
 			Env: []v1.EnvVar{
 				{
 					// Necessary for '--cluster.listen-address' flag

--- a/pkg/operator/config-reloader.go
+++ b/pkg/operator/config-reloader.go
@@ -220,6 +220,8 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		})
 	}
 
+	boolFalse := false
+	boolTrue := true
 	return v1.Container{
 		Name:                     name,
 		Image:                    configReloader.config.Image,
@@ -230,5 +232,12 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		Ports:                    ports,
 		VolumeMounts:             configReloader.volumeMounts,
 		Resources:                resources,
+		SecurityContext: &v1.SecurityContext{
+			AllowPrivilegeEscalation: &boolFalse,
+			ReadOnlyRootFilesystem:   &boolTrue,
+			Capabilities: &v1.Capabilities{
+				Drop: []v1.Capability{"ALL"},
+			},
+		},
 	}
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -423,6 +423,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		})
 	}
 
+	boolFalse := false
+	boolTrue := true
 	operatorContainers := append([]v1.Container{
 		{
 			Name:                     "thanos-ruler",
@@ -433,6 +435,13 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			Resources:                tr.Spec.Resources,
 			Ports:                    ports,
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &v1.SecurityContext{
+				AllowPrivilegeEscalation: &boolFalse,
+				ReadOnlyRootFilesystem:   &boolTrue,
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
+			},
 		},
 	}, additionalContainers...)
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Following what has been done in https://github.com/prometheus-operator/kube-prometheus/pull/1610, https://github.com/prometheus-operator/kube-prometheus/pull/1600 and https://github.com/prometheus-operator/kube-prometheus/pull/1593. This PR also sets the same securityContext to all managed containers (I believe I haven't missed any 😅)


Prometheus statefulset still doesn't have `readonlyRootFilesystem: true`, because of https://github.com/prometheus-operator/prometheus-operator/issues/4562


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Improve security with container Security Context
```
