### PR TITLE
test: remove matchers on root route

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1284,8 +1284,6 @@ func testUserDefinedAlertmanagerConfigFromSecret(t *testing.T) {
 
 	yamlConfig := `route:
   receiver: "void"
-  matchers:
-  - namespace=test
 receivers:
 - name: "void"
 inhibit_rules:
@@ -1337,13 +1335,14 @@ inhibit_rules:
 			return false, nil
 		}
 
-		if string(cfgSecret.Data["alertmanager.yaml"]) != yamlConfig {
-			lastErr = errors.Errorf("expected Alertmanager configuration %q, got %q", yamlConfig, cfgSecret.Data["alertmanager.yaml"])
+		if diff := cmp.Diff(string(cfgSecret.Data["alertmanager.yaml"]), yamlConfig); diff != "" {
+			lastErr = errors.Errorf("got(-), want(+):\n%s", diff)
 			return false, nil
 		}
 
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatalf("%v: %v", err, lastErr)
 	}
@@ -1354,6 +1353,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
+
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
@@ -1362,6 +1362,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	alertmanager.Spec.AlertmanagerConfiguration = &monitoringv1.AlertmanagerConfiguration{
 		Name: alertmanagerConfig.Name,
 	}
@@ -1412,6 +1413,7 @@ templates: []
 
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatalf("%v: %v", err, lastErr)
 	}

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -77,7 +77,11 @@ func (f *Framework) CreateAlertmanagerConfig(ctx context.Context, ns, name strin
 			},
 		},
 	}
-	subRouteJSON, _ := json.Marshal(subRoute)
+	subRouteJSON, err := json.Marshal(subRoute)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal subroute")
+	}
+
 	amConfig := &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -118,6 +122,7 @@ func (f *Framework) CreateAlertmanagerConfig(ctx context.Context, ns, name strin
 			},
 		},
 	}
+
 	return f.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, amConfig, metav1.CreateOptions{})
 }
 


### PR DESCRIPTION
testUserDefinedAlertmanagerConfigFromSecret() starts failing with
Alertmanager v0.24.0-rc.0 because this version enforces no matcher on
the root route. Detected by #4644.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
