### PR TITLE
Fix weight of API reference documentation

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -6,7 +6,7 @@ images: []
 menu:
 docs:
 parent: "operator"
-weight: 1000
+weight: 208
 toc: true
 ---
 > This page is automatically generated with `gen-crd-api-reference-docs`.

--- a/scripts/docs/templates/pkg.tpl
+++ b/scripts/docs/templates/pkg.tpl
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "operator"
-weight: 1000
+weight: 208
 toc: true
 ---
 


### PR DESCRIPTION
## Description

The right navigation button of the Troubleshooting page should link to the API reference page.

![image](https://user-images.githubusercontent.com/2587585/179520732-13ab2cb0-7357-454d-9ec2-d06c20bec631.png)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
