### PR TITLE
pkg/prometheus: fix test compilation after #4539

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1846,7 +1846,9 @@ func TestServiceMonitorWithEndpointSliceEnable(t *testing.T) {
 				Namespace: "ns-value",
 			},
 			Spec: monitoringv1.PrometheusSpec{
-				EnforcedNamespaceLabel: "ns-key",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					EnforcedNamespaceLabel: "ns-key",
+				},
 			},
 		},
 		map[string]*monitoringv1.ServiceMonitor{


### PR DESCRIPTION
## Description

~~Not sure why the CI didn't catch it before but it looks like #4539 broke pkg/prometheus/promcfg_test.go.~~
Ok, the reason is that #4535 added `TestServiceMonitorWithEndpointSliceEnable` but it wasn't rebased on the most recent main.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
