### PR TITLE
thanos-sidecar: add necessary capabilities

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -793,21 +793,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
 					Drop: []v1.Capability{"ALL"},
-					Add: []v1.Capability{
-						"DAC_OVERRIDE",
-						"FOWNER",
-						"FSETID",
-						"KILL",
-						"SETGID",
-						"SETUID",
-						"SETPCAP",
-						"NET_BIND_SERVICE",
-						"NET_RAW",
-						"SYS_CHROOT",
-						"MKNOD",
-						"AUDIT_WRITE",
-						"SETFCAP",
-					},
+					Add: []v1.Capability{"DAC_OVERRIDE"},
 				},
 			},
 			Ports: []v1.ContainerPort{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -793,7 +793,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
 					Drop: []v1.Capability{"ALL"},
-					Add: []v1.Capability{"DAC_OVERRIDE"},
+					Add:  []v1.Capability{"DAC_OVERRIDE"},
 				},
 			},
 			Ports: []v1.ContainerPort{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -793,6 +793,21 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
 					Drop: []v1.Capability{"ALL"},
+					Add: []v1.Capability{
+						"DAC_OVERRIDE",
+						"FOWNER",
+						"FSETID",
+						"KILL",
+						"SETGID",
+						"SETUID",
+						"SETPCAP",
+						"NET_BIND_SERVICE",
+						"NET_RAW",
+						"SYS_CHROOT",
+						"MKNOD",
+						"AUDIT_WRITE",
+						"SETFCAP",
+					},
 				},
 			},
 			Ports: []v1.ContainerPort{


### PR DESCRIPTION
Fixes #4664

## Description

v0.55.0 release added `securityContext.capabilities.drop: ALL`.
thanos-sidecar stop working after upgrading to v0.55.0 due to the lack of capabilities.
This PR adds necessary capabilities.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add necessary capabilities to the thanos-sidecar to fix capabilities issue.
```
