### PR TITLE
Revert "pkg/apis: Add scale subresource for Prometheus"

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21350,9 +21350,6 @@ spec:
     served: true
     storage: true
     subresources:
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
       status: {}
 ---
 ---

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8763,7 +8763,4 @@ spec:
     served: true
     storage: true
     subresources:
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
       status: {}

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8763,7 +8763,4 @@ spec:
     served: true
     storage: true
     subresources:
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
       status: {}

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -8096,10 +8096,6 @@
         "served": true,
         "storage": true,
         "subresources": {
-          "scale": {
-            "specReplicasPath": ".spec.replicas",
-            "statusReplicasPath": ".status.replicas"
-          },
           "status": {}
         }
       }

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -343,7 +343,6 @@ type CommonPrometheusFields struct {
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The desired replicas number of Prometheuses"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 
 // Prometheus defines a Prometheus deployment.
 type Prometheus struct {


### PR DESCRIPTION
Reverts prometheus-operator/prometheus-operator#4735

In light of #4946 this needs some adjustments to make it compatible with HPA:
* it should scale the number of shards rather than the number of replicas.
* it should add a `selectorpath` (see https://book.kubebuilder.io/reference/generating-crd.html#scale)