### PR TITLE
feat: permit to run prometheus in agent mode

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -511,15 +511,17 @@ func (cg *ConfigGenerator) Generate(
 
 	cfg = append(cfg, yaml.MapItem{Key: "global", Value: globalItems})
 
-	if p.Spec.RuleSelector != nil {
-		ruleFilePaths := []string{}
-		for _, name := range ruleConfigMapNames {
-			ruleFilePaths = append(ruleFilePaths, rulesDir+"/"+name+"/*.yaml")
+	if !isFeatureEnabled(p.Spec.EnableFeatures, "agent") {
+		if p.Spec.RuleSelector != nil {
+			ruleFilePaths := []string{}
+			for _, name := range ruleConfigMapNames {
+				ruleFilePaths = append(ruleFilePaths, rulesDir+"/"+name+"/*.yaml")
+			}
+			cfg = append(cfg, yaml.MapItem{
+				Key:   "rule_files",
+				Value: ruleFilePaths,
+			})
 		}
-		cfg = append(cfg, yaml.MapItem{
-			Key:   "rule_files",
-			Value: ruleFilePaths,
-		})
 	}
 
 	sMonIdentifiers := make([]string, len(sMons))
@@ -630,7 +632,7 @@ func (cg *ConfigGenerator) appendAlertingConfig(
 	additionalAlertmanagerConfigs []byte,
 	store *assets.Store,
 ) (yaml.MapSlice, error) {
-	if p.Spec.Alerting == nil && additionalAlertRelabelConfigs == nil && additionalAlertmanagerConfigs == nil {
+	if isFeatureEnabled(p.Spec.EnableFeatures, "agent") || p.Spec.Alerting == nil && additionalAlertRelabelConfigs == nil && additionalAlertmanagerConfigs == nil {
 		return cfg, nil
 	}
 

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -194,6 +194,32 @@ func TestStatefulSetPVC(t *testing.T) {
 
 }
 
+func TestStatefulSetAgentMode(t *testing.T) {
+	sset, err := makeStatefulSet("test", monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				EnableFeatures: []string{"agent"},
+			},
+		},
+	}, defaultTestConfig, nil, "", 0, nil)
+
+	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	found := false
+	for _, flag := range sset.Spec.Template.Spec.Containers[0].Args {
+		if flag == "--enable-feature=agent" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("Prometheus enabled feature is not correctly set.")
+	}
+}
+
 func TestStatefulSetEmptyDir(t *testing.T) {
 	labels := map[string]string{
 		"testlabel": "testlabelvalue",


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

At Veepee we have very big prometheus in federation on our clusters. Some have more than 50GB memory and are pretty huge to federate.
Instead of federating we are considering to use remote_write feature and agent mode in order to publish the TSDB to the long term storage prometheus and thanos clusters.

If i enable agent feature we have prometheus crash because some configurations or flags are setuped. This include some TSDB retention flags, but also some generated configurations like rule_files.

This fix permit to run prometheus as a pure agent mode and disable the querier. on our dev cluster we reduce memory footprint by 60% on all our prometheus shards.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix: permit prometheus to run in agent only mode
```
