### PR TITLE
Fix for #4560. Unable to set storage sub path for prometheus

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1106,6 +1106,7 @@ StorageSpec defines the configured storage for a group Prometheus servers. If no
 | emptyDir | EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir | *[v1.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#emptydirvolumesource-v1-core) | false |
 | ephemeral | EphemeralVolumeSource to be used by the Prometheus StatefulSets. This is a beta field in k8s 1.21, for lower versions, starting with k8s 1.19, it requires enabling the GenericEphemeralVolume feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes | *v1.EphemeralVolumeSource | false |
 | volumeClaimTemplate | A PVC spec to be used by the Prometheus StatefulSets. | [EmbeddedPersistentVolumeClaim](#embeddedpersistentvolumeclaim) | false |
+| name | Subpath for /prometheus volume mount | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7212,6 +7212,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:
@@ -16308,6 +16311,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:
@@ -23747,6 +23753,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4021,6 +4021,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5830,6 +5830,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4223,6 +4223,9 @@ spec:
                         - spec
                         type: object
                     type: object
+                  name:
+                    description: Subpath for /prometheus volume mount
+                    type: string
                   volumeClaimTemplate:
                     description: A PVC spec to be used by the Prometheus StatefulSets.
                     properties:

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3546,6 +3546,10 @@
                         },
                         "type": "object"
                       },
+                      "name": {
+                        "description": "Subpath for /prometheus volume mount",
+                        "type": "string"
+                      },
                       "volumeClaimTemplate": {
                         "description": "A PVC spec to be used by the Prometheus StatefulSets.",
                         "properties": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5419,6 +5419,10 @@
                         },
                         "type": "object"
                       },
+                      "name": {
+                        "description": "Subpath for /prometheus volume mount",
+                        "type": "string"
+                      },
                       "volumeClaimTemplate": {
                         "description": "A PVC spec to be used by the Prometheus StatefulSets.",
                         "properties": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3784,6 +3784,10 @@
                         },
                         "type": "object"
                       },
+                      "name": {
+                        "description": "Subpath for /prometheus volume mount",
+                        "type": "string"
+                      },
                       "volumeClaimTemplate": {
                         "description": "A PVC spec to be used by the Prometheus StatefulSets.",
                         "properties": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -484,6 +484,8 @@ type StorageSpec struct {
 	Ephemeral *v1.EphemeralVolumeSource `json:"ephemeral,omitempty"`
 	// A PVC spec to be used by the Prometheus StatefulSets.
 	VolumeClaimTemplate EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
+	// Subpath for /prometheus volume mount
+	MountSubPath string `json:"name,omitempty" protobuf:"bytes,1,opt,name=mountSubPath"`
 }
 
 // EmbeddedPersistentVolumeClaim is an embedded version of k8s.io/api/core/v1.PersistentVolumeClaim.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -989,10 +989,13 @@ func prefixedName(name string) string {
 }
 
 func subPathForStorage(s *monitoringv1.StorageSpec) string {
-	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-	if s == nil || s.DisableMountSubPath {
-		return ""
+	subPath := ""
+	if s != nil && s.MountSubPath != "" {
+		subPath = s.MountSubPath
+	} else if s == nil || s.DisableMountSubPath { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+		subPath = ""
+	} else {
+		subPath = "prometheus-db"
 	}
-
-	return "prometheus-db"
+	return subPath
 }


### PR DESCRIPTION
## Description

Fixes #4560 Can't set sub path

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._
Added `MountSubPath` property to storage spec so that an end user can set the subpath for a volume mount.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
