### PR TITLE
Update time range for alert PrometheusOperatorWatchErrors

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -17,7 +17,7 @@ groups:
         in {{$labels.namespace}} namespace.
       summary: Errors while performing watch operations in controller.
     expr: |
-      (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator"}[10m]))) > 0.4
+      (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator"}[5m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator"}[5m]))) > 0.4
     for: 15m
     labels:
       severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -21,7 +21,7 @@
           {
             alert: 'PrometheusOperatorWatchErrors',
             expr: |||
-              (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[10m]))) > 0.4
+              (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[5m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.4
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
## Description

The alert expression has a time range of 10 minutes so it will not resolve "quickly" if the operator experiences a transient burst of watch errors.
Given that metrics are scraped every 30 seconds, it would be better to use a time range of 5 minutes (consistent with what Prometheus & Alertmanager are doing).



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Updated the time range for the alert PrometheusOperatorWatchErrors from 10m to 5m
```
