### PR TITLE
Namespace enforcement exclusion fails due to missing object type meta

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -740,8 +740,9 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	am := aobj.(*monitoringv1.Alertmanager)
 	am = am.DeepCopy()
-	am.APIVersion = monitoringv1.SchemeGroupVersion.String()
-	am.Kind = monitoringv1.AlertmanagersKind
+	if err := k8sutil.AddTypeInformationToObject(am); err != nil {
+		return errors.Wrap(err, "failed to set Alertmanager type information")
+	}
 
 	if am.Spec.Paused {
 		return nil

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2177,7 +2177,10 @@ func (c *Operator) selectServiceMonitors(ctx context.Context, p *monitoringv1.Pr
 		err := c.smonInfs.ListAllByNamespace(ns, servMonSelector, func(obj interface{}) {
 			k, ok := c.keyFunc(obj)
 			if ok {
-				serviceMonitors[k] = obj.(*monitoringv1.ServiceMonitor)
+				svcMon := obj.(*monitoringv1.ServiceMonitor).DeepCopy()
+				svcMon.APIVersion = monitoringv1.SchemeGroupVersion.String()
+				svcMon.Kind = monitoringv1.ServiceMonitorsKind
+				serviceMonitors[k] = svcMon
 			}
 		})
 		if err != nil {
@@ -2305,7 +2308,10 @@ func (c *Operator) selectPodMonitors(ctx context.Context, p *monitoringv1.Promet
 		err := c.pmonInfs.ListAllByNamespace(ns, podMonSelector, func(obj interface{}) {
 			k, ok := c.keyFunc(obj)
 			if ok {
-				podMonitors[k] = obj.(*monitoringv1.PodMonitor)
+				podMon := obj.(*monitoringv1.PodMonitor).DeepCopy()
+				podMon.APIVersion = monitoringv1.SchemeGroupVersion.String()
+				podMon.Kind = monitoringv1.PodMonitorsKind
+				podMonitors[k] = podMon
 			}
 		})
 		if err != nil {
@@ -2424,7 +2430,10 @@ func (c *Operator) selectProbes(ctx context.Context, p *monitoringv1.Prometheus,
 	for _, ns := range namespaces {
 		err := c.probeInfs.ListAllByNamespace(ns, bMonSelector, func(obj interface{}) {
 			if k, ok := c.keyFunc(obj); ok {
-				probes[k] = obj.(*monitoringv1.Probe)
+				probe := obj.(*monitoringv1.Probe).DeepCopy()
+				probe.APIVersion = monitoringv1.SchemeGroupVersion.String()
+				probe.Kind = monitoringv1.ProbesKind
+				probes[k] = probe
 			}
 		})
 		if err != nil {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1378,8 +1378,9 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	p := pobj.(*monitoringv1.Prometheus)
 	p = p.DeepCopy()
-	p.APIVersion = monitoringv1.SchemeGroupVersion.String()
-	p.Kind = monitoringv1.PrometheusesKind
+	if err := k8sutil.AddTypeInformationToObject(p); err != nil {
+		return errors.Wrap(err, "failed to set Prometheus type information")
+	}
 
 	logger := log.With(c.logger, "key", key)
 	if p.Spec.Paused {
@@ -2178,8 +2179,10 @@ func (c *Operator) selectServiceMonitors(ctx context.Context, p *monitoringv1.Pr
 			k, ok := c.keyFunc(obj)
 			if ok {
 				svcMon := obj.(*monitoringv1.ServiceMonitor).DeepCopy()
-				svcMon.APIVersion = monitoringv1.SchemeGroupVersion.String()
-				svcMon.Kind = monitoringv1.ServiceMonitorsKind
+				if err := k8sutil.AddTypeInformationToObject(svcMon); err != nil {
+					level.Error(c.logger).Log("msg", "failed to set ServiceMonitor type information", "namespace", ns, "err", err)
+					return
+				}
 				serviceMonitors[k] = svcMon
 			}
 		})
@@ -2309,8 +2312,10 @@ func (c *Operator) selectPodMonitors(ctx context.Context, p *monitoringv1.Promet
 			k, ok := c.keyFunc(obj)
 			if ok {
 				podMon := obj.(*monitoringv1.PodMonitor).DeepCopy()
-				podMon.APIVersion = monitoringv1.SchemeGroupVersion.String()
-				podMon.Kind = monitoringv1.PodMonitorsKind
+				if err := k8sutil.AddTypeInformationToObject(podMon); err != nil {
+					level.Error(c.logger).Log("msg", "failed to set PodMonitor type information", "namespace", ns, "err", err)
+					return
+				}
 				podMonitors[k] = podMon
 			}
 		})
@@ -2431,8 +2436,10 @@ func (c *Operator) selectProbes(ctx context.Context, p *monitoringv1.Prometheus,
 		err := c.probeInfs.ListAllByNamespace(ns, bMonSelector, func(obj interface{}) {
 			if k, ok := c.keyFunc(obj); ok {
 				probe := obj.(*monitoringv1.Probe).DeepCopy()
-				probe.APIVersion = monitoringv1.SchemeGroupVersion.String()
-				probe.Kind = monitoringv1.ProbesKind
+				if err := k8sutil.AddTypeInformationToObject(probe); err != nil {
+					level.Error(c.logger).Log("msg", "failed to set Probe type information", "namespace", ns, "err", err)
+					return
+				}
 				probes[k] = probe
 			}
 		})

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -194,6 +194,8 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 		var marshalErr error
 		err := c.ruleInfs.ListAllByNamespace(ns, ruleSelector, func(obj interface{}) {
 			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
+			promRule.APIVersion = monitoringv1.SchemeGroupVersion.String()
+			promRule.Kind = monitoringv1.PrometheusRuleKind
 
 			if err := nsLabeler.EnforceNamespaceLabel(promRule); err != nil {
 				marshalErr = err

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,8 +195,10 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 		var marshalErr error
 		err := c.ruleInfs.ListAllByNamespace(ns, ruleSelector, func(obj interface{}) {
 			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
-			promRule.APIVersion = monitoringv1.SchemeGroupVersion.String()
-			promRule.Kind = monitoringv1.PrometheusRuleKind
+			if err := k8sutil.AddTypeInformationToObject(promRule); err != nil {
+				level.Error(c.logger).Log("msg", "failed to set rule type information", "namespace", ns, "err", err)
+				return
+			}
 
 			if err := nsLabeler.EnforceNamespaceLabel(promRule); err != nil {
 				marshalErr = err

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -637,8 +637,9 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 
 	tr := trobj.(*monitoringv1.ThanosRuler)
 	tr = tr.DeepCopy()
-	tr.APIVersion = monitoringv1.SchemeGroupVersion.String()
-	tr.Kind = monitoringv1.ThanosRulerKind
+	if err := k8sutil.AddTypeInformationToObject(tr); err != nil {
+		return errors.Wrap(err, "failed to set ThanosRuler type information")
+	}
 
 	if tr.Spec.Paused {
 		return nil

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	namespacelabeler "github.com/prometheus-operator/prometheus-operator/pkg/namespace-labeler"
 	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
 
@@ -192,8 +193,10 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 		var marshalErr error
 		err := o.ruleInfs.ListAllByNamespace(ns, ruleSelector, func(obj interface{}) {
 			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
-			promRule.APIVersion = monitoringv1.SchemeGroupVersion.String()
-			promRule.Kind = monitoringv1.PrometheusRuleKind
+			if err := k8sutil.AddTypeInformationToObject(promRule); err != nil {
+				level.Error(o.logger).Log("msg", "failed to set PrometheusRule type information", "namespace", ns, "err", err)
+				return
+			}
 
 			if err := nsLabeler.EnforceNamespaceLabel(promRule); err != nil {
 				marshalErr = err

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -192,6 +192,8 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 		var marshalErr error
 		err := o.ruleInfs.ListAllByNamespace(ns, ruleSelector, func(obj interface{}) {
 			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
+			promRule.APIVersion = monitoringv1.SchemeGroupVersion.String()
+			promRule.Kind = monitoringv1.PrometheusRuleKind
 
 			if err := nsLabeler.EnforceNamespaceLabel(promRule); err != nil {
 				marshalErr = err

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -219,6 +219,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromWebTLS":                             testPromWebTLS,
 		"PromMinReadySeconds":                    testPromMinReadySeconds,
 		"PromEnforcedNamespaceLabel":             testPromEnforcedNamespaceLabel,
+		"PromNamespaceEnforcementExclusion":      testPromNamespaceEnforcementExclusion,
 		"PromQueryLogFile":                       testPromQueryLogFile,
 		"PromDegradedCondition":                  testPromDegradedConditionStatus,
 	}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -3935,6 +3935,157 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 	}
 }
 
+// testPromNamespaceEnforcementExclusion checks that the enforcedNamespaceLabel field
+// is not enforced on objects defined in ExcludedFromEnforcement.
+func testPromNamespaceEnforcementExclusion(t *testing.T) {
+	t.Parallel()
+
+	for i, tc := range []struct {
+		relabelConfigs       []*monitoringv1.RelabelConfig
+		metricRelabelConfigs []*monitoringv1.RelabelConfig
+		expectedNamespace    string
+	}{
+		{
+			// override label using the labeldrop action.
+			relabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					Regex:  "namespace",
+					Action: "labeldrop",
+				},
+			},
+			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					Regex:  "namespace",
+					Action: "labeldrop",
+				},
+			},
+			expectedNamespace: "",
+		},
+		{
+			// override label using the replace action.
+			relabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "namespace",
+					Replacement: "ns1",
+				},
+			},
+			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "namespace",
+					Replacement: "ns1",
+				},
+			},
+			expectedNamespace: "ns1",
+		},
+		{
+			// override label using the labelmap action.
+			relabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "temp_namespace",
+					Replacement: "ns1",
+				},
+			},
+			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					Action:      "labelmap",
+					Regex:       "temp_namespace",
+					Replacement: "namespace",
+				},
+				{
+					Action: "labeldrop",
+					Regex:  "temp_namespace",
+				},
+			},
+			expectedNamespace: "ns1",
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ctx := framework.NewTestCtx(t)
+			defer ctx.Cleanup(t)
+			ns := framework.CreateNamespace(context.Background(), t, ctx)
+			framework.SetupPrometheusRBAC(context.Background(), t, ctx, ns)
+
+			prometheusName := "test"
+			group := "servicediscovery-test"
+			svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+
+			s := framework.MakeBasicServiceMonitor(group)
+			s.Spec.Endpoints[0].RelabelConfigs = tc.relabelConfigs
+			s.Spec.Endpoints[0].MetricRelabelConfigs = tc.metricRelabelConfigs
+			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
+				t.Fatal("Creating ServiceMonitor failed: ", err)
+			}
+
+			p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
+			p.Spec.EnforcedNamespaceLabel = "namespace"
+			p.Spec.ExcludedFromEnforcement = []monitoringv1.ObjectReference{
+				{
+					Namespace: ns,
+					Group:     "monitoring.coreos.com",
+					Resource:  monitoringv1.ServiceMonitorName,
+				},
+			}
+			_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+				t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			} else {
+				ctx.AddFinalizerFn(finalizerFn)
+			}
+
+			_, err = framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), fmt.Sprintf("prometheus-%s", prometheusName), metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("Generated Secret could not be retrieved: ", err)
+			}
+
+			err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
+			if err != nil {
+				t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+			}
+
+			// Check that the namespace label is enforced to the correct value.
+			var (
+				loopErr        error
+				namespaceLabel string
+			)
+
+			err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+				loopErr = nil
+				res, err := framework.PrometheusQuery(ns, svc.Name, "http", "prometheus_build_info")
+				if err != nil {
+					loopErr = errors.Wrap(err, "failed to query Prometheus")
+					return false, nil
+				}
+
+				if len(res) != 1 {
+					loopErr = fmt.Errorf("expecting 1 item but got %d", len(res))
+					return false, nil
+				}
+
+				for k, v := range res[0].Metric {
+					if k == "namespace" {
+						namespaceLabel = v
+						return true, nil
+					}
+				}
+
+				return true, nil
+			})
+
+			if err != nil {
+				t.Fatalf("%v: %v", err, loopErr)
+			}
+
+			if namespaceLabel != tc.expectedNamespace {
+				t.Fatalf("expecting custom 'namespace' label value %q due to exclusion. but got %q instead", tc.expectedNamespace, namespaceLabel)
+			}
+		})
+	}
+}
+
 func testPrometheusCRDValidation(t *testing.T) {
 	t.Parallel()
 	name := "test"

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -4046,7 +4046,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 				t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
 			}
 
-			// Check that the namespace label is enforced to the correct value.
+			// Check that the namespace label isn't enforced.
 			var (
 				loopErr        error
 				namespaceLabel string

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -4068,7 +4068,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 				for k, v := range res[0].Metric {
 					if k == "namespace" {
 						namespaceLabel = v
-						return true, nil
+						break
 					}
 				}
 


### PR DESCRIPTION

## Description

Based on https://github.com/kubernetes/client-go/issues/308 the type meta is erased on object returned by cache informers.

`excludedFromEnforce` functionality introduced in #4397 is requiring the Kind and APIVersion for filtering.
Explicitly set them for each object type to have them available in filtering



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix Namespace enforcement exclusion on newly created Prometheus objects 
```
