### PR TITLE
pkg/prometheus: support default relabel config in validation

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2181,10 +2181,14 @@ func validateRelabelConfig(rc monitoringv1.RelabelConfig) error {
 
 	if rc.Action == string(relabel.LabelDrop) || rc.Action == string(relabel.LabelKeep) {
 		if len(rc.SourceLabels) != 0 ||
-			rc.TargetLabel != "" ||
-			rc.Modulus != uint64(0) ||
-			rc.Separator != "" ||
-			rc.Replacement != "" {
+			!(rc.TargetLabel == "" ||
+				rc.TargetLabel == relabel.DefaultRelabelConfig.TargetLabel) ||
+			!(rc.Modulus == uint64(0) ||
+				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
+			!(rc.Separator == "" ||
+				rc.Separator == relabel.DefaultRelabelConfig.Separator) ||
+			!(rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
+				rc.Replacement == "") {
 			return errors.Errorf("%s action requires only 'regex', and no other fields", rc.Action)
 		}
 	}

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -21,6 +21,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	"github.com/prometheus/prometheus/model/relabel"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -267,6 +268,20 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 }
 
 func TestValidateRelabelConfig(t *testing.T) {
+	defaultRegexp, err := relabel.DefaultRelabelConfig.Regex.MarshalYAML()
+	if err != nil {
+		t.Errorf("Could not marshal relabel.DefaultRelabelConfig.Regex: %v", err)
+	}
+	defaultRegex, ok := defaultRegexp.(string)
+	if !ok {
+		t.Errorf("Could not assert marshaled defaultRegexp as string: %v", defaultRegexp)
+	}
+
+	defaultSourceLabels := []string{}
+	for _, label := range relabel.DefaultRelabelConfig.SourceLabels {
+		defaultSourceLabels = append(defaultSourceLabels, string(label))
+	}
+
 	for _, tc := range []struct {
 		scenario      string
 		relabelConfig monitoringv1.RelabelConfig
@@ -368,6 +383,18 @@ func TestValidateRelabelConfig(t *testing.T) {
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action: "labeldrop",
 				Regex:  "replica",
+			},
+		},
+		{
+			scenario: "valid labeldrop config with default values",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: defaultSourceLabels,
+				Separator:    relabel.DefaultRelabelConfig.Separator,
+				TargetLabel:  relabel.DefaultRelabelConfig.TargetLabel,
+				Regex:        defaultRegex,
+				Modulus:      relabel.DefaultRelabelConfig.Modulus,
+				Replacement:  relabel.DefaultRelabelConfig.Replacement,
+				Action:       "labeldrop",
 			},
 		},
 		// Test valid relabel config


### PR DESCRIPTION
## Description

Prometheus has a default relabel config that is different
from the natural zero values for the individual types.

The current validations create a situation where a valid configuration
that is marshaled and unmarshaled (e.g. when generating a
ServiceMonitor config) is suddenly no longer valid.

This changes the validation to accept both the zero values (as that
makes the most sense when writing the config by hand) and the
default config as it is used by Prometheus (see also
https://github.com/prometheus/prometheus/blob/v2.33.3/model/relabel/relabel.go#L122-L130).


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Updated relabelConfig validation to accept Prometheus default config on labeldrop relabelConfig.
```
