### PR TITLE
pkg/k8sutil: fix ordering in MergePatchContainers()

### DIFF
--- a/pkg/k8sutil/merge.go
+++ b/pkg/k8sutil/merge.go
@@ -52,7 +52,7 @@ func MergePatchContainers(base, patches []v1.Container) ([]v1.Container, error) 
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to marshal JSON for patch container %s", container.Name))
 		}
 
-		// Calculate the patch result
+		// Calculate the patch result.
 		jsonResult, err := strategicpatch.StrategicMergePatch(containerBytes, patchBytes, v1.Container{})
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to generate merge patch for container %s", container.Name))
@@ -63,14 +63,17 @@ func MergePatchContainers(base, patches []v1.Container) ([]v1.Container, error) 
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to unmarshal merged container %s", container.Name))
 		}
 
-		// Add the patch result and remove the corresponding key from the to do list
+		// Add the patch result and remove the corresponding key from the to do list.
 		out = append(out, patchResult)
 		delete(containersByName, container.Name)
 	}
 
-	// Append containers that are left in containersToPatch.
-	for _, container := range containersByName {
-		out = append(out, container)
+	// Append containers that are left in containersByName.
+	// Iterate over patches to preserve the order.
+	for _, c := range patches {
+		if container, found := containersByName[c.Name]; found {
+			out = append(out, container)
+		}
 	}
 
 	return out, nil


### PR DESCRIPTION
PR #4641 introduced a regression in MergePatchContainers(): the ordering
of the returned slice wasn't stable anymore meaning that the operator
could generate different StatefulSets from the same input parameters
leading to unnecessary deletions/creations of the pods.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Avoid unnecessary creations and deletions of StatefulSet when using strategic merge patch.
```
