### PR TITLE
Update monitoring.coreos.com_alertmanagerconfigs.yaml

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -69,7 +69,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -102,7 +102,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -4312,7 +4312,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - '='
                           - =~
                           - '!~'
                           type: string
@@ -4417,7 +4417,7 @@ spec:
                               >= v0.22.0.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -4446,7 +4446,7 @@ spec:
                               >= v0.22.0.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -8513,7 +8513,7 @@ spec:
                             >= v0.22.0.
                           enum:
                           - '!='
-                          - =
+                          - '='
                           - =~
                           - '!~'
                           type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -69,7 +69,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -102,7 +102,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -4312,7 +4312,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - '='
                           - =~
                           - '!~'
                           type: string


### PR DESCRIPTION
Signed-off-by: MH <zanhsieh@gmail.com>

## Description

See:
https://github.com/prometheus-community/helm-charts/pull/2238


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `BUGFIX` (non-breaking change which fixes an issue)

## Changelog entry

```release-note
This will fix a pyaml issue which causes the equal sign to throw a could not determine a constructor for the tag 'tag:yaml.org,2002:value' error in kube-prometheus-stack helm chart. See:

https://github.com/prometheus-community/helm-charts/pull/2238
```
