### PR TITLE
TLS certificate verification skip for prometheus-config-reloader

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -132,6 +132,10 @@ func main() {
 			},
 		)
 
+		transport := &http.Transport{}
+		client := http.Client{Transport: transport}
+		rel.SetHttpClient(client)
+
 		g.Add(func() error {
 			return rel.Watch(ctx)
 		}, func(error) {

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -176,7 +176,7 @@ func createHTTPClient() http.Client {
 	}
 
 	return http.Client{
-		Timeout:   400 * time.Millisecond, // Construct with a 400 millisecond timeout. This timeout is sufficient and calculated with Dial + TLS + TTFB + Response in mind.
+		Timeout:   30 * time.Second, // Construct with a 30 second timeout. This timeout is unchanged related to the Dialer Timeout and is subject for change. Other timeouts are neglected.
 		Transport: transport,
 	}
 }

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -161,10 +161,6 @@ func main() {
 }
 
 func createHTTPClient() http.Client {
-	config := &tls.Config{
-		InsecureSkipVerify: true, // TLS certificate verification is disabled by default.
-	}
-
 	transport := (http.DefaultTransport.(*http.Transport)).Clone() // Use the default transporter for production and future changes ready settings.
 
 	transport.DialContext = (&net.Dialer{
@@ -177,7 +173,9 @@ func createHTTPClient() http.Client {
 	transport.DisableKeepAlives = true                        // Connection pooling isn't applicable here.
 	transport.MaxConnsPerHost = transport.MaxIdleConnsPerHost // Can only have x connections per host, if it is higher than this value something is wrong. Set to max idle as this is a sensible default.
 
-	transport.TLSClientConfig = config // Apply the TLS configuration.
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true, // TLS certificate verification is disabled by default.
+	}
 
 	return http.Client{
 		Timeout:   400 * time.Millisecond, // Construct with a 400 millisecond timeout. This timeout is sufficient and calculated with Dial + TLS + TTFB + Response in mind.

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -169,14 +169,13 @@ func createHTTPClient(watchInterval *time.Duration) http.Client {
 
 	transport.DialContext = (&net.Dialer{
 		Timeout:   30 * time.Millisecond, // Timeout for Dial should never be 30 seconds, a bit of fine tuning to prevent (long) waiting time.
-		KeepAlive: 30 * time.Second,
+		KeepAlive: -1,                    // Keep alive probe is unnecessary
 	}).DialContext
 
 	transport.TLSHandshakeTimeout = 300 * time.Millisecond    // TLS should never take too long.
-	transport.ExpectContinueTimeout = 0                       // We don't send any body, so setting this is unecessary.
-	transport.IdleConnTimeout = *watchInterval                // Maximum time before another request is sent.
-	transport.MaxConnsPerHost = transport.MaxIdleConnsPerHost // Can only have x connections per host, if it is higher than this value something is wrong.
-	transport.MaxIdleConns = transport.MaxIdleConnsPerHost    // There is no need for a pool larger than the maximum amount of iddle connections per host. Defaults to 2.
+	transport.ExpectContinueTimeout = 0                       // We don't send any body, so setting this is unnecessary.
+	transport.DisableKeepAlives = true                        // Connection pooling isn't applicable here.
+	transport.MaxConnsPerHost = transport.MaxIdleConnsPerHost // Can only have x connections per host, if it is higher than this value something is wrong. Set to max idle as this is a sensible default.
 
 	transport.TLSClientConfig = config // Apply the TLS configuration.
 

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -47,10 +47,6 @@ const (
 	statefulsetOrdinalFromEnvvarDefault = "POD_NAME"
 )
 
-type tlsOptions struct {
-	skipTlsVerify bool
-}
-
 func main() {
 	app := kingpin.New("prometheus-config-reloader", "")
 	cfgFile := app.Flag("config-file", "config file watched by the reloader").
@@ -137,9 +133,7 @@ func main() {
 			},
 		)
 
-		client := createHttpClient(tlsOptions{
-			skipTlsVerify: true,
-		})
+		client := createHttpClient()
 		rel.SetHttpClient(client)
 
 		g.Add(func() error {
@@ -165,9 +159,10 @@ func main() {
 	}
 }
 
-func createHttpClient(tlsOptions tlsOptions) http.Client {
+func createHttpClient() http.Client {
 	config := &tls.Config{
-		InsecureSkipVerify: tlsOptions.skipTlsVerify,
+		// TLS certificate verification is disabled by default
+		InsecureSkipVerify: true,
 	}
 
 	transport := &http.Transport{

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -47,7 +47,7 @@ const (
 	statefulsetOrdinalFromEnvvarDefault = "POD_NAME"
 )
 
-type TlsOptions struct {
+type tlsOptions struct {
 	skipTlsVerify bool
 }
 
@@ -137,7 +137,7 @@ func main() {
 			},
 		)
 
-		client := createHttpClient(TlsOptions{
+		client := createHttpClient(tlsOptions{
 			skipTlsVerify: true,
 		})
 		rel.SetHttpClient(client)
@@ -165,7 +165,7 @@ func main() {
 	}
 }
 
-func createHttpClient(tlsOptions TlsOptions) http.Client {
+func createHttpClient(tlsOptions tlsOptions) http.Client {
 	config := &tls.Config{
 		InsecureSkipVerify: tlsOptions.skipTlsVerify,
 	}

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -134,7 +134,7 @@ func main() {
 			},
 		)
 
-		client := createHTTPClient(watchInterval)
+		client := createHTTPClient()
 		rel.SetHttpClient(client)
 
 		g.Add(func() error {
@@ -160,7 +160,7 @@ func main() {
 	}
 }
 
-func createHTTPClient(watchInterval *time.Duration) http.Client {
+func createHTTPClient() http.Client {
 	config := &tls.Config{
 		InsecureSkipVerify: true, // TLS certificate verification is disabled by default.
 	}

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -164,12 +164,10 @@ func createHTTPClient() http.Client {
 	transport := (http.DefaultTransport.(*http.Transport)).Clone() // Use the default transporter for production and future changes ready settings.
 
 	transport.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Millisecond, // Timeout for Dial should never be 30 seconds, a bit of fine tuning to prevent (long) waiting time.
-		KeepAlive: -1,                    // Keep alive probe is unnecessary
+		Timeout:   30 * time.Second, // Default Timeout as of http.DefaultTransport
+		KeepAlive: -1,               // Keep alive probe is unnecessary
 	}).DialContext
 
-	transport.TLSHandshakeTimeout = 300 * time.Millisecond    // TLS should never take too long.
-	transport.ExpectContinueTimeout = 0                       // We don't send any body, so setting this is unnecessary.
 	transport.DisableKeepAlives = true                        // Connection pooling isn't applicable here.
 	transport.MaxConnsPerHost = transport.MaxIdleConnsPerHost // Can only have x connections per host, if it is higher than this value something is wrong. Set to max idle as this is a sensible default.
 

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -88,9 +88,6 @@ func main() {
 	reloadURL := app.Flag("reload-url", "reload URL to trigger Prometheus reload on").
 		Default("http://127.0.0.1:9090/-/reload").URL()
 
-	insecureSkipTlsVerify := app.Flag("insecure-skip-tls-verify", "skip TLS verify when communicating with the Prometheus server").
-		Default("false").Bool()
-
 	versionutil.RegisterIntoKingpinFlags(app)
 
 	if _, err := app.Parse(os.Args[1:]); err != nil {
@@ -141,7 +138,7 @@ func main() {
 		)
 
 		client := createHttpClient(TlsOptions{
-			skipTlsVerify: *insecureSkipTlsVerify,
+			skipTlsVerify: true,
 		})
 		rel.SetHttpClient(client)
 

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -133,7 +133,7 @@ func main() {
 			},
 		)
 
-		client := createHttpClient()
+		client := createHTTPClient()
 		rel.SetHttpClient(client)
 
 		g.Add(func() error {
@@ -159,7 +159,7 @@ func main() {
 	}
 }
 
-func createHttpClient() http.Client {
+func createHTTPClient() http.Client {
 	config := &tls.Config{
 		// TLS certificate verification is disabled by default
 		InsecureSkipVerify: true,

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -15,7 +15,11 @@
 package main
 
 import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -31,6 +35,21 @@ var cases = []struct {
 	{"pro-10-metheus", ""},
 }
 
+var tlsOptionCases = []struct {
+	tlsOptions tlsOptions
+	client     http.Client
+}{
+	{
+		tlsOptions: tlsOptions{true},
+		client: http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}},
+}
+
 func TestCreateOrdinalEnvVar(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.in, func(t *testing.T) {
@@ -38,6 +57,17 @@ func TestCreateOrdinalEnvVar(t *testing.T) {
 			s := createOrdinalEnvvar(statefulsetOrdinalFromEnvvarDefault)
 			if os.Getenv(statefulsetOrdinalEnvvar) != tt.out {
 				t.Errorf("got %v, want %s", s, tt.out)
+			}
+		})
+	}
+}
+
+func TestCreateHttpClient(t *testing.T) {
+	for index, tt := range tlsOptionCases {
+		t.Run(fmt.Sprintf("http-client-is-created-correctly-%v", index), func(t *testing.T) {
+			client := createHttpClient(tt.tlsOptions)
+			if !reflect.DeepEqual(client, tt.client) {
+				t.Errorf("got %#v\n want %#v", client, tt.client)
 			}
 		})
 	}

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -67,7 +67,7 @@ func TestCreateHTTPClient(t *testing.T) {
 
 		expectedClient := http.Client{
 			Transport: transport,
-			Timeout:   400 * time.Millisecond,
+			Timeout:   30 * time.Second,
 		}
 
 		client := createHTTPClient()

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"os"
 	"reflect"
@@ -35,21 +34,6 @@ var cases = []struct {
 	{"pro-10-metheus", ""},
 }
 
-var tlsOptionCases = []struct {
-	tlsOptions tlsOptions
-	client     http.Client
-}{
-	{
-		tlsOptions: tlsOptions{true},
-		client: http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
-		}},
-}
-
 func TestCreateOrdinalEnvVar(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.in, func(t *testing.T) {
@@ -63,12 +47,18 @@ func TestCreateOrdinalEnvVar(t *testing.T) {
 }
 
 func TestCreateHttpClient(t *testing.T) {
-	for index, tt := range tlsOptionCases {
-		t.Run(fmt.Sprintf("http-client-is-created-correctly-%v", index), func(t *testing.T) {
-			client := createHttpClient(tt.tlsOptions)
-			if !reflect.DeepEqual(client, tt.client) {
-				t.Errorf("got %#v\n want %#v", client, tt.client)
-			}
-		})
-	}
+	t.Run("http-client-is-created-correctly", func(t *testing.T) {
+		expectedClient := http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+
+		client := createHttpClient()
+		if !reflect.DeepEqual(client, expectedClient) {
+			t.Errorf("got %#v\n want %#v", client, expectedClient)
+		}
+	})
 }

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -58,8 +58,6 @@ func TestCreateHTTPClient(t *testing.T) {
 			KeepAlive: -1,
 		}).DialContext
 
-		transport.TLSHandshakeTimeout = 300 * time.Millisecond
-		transport.ExpectContinueTimeout = 0
 		transport.DisableKeepAlives = true
 		transport.MaxConnsPerHost = transport.MaxIdleConnsPerHost
 

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -46,7 +46,7 @@ func TestCreateOrdinalEnvVar(t *testing.T) {
 	}
 }
 
-func TestCreateHttpClient(t *testing.T) {
+func TestCreateHTTPClient(t *testing.T) {
 	t.Run("http-client-is-created-correctly", func(t *testing.T) {
 		expectedClient := http.Client{
 			Transport: &http.Transport{
@@ -56,7 +56,7 @@ func TestCreateHttpClient(t *testing.T) {
 			},
 		}
 
-		client := createHttpClient()
+		client := createHTTPClient()
 		if !reflect.DeepEqual(client, expectedClient) {
 			t.Errorf("got %#v\n want %#v", client, expectedClient)
 		}

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/go-openapi/validate v0.20.2 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/go-test/deep v1.0.8 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

As discussed in #4273: proper configurable setup for config-reloader to support setting TLS parameter "skip TLS verify" when talking to Prometheus on a config reload. 

The only change is to the config-reloader command for skipping TLS verify. 
No flag is added since the solution intent was scoped to only supporting the config reloader for use in combination with the prometheus operator; no standalone application.

Support for this is then also not given. (Discussion can be found in the comments)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add skip TLS verify for the config-reloader HTTP client when informing Prometheus on a config reload.
```
