### PR TITLE
*: add docs.github.com to mdox exceptions

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -2,6 +2,9 @@ version: 1
 timeout: "1m"
 
 validators:
+  # docs.github.com returns 403 if not in browser. Cannot curl as well.
+  - regex: 'docs\.github\.com'
+    type: "ignore"
   # Cloudflare protection, so returns 503 if not in browser. Cannot curl as well.
   - regex: 'wise\.com'
     type: "ignore"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@ Please reach any of the maintainers on slack (#prometheus-operator on https://sl
 
 ## Triage
 
-We also have some nice souls that help triaging issues and PRs. See [here](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) for details about the role's permission.
+We also have some nice souls that help triaging issues and PRs. See [here](https://docs.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) for details about the role's permission.
 
 Full list of triage people is displayed below:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,7 +107,7 @@ git tag -s "pkg/client/${tag}" -m "pkg/client/${tag}"
 git push origin "${tag}" "pkg/apis/monitoring/${tag}" "pkg/client/${tag}"
 ```
 
-Signed tag with a GPG key is appreciated, but in case you can't add a GPG key to your Github account using the following [procedure](https://help.github.com/articles/generating-a-gpg-key/), you can replace the `-s` flag by `-a` flag of the `git tag` command to only annotate the tag without signing.
+Signed tag with a GPG key is appreciated, but in case you can't add a GPG key to your Github account using the following [procedure](https://docs.github.com/articles/generating-a-gpg-key), you can replace the `-s` flag by `-a` flag of the `git tag` command to only annotate the tag without signing.
 
 Our CI pipeline will automatically push the container images to [quay.io](https://quay.io/organization/prometheus-operator) and [ghcr.io](https://github.com/prometheus-operator/prometheus-operator/pkgs/container/prometheus-operator)
 


### PR DESCRIPTION
## Description

docs.github.com always return a 403 error when not requested from a browser.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
