### PR TITLE
Allow users to control block-durations Prometheus flags

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2119,6 +2119,28 @@ Applies only if enforcedNamespaceLabel set to true.</p>
 </tr>
 <tr>
 <td>
+<code>maxBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Minimum duration of a data block before being persisted. For use in testing.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code><br/>
 <em>
 string
@@ -4942,6 +4964,28 @@ only available in versions of Prometheus &gt;= 2.11.0.</p>
 <p>List of references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
 to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Minimum duration of a data block before being persisted. For use in testing.</p>
 </td>
 </tr>
 </tbody>
@@ -8101,6 +8145,28 @@ only available in versions of Prometheus &gt;= 2.11.0.</p>
 <p>List of references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
 to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minBlockDuration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Minimum duration of a data block before being persisted. For use in testing.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16737,6 +16737,14 @@ spec:
                 - warn
                 - error
                 type: string
+              maxBlockDuration:
+                description: Maximum duration compacted blocks may span. For use in
+                  testing. (Defaults to 10% of the retention period.)
+                type: string
+              minBlockDuration:
+                description: Minimum duration of a data block before being persisted.
+                  For use in testing.
+                type: string
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4150,6 +4150,14 @@ spec:
                 - warn
                 - error
                 type: string
+              maxBlockDuration:
+                description: Maximum duration compacted blocks may span. For use in
+                  testing. (Defaults to 10% of the retention period.)
+                type: string
+              minBlockDuration:
+                description: Minimum duration of a data block before being persisted.
+                  For use in testing.
+                type: string
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4150,6 +4150,14 @@ spec:
                 - warn
                 - error
                 type: string
+              maxBlockDuration:
+                description: Maximum duration compacted blocks may span. For use in
+                  testing. (Defaults to 10% of the retention period.)
+                type: string
+              minBlockDuration:
+                description: Minimum duration of a data block before being persisted.
+                  For use in testing.
+                type: string
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3790,6 +3790,14 @@
                     ],
                     "type": "string"
                   },
+                  "maxBlockDuration": {
+                    "description": "Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period.)",
+                    "type": "string"
+                  },
+                  "minBlockDuration": {
+                    "description": "Minimum duration of a data block before being persisted. For use in testing.",
+                    "type": "string"
+                  },
                   "minReadySeconds": {
                     "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -334,6 +334,10 @@ type CommonPrometheusFields struct {
 	// to be excluded from enforcing a namespace label of origin.
 	// Applies only if enforcedNamespaceLabel set to true.
 	ExcludedFromEnforcement []ObjectReference `json:"excludedFromEnforcement,omitempty"`
+	// Maximum duration compacted blocks may span. For use in testing. (Defaults to 10% of the retention period.)
+	MaxBlockDuration string `json:"maxBlockDuration,omitempty"`
+	// Minimum duration of a data block before being persisted. For use in testing.
+	MinBlockDuration string `json:"minBlockDuration,omitempty"`
 }
 
 // +genclient

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -380,6 +380,14 @@ func makeStatefulSetSpec(
 		}
 	}
 
+	if p.Spec.MaxBlockDuration != "" {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: p.Spec.MaxBlockDuration})
+	}
+
+	if p.Spec.MinBlockDuration != "" {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: p.Spec.MinBlockDuration})
+	}
+
 	if p.Spec.Query != nil {
 		if p.Spec.Query.LookbackDelta != nil {
 			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.lookback-delta", Value: *p.Spec.Query.LookbackDelta})

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1901,6 +1901,58 @@ func TestTerminationPolicy(t *testing.T) {
 	}
 }
 
+func TestMaxBlockDuration(t *testing.T) {
+	const maxBlockDuration = "6m"
+	sset, err := makeStatefulSet(newLogger(), "test", monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				MaxBlockDuration: maxBlockDuration,
+			},
+		},
+	}, defaultTestConfig, nil, "", 0, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	found := false
+	for _, flag := range sset.Spec.Template.Spec.Containers[0].Args {
+		if flag == "--storage.tsdb.max-block-duration=6m" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("Prometheus storage.tsdb.max-block-duration is not correctly set.")
+	}
+}
+
+func TestMinBlockDuration(t *testing.T) {
+	const minBlockDuration = "2h"
+	sset, err := makeStatefulSet(newLogger(), "test", monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				MinBlockDuration: minBlockDuration,
+			},
+		},
+	}, defaultTestConfig, nil, "", 0, nil)
+
+	if err != nil {
+		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
+	}
+
+	found := false
+	for _, flag := range sset.Spec.Template.Spec.Containers[0].Args {
+		if flag == "--storage.tsdb.min-block-duration=2h" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("Prometheus storage.tsdb.min-block-duration is not correctly set.")
+	}
+}
+
 func TestEnableFeaturesWithOneFeature(t *testing.T) {
 	sset, err := makeStatefulSet(newLogger(), "test", monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{


### PR DESCRIPTION
Signed-off-by: Zemtsov Vladimir <vl.zemtsov@gmail.com>

## Description

Allow users to control Prometheus flags `--storage.tsdb.max-block-duration` and `--storage.tsdb.min-block-duration`.

Issue - https://github.com/prometheus-operator/prometheus-operator/issues/4414


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


```release-note
Add MaxBlockDuration and MinBlockDuration fields to the Prometheus CRD for control Prometheus flags `--storage.tsdb.max-block-duration` and `--storage.tsdb.min-block-duration`
```
