### PR TITLE
pkg/promcfg: Add support for follow_redirects in endpoints

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -356,6 +356,7 @@ Endpoint defines a scrapeable endpoint serving Prometheus metrics.
 | metricRelabelings | MetricRelabelConfigs to apply to samples before ingestion. | []*[RelabelConfig](#relabelconfig) | false |
 | relabelings | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields and replaces original scrape job name with __tmp_prometheus_job_name. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config | []*[RelabelConfig](#relabelconfig) | false |
 | proxyUrl | ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint. | *string | false |
+| followRedirects | FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects. | bool | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -430,6 +431,7 @@ PodMetricsEndpoint defines a scrapeable endpoint of a Kubernetes Pod serving Pro
 | metricRelabelings | MetricRelabelConfigs to apply to samples before ingestion. | []*[RelabelConfig](#relabelconfig) | false |
 | relabelings | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields and replaces original scrape job name with __tmp_prometheus_job_name. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config | []*[RelabelConfig](#relabelconfig) | false |
 | proxyUrl | ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint. | *string | false |
+| followRedirects | FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9406,6 +9406,10 @@ spec:
                       required:
                       - key
                       type: object
+                    followRedirects:
+                      description: FollowRedirects Configure whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
                     honorLabels:
                       description: HonorLabels chooses the metric's labels on collisions
                         with target labels.
@@ -19035,6 +19039,10 @@ spec:
                       required:
                       - key
                       type: object
+                    followRedirects:
+                      description: FollowRedirects Configure whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
                     honorLabels:
                       description: HonorLabels chooses the metric's labels on collisions
                         with target labels.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -169,6 +169,10 @@ spec:
                       required:
                       - key
                       type: object
+                    followRedirects:
+                      description: FollowRedirects Configure whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
                     honorLabels:
                       description: HonorLabels chooses the metric's labels on collisions
                         with target labels.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -138,6 +138,10 @@ spec:
                       required:
                       - key
                       type: object
+                    followRedirects:
+                      description: FollowRedirects Configure whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
                     honorLabels:
                       description: HonorLabels chooses the metric's labels on collisions
                         with target labels.

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -182,6 +182,10 @@
                           ],
                           "type": "object"
                         },
+                        "followRedirects": {
+                          "description": "FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects.",
+                          "type": "boolean"
+                        },
                         "honorLabels": {
                           "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
                           "type": "boolean"

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -150,6 +150,10 @@
                           ],
                           "type": "object"
                         },
+                        "followRedirects": {
+                          "description": "FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects.",
+                          "type": "boolean"
+                        },
                         "honorLabels": {
                           "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
                           "type": "boolean"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -965,6 +965,8 @@ type Endpoint struct {
 	RelabelConfigs []*RelabelConfig `json:"relabelings,omitempty"`
 	// ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
 	ProxyURL *string `json:"proxyUrl,omitempty"`
+	// FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects.
+	FollowRedirects bool `json:"followRedirects,omitempty"`
 }
 
 // PodMonitor defines monitoring for a set of pods.
@@ -1049,6 +1051,8 @@ type PodMetricsEndpoint struct {
 	RelabelConfigs []*RelabelConfig `json:"relabelings,omitempty"`
 	// ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
 	ProxyURL *string `json:"proxyUrl,omitempty"`
+	// FollowRedirects Configure whether scrape requests follow HTTP 3xx redirects.
+	FollowRedirects bool `json:"followRedirects,omitempty"`
 }
 
 // PodMetricsEndpointTLSConfig specifies TLS configuration parameters.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -657,6 +657,10 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 	if ep.Scheme != "" {
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: ep.Scheme})
 	}
+	// Defaults to true, so only add when value is set to false
+	if !ep.FollowRedirects {
+		cfg = append(cfg, yaml.MapItem{Key: "follow_redirects", Value: ep.FollowRedirects})
+	}
 
 	if ep.TLSConfig != nil {
 		cfg = addSafeTLStoYaml(cfg, m.Namespace, ep.TLSConfig.SafeTLSConfig)
@@ -1150,6 +1154,10 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 	}
 	if ep.Scheme != "" {
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: ep.Scheme})
+	}
+	// Defaults to true, so only add when value is set to false
+	if !ep.FollowRedirects {
+		cfg = append(cfg, yaml.MapItem{Key: "follow_redirects", Value: ep.FollowRedirects})
 	}
 
 	assetKey := fmt.Sprintf("serviceMonitor/%s/%s/%d", m.Namespace, m.Name, i)


### PR DESCRIPTION
## Description

Add support for setting `follow_redirects` in endpoint configuration.

Since the prometheus default value is `true` only set the value when is set to `false`

Closes https://github.com/prometheus-operator/prometheus-operator/issues/4557



## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ x ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Add support for follow_redirects in endpoint scrape configuration. Prometheus default value is true so only set when the requested value is false

```
