### PR TITLE
*: mark remoteWrite and remoteRead as non-experimental

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -361,15 +361,15 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 
 ## MetadataConfig
 
-Configures the sending of series metadata to remote storage.
+MetadataConfig configures the sending of series metadata to the remote storage.
 
 
 <em>appears in: [RemoteWriteSpec](#remotewritespec)</em>
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| send | Whether metric metadata is sent to remote storage or not. | bool | false |
-| sendInterval | How frequently metric metadata is sent to remote storage. | string | false |
+| send | Whether metric metadata is sent to the remote storage or not. | bool | false |
+| sendInterval | How frequently metric metadata is sent to the remote storage. | string | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -764,8 +764,8 @@ PrometheusSpec is a specification of the desired behavior of the Prometheus clus
 | affinity | If specified, the pod's scheduling constraints. | *v1.Affinity | false |
 | tolerations | If specified, the pod's tolerations. | []v1.Toleration | false |
 | topologySpreadConstraints | If specified, the pod's topology spread constraints. | []v1.TopologySpreadConstraint | false |
-| remoteWrite | If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteWriteSpec](#remotewritespec) | false |
-| remoteRead | If specified, the remote_read spec. This is an experimental feature, it may change in any upcoming release in a breaking way. | [][RemoteReadSpec](#remotereadspec) | false |
+| remoteWrite | remoteWrite is the list of remote write configurations. | [][RemoteWriteSpec](#remotewritespec) | false |
+| remoteRead | remoteRead is the list of remote read configurations. | [][RemoteReadSpec](#remotereadspec) | false |
 | securityContext | SecurityContext holds pod-level security attributes and common container settings. This defaults to the default PodSecurityContext. | *v1.PodSecurityContext | false |
 | listenLocal | ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP. | bool | false |
 | containers | Containers allows injecting additional containers or modifying operator generated containers. This can be used to allow adding an authentication proxy to a Prometheus pod or to change the behavior of an operator generated container. Containers described here modify an operator generated container if they share the same name and modifications are done via a strategic merge patch. The current container names are: `prometheus`, `config-reloader`, and `thanos-sidecar`. Overriding containers is entirely outside the scope of what the maintainers will support and by doing so, you accept that this behaviour may break at any time without notice. | []v1.Container | false |
@@ -830,7 +830,7 @@ QuerySpec defines the query command line flags when starting Prometheus.
 
 ## QueueConfig
 
-QueueConfig allows the tuning of remote_write queue_config parameters. This object is referenced in the RemoteWriteSpec object.
+QueueConfig allows the tuning of remote write's queue_config parameters. This object is referenced in the RemoteWriteSpec object.
 
 
 <em>appears in: [RemoteWriteSpec](#remotewritespec)</em>
@@ -870,15 +870,15 @@ RelabelConfig allows dynamic rewriting of the label set, being applied to sample
 
 ## RemoteReadSpec
 
-RemoteReadSpec defines the remote_read configuration for prometheus.
+RemoteReadSpec defines the configuration for Prometheus to read back samples from a remote endpoint.
 
 
 <em>appears in: [PrometheusSpec](#prometheusspec)</em>
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| url | The URL of the endpoint to send samples to. | string | true |
-| name | The name of the remote read queue, must be unique if specified. The name is used in metrics and logging in order to differentiate read configurations.  Only valid in Prometheus versions 2.15.0 and newer. | string | false |
+| url | The URL of the endpoint to query from. | string | true |
+| name | The name of the remote read queue, it must be unique if specified. The name is used in metrics and logging in order to differentiate read configurations.  Only valid in Prometheus versions 2.15.0 and newer. | string | false |
 | requiredMatchers | An optional list of equality matchers which have to be present in a selector to query the remote read endpoint. | map[string]string | false |
 | remoteTimeout | Timeout for requests to the remote read endpoint. | string | false |
 | headers | Custom HTTP headers to be sent along with each remote read request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.26.0 and newer. | map[string]string | false |
@@ -889,13 +889,13 @@ RemoteReadSpec defines the remote_read configuration for prometheus.
 | bearerTokenFile | File to read bearer token for remote read. | string | false |
 | authorization | Authorization section for remote read | *[Authorization](#authorization) | false |
 | tlsConfig | TLS Config to use for remote read. | *[TLSConfig](#tlsconfig) | false |
-| proxyUrl | Optional ProxyURL | string | false |
+| proxyUrl | Optional ProxyURL. | string | false |
 
 [Back to TOC](#table-of-contents)
 
 ## RemoteWriteSpec
 
-RemoteWriteSpec defines the remote_write configuration for prometheus.
+RemoteWriteSpec defines the configuration to write samples from Prometheus to a remote endpoint.
 
 
 <em>appears in: [PrometheusSpec](#prometheusspec)</em>
@@ -903,7 +903,7 @@ RemoteWriteSpec defines the remote_write configuration for prometheus.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | url | The URL of the endpoint to send samples to. | string | true |
-| name | The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer. | string | false |
+| name | The name of the remote write queue, it must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer. | string | false |
 | sendExemplars | Enables sending of exemplars over remote write. Note that exemplar-storage itself must be enabled using the enableFeature option for exemplars to be scraped in the first place.  Only valid in Prometheus versions 2.27.0 and newer. | *bool | false |
 | remoteTimeout | Timeout for requests to the remote write endpoint. | string | false |
 | headers | Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.25.0 and newer. | map[string]string | false |
@@ -915,9 +915,9 @@ RemoteWriteSpec defines the remote_write configuration for prometheus.
 | authorization | Authorization section for remote write | *[Authorization](#authorization) | false |
 | sigv4 | Sigv4 allows to configures AWS's Signature Verification 4 | *[Sigv4](#sigv4) | false |
 | tlsConfig | TLS Config to use for remote write. | *[TLSConfig](#tlsconfig) | false |
-| proxyUrl | Optional ProxyURL | string | false |
+| proxyUrl | Optional ProxyURL. | string | false |
 | queueConfig | QueueConfig allows tuning of the remote write queue parameters. | *[QueueConfig](#queueconfig) | false |
-| metadataConfig | MetadataConfig configures the sending of series metadata to remote storage. | *[MetadataConfig](#metadataconfig) | false |
+| metadataConfig | MetadataConfig configures the sending of series metadata to the remote storage. | *[MetadataConfig](#metadataconfig) | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14776,11 +14776,10 @@ spec:
                   docs (https://prometheus.io/docs/guides/query-log/)
                 type: string
               remoteRead:
-                description: If specified, the remote_read spec. This is an experimental
-                  feature, it may change in any upcoming release in a breaking way.
+                description: remoteRead is the list of remote read configurations.
                 items:
-                  description: RemoteReadSpec defines the remote_read configuration
-                    for prometheus.
+                  description: RemoteReadSpec defines the configuration for Prometheus
+                    to read back samples from a remote endpoint.
                   properties:
                     authorization:
                       description: Authorization section for remote read
@@ -14870,7 +14869,7 @@ spec:
                         versions 2.26.0 and newer.
                       type: object
                     name:
-                      description: The name of the remote read queue, must be unique
+                      description: The name of the remote read queue, it must be unique
                         if specified. The name is used in metrics and logging in order
                         to differentiate read configurations.  Only valid in Prometheus
                         versions 2.15.0 and newer.
@@ -14960,7 +14959,7 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: Optional ProxyURL
+                      description: Optional ProxyURL.
                       type: string
                     readRecent:
                       description: Whether reads should be made for queries for time
@@ -15103,18 +15102,17 @@ spec:
                           type: string
                       type: object
                     url:
-                      description: The URL of the endpoint to send samples to.
+                      description: The URL of the endpoint to query from.
                       type: string
                   required:
                   - url
                   type: object
                 type: array
               remoteWrite:
-                description: If specified, the remote_write spec. This is an experimental
-                  feature, it may change in any upcoming release in a breaking way.
+                description: remoteWrite is the list of remote write configurations.
                 items:
-                  description: RemoteWriteSpec defines the remote_write configuration
-                    for prometheus.
+                  description: RemoteWriteSpec defines the configuration to write
+                    samples from Prometheus to a remote endpoint.
                   properties:
                     authorization:
                       description: Authorization section for remote write
@@ -15205,22 +15203,22 @@ spec:
                       type: object
                     metadataConfig:
                       description: MetadataConfig configures the sending of series
-                        metadata to remote storage.
+                        metadata to the remote storage.
                       properties:
                         send:
-                          description: Whether metric metadata is sent to remote storage
-                            or not.
+                          description: Whether metric metadata is sent to the remote
+                            storage or not.
                           type: boolean
                         sendInterval:
-                          description: How frequently metric metadata is sent to remote
-                            storage.
+                          description: How frequently metric metadata is sent to the
+                            remote storage.
                           type: string
                       type: object
                     name:
-                      description: The name of the remote write queue, must be unique
-                        if specified. The name is used in metrics and logging in order
-                        to differentiate queues. Only valid in Prometheus versions
-                        2.15.0 and newer.
+                      description: The name of the remote write queue, it must be
+                        unique if specified. The name is used in metrics and logging
+                        in order to differentiate queues. Only valid in Prometheus
+                        versions 2.15.0 and newer.
                       type: string
                     oauth2:
                       description: OAuth2 for the URL. Only valid in Prometheus versions
@@ -15307,7 +15305,7 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: Optional ProxyURL
+                      description: Optional ProxyURL.
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4298,11 +4298,10 @@ spec:
                   docs (https://prometheus.io/docs/guides/query-log/)
                 type: string
               remoteRead:
-                description: If specified, the remote_read spec. This is an experimental
-                  feature, it may change in any upcoming release in a breaking way.
+                description: remoteRead is the list of remote read configurations.
                 items:
-                  description: RemoteReadSpec defines the remote_read configuration
-                    for prometheus.
+                  description: RemoteReadSpec defines the configuration for Prometheus
+                    to read back samples from a remote endpoint.
                   properties:
                     authorization:
                       description: Authorization section for remote read
@@ -4392,7 +4391,7 @@ spec:
                         versions 2.26.0 and newer.
                       type: object
                     name:
-                      description: The name of the remote read queue, must be unique
+                      description: The name of the remote read queue, it must be unique
                         if specified. The name is used in metrics and logging in order
                         to differentiate read configurations.  Only valid in Prometheus
                         versions 2.15.0 and newer.
@@ -4482,7 +4481,7 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: Optional ProxyURL
+                      description: Optional ProxyURL.
                       type: string
                     readRecent:
                       description: Whether reads should be made for queries for time
@@ -4625,18 +4624,17 @@ spec:
                           type: string
                       type: object
                     url:
-                      description: The URL of the endpoint to send samples to.
+                      description: The URL of the endpoint to query from.
                       type: string
                   required:
                   - url
                   type: object
                 type: array
               remoteWrite:
-                description: If specified, the remote_write spec. This is an experimental
-                  feature, it may change in any upcoming release in a breaking way.
+                description: remoteWrite is the list of remote write configurations.
                 items:
-                  description: RemoteWriteSpec defines the remote_write configuration
-                    for prometheus.
+                  description: RemoteWriteSpec defines the configuration to write
+                    samples from Prometheus to a remote endpoint.
                   properties:
                     authorization:
                       description: Authorization section for remote write
@@ -4727,22 +4725,22 @@ spec:
                       type: object
                     metadataConfig:
                       description: MetadataConfig configures the sending of series
-                        metadata to remote storage.
+                        metadata to the remote storage.
                       properties:
                         send:
-                          description: Whether metric metadata is sent to remote storage
-                            or not.
+                          description: Whether metric metadata is sent to the remote
+                            storage or not.
                           type: boolean
                         sendInterval:
-                          description: How frequently metric metadata is sent to remote
-                            storage.
+                          description: How frequently metric metadata is sent to the
+                            remote storage.
                           type: string
                       type: object
                     name:
-                      description: The name of the remote write queue, must be unique
-                        if specified. The name is used in metrics and logging in order
-                        to differentiate queues. Only valid in Prometheus versions
-                        2.15.0 and newer.
+                      description: The name of the remote write queue, it must be
+                        unique if specified. The name is used in metrics and logging
+                        in order to differentiate queues. Only valid in Prometheus
+                        versions 2.15.0 and newer.
                       type: string
                     oauth2:
                       description: OAuth2 for the URL. Only valid in Prometheus versions
@@ -4829,7 +4827,7 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: Optional ProxyURL
+                      description: Optional ProxyURL.
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3902,9 +3902,9 @@
                     "type": "string"
                   },
                   "remoteRead": {
-                    "description": "If specified, the remote_read spec. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+                    "description": "remoteRead is the list of remote read configurations.",
                     "items": {
-                      "description": "RemoteReadSpec defines the remote_read configuration for prometheus.",
+                      "description": "RemoteReadSpec defines the configuration for Prometheus to read back samples from a remote endpoint.",
                       "properties": {
                         "authorization": {
                           "description": "Authorization section for remote read",
@@ -4005,7 +4005,7 @@
                           "type": "object"
                         },
                         "name": {
-                          "description": "The name of the remote read queue, must be unique if specified. The name is used in metrics and logging in order to differentiate read configurations.  Only valid in Prometheus versions 2.15.0 and newer.",
+                          "description": "The name of the remote read queue, it must be unique if specified. The name is used in metrics and logging in order to differentiate read configurations.  Only valid in Prometheus versions 2.15.0 and newer.",
                           "type": "string"
                         },
                         "oauth2": {
@@ -4108,7 +4108,7 @@
                           "type": "object"
                         },
                         "proxyUrl": {
-                          "description": "Optional ProxyURL",
+                          "description": "Optional ProxyURL.",
                           "type": "string"
                         },
                         "readRecent": {
@@ -4270,7 +4270,7 @@
                           "type": "object"
                         },
                         "url": {
-                          "description": "The URL of the endpoint to send samples to.",
+                          "description": "The URL of the endpoint to query from.",
                           "type": "string"
                         }
                       },
@@ -4282,9 +4282,9 @@
                     "type": "array"
                   },
                   "remoteWrite": {
-                    "description": "If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+                    "description": "remoteWrite is the list of remote write configurations.",
                     "items": {
-                      "description": "RemoteWriteSpec defines the remote_write configuration for prometheus.",
+                      "description": "RemoteWriteSpec defines the configuration to write samples from Prometheus to a remote endpoint.",
                       "properties": {
                         "authorization": {
                           "description": "Authorization section for remote write",
@@ -4385,21 +4385,21 @@
                           "type": "object"
                         },
                         "metadataConfig": {
-                          "description": "MetadataConfig configures the sending of series metadata to remote storage.",
+                          "description": "MetadataConfig configures the sending of series metadata to the remote storage.",
                           "properties": {
                             "send": {
-                              "description": "Whether metric metadata is sent to remote storage or not.",
+                              "description": "Whether metric metadata is sent to the remote storage or not.",
                               "type": "boolean"
                             },
                             "sendInterval": {
-                              "description": "How frequently metric metadata is sent to remote storage.",
+                              "description": "How frequently metric metadata is sent to the remote storage.",
                               "type": "string"
                             }
                           },
                           "type": "object"
                         },
                         "name": {
-                          "description": "The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer.",
+                          "description": "The name of the remote write queue, it must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer.",
                           "type": "string"
                         },
                         "oauth2": {
@@ -4502,7 +4502,7 @@
                           "type": "object"
                         },
                         "proxyUrl": {
-                          "description": "Optional ProxyURL",
+                          "description": "Optional ProxyURL.",
                           "type": "string"
                         },
                         "queueConfig": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -248,9 +248,9 @@ type PrometheusSpec struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// If specified, the pod's topology spread constraints.
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
-	// If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way.
+	// remoteWrite is the list of remote write configurations.
 	RemoteWrite []RemoteWriteSpec `json:"remoteWrite,omitempty"`
-	// If specified, the remote_read spec. This is an experimental feature, it may change in any upcoming release in a breaking way.
+	// remoteRead is the list of remote read configurations.
 	RemoteRead []RemoteReadSpec `json:"remoteRead,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// This defaults to the default PodSecurityContext.
@@ -682,16 +682,20 @@ type ThanosSpec struct {
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 }
 
-// RemoteWriteSpec defines the remote_write configuration for prometheus.
+// RemoteWriteSpec defines the configuration to write samples from Prometheus
+// to a remote endpoint.
 // +k8s:openapi-gen=true
 type RemoteWriteSpec struct {
 	// The URL of the endpoint to send samples to.
 	URL string `json:"url"`
-	// The name of the remote write queue, must be unique if specified. The
+	// The name of the remote write queue, it must be unique if specified. The
 	// name is used in metrics and logging in order to differentiate queues.
 	// Only valid in Prometheus versions 2.15.0 and newer.
 	Name string `json:"name,omitempty"`
-	// Enables sending of exemplars over remote write. Note that exemplar-storage itself must be enabled using the enableFeature option for exemplars to be scraped in the first place.  Only valid in Prometheus versions 2.27.0 and newer.
+	// Enables sending of exemplars over remote write. Note that
+	// exemplar-storage itself must be enabled using the enableFeature option
+	// for exemplars to be scraped in the first place.  Only valid in
+	// Prometheus versions 2.27.0 and newer.
 	SendExemplars *bool `json:"sendExemplars,omitempty"`
 	// Timeout for requests to the remote write endpoint.
 	RemoteTimeout string `json:"remoteTimeout,omitempty"`
@@ -715,16 +719,16 @@ type RemoteWriteSpec struct {
 	Sigv4 *Sigv4 `json:"sigv4,omitempty"`
 	// TLS Config to use for remote write.
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
-	// Optional ProxyURL
+	// Optional ProxyURL.
 	ProxyURL string `json:"proxyUrl,omitempty"`
 	// QueueConfig allows tuning of the remote write queue parameters.
 	QueueConfig *QueueConfig `json:"queueConfig,omitempty"`
-	// MetadataConfig configures the sending of series metadata to remote storage.
+	// MetadataConfig configures the sending of series metadata to the remote storage.
 	MetadataConfig *MetadataConfig `json:"metadataConfig,omitempty"`
 }
 
-// QueueConfig allows the tuning of remote_write queue_config parameters. This object
-// is referenced in the RemoteWriteSpec object.
+// QueueConfig allows the tuning of remote write's queue_config parameters.
+// This object is referenced in the RemoteWriteSpec object.
 // +k8s:openapi-gen=true
 type QueueConfig struct {
 	// Capacity is the number of samples to buffer per shard before we start dropping them.
@@ -764,12 +768,13 @@ type Sigv4 struct {
 	RoleArn string `json:"roleArn,omitempty"`
 }
 
-// RemoteReadSpec defines the remote_read configuration for prometheus.
+// RemoteReadSpec defines the configuration for Prometheus to read back samples
+// from a remote endpoint.
 // +k8s:openapi-gen=true
 type RemoteReadSpec struct {
-	// The URL of the endpoint to send samples to.
+	// The URL of the endpoint to query from.
 	URL string `json:"url"`
-	// The name of the remote read queue, must be unique if specified. The name
+	// The name of the remote read queue, it must be unique if specified. The name
 	// is used in metrics and logging in order to differentiate read
 	// configurations.  Only valid in Prometheus versions 2.15.0 and newer.
 	Name string `json:"name,omitempty"`
@@ -797,7 +802,7 @@ type RemoteReadSpec struct {
 	Authorization *Authorization `json:"authorization,omitempty"`
 	// TLS Config to use for remote read.
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
-	// Optional ProxyURL
+	// Optional ProxyURL.
 	ProxyURL string `json:"proxyUrl,omitempty"`
 }
 
@@ -1637,12 +1642,12 @@ type AlertmanagerList struct {
 	Items []Alertmanager `json:"items"`
 }
 
-// Configures the sending of series metadata to remote storage.
+// MetadataConfig configures the sending of series metadata to the remote storage.
 // +k8s:openapi-gen=true
 type MetadataConfig struct {
-	// Whether metric metadata is sent to remote storage or not.
+	// Whether metric metadata is sent to the remote storage or not.
 	Send bool `json:"send,omitempty"`
-	// How frequently metric metadata is sent to remote storage.
+	// How frequently metric metadata is sent to the remote storage.
 	SendInterval string `json:"sendInterval,omitempty"`
 }
 


### PR DESCRIPTION
## Description

The remote read and write features are established enough in Prometheus
that we can drop the "EXPERIMENTAL" warning in the Prometheus CRD and
support them officially from now on.

If the format of the remote write/read configuration in Prometheus
changes in a breaking way, the operator should deal with it based on the
`spec.version` field of the Prometheus resource, just like it does for
other configuration fields.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
`remoteWrite` and `remoteRead` fields of the Prometheus CRD not considered experimental anymore.
```
