### PR TITLE
*: use consistent image name for the admision webhook

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,7 +68,7 @@ jobs:
       run: |
         kind load docker-image quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)
         kind load docker-image quay.io/prometheus-operator/prometheus-config-reloader:$(git rev-parse --short HEAD)
-        kind load docker-image quay.io/prometheus-operator/prometheus-admission-webhook:$(git rev-parse --short HEAD)
+        kind load docker-image quay.io/prometheus-operator/admission-webhook:$(git rev-parse --short HEAD)
         kubectl apply -f scripts/kind-rbac.yaml
     - name: Run tests
       run: >

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 GO_PKG=github.com/prometheus-operator/prometheus-operator
 IMAGE_OPERATOR?=quay.io/prometheus-operator/prometheus-operator
 IMAGE_RELOADER?=quay.io/prometheus-operator/prometheus-config-reloader
-IMAGE_WEBHOOK?=quay.io/prometheus-operator/prometheus-admission-webhook
+IMAGE_WEBHOOK?=quay.io/prometheus-operator/admission-webhook
 TAG?=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 

--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - image: quay.io/prometheus-operator/prometheus-admission-webhook:v0.55.0
+      - image: quay.io/prometheus-operator/admission-webhook:v0.55.0
         name: prometheus-operator-admission-webhook
         ports:
         - containerPort: 8443

--- a/scripts/generate/admission-webhook.jsonnet
+++ b/scripts/generate/admission-webhook.jsonnet
@@ -1,7 +1,7 @@
 local admissionWebhook = (import 'prometheus-operator/admission-webhook.libsonnet');
 local config = (import 'config.jsonnet');
 local aw = admissionWebhook(config {
-  image: 'quay.io/prometheus-operator/prometheus-admission-webhook:v' + config.version,
+  image: 'quay.io/prometheus-operator/admission-webhook:v' + config.version,
 });
 
 {

--- a/scripts/push-docker-image.sh
+++ b/scripts/push-docker-image.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #
-# Script is meant to build multi-arch container images and publish them to multiple container registries
-# 
-# Script is:
-# - figuring out if an image is a development one (by default suffixed with `-dev` in image name)
-# - figuring out the image tag (aka version) based on GITHUB_REF value
+# This script builds multi-arch container images and publish them to multiple container registries.
 #
-# Script is not:
-# - directly executing `docker build`. This is done in Makefile
-# - logging to registries 
+# The script figures out:
+# - if an image is a development one (by default suffixed with `-dev` in image name)
+# - the image tag (aka version) based on GITHUB_REF value
+#
+# The script does not:
+# - directly execute `docker build`. This is done via the Makefile.
+# - Authenticate to the container registries
 #
 
 # exit immediately when a command fails
@@ -19,7 +19,7 @@ set -o pipefail
 CPU_ARCHS="amd64 arm64 arm ppc64le s390x"
 REGISTRIES="${REGISTRIES:-"quay.io ghcr.io"}"
 
-# IMAGE_OPERATOR and IMAGER_RELOADER need to be exported to be used by `make`
+# IMAGE_OPERATOR, IMAGER_RELOADER and IMAGE_WEBHOOK need to be exported to be used by `make`
 export IMAGE_OPERATOR="${IMAGE_OPERATOR:-"prometheus-operator/prometheus-operator"}"
 export IMAGE_RELOADER="${IMAGE_RELOADER:-"prometheus-operator/prometheus-config-reloader"}"
 export IMAGE_WEBHOOK="${IMAGE_WEBHOOK:="prometheus-operator/admission-webhook"}"

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -309,7 +309,7 @@ func (f *Framework) CreatePrometheusOperator(ctx context.Context, ns, opImage st
 					repoAndTag[1]
 			}
 		}
-		webhookServerImage = "quay.io/prometheus-operator/prometheus-admission-webhook:" + repoAndTag[1]
+		webhookServerImage = "quay.io/prometheus-operator/admission-webhook:" + repoAndTag[1]
 	}
 
 	deploy.Spec.Template.Spec.Containers[0].Args = append(deploy.Spec.Template.Spec.Containers[0].Args, "--log-level=all")


### PR DESCRIPTION
## Description

The end-to-end tests and jsonnet code were using
`quay.io/prometheus-operator/prometheus-admission-webhook` which doesn't
exist.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
