### PR TITLE
example: update thanos version to v0.25.1

### DIFF
--- a/example/thanos/prometheus.yaml
+++ b/example/thanos/prometheus.yaml
@@ -15,4 +15,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus
   thanos:
-    version: v0.11.2
+    version: v0.25.1

--- a/example/thanos/query-deployment.yaml
+++ b/example/thanos/query-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --query.replica-label=thanos_ruler_replica
         - --store=dnssrv+_grpc._tcp.thanos-sidecar.default.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-ruler.default.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.11.2
+        image: quay.io/thanos/thanos:v0.25.1
         name: thanos-query
         ports:
         - containerPort: 10902

--- a/example/thanos/thanos-ruler.yaml
+++ b/example/thanos/thanos-ruler.yaml
@@ -6,7 +6,7 @@ metadata:
   name: thanos-ruler
   namespace: default
 spec:
-  image: quay.io/thanos/thanos:v0.11.2
+  image: quay.io/thanos/thanos:v0.25.1
   queryEndpoints:
   - dnssrv+_http._tcp.thanos-query.default.svc.cluster.local
   ruleSelector:

--- a/jsonnet/thanos/config.libsonnet
+++ b/jsonnet/thanos/config.libsonnet
@@ -20,7 +20,7 @@ local service(name, namespace, labels, selector, ports) = {
     thanosRulerName: 'thanos-ruler',
     thanosSidecarName: 'thanos-sidecar',
     versions+:: {
-      thanos: 'v0.11.2',
+      thanos: 'v0.25.1',
     },
 
     imageRepos+:: {


### PR DESCRIPTION
thanos image v0.11.2 doesn't exist in the repository.
Fixes #4662

## Description

The examples have thanos image tag v0.11.2 with quay.io thanos / thanos registry.
But v0.11.2 doesn't exist in the registry.
As a result, example deployment failed to pull image.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry



<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update example thanos image tag to v0.25.1
```