### PR TITLE
 pkg/prometheus: Support upppercase and lowercase relabel actions

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -953,7 +953,7 @@ RelabelConfig allows dynamic rewriting of the label set, being applied to sample
 | regex | Regular expression against which the extracted value is matched. Default is '(.*)' | string | false |
 | modulus | Modulus to take of the hash of the source label values. | uint64 | false |
 | replacement | Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1' | string | false |
-| action | Action to perform based on regex matching. Default is 'replace' | string | false |
+| action | Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10685,7 +10685,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -10694,6 +10695,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -10849,7 +10852,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -10858,6 +10862,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -11269,7 +11275,8 @@ spec:
                     action:
                       default: replace
                       description: Action to perform based on regex matching. Default
-                        is 'replace'
+                        is 'replace'. uppercase and lowercase actions require Prometheus
+                        >= 2.36.
                       enum:
                       - replace
                       - keep
@@ -11278,6 +11285,8 @@ spec:
                       - labelmap
                       - labeldrop
                       - labelkeep
+                      - uppercase
+                      - lowercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -11474,7 +11483,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -11483,6 +11493,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -11590,7 +11602,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -11599,6 +11612,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -16931,7 +16946,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -16940,6 +16956,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -20534,7 +20552,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -20543,6 +20562,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -20698,7 +20719,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -20707,6 +20729,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -208,7 +208,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -217,6 +218,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -372,7 +375,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -381,6 +385,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -164,7 +164,8 @@ spec:
                     action:
                       default: replace
                       description: Action to perform based on regex matching. Default
-                        is 'replace'
+                        is 'replace'. uppercase and lowercase actions require Prometheus
+                        >= 2.36.
                       enum:
                       - replace
                       - keep
@@ -173,6 +174,8 @@ spec:
                       - labelmap
                       - labeldrop
                       - labelkeep
+                      - uppercase
+                      - lowercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -369,7 +372,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -378,6 +382,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -485,7 +491,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -494,6 +501,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5166,7 +5166,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -5175,6 +5176,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -168,7 +168,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -177,6 +178,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -332,7 +335,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -341,6 +345,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -208,7 +208,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -217,6 +218,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -372,7 +375,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -381,6 +385,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -164,7 +164,8 @@ spec:
                     action:
                       default: replace
                       description: Action to perform based on regex matching. Default
-                        is 'replace'
+                        is 'replace'. uppercase and lowercase actions require Prometheus
+                        >= 2.36.
                       enum:
                       - replace
                       - keep
@@ -173,6 +174,8 @@ spec:
                       - labelmap
                       - labeldrop
                       - labelkeep
+                      - uppercase
+                      - lowercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -369,7 +372,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -378,6 +382,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -485,7 +491,8 @@ spec:
                             action:
                               default: replace
                               description: Action to perform based on regex matching.
-                                Default is 'replace'
+                                Default is 'replace'. uppercase and lowercase actions
+                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - keep
@@ -494,6 +501,8 @@ spec:
                               - labelmap
                               - labeldrop
                               - labelkeep
+                              - uppercase
+                              - lowercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5166,7 +5166,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -5175,6 +5176,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -168,7 +168,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -177,6 +178,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -332,7 +335,8 @@ spec:
                           action:
                             default: replace
                             description: Action to perform based on regex matching.
-                              Default is 'replace'
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - keep
@@ -341,6 +345,8 @@ spec:
                             - labelmap
                             - labeldrop
                             - labelkeep
+                            - uppercase
+                            - lowercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -219,7 +219,7 @@
                             "properties": {
                               "action": {
                                 "default": "replace",
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
                                   "keep",
@@ -227,7 +227,9 @@
                                   "hashmod",
                                   "labelmap",
                                   "labeldrop",
-                                  "labelkeep"
+                                  "labelkeep",
+                                  "uppercase",
+                                  "lowercase"
                                 ],
                                 "type": "string"
                               },
@@ -394,7 +396,7 @@
                             "properties": {
                               "action": {
                                 "default": "replace",
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
                                   "keep",
@@ -402,7 +404,9 @@
                                   "hashmod",
                                   "labelmap",
                                   "labeldrop",
-                                  "labelkeep"
+                                  "labelkeep",
+                                  "uppercase",
+                                  "lowercase"
                                 ],
                                 "type": "string"
                               },

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -175,7 +175,7 @@
                       "properties": {
                         "action": {
                           "default": "replace",
-                          "description": "Action to perform based on regex matching. Default is 'replace'",
+                          "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                           "enum": [
                             "replace",
                             "keep",
@@ -183,7 +183,9 @@
                             "hashmod",
                             "labelmap",
                             "labeldrop",
-                            "labelkeep"
+                            "labelkeep",
+                            "uppercase",
+                            "lowercase"
                           ],
                           "type": "string"
                         },
@@ -395,7 +397,7 @@
                               "properties": {
                                 "action": {
                                   "default": "replace",
-                                  "description": "Action to perform based on regex matching. Default is 'replace'",
+                                  "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                   "enum": [
                                     "replace",
                                     "keep",
@@ -403,7 +405,9 @@
                                     "hashmod",
                                     "labelmap",
                                     "labeldrop",
-                                    "labelkeep"
+                                    "labelkeep",
+                                    "uppercase",
+                                    "lowercase"
                                   ],
                                   "type": "string"
                                 },
@@ -504,7 +508,7 @@
                               "properties": {
                                 "action": {
                                   "default": "replace",
-                                  "description": "Action to perform based on regex matching. Default is 'replace'",
+                                  "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                   "enum": [
                                     "replace",
                                     "keep",
@@ -512,7 +516,9 @@
                                     "hashmod",
                                     "labelmap",
                                     "labeldrop",
-                                    "labelkeep"
+                                    "labelkeep",
+                                    "uppercase",
+                                    "lowercase"
                                   ],
                                   "type": "string"
                                 },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4865,7 +4865,7 @@
                             "properties": {
                               "action": {
                                 "default": "replace",
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
                                   "keep",
@@ -4873,7 +4873,9 @@
                                   "hashmod",
                                   "labelmap",
                                   "labeldrop",
-                                  "labelkeep"
+                                  "labelkeep",
+                                  "uppercase",
+                                  "lowercase"
                                 ],
                                 "type": "string"
                               },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -177,7 +177,7 @@
                             "properties": {
                               "action": {
                                 "default": "replace",
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
                                   "keep",
@@ -185,7 +185,9 @@
                                   "hashmod",
                                   "labelmap",
                                   "labeldrop",
-                                  "labelkeep"
+                                  "labelkeep",
+                                  "uppercase",
+                                  "lowercase"
                                 ],
                                 "type": "string"
                               },
@@ -352,7 +354,7 @@
                             "properties": {
                               "action": {
                                 "default": "replace",
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
+                                "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
                                   "keep",
@@ -360,7 +362,9 @@
                                   "hashmod",
                                   "labelmap",
                                   "labeldrop",
-                                  "labelkeep"
+                                  "labelkeep",
+                                  "uppercase",
+                                  "lowercase"
                                 ],
                                 "type": "string"
                               },

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1025,8 +1025,9 @@ type RelabelConfig struct {
 	//Replacement value against which a regex replace is performed if the
 	//regular expression matches. Regex capture groups are available. Default is '$1'
 	Replacement string `json:"replacement,omitempty"`
-	// Action to perform based on regex matching. Default is 'replace'
-	//+kubebuilder:validation:Enum=replace;keep;drop;hashmod;labelmap;labeldrop;labelkeep
+	//Action to perform based on regex matching. Default is 'replace'.
+	//uppercase and lowercase actions require Prometheus >= 2.36.
+	//+kubebuilder:validation:Enum=replace;keep;drop;hashmod;labelmap;labeldrop;labelkeep;uppercase;lowercase
 	//+kubebuilder:default=replace
 	Action string `json:"action,omitempty"`
 }

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -439,9 +439,18 @@ func TestValidateRelabelConfig(t *testing.T) {
 		defaultSourceLabels = append(defaultSourceLabels, monitoringv1.LabelName(label))
 	}
 
+	defaultPrometheusSpec := monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Version: "v2.36.0",
+			},
+		},
+	}
+
 	for _, tc := range []struct {
 		scenario      string
 		relabelConfig monitoringv1.RelabelConfig
+		prometheus    monitoringv1.Prometheus
 		expectedErr   bool
 	}{
 		// Test invalid regex expression
@@ -450,6 +459,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			relabelConfig: monitoringv1.RelabelConfig{
 				Regex: "invalid regex)",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test invalid target label
@@ -459,6 +469,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action:      "replace",
 				TargetLabel: "l\\${3}",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test empty target label for action replace
@@ -468,6 +479,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action:      "replace",
 				TargetLabel: "",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test empty target label for action hashmod
@@ -477,6 +489,37 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action:      "hashmod",
 				TargetLabel: "",
 			},
+			prometheus:  defaultPrometheusSpec,
+			expectedErr: true,
+		},
+		// Test empty target label for action uppercase
+		{
+			scenario: "empty target label for uppercase action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "uppercase",
+				TargetLabel: "",
+			},
+			prometheus:  defaultPrometheusSpec,
+			expectedErr: true,
+		},
+		// Test empty target label for action lowercase
+		{
+			scenario: "empty target label for lowercase action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "lowercase",
+				TargetLabel: "",
+			},
+			prometheus:  defaultPrometheusSpec,
+			expectedErr: true,
+		},
+		// Test replacement set for action uppercase
+		{
+			scenario: "replacement set for uppercase action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "uppercase",
+				Replacement: "some-replace-value",
+			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test invalid hashmod relabel config
@@ -488,6 +531,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Modulus:      0,
 				TargetLabel:  "__tmp_hashmod",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test invalid labelmap relabel config
@@ -498,6 +542,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Regex:       "__meta_kubernetes_service_label_(.+)",
 				Replacement: "some-name-value",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test valid labelmap relabel config when replacement not specified
@@ -507,6 +552,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action: "labelmap",
 				Regex:  "__meta_kubernetes_service_label_(.+)",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
 		// Test valid labelmap relabel config with replacement specified
 		{
@@ -516,6 +562,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Regex:       "__meta_kubernetes_service_label_(.+)",
 				Replacement: "${2}",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
 		// Test invalid labelkeep relabel config
 		{
@@ -525,6 +572,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action:       "labelkeep",
 				TargetLabel:  "__tmp_labelkeep",
 			},
+			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
 		},
 		// Test valid labelkeep relabel config
@@ -533,6 +581,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action: "labelkeep",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
 		// Test valid labeldrop relabel config
 		{
@@ -541,6 +590,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action: "labeldrop",
 				Regex:  "replica",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
 		{
 			scenario: "valid labeldrop config with default values",
@@ -553,8 +603,9 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Replacement:  relabel.DefaultRelabelConfig.Replacement,
 				Action:       "labeldrop",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
-		// Test valid relabel config
+		// Test valid hashmod relabel config
 		{
 			scenario: "valid hashmod config",
 			relabelConfig: monitoringv1.RelabelConfig{
@@ -563,8 +614,9 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Modulus:      10,
 				TargetLabel:  "__tmp_hashmod",
 			},
+			prometheus: defaultPrometheusSpec,
 		},
-		// Test valid relabel config
+		// Test valid replace relabel config
 		{
 			scenario: "valid replace config",
 			relabelConfig: monitoringv1.RelabelConfig{
@@ -574,10 +626,65 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Replacement:  "$1:80",
 				TargetLabel:  "__address__",
 			},
+			prometheus: defaultPrometheusSpec,
+		},
+		// Test valid uppercase relabel config
+		{
+			scenario: "valid uppercase config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"foo"},
+				Action:       "uppercase",
+				TargetLabel:  "foo_uppercase",
+			},
+			prometheus: defaultPrometheusSpec,
+		},
+		// Test valid lowercase relabel config
+		{
+			scenario: "valid lowercase config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"bar"},
+				Action:       "lowercase",
+				TargetLabel:  "bar_lowercase",
+			},
+			prometheus: defaultPrometheusSpec,
+		},
+		// Test uppercase relabel config but lower prometheus version
+		{
+			scenario: "uppercase config with lower prometheus version",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"foo"},
+				Action:       "uppercase",
+				TargetLabel:  "foo_uppercase",
+			},
+			prometheus: monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Version: "v2.35.0",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		// Test lowercase relabel config but lower prometheus version
+		{
+			scenario: "lowercase config with lower prometheus version",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"bar"},
+				Action:       "lowercase",
+				TargetLabel:  "bar_lowercase",
+			},
+			prometheus: monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Version: "v2.35.0",
+					},
+				},
+			},
+			expectedErr: true,
 		},
 	} {
 		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
-			err := validateRelabelConfig(tc.relabelConfig)
+			err := validateRelabelConfig(tc.prometheus, tc.relabelConfig)
 			if err != nil && !tc.expectedErr {
 				t.Fatalf("expected no error, got: %v", err)
 			}


### PR DESCRIPTION
pkg/prometheus: Support upppercase and lowercase relabel actions
    
prometheus/prometheus#10641 introduced two
new relabel actions uppercase and lowercase. This commit
is to allow those actions using operator

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add support for `uppercase` and `lowercase` relabel actions
```
