### PR TITLE
pkg/prometheus: Update validation for labelmap

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2170,8 +2170,10 @@ func validateRelabelConfig(rc monitoringv1.RelabelConfig) error {
 	if rc.Action == string(relabel.Replace) && !relabelTarget.MatchString(rc.TargetLabel) {
 		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
-	if rc.Action == string(relabel.LabelMap) && !relabelTarget.MatchString(rc.Replacement) {
-		return errors.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
+	if rc.Action == string(relabel.LabelMap) {
+		if rc.Replacement != "" && !relabelTarget.MatchString(rc.Replacement) {
+			return errors.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
+		}
 	}
 	if rc.Action == string(relabel.HashMod) && !model.LabelName(rc.TargetLabel).IsValid() {
 		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -322,18 +322,27 @@ func TestValidateRelabelConfig(t *testing.T) {
 		{
 			scenario: "invalid labelmap config",
 			relabelConfig: monitoringv1.RelabelConfig{
-				Action: "labelmap",
-				Regex:  "__meta_kubernetes_service_label_(.+)",
+				Action:      "labelmap",
+				Regex:       "__meta_kubernetes_service_label_(.+)",
+				Replacement: "some-name-value",
 			},
 			expectedErr: true,
 		},
-		// Test valid labelmap relabel config
+		// Test valid labelmap relabel config when replacement not specified
+		{
+			scenario: "valid labelmap config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labelmap",
+				Regex:  "__meta_kubernetes_service_label_(.+)",
+			},
+		},
+		// Test valid labelmap relabel config with replacement specified
 		{
 			scenario: "valid labelmap config",
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "labelmap",
 				Regex:       "__meta_kubernetes_service_label_(.+)",
-				Replacement: "k8s_$1",
+				Replacement: "${2}",
 			},
 		},
 		// Test invalid labelkeep relabel config


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

pkg/apis: Set default values for relabelConfigs

We had implemented validation logic for relabelling as in [prometheus](https://github.com/prometheus/prometheus/blob/9a2e93228e63a3fbac950ef0a639f754c3598c5d/model/relabel/relabel.go#L94-L133). Since default values for relabel configs are set [here](https://github.com/prometheus/prometheus/blob/9a2e93228e63a3fbac950ef0a639f754c3598c5d/model/relabel/relabel.go#L31-L36) in prometheus it works well but since default values in operator for these configs are not set explicitly [validation logic](https://github.com/prometheus-operator/prometheus-operator/pull/4429) implemented for relabelling will fail ~~hence handling it at CRD level so that default values are set correctly and validation will not throw error when these values are not set in config.~~

As a fix updating the validation method logic instead of api level as per discussion in this PR

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/4572

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed relabelConfigs for labelmap action
```
