### PR TITLE
clarify distinction between prometheusrule webhooks

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -115,10 +115,9 @@ webhooks:
 
 The endpoint `/admission-alertmanagerconfigs/validate` rejects alertmanagerconfigs that are not valid alertmanager config.
 
-The following example deploys the mutating admission webhook:
+The following example deploys the validating admission webhook:
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
 kind: ValidatingWebhookConfiguration
 metadata:
   name: prometheus-operator-alertmanager-config-validation

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -111,7 +111,7 @@ webhooks:
     sideEffects: None
 ```
 
-### `/admission-prometheusrules/mutate`
+### `/admission-alertmanagerconfigs/validate`
 
 The endpoint `/admission-alertmanagerconfigs/validate` rejects alertmanagerconfigs that are not valid alertmanager config.
 


### PR DESCRIPTION
ref issue 4618

## Description
Clarify distinction between behavior of prometheusrule webhooks.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Clarify distinction between behavior of prometheusrule webhooks._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
