### PR TITLE
pkg/alertmanager: add support for `api_key_file` in OpsGenie config

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1382,19 +1382,40 @@ func (r *receiver) sanitize(amVersion semver.Version, logger log.Logger) error {
 }
 
 func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
-	actionsAndEntityAllowed := amVersion.GTE(semver.MustParse("0.24.0"))
-	if ogc.Actions != "" && !actionsAndEntityAllowed {
+	if err := ogc.HTTPConfig.sanitize(amVersion, logger); err != nil {
+		return err
+	}
+
+	lessThanV0_24 := amVersion.LT(semver.MustParse("0.24.0"))
+
+	if ogc.Actions != "" && lessThanV0_24 {
 		msg := "opsgenie_config 'actions' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.Actions = ""
 	}
-	if ogc.Entity != "" && !actionsAndEntityAllowed {
+
+	if ogc.Entity != "" && lessThanV0_24 {
 		msg := "opsgenie_config 'entity' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.Entity = ""
 	}
 
-	return ogc.HTTPConfig.sanitize(amVersion, logger)
+	if ogc.APIKey != "" {
+		level.Warn(logger).Log("msg", "'api_key' and 'api_key_file' are mutually exclusive for OpsGenie receiver config - 'api_key' has taken precedence")
+		ogc.APIKeyFile = ""
+	}
+
+	if ogc.APIKeyFile == "" {
+		return nil
+	}
+
+	if lessThanV0_24 {
+		msg := "'api_key_file' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		ogc.APIKeyFile = ""
+	}
+
+	return nil
 }
 
 func (pdc *pagerdutyConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
@@ -1414,6 +1435,7 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger log.Logger) err
 	if sc.APIURLFile == "" {
 		return nil
 	}
+
 	// We need to sanitize the config for slack receivers
 	// As of v0.22.0 AlertManager config supports passing URL via file name
 	fileURLAllowed := amVersion.GTE(semver.MustParse("0.22.0"))
@@ -1428,6 +1450,7 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger log.Logger) err
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		sc.APIURLFile = ""
 	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -1623,7 +1623,7 @@ func TestSanitizeConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "Test slack_api_url_file config",
+			name:           "opsgenie_api_key_file config",
 			againstVersion: versionOpsGenieAPIKeyFileAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
@@ -1637,7 +1637,64 @@ func TestSanitizeConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "Test slack_api_url_file is dropped for unsupported versions",
+			name:           "api_key_file field for OpsGenie config",
+			againstVersion: versionOpsGenieAPIKeyFileAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{
+							{
+								APIKeyFile: "/test",
+							},
+						},
+					},
+				},
+			},
+			expect: alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{
+							{
+								APIKeyFile: "/test",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "api_key_file and api_key fields for OpsGenie config",
+			againstVersion: versionOpsGenieAPIKeyFileAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{
+							{
+								APIKey:     "test",
+								APIKeyFile: "/test",
+							},
+						},
+					},
+				},
+			},
+			expect: alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{
+							{
+								APIKey: "test",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "opsgenie_api_key_file is dropped for unsupported versions",
 			againstVersion: versionOpsGenieAPIKeyFileNotAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
@@ -1646,6 +1703,30 @@ func TestSanitizeConfig(t *testing.T) {
 			},
 			expect: alertmanagerConfig{
 				Global: &globalConfig{},
+			},
+		},
+		{
+			name:           "api_key_file is dropped for unsupported versions",
+			againstVersion: versionOpsGenieAPIKeyFileNotAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{
+							{
+								APIKeyFile: "/test",
+							},
+						},
+					},
+				},
+			},
+			expect: alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name:            "opsgenie",
+						OpsgenieConfigs: []*opsgenieConfig{{}},
+					},
+				},
 			},
 		},
 	} {

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -58,12 +58,12 @@ type globalConfig struct {
 	HipchatAuthToken   string          `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
 	OpsGenieAPIURL     *config.URL     `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
 	OpsGenieAPIKey     string          `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	OpsGenieAPIKeyFile string          `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
 	WeChatAPIURL       *config.URL     `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
 	WeChatAPISecret    string          `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
 	WeChatAPICorpID    string          `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL    *config.URL     `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey    string          `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
-	OpsGenieAPIKeyFile string          `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
 }
 
 type route struct {
@@ -132,6 +132,7 @@ type opsgenieConfig struct {
 	VSendResolved *bool               `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig    *httpClientConfig   `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	APIKey        string              `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKeyFile    string              `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL        string              `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Message       string              `yaml:"message,omitempty" json:"message,omitempty"`
 	Description   string              `yaml:"description,omitempty" json:"description,omitempty"`


### PR DESCRIPTION
## Description

Fixes #4714

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed support for OpsGenie configurations with `api_key_file`. 
```
