### PR TITLE
pkg/prometheus: exclude status from hash computation

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1625,6 +1625,10 @@ func checkPrometheusSpecDeprecation(key string, p *monitoringv1.Prometheus, logg
 }
 
 func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfigMapNames []string, tlsAssets *operator.ShardedSecret, ss interface{}) (string, error) {
+	// The status field is updated only by the operator hence it shouldn't be
+	// taken into account for computing the hash value.
+	p.Status = monitoringv1.PrometheusStatus{}
+
 	hash, err := hashstructure.Hash(struct {
 		P monitoringv1.Prometheus
 		C operator.Config


### PR DESCRIPTION
## Description

The operator computes a hash value which is derived from different
inputs such as the Prometheus object, the operator's configuration, the
StatefulSet spec, etc. The operator records the hash value as an
annotation on the generated StatefulSet then it compares the current and
new values to decide whether an update of the StatefulSet is needed or
not.

Because the operator updates the status subresource in parallel, the
status field of the Prometheus object should not be taken into account
to compute the hash value.

The issue was indirectly detected when bumping the downstream github.com/openshift/prometheus-operator to v0.56.0. After this, we noticed more failures in the CI that could be explained by the Prometheus operator doing too many updates of the Prometheus statefulset. After reverting the bump, the CI got healthier.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Avoid unnecessary updates of the Prometheus StatefulSet object.
```
