### PR TITLE
Fix service selector

### DIFF
--- a/Documentation/user-guides/running-exporters.md
+++ b/Documentation/user-guides/running-exporters.md
@@ -38,7 +38,7 @@ spec:
     targetPort: metrics
     protocol: TCP
   selector:
-    app: kube-state-metrics
+    k8s-app: kube-state-metrics
 ```
 
 This Service targets all Pods with the label `k8s-app: kube-state-metrics`.


### PR DESCRIPTION

## Description

Fix the service selector to target pods with the label `k8s-app: kube-state-metrics` as described in the documentation.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Fix typo in documentation.