### PR TITLE
Add prometheus_operator_reconcile_duration_seconds histogram metrics

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -536,7 +536,9 @@ func (c *Operator) processNextWorkItem(ctx context.Context) bool {
 	defer c.queue.Done(key)
 
 	c.metrics.ReconcileCounter().Inc()
+	startTime := time.Now()
 	err := c.sync(ctx, key.(string))
+	c.metrics.ReconcileDurationHistogram().Observe(time.Since(startTime).Seconds())
 	c.metrics.SetSyncStatus(key.(string), err == nil)
 	if err == nil {
 		c.queue.Forget(key)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -49,13 +49,14 @@ var (
 type Metrics struct {
 	reg prometheus.Registerer
 
-	listCounter            prometheus.Counter
-	listFailedCounter      prometheus.Counter
-	watchCounter           prometheus.Counter
-	watchFailedCounter     prometheus.Counter
-	reconcileCounter       prometheus.Counter
-	reconcileErrorsCounter prometheus.Counter
-	stsDeleteCreateCounter prometheus.Counter
+	listCounter                prometheus.Counter
+	listFailedCounter          prometheus.Counter
+	watchCounter               prometheus.Counter
+	watchFailedCounter         prometheus.Counter
+	reconcileCounter           prometheus.Counter
+	reconcileErrorsCounter     prometheus.Counter
+	stsDeleteCreateCounter     prometheus.Counter
+	reconcileDurationHistogram prometheus.Histogram
 	// triggerByCounter is a set of counters keeping track of the amount
 	// of times Prometheus Operator was triggered to reconcile its created
 	// objects. It is split in the dimensions of Kubernetes objects and
@@ -83,6 +84,11 @@ func NewMetrics(name string, r prometheus.Registerer) *Metrics {
 		reconcileCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_operator_reconcile_operations_total",
 			Help: "Total number of reconcile operations",
+		}),
+		reconcileDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "prometheus_operator_reconcile_duration_seconds",
+			Help:    "Histogram of reconcile operations",
+			Buckets: []float64{.1, .5, 1, 5, 10},
 		}),
 		reconcileErrorsCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_operator_reconcile_errors_total",
@@ -124,6 +130,7 @@ func NewMetrics(name string, r prometheus.Registerer) *Metrics {
 
 	m.reg.MustRegister(
 		m.reconcileCounter,
+		m.reconcileDurationHistogram,
 		m.reconcileErrorsCounter,
 		m.triggerByCounter,
 		m.stsDeleteCreateCounter,
@@ -141,6 +148,11 @@ func NewMetrics(name string, r prometheus.Registerer) *Metrics {
 // ReconcileCounter returns a counter to track attempted reconciliations.
 func (m *Metrics) ReconcileCounter() prometheus.Counter {
 	return m.reconcileCounter
+}
+
+// ReconcileDurationHistogram returns a histogram to track the duration of reconciliations.
+func (m *Metrics) ReconcileDurationHistogram() prometheus.Histogram {
+	return m.reconcileDurationHistogram
 }
 
 // ReconcileErrorsCounter returns a counter to track reconciliation errors.

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1041,7 +1041,9 @@ func (c *Operator) processNextWorkItem(ctx context.Context) bool {
 	defer c.queue.Done(key)
 
 	c.metrics.ReconcileCounter().Inc()
+	startTime := time.Now()
 	err := c.sync(ctx, key.(string))
+	c.metrics.ReconcileDurationHistogram().Observe(time.Since(startTime).Seconds())
 	c.metrics.SetSyncStatus(key.(string), err == nil)
 	if err == nil {
 		c.queue.Forget(key)

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -565,7 +565,9 @@ func (o *Operator) processNextWorkItem(ctx context.Context) bool {
 	defer o.queue.Done(key)
 
 	o.metrics.ReconcileCounter().Inc()
+	startTime := time.Now()
 	err := o.sync(ctx, key.(string))
+	o.metrics.ReconcileDurationHistogram().Observe(time.Since(startTime).Seconds())
 	o.metrics.SetSyncStatus(key.(string), err == nil)
 	if err == nil {
 		o.queue.Forget(key)


### PR DESCRIPTION
Signed-off-by: heylongdacoder <heylongdacoder@gmail.com>

## Description

_Fixes #3408 ._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add prometheus_operator_reconcile_duration_seconds histogram metrics
```
