### PR TITLE
[tech debt] clean up makeStatefulSetSpec() functions

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -216,9 +216,6 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 }
 
 func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSecrets []string) (*appsv1.StatefulSetSpec, error) {
-	// Before editing 'a' create deep copy, to prevent side effects. For more
-	// details see https://github.com/prometheus-operator/prometheus-operator/issues/1659
-	a = a.DeepCopy()
 	amVersion := operator.StringValOrDefault(a.Spec.Version, operator.DefaultAlertmanagerVersion)
 
 	amImagePath, err := operator.BuildImagePath(

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -25,7 +25,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -129,24 +128,6 @@ func makeStatefulSet(
 	intZero := int32(0)
 	if p.Spec.Replicas != nil && *p.Spec.Replicas < 0 {
 		p.Spec.Replicas = &intZero
-	}
-
-	if p.Spec.Resources.Requests == nil {
-		p.Spec.Resources.Requests = v1.ResourceList{}
-	}
-	_, memoryRequestFound := p.Spec.Resources.Requests[v1.ResourceMemory]
-	memoryLimit, memoryLimitFound := p.Spec.Resources.Limits[v1.ResourceMemory]
-	if !memoryRequestFound && parsedVersion.Major == 1 {
-		defaultMemoryRequest := resource.MustParse("2Gi")
-		compareResult := memoryLimit.Cmp(defaultMemoryRequest)
-		// If limit is given and smaller or equal to 2Gi, then set memory
-		// request to the given limit. This is necessary as if limit < request,
-		// then a Pod is not schedulable.
-		if memoryLimitFound && compareResult <= 0 {
-			p.Spec.Resources.Requests[v1.ResourceMemory] = memoryLimit
-		} else {
-			p.Spec.Resources.Requests[v1.ResourceMemory] = defaultMemoryRequest
-		}
 	}
 
 	spec, err := makeStatefulSetSpec(logger, p, config, shard, ruleConfigMapNames, tlsAssetSecrets, parsedVersion)

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -106,12 +106,6 @@ func makeStatefulSet(
 	shard int32,
 	tlsAssetSecrets []string,
 ) (*appsv1.StatefulSet, error) {
-	// p is passed in by value, not by reference. But p contains references like
-	// to annotation map, that do not get copied on function invocation. Ensure to
-	// prevent side effects before editing p by creating a deep copy. For more
-	// details see https://github.com/prometheus-operator/prometheus-operator/issues/1659.
-	p = *p.DeepCopy()
-
 	promVersion := operator.StringValOrDefault(p.Spec.Version, operator.DefaultPrometheusVersion)
 	parsedVersion, err := semver.ParseTolerant(promVersion)
 	if err != nil {

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -150,10 +150,6 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapN
 }
 
 func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapNames []string) (*appsv1.StatefulSetSpec, error) {
-	// Before editing 'tr' create deep copy, to prevent side effects. For more
-	// details see https://github.com/prometheus-operator/prometheus-operator/issues/1659
-	tr = tr.DeepCopy()
-
 	if tr.Spec.QueryConfig == nil && len(tr.Spec.QueryEndpoints) < 1 {
 		return nil, errors.New(tr.GetName() + ": thanos ruler requires query config or at least one query endpoint to be specified")
 	}


### PR DESCRIPTION
## Description

Remove unnecessary code:
* support for Prometheus v1 has gone away long time ago.
* makeStatefulSetSpec() functions don't need to deep-copy the object since it already happened before.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
