### PR TITLE
pkg/prometheus: reduce the number of reconciliations

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -561,8 +561,61 @@ func (c *Operator) handlePrometheusDelete(obj interface{}) {
 	c.addToReconcileQueue(key)
 }
 
+// hasStateChanged returns true if the 2 objects are different in a way that
+// the controller should reconcile the actual state against the desired state.
+// It helps preventing hot loops when the controller updates the status
+// subresource for instance.
+func (c *Operator) hasStateChanged(old, cur metav1.Object) bool {
+	if old.GetGeneration() != cur.GetGeneration() {
+		level.Debug(c.logger).Log(
+			"msg", "different generations",
+			"current", cur.GetGeneration(),
+			"old", old.GetGeneration(),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	if !reflect.DeepEqual(old.GetLabels(), cur.GetLabels()) {
+		level.Debug(c.logger).Log(
+			"msg", "different labels",
+			"current", fmt.Sprintf("%v", cur.GetLabels()),
+			"old", fmt.Sprintf("%v", old.GetLabels()),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+
+	}
+	if !reflect.DeepEqual(old.GetAnnotations(), cur.GetAnnotations()) {
+		level.Debug(c.logger).Log(
+			"msg", "different annotations",
+			"current", fmt.Sprintf("%v", cur.GetAnnotations()),
+			"old", fmt.Sprintf("%v", old.GetAnnotations()),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	return false
+}
+
+// hasObjectChanged returns true if the 2 objects are different.
+func (c *Operator) hasObjectChanged(old, cur metav1.Object) bool {
+	if old.GetResourceVersion() != cur.GetResourceVersion() {
+		level.Debug(c.logger).Log(
+			"msg", "different resource versions",
+			"current", cur.GetResourceVersion(),
+			"old", old.GetResourceVersion(),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	return false
+}
+
 func (c *Operator) handlePrometheusUpdate(old, cur interface{}) {
-	if old.(*monitoringv1.Prometheus).ResourceVersion == cur.(*monitoringv1.Prometheus).ResourceVersion {
+	if !c.hasStateChanged(&old.(*monitoringv1.Prometheus).ObjectMeta, &cur.(*monitoringv1.Prometheus).ObjectMeta) {
 		return
 	}
 
@@ -1206,21 +1259,27 @@ func prometheusKeyToStatefulSetKey(key string, shard int) string {
 }
 
 func (c *Operator) handleStatefulSetDelete(obj interface{}) {
-	if ps := c.prometheusForStatefulSet(obj); ps != nil {
-		level.Debug(c.logger).Log("msg", "StatefulSet delete")
-		c.metrics.TriggerByCounter("StatefulSet", "delete").Inc()
-
-		c.addToReconcileQueue(ps)
+	ps := c.prometheusForStatefulSet(obj)
+	if ps == nil {
+		return
 	}
+
+	level.Debug(c.logger).Log("msg", "StatefulSet delete")
+	c.metrics.TriggerByCounter("StatefulSet", "delete").Inc()
+
+	c.addToReconcileQueue(ps)
 }
 
 func (c *Operator) handleStatefulSetAdd(obj interface{}) {
-	if ps := c.prometheusForStatefulSet(obj); ps != nil {
-		level.Debug(c.logger).Log("msg", "StatefulSet added")
-		c.metrics.TriggerByCounter("StatefulSet", "add").Inc()
-
-		c.addToReconcileQueue(ps)
+	ps := c.prometheusForStatefulSet(obj)
+	if ps == nil {
+		return
 	}
+
+	level.Debug(c.logger).Log("msg", "StatefulSet added")
+	c.metrics.TriggerByCounter("StatefulSet", "add").Inc()
+
+	c.addToReconcileQueue(ps)
 }
 
 func (c *Operator) handleStatefulSetUpdate(oldo, curo interface{}) {
@@ -1229,19 +1288,27 @@ func (c *Operator) handleStatefulSetUpdate(oldo, curo interface{}) {
 
 	level.Debug(c.logger).Log("msg", "update handler", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	// Periodic resync may resend the StatefulSet without changes
-	// in-between. Also breaks loops created by updating the resource
-	// ourselves.
-	if old.ResourceVersion == cur.ResourceVersion {
+	if !c.hasObjectChanged(old, cur) {
 		return
 	}
 
-	if p := c.prometheusForStatefulSet(cur); p != nil {
-		level.Debug(c.logger).Log("msg", "StatefulSet updated")
-		c.metrics.TriggerByCounter("StatefulSet", "update").Inc()
-
-		c.addToReconcileQueue(p)
+	p := c.prometheusForStatefulSet(cur)
+	if p == nil {
+		return
 	}
+
+	level.Debug(c.logger).Log("msg", "StatefulSet updated")
+	c.metrics.TriggerByCounter("StatefulSet", "update").Inc()
+
+	if !c.hasStateChanged(old, cur) {
+		// If the statefulset state (spec, labels or annotations) hasn't
+		// changed, the operator can only update the status subresource instead
+		// of doing a full reconciliation.
+		c.addToStatusQueue(p)
+		return
+	}
+
+	c.addToReconcileQueue(p)
 }
 
 func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo interface{}) {
@@ -1364,10 +1431,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		if obj != nil {
 			existingStatefulSet = obj.(*appsv1.StatefulSet)
 			if existingStatefulSet.DeletionTimestamp != nil {
-				// We want to avoid entering a hot-loop of update/delete cycles here since the sts was
-				// marked for deletion in foreground, which means it may take some time before the finalizers complete and
-				// the resource disappears from the API. The deletion timestamp will have been set when the initial
-				// delete request was issued. In that case, we avoid further processing.
+				// We want to avoid entering a hot-loop of update/delete cycles
+				// here since the sts was marked for deletion in foreground,
+				// which means it may take some time before the finalizers
+				// complete and the resource disappears from the API. The
+				// deletion timestamp will have been set when the initial
+				// delete request was issued. In that case, we avoid further
+				// processing.
 				level.Info(logger).Log(
 					"msg", "halting update of StatefulSet",
 					"reason", "resource has been marked for deletion",
@@ -1402,7 +1472,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			continue
 		}
 
-		level.Debug(logger).Log("msg", "updating current statefulset")
+		level.Debug(logger).Log(
+			"msg", "updating current statefulset because of hash divergence",
+			"new_hash", newSSetInputHash,
+			"existing_hash", existingStatefulSet.ObjectMeta.Annotations[sSetInputHashName],
+		)
 
 		err = k8sutil.UpdateStatefulSet(ctx, ssetClient, sset)
 		sErr, ok := err.(*apierrors.StatusError)
@@ -1624,26 +1698,28 @@ func checkPrometheusSpecDeprecation(key string, p *monitoringv1.Prometheus, logg
 	}
 }
 
-func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfigMapNames []string, tlsAssets *operator.ShardedSecret, ss interface{}) (string, error) {
-	// The status field is updated only by the operator hence it shouldn't be
-	// taken into account for computing the hash value.
-	p.Status = monitoringv1.PrometheusStatus{}
-
+func createSSetInputHash(p monitoringv1.Prometheus, c operator.Config, ruleConfigMapNames []string, tlsAssets *operator.ShardedSecret, ssSpec appsv1.StatefulSetSpec) (string, error) {
 	hash, err := hashstructure.Hash(struct {
-		P monitoringv1.Prometheus
-		C operator.Config
-		S interface{}
-		R []string `hash:"set"`
-		A []string `hash:"set"`
-	}{p, c, ss, ruleConfigMapNames, tlsAssets.ShardNames()},
+		PrometheusLabels      map[string]string
+		PrometheusAnnotations map[string]string
+		PrometheusSpec        monitoringv1.PrometheusSpec
+		Config                operator.Config
+		StatefulSetSpec       appsv1.StatefulSetSpec
+		RuleConfigMaps        []string `hash:"set"`
+		Assets                []string `hash:"set"`
+	}{
+		PrometheusLabels:      p.Labels,
+		PrometheusAnnotations: p.Annotations,
+		PrometheusSpec:        p.Spec,
+		Config:                c,
+		StatefulSetSpec:       ssSpec,
+		RuleConfigMaps:        ruleConfigMapNames,
+		Assets:                tlsAssets.ShardNames(),
+	},
 		nil,
 	)
 	if err != nil {
-		return "", errors.Wrap(
-			err,
-			"failed to calculate combined hash of Prometheus StatefulSet, Prometheus CRD, config and"+
-				" rule ConfigMap names",
-		)
+		return "", errors.Wrap(err, "failed to calculate combined hash")
 	}
 
 	return fmt.Sprintf("%d", hash), nil

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -851,10 +851,10 @@ func testPromVersionMigration(t *testing.T) {
 			},
 		)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("update to version %s: %v", v, err)
 		}
 		if err := framework.WaitForPrometheusRunImageAndReady(context.Background(), ns, p); err != nil {
-			t.Fatal(err)
+			t.Fatalf("update to version %s: %v", v, err)
 		}
 	}
 }


### PR DESCRIPTION
Since the operator modifies the Prometheus status subresource, the
update event handler is called much more often than before which may
lead to higher CPU usage. To reduce the number of times the operator
runs the sync() method, it now compares the generation + labels +
annotations between the old and new objects (instead of using the
`resourceVersion` field) to decide whether a reconciliation is needed or
not. The same change is made for StatefulSet update handler.

This is inspired by `GenerationChangedPredicate`,
`LabelChangedPredicate` and `AnnotationChangedPredicate` from
controller-runtime.

Closes #4784

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
reduce the number of reconciliations on Prometheus objects.
```
