### PR TITLE
pkg/apis: Add validations for time settings of prometheus at CRD level

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10234,7 +10234,9 @@ spec:
                         the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: MetricRelabelConfigs to apply to samples before
@@ -10463,7 +10465,9 @@ spec:
                       description: HTTP scheme to use for scraping.
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
@@ -10798,6 +10802,7 @@ spec:
               interval:
                 description: Interval at which targets are probed using the configured
                   prober. If not specified Prometheus' global scrape interval is used.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               jobName:
                 description: The job name assigned to scraped metrics by default.
@@ -10988,6 +10993,8 @@ spec:
                 type: integer
               scrapeTimeout:
                 description: Timeout for scraping metrics from the Prometheus exporter.
+                  If not specified, the Prometheus global scrape interval is used.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped
@@ -14057,7 +14064,9 @@ spec:
                 format: int64
                 type: integer
               evaluationInterval:
-                description: 'Interval between consecutive evaluations. Default: `1m`'
+                default: 30s
+                description: 'Interval between consecutive evaluations. Default: `30s`'
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               excludedFromEnforcement:
                 description: List of references to PodMonitor, ServiceMonitor, Probe
@@ -15670,6 +15679,7 @@ spec:
                     type: integer
                   timeout:
                     description: Maximum time a query may take before being aborted.
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
               queryLogFile:
@@ -15877,6 +15887,7 @@ spec:
                       type: boolean
                     remoteTimeout:
                       description: Timeout for requests to the remote read endpoint.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     requiredMatchers:
                       additionalProperties:
@@ -16122,6 +16133,7 @@ spec:
                         sendInterval:
                           description: How frequently metric metadata is sent to the
                             remote storage.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                       type: object
                     name:
@@ -16260,6 +16272,7 @@ spec:
                       type: object
                     remoteTimeout:
                       description: Timeout for requests to the remote write endpoint.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     sendExemplars:
                       description: Enables sending of exemplars over remote write.
@@ -16554,6 +16567,7 @@ spec:
                   is '24h' if retentionSize is not set, and must match the regular
                   expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes
                   hours days weeks years).
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               retentionSize:
                 description: Maximum amount of disk space used by blocks.
@@ -16683,11 +16697,14 @@ spec:
                     type: object
                 type: object
               scrapeInterval:
-                description: 'Interval between consecutive scrapes. Default: `1m`'
+                default: 30s
+                description: 'Interval between consecutive scrapes. Default: `30s`'
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               scrapeTimeout:
                 description: Number of seconds to wait for target to respond before
                   erroring.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               secrets:
                 description: Secrets is a list of Secrets in the same namespace as
@@ -17733,6 +17750,7 @@ spec:
                   readyTimeout:
                     description: ReadyTimeout is the maximum time Thanos sidecar will
                       wait for Prometheus to start. Eg 10m
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                   resources:
                     description: Resources defines the resource requirements for the
@@ -19972,7 +19990,9 @@ spec:
                         the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: MetricRelabelConfigs to apply to samples before
@@ -20201,7 +20221,10 @@ spec:
                       description: HTTP scheme to use for scraping.
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape timeout is used unless
+                        it is less than `Interval` in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -183,7 +183,9 @@ spec:
                         the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: MetricRelabelConfigs to apply to samples before
@@ -412,7 +414,9 @@ spec:
                       description: HTTP scheme to use for scraping.
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -132,6 +132,7 @@ spec:
               interval:
                 description: Interval at which targets are probed using the configured
                   prober. If not specified Prometheus' global scrape interval is used.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               jobName:
                 description: The job name assigned to scraped metrics by default.
@@ -322,6 +323,8 @@ spec:
                 type: integer
               scrapeTimeout:
                 description: Timeout for scraping metrics from the Prometheus exporter.
+                  If not specified, the Prometheus global scrape interval is used.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -2734,7 +2734,9 @@ spec:
                 format: int64
                 type: integer
               evaluationInterval:
-                description: 'Interval between consecutive evaluations. Default: `1m`'
+                default: 30s
+                description: 'Interval between consecutive evaluations. Default: `30s`'
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               excludedFromEnforcement:
                 description: List of references to PodMonitor, ServiceMonitor, Probe
@@ -4347,6 +4349,7 @@ spec:
                     type: integer
                   timeout:
                     description: Maximum time a query may take before being aborted.
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
               queryLogFile:
@@ -4554,6 +4557,7 @@ spec:
                       type: boolean
                     remoteTimeout:
                       description: Timeout for requests to the remote read endpoint.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     requiredMatchers:
                       additionalProperties:
@@ -4799,6 +4803,7 @@ spec:
                         sendInterval:
                           description: How frequently metric metadata is sent to the
                             remote storage.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                       type: object
                     name:
@@ -4937,6 +4942,7 @@ spec:
                       type: object
                     remoteTimeout:
                       description: Timeout for requests to the remote write endpoint.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     sendExemplars:
                       description: Enables sending of exemplars over remote write.
@@ -5231,6 +5237,7 @@ spec:
                   is '24h' if retentionSize is not set, and must match the regular
                   expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes
                   hours days weeks years).
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               retentionSize:
                 description: Maximum amount of disk space used by blocks.
@@ -5360,11 +5367,14 @@ spec:
                     type: object
                 type: object
               scrapeInterval:
-                description: 'Interval between consecutive scrapes. Default: `1m`'
+                default: 30s
+                description: 'Interval between consecutive scrapes. Default: `30s`'
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               scrapeTimeout:
                 description: Number of seconds to wait for target to respond before
                   erroring.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               secrets:
                 description: Secrets is a list of Secrets in the same namespace as
@@ -6410,6 +6420,7 @@ spec:
                   readyTimeout:
                     description: ReadyTimeout is the maximum time Thanos sidecar will
                       wait for Prometheus to start. Eg 10m
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                   resources:
                     description: Resources defines the resource requirements for the

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -152,7 +152,9 @@ spec:
                         the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
                       description: MetricRelabelConfigs to apply to samples before
@@ -381,7 +383,10 @@ spec:
                       description: HTTP scheme to use for scraping.
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape timeout is used unless
+                        it is less than `Interval` in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -198,7 +198,8 @@
                           "type": "boolean"
                         },
                         "interval": {
-                          "description": "Interval at which metrics should be scraped",
+                          "description": "Interval at which metrics should be scraped If not specified Prometheus' global scrape interval is used.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "metricRelabelings": {
@@ -435,7 +436,8 @@
                           "type": "string"
                         },
                         "scrapeTimeout": {
-                          "description": "Timeout after which the scrape is ended",
+                          "description": "Timeout after which the scrape is ended If not specified, the Prometheus global scrape interval is used.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "targetPort": {

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -146,6 +146,7 @@
                   },
                   "interval": {
                     "description": "Interval at which targets are probed using the configured prober. If not specified Prometheus' global scrape interval is used.",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "jobName": {
@@ -355,7 +356,8 @@
                     "type": "integer"
                   },
                   "scrapeTimeout": {
-                    "description": "Timeout for scraping metrics from the Prometheus exporter.",
+                    "description": "Timeout for scraping metrics from the Prometheus exporter. If not specified, the Prometheus global scrape interval is used.",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "targetLimit": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2459,7 +2459,9 @@
                     "type": "integer"
                   },
                   "evaluationInterval": {
-                    "description": "Interval between consecutive evaluations. Default: `1m`",
+                    "default": "30s",
+                    "description": "Interval between consecutive evaluations. Default: `30s`",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "excludedFromEnforcement": {
@@ -3953,6 +3955,7 @@
                       },
                       "timeout": {
                         "description": "Maximum time a query may take before being aborted.",
+                        "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                         "type": "string"
                       }
                     },
@@ -4178,6 +4181,7 @@
                         },
                         "remoteTimeout": {
                           "description": "Timeout for requests to the remote read endpoint.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "requiredMatchers": {
@@ -4454,6 +4458,7 @@
                             },
                             "sendInterval": {
                               "description": "How frequently metric metadata is sent to the remote storage.",
+                              "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                               "type": "string"
                             }
                           },
@@ -4610,6 +4615,7 @@
                         },
                         "remoteTimeout": {
                           "description": "Timeout for requests to the remote write endpoint.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "sendExemplars": {
@@ -4934,6 +4940,7 @@
                   },
                   "retention": {
                     "description": "Time duration Prometheus shall retain data for. Default is '24h' if retentionSize is not set, and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "retentionSize": {
@@ -5054,11 +5061,14 @@
                     "type": "object"
                   },
                   "scrapeInterval": {
-                    "description": "Interval between consecutive scrapes. Default: `1m`",
+                    "default": "30s",
+                    "description": "Interval between consecutive scrapes. Default: `30s`",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "scrapeTimeout": {
                     "description": "Number of seconds to wait for target to respond before erroring.",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "secrets": {
@@ -5978,6 +5988,7 @@
                       },
                       "readyTimeout": {
                         "description": "ReadyTimeout is the maximum time Thanos sidecar will wait for Prometheus to start. Eg 10m",
+                        "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                         "type": "string"
                       },
                       "resources": {

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -166,7 +166,8 @@
                           "type": "boolean"
                         },
                         "interval": {
-                          "description": "Interval at which metrics should be scraped",
+                          "description": "Interval at which metrics should be scraped If not specified Prometheus' global scrape interval is used.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "metricRelabelings": {
@@ -403,7 +404,8 @@
                           "type": "string"
                         },
                         "scrapeTimeout": {
-                          "description": "Timeout after which the scrape is ended",
+                          "description": "Timeout after which the scrape is ended If not specified, the Prometheus global scrape timeout is used unless it is less than `Interval` in which the latter is used.",
+                          "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                           "type": "string"
                         },
                         "targetPort": {

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1497,7 +1497,7 @@ func (in *QuerySpec) DeepCopyInto(out *QuerySpec) {
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
-		*out = new(string)
+		*out = new(Duration)
 		**out = **in
 	}
 }

--- a/pkg/operator/validations.go
+++ b/pkg/operator/validations.go
@@ -17,6 +17,7 @@ package operator
 import (
 	"github.com/alecthomas/units"
 	"github.com/pkg/errors"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -37,7 +38,7 @@ func ValidateDurationField(durationField string) error {
 }
 
 // CompareScrapeTimeoutToScrapeInterval validates value of scrapeTimeout based on scrapeInterval
-func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval string) error {
+func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval monitoringv1.Duration) error {
 	var err error
 	var si, st model.Duration
 
@@ -46,10 +47,12 @@ func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval string) 
 		scrapeInterval = "30s"
 	}
 
-	if si, err = model.ParseDuration(scrapeInterval); err != nil {
+	// TODO(slashpai): Remove this validation after v0.57 since this is set at CRD level
+	if si, err = model.ParseDuration(string(scrapeInterval)); err != nil {
 		return errors.Wrapf(err, "invalid scrapeInterval %q", scrapeInterval)
 	}
-	if st, err = model.ParseDuration(scrapeTimeout); err != nil {
+	// TODO(slashpai): Remove this validation after v0.57 since this is set at CRD level
+	if st, err = model.ParseDuration(string(scrapeTimeout)); err != nil {
 		return errors.Wrapf(err, "invalid scrapeTimeout: %q", scrapeTimeout)
 	}
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2226,7 +2226,7 @@ func validateProberURL(url string) error {
 	return nil
 }
 
-func validateScrapeIntervalAndTimeout(p *monitoringv1.Prometheus, scrapeInterval, scrapeTimeout string) error {
+func validateScrapeIntervalAndTimeout(p *monitoringv1.Prometheus, scrapeInterval, scrapeTimeout monitoringv1.Duration) error {
 	if scrapeTimeout == "" {
 		return nil
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -377,20 +377,23 @@ func validateConfigInputs(p *v1.Prometheus) error {
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	if p.Spec.Retention != "" {
-		if err := operator.ValidateDurationField(p.Spec.Retention); err != nil {
+		if err := operator.ValidateDurationField(string(p.Spec.Retention)); err != nil {
 			return errors.Wrap(err, "invalid retention value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	if p.Spec.ScrapeInterval != "" {
-		if err := operator.ValidateDurationField(p.Spec.ScrapeInterval); err != nil {
+		if err := operator.ValidateDurationField(string(p.Spec.ScrapeInterval)); err != nil {
 			return errors.Wrap(err, "invalid scrapeInterval value specified")
 		}
 	}
 
 	if p.Spec.ScrapeTimeout != "" {
-		if err := operator.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
+		// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
+		if err := operator.ValidateDurationField(string(p.Spec.ScrapeTimeout)); err != nil {
 			return errors.Wrap(err, "invalid scrapeTimeout value specified")
 		}
 		if err := operator.CompareScrapeTimeoutToScrapeInterval(p.Spec.ScrapeTimeout, p.Spec.ScrapeInterval); err != nil {
@@ -398,41 +401,47 @@ func validateConfigInputs(p *v1.Prometheus) error {
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	if p.Spec.EvaluationInterval != "" {
-		if err := operator.ValidateDurationField(p.Spec.EvaluationInterval); err != nil {
+		if err := operator.ValidateDurationField(string(p.Spec.EvaluationInterval)); err != nil {
 			return errors.Wrap(err, "invalid evaluationInterval value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	if p.Spec.Thanos != nil && p.Spec.Thanos.ReadyTimeout != "" {
-		if err := operator.ValidateDurationField(p.Spec.Thanos.ReadyTimeout); err != nil {
+		if err := operator.ValidateDurationField(string(p.Spec.Thanos.ReadyTimeout)); err != nil {
 			return errors.Wrap(err, "invalid thanos.readyTimeout value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	if p.Spec.Query != nil && p.Spec.Query.Timeout != nil && *p.Spec.Query.Timeout != "" {
-		if err := operator.ValidateDurationField(*p.Spec.Query.Timeout); err != nil {
+		if err := operator.ValidateDurationField(string(*p.Spec.Query.Timeout)); err != nil {
 			return errors.Wrap(err, "invalid query.timeout value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	for i, rr := range p.Spec.RemoteRead {
 		if rr.RemoteTimeout != "" {
-			if err := operator.ValidateDurationField(rr.RemoteTimeout); err != nil {
+			if err := operator.ValidateDurationField(string(rr.RemoteTimeout)); err != nil {
 				return errors.Wrapf(err, "invalid remoteRead[%d].remoteTimeout value specified", i)
 			}
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 	for i, rw := range p.Spec.RemoteWrite {
 		if rw.RemoteTimeout != "" {
-			if err := operator.ValidateDurationField(rw.RemoteTimeout); err != nil {
+			if err := operator.ValidateDurationField(string(rw.RemoteTimeout)); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].remoteTimeout value specified", i)
 			}
 		}
 
+		// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
 		if rw.MetadataConfig != nil && rw.MetadataConfig.SendInterval != "" {
-			if err := operator.ValidateDurationField(rw.MetadataConfig.SendInterval); err != nil {
+			if err := operator.ValidateDurationField(string(rw.MetadataConfig.SendInterval)); err != nil {
 				return errors.Wrapf(err, "invalid remoteWrite[%d].metadataConfig.sendInterval value specified", i)
 			}
 		}
@@ -441,7 +450,7 @@ func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.Alerting != nil {
 		for i, ap := range p.Spec.Alerting.Alertmanagers {
 			if ap.Timeout != nil && *ap.Timeout != "" {
-				if err := operator.ValidateDurationField(*ap.Timeout); err != nil {
+				if err := operator.ValidateDurationField(string(*ap.Timeout)); err != nil {
 					return errors.Wrapf(err, "invalid alertmanagers[%d].timeout value specified", i)
 				}
 			}
@@ -470,14 +479,18 @@ func (cg *ConfigGenerator) Generate(
 
 	cfg := yaml.MapSlice{}
 
+	// TODO(slashpai): Remove this default assignment after v0.57 since this is set at CRD level
 	scrapeInterval := "30s"
+	// TODO(slashpai): Remove this check after v0.57 since default is set at CRD level
 	if p.Spec.ScrapeInterval != "" {
-		scrapeInterval = p.Spec.ScrapeInterval
+		scrapeInterval = string(p.Spec.ScrapeInterval)
 	}
 
+	// TODO(slashpai): Remove this default assignment after v0.57 since this is set at CRD level
 	evaluationInterval := "30s"
+	// TODO(slashpai): Remove this check after v0.57 since default is set at CRD level
 	if p.Spec.EvaluationInterval != "" {
-		evaluationInterval = p.Spec.EvaluationInterval
+		evaluationInterval = string(p.Spec.EvaluationInterval)
 	}
 
 	globalItems := yaml.MapSlice{

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -87,9 +87,9 @@ func TestConfigGeneration(t *testing.T) {
 func TestGlobalSettings(t *testing.T) {
 	for _, tc := range []struct {
 		Scenario           string
-		EvaluationInterval string
-		ScrapeInterval     string
-		ScrapeTimeout      string
+		EvaluationInterval monitoringv1.Duration
+		ScrapeInterval     monitoringv1.Duration
+		ScrapeTimeout      monitoringv1.Duration
 		ExternalLabels     map[string]string
 		QueryLogFile       string
 		Version            string

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -361,7 +361,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 			promArgs = append(promArgs, retentionTimeFlag+defaultRetention)
 		} else {
 			if p.Spec.Retention != "" {
-				promArgs = append(promArgs, retentionTimeFlag+p.Spec.Retention)
+				promArgs = append(promArgs, retentionTimeFlag+string(p.Spec.Retention))
 			}
 
 			if p.Spec.RetentionSize != "" {
@@ -374,7 +374,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		if p.Spec.Retention == "" {
 			promArgs = append(promArgs, retentionTimeFlag+defaultRetention)
 		} else {
-			promArgs = append(promArgs, retentionTimeFlag+p.Spec.Retention)
+			promArgs = append(promArgs, retentionTimeFlag+string(p.Spec.Retention))
 		}
 	}
 
@@ -865,7 +865,7 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		}
 
 		if p.Spec.Thanos.ReadyTimeout != "" {
-			container.Args = append(container.Args, "--prometheus.ready_timeout="+p.Spec.Thanos.ReadyTimeout)
+			container.Args = append(container.Args, "--prometheus.ready_timeout="+string(p.Spec.Thanos.ReadyTimeout))
 		}
 		additionalContainers = append(additionalContainers, container)
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1337,7 +1337,7 @@ func TestThanosSideCarVolumes(t *testing.T) {
 func TestRetentionAndRetentionSize(t *testing.T) {
 	tests := []struct {
 		version                    string
-		specRetention              string
+		specRetention              monitoringv1.Duration
 		specRetentionSize          monitoringv1.ByteSize
 		expectedRetentionArg       string
 		expectedRetentionSizeArg   string

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -3877,16 +3877,6 @@ func testPrometheusCRDValidation(t *testing.T) {
 	t.Parallel()
 	name := "test"
 	replicas := int32(1)
-	commonFields := monitoringv1.CommonPrometheusFields{
-		Replicas:           &replicas,
-		Version:            operator.DefaultPrometheusVersion,
-		ServiceAccountName: "prometheus",
-		Resources: v1.ResourceRequirements{
-			Requests: v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("400Mi"),
-			},
-		},
-	}
 
 	tests := []struct {
 		name           string
@@ -3899,45 +3889,183 @@ func testPrometheusCRDValidation(t *testing.T) {
 		{
 			name: "zero-size-without-unit",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "0",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "0",
 			},
 		},
 		{
 			name: "legacy-unit",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "1.5GB",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "1.5GB",
 			},
 		},
 		{
 			name: "iec-unit",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "100MiB",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "100MiB",
 			},
 		},
 		{
 			name: "legacy-missing-symbol",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "10M",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "10M",
 			},
 			expectedError: true,
 		},
 		{
 			name: "legacy-missing-unit",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "1000",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "1000",
 			},
 			expectedError: true,
 		},
 		{
 			name: "iec-missing-symbol",
 			prometheusSpec: monitoringv1.PrometheusSpec{
-				CommonPrometheusFields: commonFields,
-				RetentionSize:          "15Gi",
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				RetentionSize: "15Gi",
+			},
+			expectedError: true,
+		},
+		//
+		// ScrapeInterval validation
+		{
+			name: "zero-time-without-unit",
+			prometheusSpec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+					ScrapeInterval: "0",
+				},
+			},
+		},
+		{
+			name: "time-in-seconds-unit",
+			prometheusSpec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+					ScrapeInterval: "30s",
+				},
+			},
+		},
+		{
+			name: "complex-time-unit",
+			prometheusSpec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+					ScrapeInterval: "1h30m15s",
+				},
+			},
+		},
+		{
+			name: "time-missing-symbols",
+			prometheusSpec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+					ScrapeInterval: "600",
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "time-unit-misspelled",
+			prometheusSpec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Replicas:           &replicas,
+					Version:            operator.DefaultPrometheusVersion,
+					ServiceAccountName: "prometheus",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+					ScrapeInterval: "60ss",
+				},
 			},
 			expectedError: true,
 		},


### PR DESCRIPTION
pkg/apis: Add validations for time settings of prometheus at CRD level

test: Update e2e test for CRD validation

This is needed to avoid invalid values from user which would
cause problem for application to load or not work as expected

Related-to https://github.com/prometheus-operator/prometheus-operator/issues/4524

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

**Note:**  I haven't full covered all time fields in this since alertmanager uses time.ParseDuration for a few and I don't want to mix different types in same PR. 

pkg/apis: Add validations for time settings of prometheus at CRD level

Regex validation is based on https://github.com/prometheus/common/blob/main/model/time.go#L186 included `0` also as valid

Regex test: https://regex101.com/r/2ciWaP/1

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add validations for time settings of prometheus at CRD level
```
