### PR TITLE
Makefile: add stripped-down-crds.yaml target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,11 +11,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Upload binaries to release
+      - name: Upload bundle.yaml to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: bundle.yaml
           asset_name: bundle.yaml
+          tag: ${{ github.ref }}
+          overwrite: true
+      - name: Generate stripped down version of CRDs
+        run: make stripped-down-crds.yaml
+      - name: Upload stripped-down-crds.yaml to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: stripped-down-crds.yaml
+          asset_name: stripped-down-crds.yaml
           tag: ${{ github.ref }}
           overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 .history/
 .vscode/
 tmp
+stripped-down-crds.yaml
 
 # These are empty target files, created on every docker build. Their sole
 # purpose is to track the last target execution time to evalualte, whether the


### PR DESCRIPTION
## Description

Workaround for `kubectl apply` failing because of annotation being too
long.

Running `make stripped-down-crds.yaml` will generate a version of the CRDs with all description fields removed.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
