### PR TITLE
Re-generate Kubernetes clients

### DIFF
--- a/pkg/client/listers/monitoring/v1/alertmanager.go
+++ b/pkg/client/listers/monitoring/v1/alertmanager.go
@@ -24,8 +24,10 @@ import (
 )
 
 // AlertmanagerLister helps list Alertmanagers.
+// All objects returned here must be treated as read-only.
 type AlertmanagerLister interface {
 	// List lists all Alertmanagers in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Alertmanager, err error)
 	// Alertmanagers returns an object that can list and get Alertmanagers.
 	Alertmanagers(namespace string) AlertmanagerNamespaceLister
@@ -56,10 +58,13 @@ func (s *alertmanagerLister) Alertmanagers(namespace string) AlertmanagerNamespa
 }
 
 // AlertmanagerNamespaceLister helps list and get Alertmanagers.
+// All objects returned here must be treated as read-only.
 type AlertmanagerNamespaceLister interface {
 	// List lists all Alertmanagers in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Alertmanager, err error)
 	// Get retrieves the Alertmanager from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Alertmanager, error)
 	AlertmanagerNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/podmonitor.go
+++ b/pkg/client/listers/monitoring/v1/podmonitor.go
@@ -24,8 +24,10 @@ import (
 )
 
 // PodMonitorLister helps list PodMonitors.
+// All objects returned here must be treated as read-only.
 type PodMonitorLister interface {
 	// List lists all PodMonitors in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PodMonitor, err error)
 	// PodMonitors returns an object that can list and get PodMonitors.
 	PodMonitors(namespace string) PodMonitorNamespaceLister
@@ -56,10 +58,13 @@ func (s *podMonitorLister) PodMonitors(namespace string) PodMonitorNamespaceList
 }
 
 // PodMonitorNamespaceLister helps list and get PodMonitors.
+// All objects returned here must be treated as read-only.
 type PodMonitorNamespaceLister interface {
 	// List lists all PodMonitors in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PodMonitor, err error)
 	// Get retrieves the PodMonitor from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.PodMonitor, error)
 	PodMonitorNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/probe.go
+++ b/pkg/client/listers/monitoring/v1/probe.go
@@ -24,8 +24,10 @@ import (
 )
 
 // ProbeLister helps list Probes.
+// All objects returned here must be treated as read-only.
 type ProbeLister interface {
 	// List lists all Probes in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Probe, err error)
 	// Probes returns an object that can list and get Probes.
 	Probes(namespace string) ProbeNamespaceLister
@@ -56,10 +58,13 @@ func (s *probeLister) Probes(namespace string) ProbeNamespaceLister {
 }
 
 // ProbeNamespaceLister helps list and get Probes.
+// All objects returned here must be treated as read-only.
 type ProbeNamespaceLister interface {
 	// List lists all Probes in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Probe, err error)
 	// Get retrieves the Probe from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Probe, error)
 	ProbeNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/prometheus.go
+++ b/pkg/client/listers/monitoring/v1/prometheus.go
@@ -24,8 +24,10 @@ import (
 )
 
 // PrometheusLister helps list Prometheuses.
+// All objects returned here must be treated as read-only.
 type PrometheusLister interface {
 	// List lists all Prometheuses in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Prometheus, err error)
 	// Prometheuses returns an object that can list and get Prometheuses.
 	Prometheuses(namespace string) PrometheusNamespaceLister
@@ -56,10 +58,13 @@ func (s *prometheusLister) Prometheuses(namespace string) PrometheusNamespaceLis
 }
 
 // PrometheusNamespaceLister helps list and get Prometheuses.
+// All objects returned here must be treated as read-only.
 type PrometheusNamespaceLister interface {
 	// List lists all Prometheuses in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Prometheus, err error)
 	// Get retrieves the Prometheus from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Prometheus, error)
 	PrometheusNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/prometheusrule.go
+++ b/pkg/client/listers/monitoring/v1/prometheusrule.go
@@ -24,8 +24,10 @@ import (
 )
 
 // PrometheusRuleLister helps list PrometheusRules.
+// All objects returned here must be treated as read-only.
 type PrometheusRuleLister interface {
 	// List lists all PrometheusRules in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PrometheusRule, err error)
 	// PrometheusRules returns an object that can list and get PrometheusRules.
 	PrometheusRules(namespace string) PrometheusRuleNamespaceLister
@@ -56,10 +58,13 @@ func (s *prometheusRuleLister) PrometheusRules(namespace string) PrometheusRuleN
 }
 
 // PrometheusRuleNamespaceLister helps list and get PrometheusRules.
+// All objects returned here must be treated as read-only.
 type PrometheusRuleNamespaceLister interface {
 	// List lists all PrometheusRules in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.PrometheusRule, err error)
 	// Get retrieves the PrometheusRule from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.PrometheusRule, error)
 	PrometheusRuleNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/servicemonitor.go
+++ b/pkg/client/listers/monitoring/v1/servicemonitor.go
@@ -24,8 +24,10 @@ import (
 )
 
 // ServiceMonitorLister helps list ServiceMonitors.
+// All objects returned here must be treated as read-only.
 type ServiceMonitorLister interface {
 	// List lists all ServiceMonitors in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ServiceMonitor, err error)
 	// ServiceMonitors returns an object that can list and get ServiceMonitors.
 	ServiceMonitors(namespace string) ServiceMonitorNamespaceLister
@@ -56,10 +58,13 @@ func (s *serviceMonitorLister) ServiceMonitors(namespace string) ServiceMonitorN
 }
 
 // ServiceMonitorNamespaceLister helps list and get ServiceMonitors.
+// All objects returned here must be treated as read-only.
 type ServiceMonitorNamespaceLister interface {
 	// List lists all ServiceMonitors in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ServiceMonitor, err error)
 	// Get retrieves the ServiceMonitor from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ServiceMonitor, error)
 	ServiceMonitorNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1/thanosruler.go
+++ b/pkg/client/listers/monitoring/v1/thanosruler.go
@@ -24,8 +24,10 @@ import (
 )
 
 // ThanosRulerLister helps list ThanosRulers.
+// All objects returned here must be treated as read-only.
 type ThanosRulerLister interface {
 	// List lists all ThanosRulers in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ThanosRuler, err error)
 	// ThanosRulers returns an object that can list and get ThanosRulers.
 	ThanosRulers(namespace string) ThanosRulerNamespaceLister
@@ -56,10 +58,13 @@ func (s *thanosRulerLister) ThanosRulers(namespace string) ThanosRulerNamespaceL
 }
 
 // ThanosRulerNamespaceLister helps list and get ThanosRulers.
+// All objects returned here must be treated as read-only.
 type ThanosRulerNamespaceLister interface {
 	// List lists all ThanosRulers in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ThanosRuler, err error)
 	// Get retrieves the ThanosRuler from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.ThanosRuler, error)
 	ThanosRulerNamespaceListerExpansion
 }

--- a/pkg/client/listers/monitoring/v1alpha1/alertmanagerconfig.go
+++ b/pkg/client/listers/monitoring/v1alpha1/alertmanagerconfig.go
@@ -24,8 +24,10 @@ import (
 )
 
 // AlertmanagerConfigLister helps list AlertmanagerConfigs.
+// All objects returned here must be treated as read-only.
 type AlertmanagerConfigLister interface {
 	// List lists all AlertmanagerConfigs in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.AlertmanagerConfig, err error)
 	// AlertmanagerConfigs returns an object that can list and get AlertmanagerConfigs.
 	AlertmanagerConfigs(namespace string) AlertmanagerConfigNamespaceLister
@@ -56,10 +58,13 @@ func (s *alertmanagerConfigLister) AlertmanagerConfigs(namespace string) Alertma
 }
 
 // AlertmanagerConfigNamespaceLister helps list and get AlertmanagerConfigs.
+// All objects returned here must be treated as read-only.
 type AlertmanagerConfigNamespaceLister interface {
 	// List lists all AlertmanagerConfigs in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.AlertmanagerConfig, err error)
 	// Get retrieves the AlertmanagerConfig from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.AlertmanagerConfig, error)
 	AlertmanagerConfigNamespaceListerExpansion
 }

--- a/pkg/client/versioned/fake/clientset_generated.go
+++ b/pkg/client/versioned/fake/clientset_generated.go
@@ -74,7 +74,10 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-var _ clientset.Interface = &Clientset{}
+var (
+	_ clientset.Interface = &Clientset{}
+	_ testing.FakeClient  = &Clientset{}
+)
 
 // MonitoringV1 retrieves the MonitoringV1Client
 func (c *Clientset) MonitoringV1() monitoringv1.MonitoringV1Interface {

--- a/pkg/client/versioned/fake/register.go
+++ b/pkg/client/versioned/fake/register.go
@@ -28,7 +28,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
+
 var localSchemeBuilder = runtime.SchemeBuilder{
 	monitoringv1.AddToScheme,
 	monitoringv1alpha1.AddToScheme,

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_alertmanager.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_alertmanager.go
@@ -115,7 +115,7 @@ func (c *FakeAlertmanagers) UpdateStatus(ctx context.Context, alertmanager *moni
 // Delete takes name of the alertmanager and deletes it. Returns an error if one occurs.
 func (c *FakeAlertmanagers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(alertmanagersResource, c.ns, name), &monitoringv1.Alertmanager{})
+		Invokes(testing.NewDeleteActionWithOptions(alertmanagersResource, c.ns, name, opts), &monitoringv1.Alertmanager{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_podmonitor.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_podmonitor.go
@@ -103,7 +103,7 @@ func (c *FakePodMonitors) Update(ctx context.Context, podMonitor *monitoringv1.P
 // Delete takes name of the podMonitor and deletes it. Returns an error if one occurs.
 func (c *FakePodMonitors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podmonitorsResource, c.ns, name), &monitoringv1.PodMonitor{})
+		Invokes(testing.NewDeleteActionWithOptions(podmonitorsResource, c.ns, name, opts), &monitoringv1.PodMonitor{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_probe.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_probe.go
@@ -103,7 +103,7 @@ func (c *FakeProbes) Update(ctx context.Context, probe *monitoringv1.Probe, opts
 // Delete takes name of the probe and deletes it. Returns an error if one occurs.
 func (c *FakeProbes) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(probesResource, c.ns, name), &monitoringv1.Probe{})
+		Invokes(testing.NewDeleteActionWithOptions(probesResource, c.ns, name, opts), &monitoringv1.Probe{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheus.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheus.go
@@ -115,7 +115,7 @@ func (c *FakePrometheuses) UpdateStatus(ctx context.Context, prometheus *monitor
 // Delete takes name of the prometheus and deletes it. Returns an error if one occurs.
 func (c *FakePrometheuses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(prometheusesResource, c.ns, name), &monitoringv1.Prometheus{})
+		Invokes(testing.NewDeleteActionWithOptions(prometheusesResource, c.ns, name, opts), &monitoringv1.Prometheus{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheusrule.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheusrule.go
@@ -103,7 +103,7 @@ func (c *FakePrometheusRules) Update(ctx context.Context, prometheusRule *monito
 // Delete takes name of the prometheusRule and deletes it. Returns an error if one occurs.
 func (c *FakePrometheusRules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(prometheusrulesResource, c.ns, name), &monitoringv1.PrometheusRule{})
+		Invokes(testing.NewDeleteActionWithOptions(prometheusrulesResource, c.ns, name, opts), &monitoringv1.PrometheusRule{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_servicemonitor.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_servicemonitor.go
@@ -103,7 +103,7 @@ func (c *FakeServiceMonitors) Update(ctx context.Context, serviceMonitor *monito
 // Delete takes name of the serviceMonitor and deletes it. Returns an error if one occurs.
 func (c *FakeServiceMonitors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(servicemonitorsResource, c.ns, name), &monitoringv1.ServiceMonitor{})
+		Invokes(testing.NewDeleteActionWithOptions(servicemonitorsResource, c.ns, name, opts), &monitoringv1.ServiceMonitor{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_thanosruler.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_thanosruler.go
@@ -115,7 +115,7 @@ func (c *FakeThanosRulers) UpdateStatus(ctx context.Context, thanosRuler *monito
 // Delete takes name of the thanosRuler and deletes it. Returns an error if one occurs.
 func (c *FakeThanosRulers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(thanosrulersResource, c.ns, name), &monitoringv1.ThanosRuler{})
+		Invokes(testing.NewDeleteActionWithOptions(thanosrulersResource, c.ns, name, opts), &monitoringv1.ThanosRuler{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/monitoring_client.go
+++ b/pkg/client/versioned/typed/monitoring/v1/monitoring_client.go
@@ -17,6 +17,8 @@
 package v1
 
 import (
+	"net/http"
+
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -67,12 +69,28 @@ func (c *MonitoringV1Client) ThanosRulers(namespace string) ThanosRulerInterface
 }
 
 // NewForConfig creates a new MonitoringV1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*MonitoringV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new MonitoringV1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*MonitoringV1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/versioned/typed/monitoring/v1alpha1/fake/fake_alertmanagerconfig.go
+++ b/pkg/client/versioned/typed/monitoring/v1alpha1/fake/fake_alertmanagerconfig.go
@@ -103,7 +103,7 @@ func (c *FakeAlertmanagerConfigs) Update(ctx context.Context, alertmanagerConfig
 // Delete takes name of the alertmanagerConfig and deletes it. Returns an error if one occurs.
 func (c *FakeAlertmanagerConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(alertmanagerconfigsResource, c.ns, name), &v1alpha1.AlertmanagerConfig{})
+		Invokes(testing.NewDeleteActionWithOptions(alertmanagerconfigsResource, c.ns, name, opts), &v1alpha1.AlertmanagerConfig{})
 
 	return err
 }

--- a/pkg/client/versioned/typed/monitoring/v1alpha1/monitoring_client.go
+++ b/pkg/client/versioned/typed/monitoring/v1alpha1/monitoring_client.go
@@ -17,6 +17,8 @@
 package v1alpha1
 
 import (
+	"net/http"
+
 	v1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -37,12 +39,28 @@ func (c *MonitoringV1alpha1Client) AlertmanagerConfigs(namespace string) Alertma
 }
 
 // NewForConfig creates a new MonitoringV1alpha1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*MonitoringV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new MonitoringV1alpha1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*MonitoringV1alpha1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This is just a re-generation of the Kubernetes clients via the `make k8s-gen` command. A few comments and other small bits as generated by the Kubernetes tools have changed, which was resulting in a dirty tree after running this.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
