### PR TITLE
pkg/apis/monitoring/v1beta1: fix httpConfig conversion

### DIFF
--- a/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -147,6 +147,7 @@ func convertHTTPConfigFrom(in *v1alpha1.HTTPConfig) *HTTPConfig {
 		BearerTokenSecret: convertSecretKeySelectorFrom(in.BearerTokenSecret),
 		TLSConfig:         in.TLSConfig,
 		ProxyURL:          in.ProxyURL,
+		FollowRedirects:   in.FollowRedirects,
 	}
 }
 

--- a/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -140,6 +140,7 @@ func convertHTTPConfigTo(in *HTTPConfig) *v1alpha1.HTTPConfig {
 		BearerTokenSecret: convertSecretKeySelectorTo(in.BearerTokenSecret),
 		TLSConfig:         in.TLSConfig,
 		ProxyURL:          in.ProxyURL,
+		FollowRedirects:   in.FollowRedirects,
 	}
 }
 


### PR DESCRIPTION
## Description

The `followRedirects` field was missed in #4709.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed missing conversion of the `followRedirects` field in HTTP configuration for AlertmanagerConfig v1beta1.
```
