### PR TITLE
Support Web basic_auth_users config for Prometheus and Alertmanager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 
-require golang.org/x/net v0.0.0-20220708220712-1185a9018129
+require (
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129
+)
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1182,8 +1182,9 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88 h1:Tgea0cVUD0ivh5ADBX4WwuI12DUd2to3nCYe2eayMIw=
 golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -566,7 +566,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 			fields = a.Spec.Web.WebConfigFileFields
 		}
 
-		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(a.Name), fields)
+		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(a.Name), a.Namespace, fields)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -773,6 +773,8 @@ type WebConfigFileFields struct {
 	TLSConfig *WebTLSConfig `json:"tlsConfig,omitempty"`
 	// Defines HTTP parameters for web server.
 	HTTPConfig *WebHTTPConfig `json:"httpConfig,omitempty"`
+	// Defines...
+	BasicAuthUsers []BasicAuth `json:"basicAuthUsers,omitempty"`
 }
 
 // WebHTTPConfig defines HTTP parameters for web server.

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -564,7 +564,7 @@ func makeStatefulSetSpec(
 			fields = p.Spec.Web.WebConfigFileFields
 		}
 
-		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(p.Name), fields)
+		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(p.Name), p.Namespace, fields)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webconfig/auth_config.go
+++ b/pkg/webconfig/auth_config.go
@@ -1,0 +1,81 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webconfig
+
+import (
+	"context"
+	"fmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+)
+
+var (
+	managedKey      = "webconfig/managed/"
+	userKey         = "webconfig/userDefine/"
+	managedUserName = "prometheus-operator-managed-user"
+)
+
+// authConfig
+type authConfig struct {
+	namespace      string
+	basicAuthUsers []monitoringv1.BasicAuth
+}
+
+func newAuthConfig(namespace string, basicAuthUsers []monitoringv1.BasicAuth) authConfig {
+	return authConfig{
+		namespace:      namespace,
+		basicAuthUsers: basicAuthUsers,
+	}
+}
+
+func (a authConfig) addAuthsToStore(ctx context.Context, managedUserPassword string, store *assets.Store) error {
+	store.BasicAuthAssets[fmt.Sprintf("%s%s", managedKey, managedUserName)] = assets.BasicAuthCredentials{
+		Username: managedUserName,
+		Password: managedUserPassword,
+	}
+
+	for _, bau := range a.basicAuthUsers {
+		if err := store.AddBasicAuth(ctx, a.namespace, &bau, fmt.Sprintf("%s%s", userKey, bau.Username.Key)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a authConfig) getManagedAuth(store *assets.Store) (string, string, error) {
+	v, ok := store.BasicAuthAssets[fmt.Sprintf("%s%s", managedKey, managedUserName)]
+	if !ok {
+		return "", "", fmt.Errorf("key %s not found", fmt.Sprintf("%s%s", managedKey, managedUserName))
+	}
+
+	return v.Username, v.Password, nil
+}
+
+func (a authConfig) getUserDefineAuths(store *assets.Store) (map[string]string, error) {
+	auths := map[string]string{}
+
+	for _, bau := range a.basicAuthUsers {
+		v, ok := store.BasicAuthAssets[fmt.Sprintf("%s%s", userKey, bau.Username.Name)]
+		if !ok {
+			return nil, fmt.Errorf("key %s not found", fmt.Sprintf("%s%s", userKey, bau.Username.Name))
+		}
+
+		auths[v.Username] = v.Password
+	}
+
+	return auths, nil
+}


### PR DESCRIPTION
## Description

Fixes: #4200



## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added support for Web basic_auth_users config for Prometheus and Alertmanager CRD
```
