### PR TITLE
fix alertmanagerConfig.Spec.Route nil panic

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -135,7 +135,9 @@ func (cb *configBuilder) initializeFromAlertmanagerConfig(ctx context.Context, a
 	}
 
 	// Add routes to globalAlertmanagerConfig.Route without enforce namespace
-	globalAlertmanagerConfig.Route = cb.convertRoute(amConfig.Spec.Route, crKey)
+	if amConfig.Spec.Route != nil {
+		globalAlertmanagerConfig.Route = cb.convertRoute(amConfig.Spec.Route, crKey)
+	}
 
 	for _, receiver := range amConfig.Spec.Receivers {
 		receivers, err := cb.convertReceiver(ctx, &receiver, crKey)

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -135,8 +135,8 @@ func (cb *configBuilder) initializeFromAlertmanagerConfig(ctx context.Context, a
 	}
 
 	// Add routes to globalAlertmanagerConfig.Route without enforce namespace
-	if amConfig.Spec.Route != nil {
-		globalAlertmanagerConfig.Route = cb.convertRoute(amConfig.Spec.Route, crKey)
+	if convertedRoute := cb.convertRoute(amConfig.Spec.Route, crKey); convertedRoute != nil {
+		globalAlertmanagerConfig.Route = convertedRoute
 	}
 
 	for _, receiver := range amConfig.Spec.Receivers {
@@ -328,6 +328,9 @@ func (cb *configBuilder) getValidURLFromSecret(ctx context.Context, namespace st
 }
 
 func (cb *configBuilder) convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName) *route {
+	if in == nil {
+		return nil
+	}
 	var matchers []string
 
 	// deprecated


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

## Description

fix #4715 

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

fix AlertmanagerConfig.Spec.Route nil panic
