### PR TITLE
pkg/apis: Add openapi validation for alertmanager timeout

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -192,7 +192,7 @@ AlertmanagerEndpoints defines a selection of a single Endpoints object containin
 | bearerTokenFile | BearerTokenFile to read from filesystem to use when authenticating to Alertmanager. | string | false |
 | authorization | Authorization section for this alertmanager endpoint | *[SafeAuthorization](#safeauthorization) | false |
 | apiVersion | Version of the Alertmanager API that Prometheus uses to send alerts. It can be \"v1\" or \"v2\". | string | false |
-| timeout | Timeout is a per-target Alertmanager timeout when pushing alerts. | *string | false |
+| timeout | Timeout is a per-target Alertmanager timeout when pushing alerts. | *Duration | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -12855,6 +12855,7 @@ spec:
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                         tlsConfig:
                           description: TLS Config to use for alertmanager connection.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1028,6 +1028,7 @@ spec:
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                         tlsConfig:
                           description: TLS Config to use for alertmanager connection.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1028,6 +1028,7 @@ spec:
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.
+                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                         tlsConfig:
                           description: TLS Config to use for alertmanager connection.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -849,6 +849,7 @@
                             },
                             "timeout": {
                               "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",
+                              "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                               "type": "string"
                             },
                             "tlsConfig": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1079,7 +1079,7 @@ type AlertmanagerEndpoints struct {
 	// can be "v1" or "v2".
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Timeout is a per-target Alertmanager timeout when pushing alerts.
-	Timeout *string `json:"timeout,omitempty"`
+	Timeout *Duration `json:"timeout,omitempty"`
 }
 
 // ServiceMonitor defines monitoring for a set of services.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -131,7 +131,7 @@ func (in *AlertmanagerEndpoints) DeepCopyInto(out *AlertmanagerEndpoints) {
 	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
-		*out = new(string)
+		*out = new(Duration)
 		**out = **in
 	}
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -447,6 +447,7 @@ func validateConfigInputs(p *v1.Prometheus) error {
 		}
 	}
 
+	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
 	if p.Spec.Alerting != nil {
 		for i, ap := range p.Spec.Alerting.Alertmanagers {
 			if ap.Timeout != nil && *ap.Timeout != "" {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1608,7 +1608,7 @@ func TestAlertmanagerTimeoutConfig(t *testing.T) {
 						Namespace:  "default",
 						Port:       intstr.FromString("web"),
 						APIVersion: "v2",
-						Timeout:    pointer.StringPtr("60s"),
+						Timeout:    (*monitoringv1.Duration)(pointer.StringPtr("60s")),
 					},
 				},
 			},
@@ -7754,6 +7754,7 @@ scrape_configs: []
 		})
 	}
 }
+
 func TestGenerateRelabelConfig(t *testing.T) {
 	p := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Looks like I missed this field in alertmanager in previous validation PR

Related-to #4524

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add validation for Alertmanager timeout
```
