### PR TITLE
Add TracingConfigFile option to ThanosRuler

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -10715,6 +10715,18 @@ Kubernetes core/v1.SecretKeySelector
 </tr>
 <tr>
 <td>
+<code>tracingConfigFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>TracingConfig specifies the path of the tracing configuration file.
+When used alongside with TracingConfig, TracingConfigFile takes precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>labels</code><br/>
 <em>
 map[string]string
@@ -11350,6 +11362,18 @@ Kubernetes core/v1.SecretKeySelector
 </td>
 <td>
 <p>TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tracingConfigFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>TracingConfig specifies the path of the tracing configuration file.
+When used alongside with TracingConfig, TracingConfigFile takes precedence.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -26967,6 +26967,11 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              tracingConfigFile:
+                description: TracingConfig specifies the path of the tracing configuration
+                  file. When used alongside with TracingConfig, TracingConfigFile
+                  takes precedence.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4831,6 +4831,11 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              tracingConfigFile:
+                description: TracingConfig specifies the path of the tracing configuration
+                  file. When used alongside with TracingConfig, TracingConfigFile
+                  takes precedence.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4831,6 +4831,11 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              tracingConfigFile:
+                description: TracingConfig specifies the path of the tracing configuration
+                  file. When used alongside with TracingConfig, TracingConfigFile
+                  takes precedence.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4325,6 +4325,10 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic"
                   },
+                  "tracingConfigFile": {
+                    "description": "TracingConfig specifies the path of the tracing configuration file. When used alongside with TracingConfig, TracingConfigFile takes precedence.",
+                    "type": "string"
+                  },
                   "volumes": {
                     "description": "Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects.",
                     "items": {

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -175,6 +175,9 @@ type ThanosRulerSpec struct {
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
 	// TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.
 	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
+	// TracingConfig specifies the path of the tracing configuration file.
+	// When used alongside with TracingConfig, TracingConfigFile takes precedence.
+	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
 	// Labels configure the external label pairs to ThanosRuler. A default replica label
 	// `thanos_ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -282,14 +282,18 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		})
 	}
 
-	if tr.Spec.TracingConfig != nil {
-		trCLIArgs = append(trCLIArgs, "--tracing.config=$(TRACING_CONFIG)")
-		trEnvVars = append(trEnvVars, v1.EnvVar{
-			Name: "TRACING_CONFIG",
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: tr.Spec.TracingConfig,
-			},
-		})
+	if tr.Spec.TracingConfig != nil || len(tr.Spec.TracingConfigFile) > 0 {
+		if len(tr.Spec.TracingConfigFile) > 0 {
+			trCLIArgs = append(trCLIArgs, "--tracing.config-file="+tr.Spec.TracingConfigFile)
+		} else {
+			trCLIArgs = append(trCLIArgs, "--tracing.config=$(TRACING_CONFIG)")
+			trEnvVars = append(trEnvVars, v1.EnvVar{
+				Name: "TRACING_CONFIG",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: tr.Spec.TracingConfig,
+				},
+			})
+		}
 	}
 
 	if tr.Spec.GRPCServerTLSConfig != nil {

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -247,6 +247,49 @@ func TestTracing(t *testing.T) {
 	}
 }
 
+func TestTracingFile(t *testing.T) {
+	testPath := "/vault/secret/config.yaml"
+	testKey := "thanos-tracing-config-secret"
+
+	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: monitoringv1.ThanosRulerSpec{
+			QueryEndpoints:    emptyQueryEndpoints,
+			TracingConfigFile: testPath,
+			TracingConfig: &v1.SecretKeySelector{
+				Key: testKey,
+			},
+		},
+	}, defaultTestConfig, nil, "")
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	{
+		var containsArgConfigFile, containsArgConfig bool
+		expectedArgConfigFile := "--tracing.config-file=" + testPath
+		expectedArgConfig := "--tracing.config=$(TRACING_CONFIG)"
+		for _, container := range sset.Spec.Template.Spec.Containers {
+			if container.Name == "thanos-ruler" {
+				for _, arg := range container.Args {
+					if arg == expectedArgConfigFile {
+						containsArgConfigFile = true
+					}
+					if arg == expectedArgConfig {
+						containsArgConfig = true
+					}
+				}
+			}
+		}
+		if !containsArgConfigFile {
+			t.Fatalf("Thanos ruler is missing expected argument: %s", expectedArgConfigFile)
+		}
+		if containsArgConfig {
+			t.Fatalf("Thanos ruler should not contain argument: %s", expectedArgConfig)
+		}
+	}
+}
+
 func TestObjectStorage(t *testing.T) {
 	testKey := "thanos-objstore-config-secret"
 


### PR DESCRIPTION
## Description

Add the TracingConfigFile option to the Thanos Ruler similar to the Sidecar in in Prometheus spec.
This us useful/needed when the tracing config is a configmap and not a secret.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add TracingConfigFile option to ThanosRuler
```
