### PR TITLE
test: improve resiliency of testPromWebTLS()

### DIFF
--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -129,13 +129,15 @@ func execute(method string, url *url.URL, config *rest.Config, stdin io.Reader, 
 	})
 }
 
-// StartPortForward initiates a port forwarding connection to a pod on the localhost interface.
-//
-// StartPortForward blocks until the port forwarding proxy server is ready to receive connections.
-func StartPortForward(config *rest.Config, scheme string, name string, ns string, port string) error {
+// StartPortForward initiates a port forwarding connection to a pod on the
+// localhost interface. It returns a closer function that should be invoked to
+// stop the proxy server.
+// The function blocks until the port forwarding proxy server is ready to
+// receive connections.
+func StartPortForward(config *rest.Config, scheme string, name string, ns string, port string, errLogger func(string, ...interface{})) (func(), error) {
 	roundTripper, upgrader, err := spdy.RoundTripperFor(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", ns, name)
@@ -147,15 +149,15 @@ func StartPortForward(config *rest.Config, scheme string, name string, ns string
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 	forwarder, err := portforward.New(dialer, []string{port}, stopChan, readyChan, out, errOut)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	go func() {
 		if err := forwarder.ForwardPorts(); err != nil {
-			panic(err)
+			errLogger("ForwardPorts() failed: %v", err)
 		}
 	}()
 
 	<-readyChan
-	return nil
+	return func() { close(stopChan) }, nil
 }


### PR DESCRIPTION
## Description

I spotted that `testPromWebTLS()` started failing more often due to port forwarding not working as expected. Lets see if retrying helps.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
