### PR TITLE
pkg/alertmanager: refactor configuration provisioning

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -110,19 +110,20 @@ func TestGenerateGlobalConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 		kclient := fake.NewSimpleClientset()
-		cg := newConfigGenerator(
+		cb := newConfigBuilder(
 			log.NewNopLogger(),
 			version,
 			assets.NewStore(kclient.CoreV1(), kclient.CoreV1()),
 		)
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cg.generateGlobalConfig(context.TODO(), tt.amConfig)
+			err := cb.initializeFromAlertmanagerConfig(context.TODO(), tt.amConfig)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("configGenerator.generateGlobalConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("configGenerator.generateGlobalConfig() = %v, want %v", got, tt.want)
+
+			if !reflect.DeepEqual(cb.cfg, tt.want) {
+				t.Errorf("configGenerator.generateGlobalConfig() = %v, want %v", cb.cfg, tt.want)
 			}
 		})
 	}
@@ -253,7 +254,6 @@ templates: []
 			baseConfig: alertmanagerConfig{
 				Route: &route{
 					Receiver: "null",
-					Matchers: []string{"namespace=test"},
 					Routes: []*route{{
 						Matchers: []string{"namespace=custom-test"},
 						Receiver: "custom",
@@ -267,8 +267,6 @@ templates: []
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
 			expected: `route:
   receiver: "null"
-  matchers:
-  - namespace=test
   routes:
   - receiver: custom
     matchers:
@@ -1335,21 +1333,25 @@ templates: []
 				tc.amVersion = &version
 			}
 
-			cg := newConfigGenerator(logger, *tc.amVersion, store)
-			cfgBytes, err := cg.generateConfig(context.Background(), tc.baseConfig, tc.amConfigs)
+			cb := newConfigBuilder(logger, *tc.amVersion, store)
+			cb.cfg = &tc.baseConfig
+
+			if err := cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs); err != nil {
+				t.Fatal(err)
+			}
+
+			cfgBytes, err := cb.marshalJSON()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			result := string(cfgBytes)
-
 			// Verify the generated yaml is as expected
-			if diff := cmp.Diff(tc.expected, result); diff != "" {
+			if diff := cmp.Diff(tc.expected, string(cfgBytes)); diff != "" {
 				t.Errorf("Unexpected result (-want +got):\n%s", diff)
 			}
 
 			// Verify the generated config is something that Alertmanager will be happy with
-			_, err = config.Load(result)
+			_, err = alertmanagerConfigFromBytes(cfgBytes)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1791,12 +1793,12 @@ func TestSanitizeRoute(t *testing.T) {
 func TestLoadConfig(t *testing.T) {
 	testCase := []struct {
 		name     string
-		rawConf  string
+		rawConf  []byte
 		expected *alertmanagerConfig
 	}{
 		{
 			name: "Test mute_time_intervals",
-			rawConf: `route:
+			rawConf: []byte(`route:
   receiver: "null"
 receivers:
 - name: "null"
@@ -1809,7 +1811,7 @@ mute_time_intervals:
     days_of_month: ["7", "18", "28"]
     months: ["january"]
 templates: []
-`,
+`),
 			expected: &alertmanagerConfig{
 				Global: nil,
 				Route: &route{
@@ -1869,7 +1871,7 @@ templates: []
 	}
 
 	for _, tc := range testCase {
-		ac, err := alertmanagerConfigFrom(tc.rawConf)
+		ac, err := alertmanagerConfigFromBytes(tc.rawConf)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -16,10 +16,12 @@ package alertmanager
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -867,8 +869,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 					Namespace: "test",
 				},
 				Spec: monitoringv1.AlertmanagerSpec{
-					ConfigSecret:               "amconfig",
-					AlertmanagerConfigSelector: nil,
+					ConfigSecret: "amconfig",
 				},
 			},
 			objects: []runtime.Object{
@@ -1088,7 +1089,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			o := &Operator{
 				kclient: c,
 				mclient: monitoringfake.NewSimpleClientset(),
-				logger:  log.NewNopLogger(),
+				logger:  level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowInfo()),
 				metrics: operator.NewMetrics("alertmanager", prometheus.NewRegistry()),
 			}
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -633,8 +633,12 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 	}, nil
 }
 
-func defaultConfigSecretName(name string) string {
-	return prefixedName(name)
+func defaultConfigSecretName(am *monitoringv1.Alertmanager) string {
+	if am.Spec.ConfigSecret == "" {
+		return prefixedName(am.Name)
+	}
+
+	return am.Spec.ConfigSecret
 }
 
 func generatedConfigSecretName(name string) string {


### PR DESCRIPTION
This change reorganizes the code to have a clearer separation between
the different modes:
* Alertmanager configuration obtained from secret
* Alertmanager configuration obtained from AlertmanagerConfig objects

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
