### PR TITLE
Refactor controller

### DIFF
--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1253,7 +1253,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				kclient: c,
 				mclient: monitoringfake.NewSimpleClientset(),
 				logger:  level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowInfo()),
-				metrics: operator.NewMetrics("alertmanager", prometheus.NewRegistry()),
+				metrics: operator.NewMetrics(prometheus.NewRegistry()),
 			}
 
 			err := o.bootstrap(context.Background())

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -1,0 +1,375 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Syncer knows how to synchronize statefulset-based resources.
+type Syncer interface {
+	// Sync the state of the object identified by its key.
+	Sync(context.Context, string) error
+	// UpdateStatus updates the status of the object identified by its key.
+	UpdateStatus(context.Context, string) error
+	// Resolve returns the resource associated to the statefulset.
+	Resolve(*appsv1.StatefulSet) metav1.Object
+}
+
+// ReconcilerMetrics tracks reconciler metrics.
+// TODO: remove the interface and store metrics directly in ResourceReconciler
+// once all controllers (e.g. Alertmanager and ThanosRuler) have been migrated
+// to use ResourceReconciler.
+type ReconcilerMetrics interface {
+	ReconcileCounter() prometheus.Counter
+	TriggerByCounter(triggeredBy, action string) prometheus.Counter
+	ReconcileDurationHistogram() prometheus.Histogram
+	ReconcileErrorsCounter() prometheus.Counter
+}
+
+// ResourceReconciler reacts on changes for statefulset-based resources and
+// triggers synchronization of the resources.
+//
+// ResourceReconciler implements the cache.ResourceEventHandler interface and
+// it can subscribe to resource events like this:
+//
+// var statefulSetInformer, resourceInformer cache.SharedInformer
+// ...
+// rr := NewResourceReconciler(...)
+// statefulSetInformer.AddEventHandler(rr)
+// resourceInformer.AddEventHandler(rr)
+//
+// ResourceReconciler will trigger object and status reconciliations based on
+// the events received from the informer.
+type ResourceReconciler struct {
+	logger log.Logger
+
+	resourceKind string
+
+	syncer  Syncer
+	metrics ReconcilerMetrics
+
+	// Queue to trigger state reconciliations of  objects.
+	reconcileQ workqueue.RateLimitingInterface
+	// Queue to trigger status updates of Prometheus objects.
+	statusQ workqueue.RateLimitingInterface
+
+	g errgroup.Group
+}
+
+// NewResourceReconciler returns a reconciler for the "kind" resource.
+func NewResourceReconciler(
+	l log.Logger,
+	syncer Syncer,
+	kind string,
+	metrics ReconcilerMetrics,
+) *ResourceReconciler {
+	qname := strings.ToLower(kind)
+	return &ResourceReconciler{
+		logger:       l,
+		resourceKind: kind,
+		syncer:       syncer,
+		metrics:      metrics,
+		reconcileQ:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), qname),
+		statusQ:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), qname+"_status"),
+	}
+}
+
+// hasObjectChanged returns true if the objects have different resource revisions.
+func (rr *ResourceReconciler) hasObjectChanged(old, cur metav1.Object) bool {
+	if old.GetResourceVersion() != cur.GetResourceVersion() {
+		level.Debug(rr.logger).Log(
+			"msg", "different resource versions",
+			"current", cur.GetResourceVersion(),
+			"old", old.GetResourceVersion(),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	return false
+}
+
+// hasStateChanged returns true if the 2 objects are different in a way that
+// the controller should reconcile the actual state against the desired state.
+// It helps preventing hot loops when the controller updates the status
+// subresource for instance.
+func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
+	if old.GetGeneration() != cur.GetGeneration() {
+		level.Debug(rr.logger).Log(
+			"msg", "different generations",
+			"current", cur.GetGeneration(),
+			"old", old.GetGeneration(),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	if !reflect.DeepEqual(old.GetLabels(), cur.GetLabels()) {
+		level.Debug(rr.logger).Log(
+			"msg", "different labels",
+			"current", fmt.Sprintf("%v", cur.GetLabels()),
+			"old", fmt.Sprintf("%v", old.GetLabels()),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+
+	}
+	if !reflect.DeepEqual(old.GetAnnotations(), cur.GetAnnotations()) {
+		level.Debug(rr.logger).Log(
+			"msg", "different annotations",
+			"current", fmt.Sprintf("%v", cur.GetAnnotations()),
+			"old", fmt.Sprintf("%v", old.GetAnnotations()),
+			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+		)
+		return true
+	}
+
+	return false
+}
+
+// objectKey returns the `namespace/name` key of a Kubernetes object, typically
+// retrieved from a controller's cache.
+func (rr *ResourceReconciler) objectKey(obj interface{}) (string, bool) {
+	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		level.Error(rr.logger).Log("msg", "creating key failed", "err", err)
+		return "", false
+	}
+
+	return k, true
+}
+
+// OnAdd implements the cache.ResourceEventHandler interface.
+func (rr *ResourceReconciler) OnAdd(obj interface{}) {
+	if _, ok := obj.(*appsv1.StatefulSet); ok {
+		rr.onStatefulSetAdd(obj.(*appsv1.StatefulSet))
+		return
+	}
+
+	key, ok := rr.objectKey(obj)
+	if !ok {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s added", rr.resourceKind), "key", key)
+	rr.metrics.TriggerByCounter(rr.resourceKind, "add").Inc()
+
+	rr.reconcileQ.Add(key)
+}
+
+// OnUpdate implements the cache.ResourceEventHandler interface.
+func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
+	if _, ok := cur.(*appsv1.StatefulSet); ok {
+		rr.onStatefulSetUpdate(old.(*appsv1.StatefulSet), cur.(*appsv1.StatefulSet))
+		return
+	}
+
+	key, ok := rr.objectKey(cur)
+	if !ok {
+		return
+	}
+
+	mOld, err := meta.Accessor(old)
+	if err != nil {
+		level.Error(rr.logger).Log("err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
+	}
+
+	mCur, err := meta.Accessor(cur)
+	if err != nil {
+		level.Error(rr.logger).Log("err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
+	}
+
+	if !rr.hasStateChanged(mOld, mCur) {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s updated", rr.resourceKind), "key", key)
+	rr.metrics.TriggerByCounter(rr.resourceKind, "update").Inc()
+
+	rr.reconcileQ.Add(key)
+}
+
+// OnDelete implements the cache.ResourceEventHandler interface.
+func (rr *ResourceReconciler) OnDelete(obj interface{}) {
+	if _, ok := obj.(*appsv1.StatefulSet); ok {
+		rr.onStatefulSetDelete(obj.(*appsv1.StatefulSet))
+		return
+	}
+
+	key, ok := rr.objectKey(obj)
+	if !ok {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s deleted", rr.resourceKind), "key", key)
+	rr.metrics.TriggerByCounter(rr.resourceKind, "delete").Inc()
+
+	rr.reconcileQ.Add(key)
+}
+
+func (rr *ResourceReconciler) onStatefulSetAdd(ss *appsv1.StatefulSet) {
+	obj := rr.syncer.Resolve(ss)
+	if obj == nil {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", "StatefulSet added")
+	rr.metrics.TriggerByCounter("StatefulSet", "add").Inc()
+
+	rr.EnqueueForReconciliation(obj)
+}
+
+func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
+	level.Debug(rr.logger).Log("msg", "update handler", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+
+	if !rr.hasObjectChanged(old, cur) {
+		return
+	}
+
+	obj := rr.syncer.Resolve(cur)
+	if obj == nil {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", "StatefulSet updated")
+	rr.metrics.TriggerByCounter("StatefulSet", "update").Inc()
+
+	if !rr.hasStateChanged(old, cur) {
+		// If the statefulset state (spec, labels or annotations) hasn't
+		// changed, the operator can only update the status subresource instead
+		// of doing a full reconciliation.
+		rr.EnqueueForStatus(obj)
+		return
+	}
+
+	rr.EnqueueForReconciliation(obj)
+}
+
+func (rr *ResourceReconciler) onStatefulSetDelete(ss *appsv1.StatefulSet) {
+	obj := rr.syncer.Resolve(ss)
+	if obj == nil {
+		return
+	}
+
+	level.Debug(rr.logger).Log("msg", "StatefulSet delete")
+	rr.metrics.TriggerByCounter("StatefulSet", "delete").Inc()
+
+	rr.EnqueueForReconciliation(obj)
+}
+
+// EnqueueForReconciliation asks for reconciling the object.
+func (rr *ResourceReconciler) EnqueueForReconciliation(obj metav1.Object) {
+	rr.reconcileQ.Add(obj.GetNamespace() + "/" + obj.GetName())
+}
+
+// EnqueueForStatus asks for updating the status of the object.
+func (rr *ResourceReconciler) EnqueueForStatus(obj metav1.Object) {
+	rr.statusQ.Add(obj.GetNamespace() + "/" + obj.GetName())
+}
+
+// Run the goroutines responsible for processing the reconciliation and status
+// queues.
+func (rr *ResourceReconciler) Run(ctx context.Context) {
+	// Goroutine that reconciles the desired state of objects.
+	rr.g.Go(func() error {
+		for rr.processNextReconcileItem(ctx) {
+		}
+		return nil
+	})
+
+	// Goroutine that reconciles the status of objects.
+	rr.g.Go(func() error {
+		for rr.processNextStatusItem(ctx) {
+		}
+		return nil
+	})
+}
+
+// Stop the processing queues and wait for goroutines to exit.
+func (rr *ResourceReconciler) Stop() {
+	rr.reconcileQ.ShutDown()
+	rr.statusQ.ShutDown()
+
+	_ = rr.g.Wait()
+}
+
+// processNextReconcileItem dequeues items, processes them, and marks them done.
+// It is guaranteed that the sync() method is never invoked concurrently with
+// the same key.
+// Before returning, the object's key is automatically added to the status queue.
+func (rr *ResourceReconciler) processNextReconcileItem(ctx context.Context) bool {
+	item, quit := rr.reconcileQ.Get()
+	if quit {
+		return false
+	}
+
+	key := item.(string)
+	defer rr.reconcileQ.Done(key)
+	defer rr.statusQ.Add(key) // enqueues the object's key to update the status subresource
+
+	rr.metrics.ReconcileCounter().Inc()
+	startTime := time.Now()
+	err := rr.syncer.Sync(ctx, key)
+	rr.metrics.ReconcileDurationHistogram().Observe(time.Since(startTime).Seconds())
+
+	if err == nil {
+		rr.reconcileQ.Forget(key)
+		return true
+	}
+
+	rr.metrics.ReconcileErrorsCounter().Inc()
+	utilruntime.HandleError(errors.Wrap(err, fmt.Sprintf("sync %q failed", key)))
+	rr.reconcileQ.AddRateLimited(key)
+
+	return true
+}
+
+func (rr *ResourceReconciler) processNextStatusItem(ctx context.Context) bool {
+	item, quit := rr.statusQ.Get()
+	if quit {
+		return false
+	}
+
+	key := item.(string)
+	defer rr.statusQ.Done(key)
+
+	err := rr.syncer.UpdateStatus(ctx, key)
+	if err == nil {
+		rr.statusQ.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(errors.Wrap(err, fmt.Sprintf("status %q failed", key)))
+	rr.statusQ.AddRateLimited(key)
+
+	return true
+}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -40,11 +40,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 )
 
 const (
@@ -64,10 +62,10 @@ type Operator struct {
 	ruleInfs        *informers.ForResource
 	ssetInfs        *informers.ForResource
 
+	rr *operator.ResourceReconciler
+
 	nsThanosRulerInf cache.SharedIndexInformer
 	nsRuleInf        cache.SharedIndexInformer
-
-	queue workqueue.RateLimitingInterface
 
 	metrics         *operator.Metrics
 	reconciliations *operator.ReconciliationTracker
@@ -111,12 +109,14 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		return nil, errors.Wrap(err, "can not parse thanos ruler selector value")
 	}
 
+	// All the metrics exposed by the controller get the controller="thanos" label.
+	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "thanos"}, r)
+
 	o := &Operator{
 		kclient:         client,
 		mclient:         mclient,
 		logger:          logger,
-		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "thanos"),
-		metrics:         operator.NewMetrics("thanos", r),
+		metrics:         operator.NewMetrics(r),
 		reconciliations: &operator.ReconciliationTracker{},
 		config: Config{
 			Host:                   conf.Host,
@@ -132,6 +132,14 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 			ThanosRulerSelector:    conf.ThanosRulerSelector,
 		},
 	}
+
+	o.rr = operator.NewResourceReconciler(
+		o.logger,
+		o,
+		o.metrics,
+		monitoringv1.ThanosRulerKind,
+		r,
+	)
 
 	o.cmapInfs, err = informers.NewInformersForResource(
 		informers.NewKubeInformerFactories(
@@ -266,11 +274,9 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 
 // addHandlers adds the eventhandlers to the informers.
 func (o *Operator) addHandlers() {
-	o.thanosRulerInfs.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    o.handleThanosRulerAdd,
-		DeleteFunc: o.handleThanosRulerDelete,
-		UpdateFunc: o.handleThanosRulerUpdate,
-	})
+	o.thanosRulerInfs.AddEventHandler(o.rr)
+	o.ssetInfs.AddEventHandler(o.rr)
+
 	o.cmapInfs.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    o.handleConfigMapAdd,
 		DeleteFunc: o.handleConfigMapDelete,
@@ -280,11 +286,6 @@ func (o *Operator) addHandlers() {
 		AddFunc:    o.handleRuleAdd,
 		DeleteFunc: o.handleRuleDelete,
 		UpdateFunc: o.handleRuleUpdate,
-	})
-	o.ssetInfs.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    o.handleStatefulSetAdd,
-		DeleteFunc: o.handleStatefulSetDelete,
-		UpdateFunc: o.handleStatefulSetUpdate,
 	})
 
 	// The controller needs to watch the namespaces in which the rules live
@@ -299,8 +300,6 @@ func (o *Operator) addHandlers() {
 
 // Run the controller.
 func (o *Operator) Run(ctx context.Context) error {
-	defer o.queue.ShutDown()
-
 	errChan := make(chan error)
 	go func() {
 		v, err := o.kclient.Discovery().ServerVersion()
@@ -322,7 +321,8 @@ func (o *Operator) Run(ctx context.Context) error {
 		return nil
 	}
 
-	go o.worker(ctx)
+	go o.rr.Run(ctx)
+	defer o.rr.Stop()
 
 	go o.thanosRulerInfs.Start(ctx.Done())
 	go o.cmapInfs.Start(ctx.Done())
@@ -335,6 +335,7 @@ func (o *Operator) Run(ctx context.Context) error {
 	if err := o.waitForCacheSync(ctx); err != nil {
 		return err
 	}
+
 	o.addHandlers()
 
 	o.metrics.Ready().Set(1)
@@ -351,49 +352,12 @@ func (o *Operator) keyFunc(obj interface{}) (string, bool) {
 	return k, true
 }
 
-func (o *Operator) handleThanosRulerAdd(obj interface{}) {
-	key, ok := o.keyFunc(obj)
-	if !ok {
-		return
-	}
-
-	level.Debug(o.logger).Log("msg", "ThanosRuler added", "key", key)
-	o.metrics.TriggerByCounter(monitoringv1.ThanosRulerKind, "add").Inc()
-	o.enqueue(key)
-}
-
-func (o *Operator) handleThanosRulerDelete(obj interface{}) {
-	key, ok := o.keyFunc(obj)
-	if !ok {
-		return
-	}
-
-	level.Debug(o.logger).Log("msg", "ThanosRuler deleted", "key", key)
-	o.metrics.TriggerByCounter(monitoringv1.ThanosRulerKind, "delete").Inc()
-	o.enqueue(key)
-}
-
-func (o *Operator) handleThanosRulerUpdate(old, cur interface{}) {
-	if old.(*monitoringv1.ThanosRuler).ResourceVersion == cur.(*monitoringv1.ThanosRuler).ResourceVersion {
-		return
-	}
-
-	key, ok := o.keyFunc(cur)
-	if !ok {
-		return
-	}
-
-	level.Debug(o.logger).Log("msg", "ThanosRuler updated", "key", key)
-	o.metrics.TriggerByCounter(monitoringv1.ThanosRulerKind, "update").Inc()
-	o.enqueue(key)
-}
-
 // TODO: Do we need to enqueue configmaps just for the namespace or in general?
 func (o *Operator) handleConfigMapAdd(obj interface{}) {
 	meta, ok := o.getObjectMeta(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "ConfigMap added")
-		o.metrics.TriggerByCounter("ConfigMap", "add").Inc()
+		o.metrics.TriggerByCounter("ConfigMap", operator.AddEvent).Inc()
 
 		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
@@ -403,7 +367,7 @@ func (o *Operator) handleConfigMapDelete(obj interface{}) {
 	meta, ok := o.getObjectMeta(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "ConfigMap deleted")
-		o.metrics.TriggerByCounter("ConfigMap", "delete").Inc()
+		o.metrics.TriggerByCounter("ConfigMap", operator.DeleteEvent).Inc()
 
 		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
@@ -417,7 +381,7 @@ func (o *Operator) handleConfigMapUpdate(old, cur interface{}) {
 	meta, ok := o.getObjectMeta(cur)
 	if ok {
 		level.Debug(o.logger).Log("msg", "ConfigMap updated")
-		o.metrics.TriggerByCounter("ConfigMap", "update").Inc()
+		o.metrics.TriggerByCounter("ConfigMap", operator.UpdateEvent).Inc()
 
 		o.enqueueForThanosRulerNamespace(meta.GetNamespace())
 	}
@@ -428,7 +392,7 @@ func (o *Operator) handleRuleAdd(obj interface{}) {
 	meta, ok := o.getObjectMeta(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule added")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "add").Inc()
+		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.AddEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
@@ -443,7 +407,7 @@ func (o *Operator) handleRuleUpdate(old, cur interface{}) {
 	meta, ok := o.getObjectMeta(cur)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule updated")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "update").Inc()
+		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.UpdateEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
@@ -454,14 +418,15 @@ func (o *Operator) handleRuleDelete(obj interface{}) {
 	meta, ok := o.getObjectMeta(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule deleted")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, "delete").Inc()
+		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.DeleteEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
 }
 
-func (o *Operator) thanosForStatefulSet(sset interface{}) *monitoringv1.ThanosRuler {
-	key, ok := o.keyFunc(sset)
+// Resolve implements the operator.Syncer interface.
+func (o *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
+	key, ok := o.keyFunc(ss)
 	if !ok {
 		return nil
 	}
@@ -494,96 +459,6 @@ func thanosKeyToStatefulSetKey(key string) string {
 	return keyParts[0] + "/thanos-ruler-" + keyParts[1]
 }
 
-func (o *Operator) handleStatefulSetAdd(obj interface{}) {
-	if ps := o.thanosForStatefulSet(obj); ps != nil {
-		level.Debug(o.logger).Log("msg", "StatefulSet added")
-		o.metrics.TriggerByCounter("StatefulSet", "add").Inc()
-
-		o.enqueue(ps)
-	}
-}
-
-func (o *Operator) handleStatefulSetDelete(obj interface{}) {
-	if ps := o.thanosForStatefulSet(obj); ps != nil {
-		level.Debug(o.logger).Log("msg", "StatefulSet delete")
-		o.metrics.TriggerByCounter("StatefulSet", "delete").Inc()
-
-		o.enqueue(ps)
-	}
-}
-
-func (o *Operator) handleStatefulSetUpdate(oldo, curo interface{}) {
-	old := oldo.(*appsv1.StatefulSet)
-	cur := curo.(*appsv1.StatefulSet)
-
-	level.Debug(o.logger).Log("msg", "update handler", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
-
-	// Periodic resync may resend the StatefulSet without changes
-	// in-between. Also breaks loops created by updating the resource
-	// ourselves.
-	if old.ResourceVersion == cur.ResourceVersion {
-		return
-	}
-
-	if ps := o.thanosForStatefulSet(cur); ps != nil {
-		level.Debug(o.logger).Log("msg", "StatefulSet updated")
-		o.metrics.TriggerByCounter("StatefulSet", "update").Inc()
-
-		o.enqueue(ps)
-	}
-}
-
-// enqueue adds a key to the queue. If obj is a key already it gets added
-// directly. Otherwise, the key is extracted via keyFunc.
-func (o *Operator) enqueue(obj interface{}) {
-	if obj == nil {
-		return
-	}
-
-	key, ok := obj.(string)
-	if !ok {
-		key, ok = o.keyFunc(obj)
-		if !ok {
-			return
-		}
-	}
-
-	o.queue.Add(key)
-}
-
-// worker runs a worker thread that just dequeues items, processes them, and
-// marks them done. It enforces that the syncHandler is never invoked
-// concurrently with the same key.
-func (o *Operator) worker(ctx context.Context) {
-	for o.processNextWorkItem(ctx) {
-	}
-}
-
-func (o *Operator) processNextWorkItem(ctx context.Context) bool {
-	key, quit := o.queue.Get()
-	if quit {
-		return false
-	}
-	defer o.queue.Done(key)
-
-	o.metrics.ReconcileCounter().Inc()
-	startTime := time.Now()
-	err := o.sync(ctx, key.(string))
-	o.metrics.ReconcileDurationHistogram().Observe(time.Since(startTime).Seconds())
-	o.reconciliations.SetStatus(key.(string), err)
-
-	if err == nil {
-		o.queue.Forget(key)
-		return true
-	}
-
-	o.metrics.ReconcileErrorsCounter().Inc()
-	utilruntime.HandleError(errors.Wrapf(err, "Sync %q failed", key))
-	o.queue.AddRateLimited(key)
-
-	return true
-}
-
 func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 	old := oldo.(*v1.Namespace)
 	cur := curo.(*v1.Namespace)
@@ -596,7 +471,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 	}
 
 	level.Debug(o.logger).Log("msg", "Namespace updated", "namespace", cur.GetName())
-	o.metrics.TriggerByCounter("Namespace", "update").Inc()
+	o.metrics.TriggerByCounter("Namespace", operator.UpdateEvent).Inc()
 
 	// Check for ThanosRuler instances selecting PrometheusRules in the namespace.
 	err := o.thanosRulerInfs.ListAll(labels.Everything(), func(obj interface{}) {
@@ -613,7 +488,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 		}
 
 		if sync {
-			o.enqueue(tr)
+			o.rr.EnqueueForReconciliation(tr)
 		}
 	})
 	if err != nil {
@@ -622,6 +497,14 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 			"err", err,
 		)
 	}
+}
+
+// Sync implements the operator.Syncer interface.
+func (o *Operator) Sync(ctx context.Context, key string) error {
+	err := o.sync(ctx, key)
+	o.reconciliations.SetStatus(key, err)
+
+	return err
 }
 
 func (o *Operator) sync(ctx context.Context, key string) error {
@@ -735,6 +618,12 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return errors.Wrap(err, "updating StatefulSet failed")
 	}
 
+	return nil
+}
+
+// UpdateStatus implements the operator.Syncer interface.
+func (o *Operator) UpdateStatus(ctx context.Context, key string) error {
+	// FIXME(simonpasquier): implement status update logic.
 	return nil
 }
 
@@ -867,7 +756,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		// Check for ThanosRuler instances in the namespace.
 		tr := obj.(*monitoringv1.ThanosRuler)
 		if tr.Namespace == nsName {
-			o.enqueue(tr)
+			o.rr.EnqueueForReconciliation(tr)
 			return
 		}
 
@@ -885,7 +774,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		}
 
 		if ruleNSSelector.Matches(labels.Set(ns.Labels)) {
-			o.enqueue(tr)
+			o.rr.EnqueueForReconciliation(tr)
 			return
 		}
 	})


### PR DESCRIPTION
## Description

This change extracts the code that watches statefulset-based resources and deals with state reconciliation. The PR reuses the same logic across Prometheus, Alertmanager and ThanosRuler which would facilitate the implementation of the status subresource for all of them.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
