### PR TITLE
Fix:  add missing space in `PrometheusRule` design description

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -120,7 +120,7 @@ The `Probe` custom resource definition (CRD) allows to declarative define how gr
 
 The `PrometheusRule` custom resource definition (CRD) declaratively defines desired Prometheus rules to be consumed by Prometheus or Thanos Ruler instances.
 
-Alerts and recording rules are reconciled by the Operatorand dynamically loaded without requiring any restart of Prometheus/Thanos Rulre.
+Alerts and recording rules are reconciled by the Operator and dynamically loaded without requiring any restart of Prometheus/Thanos Rulre.
 
 ## AlertmanagerConfig
 


### PR DESCRIPTION
## Description

In the [PrometheusRule](https://prometheus-operator.dev/docs/operator/design/#prometheusrule)'s design description, it says

> Alerts and recording rules are reconciled by the Operatorand dynamically loaded without requiring any restart of Prometheus/Thanos Rulre.

and I think the space is missing between `Operator` and `and`. This PR adds it.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
