### PR TITLE
pkg/apis: Add validations for time settings of alertmanager at CRD level

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -228,7 +228,7 @@ AlertmanagerSpec is a specification of the desired behavior of the Alertmanager 
 | logLevel | Log level for Alertmanager to be configured with. | string | false |
 | logFormat | Log format for Alertmanager to be configured with. | string | false |
 | replicas | Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
-| retention | Time duration Alertmanager shall retain data for. Default is '120h', and must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | string | false |
+| retention | Time duration Alertmanager shall retain data for. Default is '120h', and must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | GoDuration | false |
 | storage | Storage is the definition of how storage will be used by the Alertmanager instances. | *[StorageSpec](#storagespec) | false |
 | volumes | Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | []v1.Volume | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition. VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container, that are generated as a result of StorageSpec objects. | []v1.VolumeMount | false |
@@ -248,9 +248,9 @@ AlertmanagerSpec is a specification of the desired behavior of the Alertmanager 
 | priorityClassName | Priority class assigned to the Pods | string | false |
 | additionalPeers | AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster. | []string | false |
 | clusterAdvertiseAddress | ClusterAdvertiseAddress is the explicit address to advertise in cluster. Needs to be provided for non RFC1918 [1] (public) addresses. [1] RFC1918: https://tools.ietf.org/html/rfc1918 | string | false |
-| clusterGossipInterval | Interval between gossip attempts. | string | false |
-| clusterPushpullInterval | Interval between pushpull attempts. | string | false |
-| clusterPeerTimeout | Timeout for cluster peering. | string | false |
+| clusterGossipInterval | Interval between gossip attempts. | GoDuration | false |
+| clusterPushpullInterval | Interval between pushpull attempts. | GoDuration | false |
+| clusterPeerTimeout | Timeout for cluster peering. | GoDuration | false |
 | portName | Port name used for the pods and governing service. This defaults to web | string | false |
 | forceEnableClusterMode | ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica. Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each. | bool | false |
 | alertmanagerConfigSelector | AlertmanagerConfigs to be selected for to merge and configure Alertmanager with. | *[metav1.LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#labelselector-v1-meta) | false |

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -5373,12 +5373,15 @@ spec:
                 type: string
               clusterGossipInterval:
                 description: Interval between gossip attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPushpullInterval:
                 description: Interval between pushpull attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
@@ -8006,9 +8009,11 @@ spec:
                     type: object
                 type: object
               retention:
+                default: 120h
                 description: Time duration Alertmanager shall retain data for. Default
                   is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
                   (milliseconds seconds minutes hours).
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               routePrefix:
                 description: The route prefix Alertmanager registers HTTP handlers

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -998,12 +998,15 @@ spec:
                 type: string
               clusterGossipInterval:
                 description: Interval between gossip attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPushpullInterval:
                 description: Interval between pushpull attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
@@ -3631,9 +3634,11 @@ spec:
                     type: object
                 type: object
               retention:
+                default: 120h
                 description: Time duration Alertmanager shall retain data for. Default
                   is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
                   (milliseconds seconds minutes hours).
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               routePrefix:
                 description: The route prefix Alertmanager registers HTTP handlers

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -998,12 +998,15 @@ spec:
                 type: string
               clusterGossipInterval:
                 description: Interval between gossip attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterPushpullInterval:
                 description: Interval between pushpull attempts.
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               configMaps:
                 description: ConfigMaps is a list of ConfigMaps in the same namespace
@@ -3631,9 +3634,11 @@ spec:
                     type: object
                 type: object
               retention:
+                default: 120h
                 description: Time duration Alertmanager shall retain data for. Default
                   is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
                   (milliseconds seconds minutes hours).
+                pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               routePrefix:
                 description: The route prefix Alertmanager registers HTTP handlers

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -821,14 +821,17 @@
                   },
                   "clusterGossipInterval": {
                     "description": "Interval between gossip attempts.",
+                    "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "clusterPeerTimeout": {
                     "description": "Timeout for cluster peering.",
+                    "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "clusterPushpullInterval": {
                     "description": "Interval between pushpull attempts.",
+                    "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "configMaps": {
@@ -3261,7 +3264,9 @@
                     "type": "object"
                   },
                   "retention": {
+                    "default": "120h",
                     "description": "Time duration Alertmanager shall retain data for. Default is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).",
+                    "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
                   "routePrefix": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -66,6 +66,7 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, config Config, inputHash str
 	if am.Spec.Replicas != nil && *am.Spec.Replicas < 0 {
 		am.Spec.Replicas = &intZero
 	}
+	// TODO(slashpai): Remove this assignment after v0.60 since this is handled at CRD level
 	if am.Spec.Retention == "" {
 		am.Spec.Retention = defaultRetention
 	}

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -602,8 +602,8 @@ func TestSHAAndTagAndVersion(t *testing.T) {
 
 func TestRetention(t *testing.T) {
 	tests := []struct {
-		specRetention     string
-		expectedRetention string
+		specRetention     monitoringv1.GoDuration
+		expectedRetention monitoringv1.GoDuration
 	}{
 		{"", "120h"},
 		{"1d", "1d"},

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -27,26 +27,30 @@ import (
 // ValidateAlertmanager runs extra validation on the AlertManager fields which
 // can't be done at the CRD schema validation level.
 func ValidateAlertmanager(am *monitoringv1.Alertmanager) error {
+	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
 	if am.Spec.Retention != "" {
-		if err := operator.ValidateDurationField(am.Spec.Retention); err != nil {
+		if err := operator.ValidateDurationField(string(am.Spec.Retention)); err != nil {
 			return errors.Wrap(err, "invalid retention value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
 	if am.Spec.ClusterGossipInterval != "" {
-		if err := operator.ValidateDurationField(am.Spec.ClusterGossipInterval); err != nil {
+		if err := operator.ValidateDurationField(string(am.Spec.ClusterGossipInterval)); err != nil {
 			return errors.Wrap(err, "invalid clusterGossipInterval value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
 	if am.Spec.ClusterPushpullInterval != "" {
-		if err := operator.ValidateDurationField(am.Spec.ClusterPushpullInterval); err != nil {
+		if err := operator.ValidateDurationField(string(am.Spec.ClusterPushpullInterval)); err != nil {
 			return errors.Wrap(err, "invalid clusterPushpullInterval value specified")
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
 	if am.Spec.ClusterPeerTimeout != "" {
-		if err := operator.ValidateDurationField(am.Spec.ClusterPeerTimeout); err != nil {
+		if err := operator.ValidateDurationField(string(am.Spec.ClusterPeerTimeout)); err != nil {
 			return errors.Wrap(err, "invalid clusterPeerTimeout value specified")
 		}
 	}

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -379,10 +379,17 @@ type PrometheusList struct {
 // +kubebuilder:validation:Pattern:="(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$"
 type ByteSize string
 
-// Duration is a valid time unit
-// Supported units: y, w, d, h, m, s, ms Examples: `30s`, `1m`, `1h20m15s`
+// Duration is a valid time duration that can be parsed by Prometheus model.ParseDuration() function.
+// Supported units: y, w, d, h, m, s, ms
+// Examples: `30s`, `1m`, `1h20m15s`, `15d`
 // +kubebuilder:validation:Pattern:="^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"
 type Duration string
+
+// GoDuration is a valid time duration that can be parsed by Go's time.ParseDuration() function.
+// Supported units: h, m, s, ms
+// Examples: `45ms`, `30s`, `1m`, `1h20m15s`
+// +kubebuilder:validation:Pattern:="^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"
+type GoDuration string
 
 // HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
 // pod's hosts file.
@@ -1768,7 +1775,8 @@ type AlertmanagerSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Time duration Alertmanager shall retain data for. Default is '120h',
 	// and must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).
-	Retention string `json:"retention,omitempty"`
+	// +kubebuilder:default:="120h"
+	Retention GoDuration `json:"retention,omitempty"`
 	// Storage is the definition of how storage will be used by the Alertmanager
 	// instances.
 	Storage *StorageSpec `json:"storage,omitempty"`
@@ -1837,11 +1845,11 @@ type AlertmanagerSpec struct {
 	// [1] RFC1918: https://tools.ietf.org/html/rfc1918
 	ClusterAdvertiseAddress string `json:"clusterAdvertiseAddress,omitempty"`
 	// Interval between gossip attempts.
-	ClusterGossipInterval string `json:"clusterGossipInterval,omitempty"`
+	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Interval between pushpull attempts.
-	ClusterPushpullInterval string `json:"clusterPushpullInterval,omitempty"`
+	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`
 	// Timeout for cluster peering.
-	ClusterPeerTimeout string `json:"clusterPeerTimeout,omitempty"`
+	ClusterPeerTimeout GoDuration `json:"clusterPeerTimeout,omitempty"`
 	// Port name used for the pods and governing service.
 	// This defaults to web
 	PortName string `json:"portName,omitempty"`

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -152,6 +152,7 @@ func TestAllNS(t *testing.T) {
 func testAllNSAlertmanager(t *testing.T) {
 	skipAlertmanagerTests(t)
 	testFuncs := map[string]func(t *testing.T){
+		"AlertmanagerCRD":                         testAlertmanagerCRDValidation,
 		"AMCreateDeleteCluster":                   testAMCreateDeleteCluster,
 		"AMScaling":                               testAMScaling,
 		"AMVersionMigration":                      testAMVersionMigration,


### PR DESCRIPTION
This is needed to avoid invalid values from user which would
cause problem for application to load or not work as expected

Related-to prometheus-operator#4524

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add validations for time settings of alertmanager at CRD level
```
