### PR TITLE
jsonnet: add PodDisruptionBudget for admission webhook

### DIFF
--- a/example/admission-webhook/pod-disruption-budget.yaml
+++ b/example/admission-webhook/pod-disruption-budget.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.56.1
+  name: prometheus-operator-admission-webhook
+  namespace: default
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook

--- a/jsonnet/prometheus-operator/admission-webhook.libsonnet
+++ b/jsonnet/prometheus-operator/admission-webhook.libsonnet
@@ -26,9 +26,9 @@ function(params) {
   local aw = self,
   _config:: defaults + params,
   _metadata:: {
-      name: aw._config.name,
-      namespace: aw._config.namespace,
-      labels: aw._config.commonLabels,
+    name: aw._config.name,
+    namespace: aw._config.namespace,
+    labels: aw._config.commonLabels,
   },
 
   serviceAccount: {
@@ -77,8 +77,8 @@ function(params) {
           metadata: {
             labels: aw._config.commonLabels,
             annotations: {
-              "kubectl.kubernetes.io/default-container": container.name,
-            }
+              'kubectl.kubernetes.io/default-container': container.name,
+            },
           },
           spec: {
             containers: [container],
@@ -107,6 +107,17 @@ function(params) {
       selector: {
         matchLabels: aw._config.commonLabels,
       },
+    },
+  },
+
+  [if (defaults + params).replicas > 1 then 'podDisruptionBudget']: {
+    apiVersion: 'policy/v1',
+    kind: 'PodDisruptionBudget',
+    metadata: aw._metadata,
+    spec: {
+      minAvailable: 1,
+      selector: { matchLabels: aw._config.selectorLabels },
+
     },
   },
 }

--- a/scripts/generate/admission-webhook.jsonnet
+++ b/scripts/generate/admission-webhook.jsonnet
@@ -9,4 +9,5 @@ local aw = admissionWebhook(config {
   'deployment.yaml': aw.deployment,
   'service.yaml': aw.service,
   'service-monitor.yaml': aw.serviceMonitor,
+  'pod-disruption-budget.yaml': aw.podDisruptionBudget,
 }


### PR DESCRIPTION
## Description

Update the admission webhook's jsonnet to include a PodDisruptionBudget if more than 1 replica is deployed.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
