### PR TITLE
Add CAP_FOWNER capability to thanos-sidecar container

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -791,6 +791,7 @@ func makeStatefulSetSpec(
 				AllowPrivilegeEscalation: &boolFalse,
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
+					// The Thanos sidecar needs the CAP_FOWNER capability because it links block files as hard link.
 					Add:  []v1.Capability{"CAP_FOWNER"},
 					Drop: []v1.Capability{"ALL"},
 				},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -791,7 +791,7 @@ func makeStatefulSetSpec(
 				AllowPrivilegeEscalation: &boolFalse,
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
-					Add: []v1.Capability{"CAP_FOWNER"},
+					Add:  []v1.Capability{"CAP_FOWNER"},
 					Drop: []v1.Capability{"ALL"},
 				},
 			},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -791,6 +791,7 @@ func makeStatefulSetSpec(
 				AllowPrivilegeEscalation: &boolFalse,
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
+					Add: []v1.Capability{"CAP_FOWNER"},
 					Drop: []v1.Capability{"ALL"},
 				},
 			},


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Stating promtheus-operator v0.56.0, by default thanos-sidecar container failed to upload blocks to object storage as explained in https://github.com/prometheus-operator/prometheus-operator/issues/4928. This PR adds necessary permissions to thanos-sidecar container under securityContext level so that hard link creation action will be successful as it was needed before uploading block to object storage

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Adds CAP_FOWNER capability to thanos-sidecar container
```
