### PR TITLE
pkg/apis: Add support to specify relabel actions in CamelCase

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10689,14 +10689,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -10856,14 +10865,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -11279,14 +11297,23 @@ spec:
                         >= 2.36.
                       enum:
                       - replace
+                      - Replace
                       - keep
+                      - Keep
                       - drop
+                      - Drop
                       - hashmod
+                      - HashMod
                       - labelmap
+                      - LabelMap
                       - labeldrop
+                      - LabelDrop
                       - labelkeep
-                      - uppercase
+                      - LabelKeep
                       - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -11487,14 +11514,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -11606,14 +11642,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -16961,14 +17006,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -20567,14 +20621,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -20734,14 +20797,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -212,14 +212,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -379,14 +388,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -168,14 +168,23 @@ spec:
                         >= 2.36.
                       enum:
                       - replace
+                      - Replace
                       - keep
+                      - Keep
                       - drop
+                      - Drop
                       - hashmod
+                      - HashMod
                       - labelmap
+                      - LabelMap
                       - labeldrop
+                      - LabelDrop
                       - labelkeep
-                      - uppercase
+                      - LabelKeep
                       - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -376,14 +385,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -495,14 +513,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5181,14 +5181,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -172,14 +172,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -339,14 +348,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -212,14 +212,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -379,14 +388,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -168,14 +168,23 @@ spec:
                         >= 2.36.
                       enum:
                       - replace
+                      - Replace
                       - keep
+                      - Keep
                       - drop
+                      - Drop
                       - hashmod
+                      - HashMod
                       - labelmap
+                      - LabelMap
                       - labeldrop
+                      - LabelDrop
                       - labelkeep
-                      - uppercase
+                      - LabelKeep
                       - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
                       type: string
                     modulus:
                       description: Modulus to take of the hash of the source label
@@ -376,14 +385,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source
@@ -495,14 +513,23 @@ spec:
                                 require Prometheus >= 2.36.
                               enum:
                               - replace
+                              - Replace
                               - keep
+                              - Keep
                               - drop
+                              - Drop
                               - hashmod
+                              - HashMod
                               - labelmap
+                              - LabelMap
                               - labeldrop
+                              - LabelDrop
                               - labelkeep
-                              - uppercase
+                              - LabelKeep
                               - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5181,14 +5181,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -172,14 +172,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -339,14 +348,23 @@ spec:
                               require Prometheus >= 2.36.
                             enum:
                             - replace
+                            - Replace
                             - keep
+                            - Keep
                             - drop
+                            - Drop
                             - hashmod
+                            - HashMod
                             - labelmap
+                            - LabelMap
                             - labeldrop
+                            - LabelDrop
                             - labelkeep
-                            - uppercase
+                            - LabelKeep
                             - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -222,14 +222,23 @@
                                 "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
+                                  "Replace",
                                   "keep",
+                                  "Keep",
                                   "drop",
+                                  "Drop",
                                   "hashmod",
+                                  "HashMod",
                                   "labelmap",
+                                  "LabelMap",
                                   "labeldrop",
+                                  "LabelDrop",
                                   "labelkeep",
+                                  "LabelKeep",
+                                  "lowercase",
+                                  "Lowercase",
                                   "uppercase",
-                                  "lowercase"
+                                  "Uppercase"
                                 ],
                                 "type": "string"
                               },
@@ -399,14 +408,23 @@
                                 "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
+                                  "Replace",
                                   "keep",
+                                  "Keep",
                                   "drop",
+                                  "Drop",
                                   "hashmod",
+                                  "HashMod",
                                   "labelmap",
+                                  "LabelMap",
                                   "labeldrop",
+                                  "LabelDrop",
                                   "labelkeep",
+                                  "LabelKeep",
+                                  "lowercase",
+                                  "Lowercase",
                                   "uppercase",
-                                  "lowercase"
+                                  "Uppercase"
                                 ],
                                 "type": "string"
                               },

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -178,14 +178,23 @@
                           "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                           "enum": [
                             "replace",
+                            "Replace",
                             "keep",
+                            "Keep",
                             "drop",
+                            "Drop",
                             "hashmod",
+                            "HashMod",
                             "labelmap",
+                            "LabelMap",
                             "labeldrop",
+                            "LabelDrop",
                             "labelkeep",
+                            "LabelKeep",
+                            "lowercase",
+                            "Lowercase",
                             "uppercase",
-                            "lowercase"
+                            "Uppercase"
                           ],
                           "type": "string"
                         },
@@ -400,14 +409,23 @@
                                   "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                   "enum": [
                                     "replace",
+                                    "Replace",
                                     "keep",
+                                    "Keep",
                                     "drop",
+                                    "Drop",
                                     "hashmod",
+                                    "HashMod",
                                     "labelmap",
+                                    "LabelMap",
                                     "labeldrop",
+                                    "LabelDrop",
                                     "labelkeep",
+                                    "LabelKeep",
+                                    "lowercase",
+                                    "Lowercase",
                                     "uppercase",
-                                    "lowercase"
+                                    "Uppercase"
                                   ],
                                   "type": "string"
                                 },
@@ -511,14 +529,23 @@
                                   "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                   "enum": [
                                     "replace",
+                                    "Replace",
                                     "keep",
+                                    "Keep",
                                     "drop",
+                                    "Drop",
                                     "hashmod",
+                                    "HashMod",
                                     "labelmap",
+                                    "LabelMap",
                                     "labeldrop",
+                                    "LabelDrop",
                                     "labelkeep",
+                                    "LabelKeep",
+                                    "lowercase",
+                                    "Lowercase",
                                     "uppercase",
-                                    "lowercase"
+                                    "Uppercase"
                                   ],
                                   "type": "string"
                                 },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4879,14 +4879,23 @@
                                 "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
+                                  "Replace",
                                   "keep",
+                                  "Keep",
                                   "drop",
+                                  "Drop",
                                   "hashmod",
+                                  "HashMod",
                                   "labelmap",
+                                  "LabelMap",
                                   "labeldrop",
+                                  "LabelDrop",
                                   "labelkeep",
+                                  "LabelKeep",
+                                  "lowercase",
+                                  "Lowercase",
                                   "uppercase",
-                                  "lowercase"
+                                  "Uppercase"
                                 ],
                                 "type": "string"
                               },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -180,14 +180,23 @@
                                 "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
+                                  "Replace",
                                   "keep",
+                                  "Keep",
                                   "drop",
+                                  "Drop",
                                   "hashmod",
+                                  "HashMod",
                                   "labelmap",
+                                  "LabelMap",
                                   "labeldrop",
+                                  "LabelDrop",
                                   "labelkeep",
+                                  "LabelKeep",
+                                  "lowercase",
+                                  "Lowercase",
                                   "uppercase",
-                                  "lowercase"
+                                  "Uppercase"
                                 ],
                                 "type": "string"
                               },
@@ -357,14 +366,23 @@
                                 "description": "Action to perform based on regex matching. Default is 'replace'. uppercase and lowercase actions require Prometheus >= 2.36.",
                                 "enum": [
                                   "replace",
+                                  "Replace",
                                   "keep",
+                                  "Keep",
                                   "drop",
+                                  "Drop",
                                   "hashmod",
+                                  "HashMod",
                                   "labelmap",
+                                  "LabelMap",
                                   "labeldrop",
+                                  "LabelDrop",
                                   "labelkeep",
+                                  "LabelKeep",
+                                  "lowercase",
+                                  "Lowercase",
                                   "uppercase",
-                                  "lowercase"
+                                  "Uppercase"
                                 ],
                                 "type": "string"
                               },

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1030,7 +1030,7 @@ type RelabelConfig struct {
 	Replacement string `json:"replacement,omitempty"`
 	//Action to perform based on regex matching. Default is 'replace'.
 	//uppercase and lowercase actions require Prometheus >= 2.36.
-	//+kubebuilder:validation:Enum=replace;keep;drop;hashmod;labelmap;labeldrop;labelkeep;uppercase;lowercase
+	//+kubebuilder:validation:Enum=replace;Replace;keep;Keep;drop;Drop;hashmod;HashMod;labelmap;LabelMap;labeldrop;LabelDrop;labelkeep;LabelKeep;lowercase;Lowercase;uppercase;Uppercase
 	//+kubebuilder:default=replace
 	Action string `json:"action,omitempty"`
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1493,7 +1493,7 @@ func generateRelabelConfig(rc []*v1.RelabelConfig) []yaml.MapSlice {
 		}
 
 		if c.Action != "" {
-			relabeling = append(relabeling, yaml.MapItem{Key: "action", Value: c.Action})
+			relabeling = append(relabeling, yaml.MapItem{Key: "action", Value: strings.ToLower(c.Action)})
 		}
 
 		cfg = append(cfg, relabeling)
@@ -1862,7 +1862,7 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(
 				}
 
 				if c.Action != "" {
-					relabeling = append(relabeling, yaml.MapItem{Key: "action", Value: c.Action})
+					relabeling = append(relabeling, yaml.MapItem{Key: "action", Value: strings.ToLower(c.Action)})
 				}
 				relabelings = append(relabelings, relabeling)
 			}


### PR DESCRIPTION
Adds support to specify relabel actions in CamelCase format
to follow https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#constants
and at the same time always downcase the value in the generated config.
Eventually remove the lowercase way of specifying actions once
monitoring.coreos.com/v2 is created

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add support to specify relabel actions in CamelCase
```
