### PR TITLE
ci: Add `$GITHUB_STEP_SUMMARY` to github  actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
-    - run: make check-docs
+    - run: make check-docs >> $GITHUB_STEP_SUMMARY
   check-golang:
     runs-on: ubuntu-latest
     name: Golang linter
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
-    - run: make check-metrics
+    - run: make check-metrics >> $GITHUB_STEP_SUMMARY
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
-    - run: make operator
+    - run: make operator >> $GITHUB_STEP_SUMMARY
   po-rule-migration:
     runs-on: ubuntu-latest
     name: Build Prometheus Operator rule config map to rule file CRDs CLI tool
@@ -88,5 +88,5 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
-    - run: cd cmd/po-rule-migration && go install
+    - run: cd cmd/po-rule-migration && go install >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '${{ env.golang-version }}'
-    - run: make test-unit
+    - run: make test-unit >> $GITHUB_STEP_SUMMARY
   extended-tests:
     runs-on: ubuntu-latest
     name: Extended tests
@@ -30,4 +30,4 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.golang-version }}
-    - run: make test-long
+    - run: make test-long >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Based on https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

**Currently testing this not ready for review**

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
