### PR TITLE
add support for basic auth web config

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -304,7 +304,7 @@ Authorization contains optional `Authorization` header configuration. This secti
 BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints
 
 
-<em>appears in: [APIServerConfig](#apiserverconfig), [Endpoint](#endpoint), [PodMetricsEndpoint](#podmetricsendpoint), [ProbeSpec](#probespec), [RemoteReadSpec](#remotereadspec), [RemoteWriteSpec](#remotewritespec)</em>
+<em>appears in: [APIServerConfig](#apiserverconfig), [Endpoint](#endpoint), [PodMetricsEndpoint](#podmetricsendpoint), [ProbeSpec](#probespec), [RemoteReadSpec](#remotereadspec), [RemoteWriteSpec](#remotewritespec), [WebSpec](#webspec)</em>
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -1168,6 +1168,7 @@ WebSpec defines the query command line flags when starting Prometheus.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | pageTitle | The prometheus web page title | *string | false |
+| basicAuthUsers | Defines the basic auth users to access the Prometheus API/UI. See https://prometheus.io/docs/guides/basic-auth/ | [][BasicAuth](#basicauth) | false |
 | tlsConfig |  | *[WebTLSConfig](#webtlsconfig) | false |
 
 [Back to TOC](#table-of-contents)

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -19432,6 +19432,53 @@ spec:
                 description: WebSpec defines the web command line flags when starting
                   Prometheus.
                 properties:
+                  basicAuthUsers:
+                    description: Defines the basic auth users to access the Prometheus
+                      API/UI. See https://prometheus.io/docs/guides/basic-auth/
+                    items:
+                      description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      properties:
+                        password:
+                          description: The secret in the service monitor namespace
+                            that contains the password for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        username:
+                          description: The secret in the service monitor namespace
+                            that contains the username for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                    type: array
                   pageTitle:
                     description: The prometheus web page title
                     type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8135,6 +8135,53 @@ spec:
                 description: WebSpec defines the web command line flags when starting
                   Prometheus.
                 properties:
+                  basicAuthUsers:
+                    description: Defines the basic auth users to access the Prometheus
+                      API/UI. See https://prometheus.io/docs/guides/basic-auth/
+                    items:
+                      description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      properties:
+                        password:
+                          description: The secret in the service monitor namespace
+                            that contains the password for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        username:
+                          description: The secret in the service monitor namespace
+                            that contains the username for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                    type: array
                   pageTitle:
                     description: The prometheus web page title
                     type: string

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7461,6 +7461,58 @@
                   "web": {
                     "description": "WebSpec defines the web command line flags when starting Prometheus.",
                     "properties": {
+                      "basicAuthUsers": {
+                        "description": "Defines the basic auth users to access the Prometheus API/UI. See https://prometheus.io/docs/guides/basic-auth/",
+                        "items": {
+                          "description": "BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints",
+                          "properties": {
+                            "password": {
+                              "description": "The secret in the service monitor namespace that contains the password for authentication.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            },
+                            "username": {
+                              "description": "The secret in the service monitor namespace that contains the username for authentication.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
                       "pageTitle": {
                         "description": "The prometheus web page title",
                         "type": "string"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -579,8 +579,10 @@ type QuerySpec struct {
 // +k8s:openapi-gen=true
 type WebSpec struct {
 	// The prometheus web page title
-	PageTitle *string       `json:"pageTitle,omitempty"`
-	TLSConfig *WebTLSConfig `json:"tlsConfig,omitempty"`
+	PageTitle *string `json:"pageTitle,omitempty"`
+	// Defines the basic auth users to access the Prometheus API/UI. See https://prometheus.io/docs/guides/basic-auth/
+	BasicAuthUsers []BasicAuth   `json:"basicAuthUsers,omitempty"`
+	TLSConfig      *WebTLSConfig `json:"tlsConfig,omitempty"`
 }
 
 // WebTLSConfig defines the TLS parameters for HTTPS.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2284,6 +2284,13 @@ func (in *WebSpec) DeepCopyInto(out *WebSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BasicAuthUsers != nil {
+		in, out := &in.BasicAuthUsers, &out.BasicAuthUsers
+		*out = make([]BasicAuth, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.TLSConfig != nil {
 		in, out := &in.TLSConfig, &out.TLSConfig
 		*out = new(WebTLSConfig)

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -104,6 +104,7 @@ func makeStatefulSet(
 	inputHash string,
 	shard int32,
 	tlsAssetSecrets []string,
+	basicAuthUsers map[string]string,
 ) (*appsv1.StatefulSet, error) {
 	// p is passed in by value, not by reference. But p contains references like
 	// to annotation map, that do not get copied on function invocation. Ensure to
@@ -147,7 +148,7 @@ func makeStatefulSet(
 		}
 	}
 
-	spec, err := makeStatefulSetSpec(p, config, shard, ruleConfigMapNames, tlsAssetSecrets, parsedVersion)
+	spec, err := makeStatefulSetSpec(p, config, shard, ruleConfigMapNames, tlsAssetSecrets, parsedVersion, basicAuthUsers)
 	if err != nil {
 		return nil, errors.Wrap(err, "make StatefulSet spec")
 	}
@@ -324,7 +325,7 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config operator.Config) 
 }
 
 func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard int32, ruleConfigMapNames []string,
-	tlsAssetSecrets []string, version semver.Version) (*appsv1.StatefulSetSpec, error) {
+	tlsAssetSecrets []string, version semver.Version, basicAuthUsers map[string]string) (*appsv1.StatefulSetSpec, error) {
 	// Prometheus may take quite long to shut down to checkpoint existing data.
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
@@ -602,7 +603,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 			webTLSConfig = p.Spec.Web.TLSConfig
 		}
 
-		webConfig, err := webconfig.New(webConfigDir, WebConfigSecretName(p.Name), webTLSConfig)
+		webConfig, err := webconfig.New(webConfigDir, WebConfigSecretName(p.Name), webTLSConfig, basicAuthUsers)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -84,7 +84,7 @@ func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestPodLabelsAnnotations(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	require.NoError(t, err)
 	if val, ok := sset.Spec.Template.ObjectMeta.Labels["testlabel"]; !ok || val != "testvalue" {
 		t.Fatal("Pod labels are not properly propagated")
@@ -143,7 +143,7 @@ func TestPodLabelsShouldNotBeSelectorLabels(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 
@@ -184,7 +184,7 @@ func TestStatefulSetPVC(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 	ssetPvc := sset.Spec.VolumeClaimTemplates[0]
@@ -218,7 +218,7 @@ func TestStatefulSetEmptyDir(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -258,7 +258,7 @@ func TestStatefulSetEphemeral(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 	ssetVolumes := sset.Spec.Template.Spec.Volumes
@@ -397,7 +397,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test") + "-0"})
+	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test") + "-0"}, nil)
 
 	require.NoError(t, err)
 
@@ -419,7 +419,7 @@ func TestAdditionalConfigMap(t *testing.T) {
 				ConfigMaps: []string{"test-cm1"},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestListenLocal(t *testing.T) {
 				ListenLocal: true,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -541,7 +541,7 @@ func TestListenTLS(t *testing.T) {
 			},
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -623,7 +623,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Version: "v2.3.2",
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -643,7 +643,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Version: "v2.3.2",
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -666,7 +666,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image:   &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -688,7 +688,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image:   &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -708,7 +708,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image:   &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -729,7 +729,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image:   &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -748,7 +748,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image: &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -768,7 +768,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image: &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -788,7 +788,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image: &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -809,7 +809,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 					Image: &image,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -846,7 +846,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, prometheusBaseImageConfig, nil, "", 0, nil)
+	}, prometheusBaseImageConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 
@@ -884,7 +884,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, thanosBaseImageConfig, nil, "", 0, nil)
+	}, thanosBaseImageConfig, nil, "", 0, nil, nil)
 
 	require.NoError(t, err)
 
@@ -906,7 +906,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -929,7 +929,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Tag:     &thanosTag,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -954,7 +954,7 @@ func TestThanosTagAndShaAndVersion(t *testing.T) {
 					Image:   &thanosImage,
 				},
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 		}
@@ -972,7 +972,7 @@ func TestThanosResourcesNotSet(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1000,7 +1000,7 @@ func TestThanosResourcesSet(t *testing.T) {
 				Resources: expected,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1016,7 +1016,7 @@ func TestThanosNoObjectStorage(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1059,7 +1059,7 @@ func TestThanosObjectStorage(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestThanosObjectStorageFile(t *testing.T) {
 				ObjectStorageConfigFile: &testPath,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1235,7 +1235,7 @@ func TestThanosTracing(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1300,7 +1300,7 @@ func TestThanosSideCarVolumes(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1363,7 +1363,7 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 				Retention:     test.specRetention,
 				RetentionSize: test.specRetentionSize,
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1418,7 +1418,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 				Shards:   &shards,
 			},
 		},
-	}, testConfig, nil, "", 1, nil)
+	}, testConfig, nil, "", 1, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1456,7 +1456,7 @@ func TestSidecarsNoResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1486,7 +1486,7 @@ func TestSidecarsNoRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1519,7 +1519,7 @@ func TestSidecarsNoLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1552,7 +1552,7 @@ func TestSidecarsNoCPUResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1586,7 +1586,7 @@ func TestSidecarsNoCPURequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1621,7 +1621,7 @@ func TestSidecarsNoCPULimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1656,7 +1656,7 @@ func TestSidecarsNoMemoryResources(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1690,7 +1690,7 @@ func TestSidecarsNoMemoryRequests(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1725,7 +1725,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 	}
 	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, testConfig, nil, "", 0, nil)
+	}, testConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1748,7 +1748,7 @@ func TestSidecarsNoMemoryLimits(t *testing.T) {
 
 func TestAdditionalContainers(t *testing.T) {
 	// The base to compare everything against
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0, nil)
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", 0, nil, nil)
 	require.NoError(t, err)
 
 	// Add an extra container
@@ -1762,7 +1762,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers)+1 != len(addSset.Spec.Template.Spec.Containers) {
@@ -1783,7 +1783,7 @@ func TestAdditionalContainers(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	require.NoError(t, err)
 
 	if len(baseSet.Spec.Template.Spec.Containers) != len(modSset.Spec.Template.Spec.Containers) {
@@ -1828,7 +1828,7 @@ func TestWALCompression(t *testing.T) {
 				},
 				WALCompression: test.enabled,
 			},
-		}, defaultTestConfig, nil, "", 0, nil)
+		}, defaultTestConfig, nil, "", 0, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1859,7 +1859,7 @@ func TestThanosListenLocal(t *testing.T) {
 				ListenLocal: true,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1880,7 +1880,7 @@ func TestThanosListenLocal(t *testing.T) {
 }
 
 func TestTerminationPolicy(t *testing.T) {
-	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0, nil)
+	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{Spec: monitoringv1.PrometheusSpec{}}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -1899,7 +1899,7 @@ func TestEnableFeaturesWithOneFeature(t *testing.T) {
 				EnableFeatures: []string{"exemplar-storage"},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1924,7 +1924,7 @@ func TestEnableFeaturesWithMultipleFeature(t *testing.T) {
 				EnableFeatures: []string{"exemplar-storage1", "exemplar-storage2"},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -1952,7 +1952,7 @@ func TestWebPageTitle(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
@@ -2001,7 +2001,7 @@ func TestExpectedStatefulSetShardNames(t *testing.T) {
 func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 	statefulSet, err := makeStatefulSet("test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -2018,7 +2018,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 				MinReadySeconds: &expect,
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -2031,7 +2031,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 
 func TestConfigReloader(t *testing.T) {
 	expectedShardNum := 0
-	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum), nil)
+	baseSet, err := makeStatefulSet("test", monitoringv1.Prometheus{}, defaultTestConfig, nil, "", int32(expectedShardNum), nil, nil)
 	require.NoError(t, err)
 
 	expectedArgsConfigReloader := []string{
@@ -2083,7 +2083,7 @@ func TestThanosReadyTimeout(t *testing.T) {
 				ReadyTimeout: "20m",
 			},
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -2109,7 +2109,7 @@ func TestQueryLogFileVolumeMountPresent(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			QueryLogFile: "test.log",
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -2148,7 +2148,7 @@ func TestQueryLogFileVolumeMountNotPresent(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			QueryLogFile: "/tmp/test.log",
 		},
-	}, defaultTestConfig, nil, "", 0, nil)
+	}, defaultTestConfig, nil, "", 0, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
@@ -2217,7 +2217,7 @@ func TestEnableRemoteWriteReceiver(t *testing.T) {
 						EnableRemoteWriteReceiver: tc.enableRemoteWriteReceiver,
 					},
 				},
-			}, defaultTestConfig, nil, "", 0, nil)
+			}, defaultTestConfig, nil, "", 0, nil, nil)
 
 			if err != nil {
 				t.Fatalf("Unexpected error while making StatefulSet: %v", err)

--- a/pkg/webconfig/config_test.go
+++ b/pkg/webconfig/config_test.go
@@ -27,14 +27,25 @@ var falseVal = false
 
 func TestMakeSecret(t *testing.T) {
 	tc := []struct {
-		name         string
-		webTLSConfig *monitoringv1.WebTLSConfig
-		expectedData string
+		name           string
+		webTLSConfig   *monitoringv1.WebTLSConfig
+		expectedData   string
+		basicAuthUsers map[string]string
 	}{
 		{
 			name:         "tls config not defined",
 			webTLSConfig: nil,
 			expectedData: "",
+		},
+		{
+			name:         "basic auth",
+			webTLSConfig: nil,
+			basicAuthUsers: map[string]string{
+				"admin": "$2b$12$hNf2lSsxfm0.i4a.1kVpSOVyBCfIB51VRjgBUyv6kdnyTlgWj81Ay",
+			},
+			expectedData: `basic_auth_users:
+  admin: $2b$12$hNf2lSsxfm0.i4a.1kVpSOVyBCfIB51VRjgBUyv6kdnyTlgWj81Ay
+`,
 		},
 		{
 			name: "minimal TLS config with certificate from secret",
@@ -165,7 +176,7 @@ func TestMakeSecret(t *testing.T) {
 	}
 
 	for _, tt := range tc {
-		config, err := webconfig.New("/web_certs_path_prefix", "test-secret", tt.webTLSConfig)
+		config, err := webconfig.New("/web_certs_path_prefix", "test-secret", tt.webTLSConfig, tt.basicAuthUsers)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -307,7 +318,7 @@ func TestGetMountParameters(t *testing.T) {
 	}
 
 	for _, tt := range ts {
-		tlsAssets, err := webconfig.New("/etc/prometheus/web_config", "web-config", tt.tlsConfig)
+		tlsAssets, err := webconfig.New("/etc/prometheus/web_config", "web-config", tt.tlsConfig, nil)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Description

Extends WebSpec with basic-auth user information to secure the Prometheus API

This fixes #4200 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Add support for configuring HTTP basic auth. See [Prometheus docs](https://prometheus.io/docs/guides/basic-auth/) for details.

## Draft: Open Points
* [x] refactor to use secrets to store basic auth users
* [ ] add internal user for health-check and config reloader