### PR TITLE
jsonnet/mixin: add config option for group labels

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -57,7 +57,7 @@ groups:
         ready to reconcile {{ $labels.controller }} resources.
       summary: Prometheus operator not ready
     expr: |
-      min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator"}[5m]) == 0)
+      min by (controller,namespace) (max_over_time(prometheus_operator_ready{job="prometheus-operator"}[5m]) == 0)
     for: 5m
     labels:
       severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'PrometheusOperatorListErrors',
             expr: |||
-              (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{%(prometheusOperatorSelector)s}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{%(prometheusOperatorSelector)s}[10m]))) > 0.4
+              (sum by (%(groupLabels)s) (rate(prometheus_operator_list_operations_failed_total{%(prometheusOperatorSelector)s}[10m])) / sum by (%(groupLabels)s) (rate(prometheus_operator_list_operations_total{%(prometheusOperatorSelector)s}[10m]))) > 0.4
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -21,7 +21,7 @@
           {
             alert: 'PrometheusOperatorWatchErrors',
             expr: |||
-              (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[5m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.4
+              (sum by (%(groupLabels)s) (rate(prometheus_operator_watch_operations_failed_total{%(prometheusOperatorSelector)s}[5m])) / sum by (%(groupLabels)s) (rate(prometheus_operator_watch_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.4
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -49,7 +49,7 @@
           {
             alert: 'PrometheusOperatorReconcileErrors',
             expr: |||
-              (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{%(prometheusOperatorSelector)s}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.1
+              (sum by (%(groupLabels)s) (rate(prometheus_operator_reconcile_errors_total{%(prometheusOperatorSelector)s}[5m]))) / (sum by (%(groupLabels)s) (rate(prometheus_operator_reconcile_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.1
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -77,7 +77,7 @@
           {
             alert: 'PrometheusOperatorNotReady',
             expr: |||
-              min by(namespace, controller) (max_over_time(prometheus_operator_ready{%(prometheusOperatorSelector)s}[5m]) == 0)
+              min by (%(groupLabels)s) (max_over_time(prometheus_operator_ready{%(prometheusOperatorSelector)s}[5m]) == 0)
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/jsonnet/mixin/config.libsonnet
+++ b/jsonnet/mixin/config.libsonnet
@@ -2,5 +2,6 @@
   _config+:: {
     prometheusOperatorSelector: 'job="prometheus-operator"',
     configReloaderSelector: 'namespace=~".+"',
+    groupLabels: 'controller,namespace',
   },
 }


### PR DESCRIPTION
## Description

At the moment the alert metrics are hardcoded to have only two labels, controller and namespace. This might be inconvenient. For example when managing multiple clusters, you might want to add a cluster-id label to your alerts. This change makes it possible to add custom labels similar to custom selectors.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Add groupLabels config option to jsonnet mixin for alert label customization
```
