### PR TITLE
Optimizing addition secret list perform scene

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1958,11 +1958,13 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return errors.Wrap(err, "selecting Probes failed")
 	}
 	sClient := c.kclient.CoreV1().Secrets(p.Namespace)
-	SecretsInPromNS, err := sClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+	var SecretsInPromNS = new(v1.SecretList)
+	if p.Spec.AdditionalAlertManagerConfigs != nil || p.Spec.AdditionalAlertRelabelConfigs != nil || p.Spec.AdditionalScrapeConfigs != nil {
+		SecretsInPromNS, err = sClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
 	}
-
 	for i, remote := range p.Spec.RemoteRead {
 		if err := store.AddBasicAuth(ctx, p.GetNamespace(), remote.BasicAuth, fmt.Sprintf("remoteRead/%d", i)); err != nil {
 			return errors.Wrapf(err, "remote read %d", i)


### PR DESCRIPTION
Signed-off-by: gaoxiang <gao_xiang@126.com>

## Description

In my env, my prometheus cr donot have addition secret , but every time code request  sClient.list. howerver my ns not just 
have monitor unit ,and have other resource. So I want to make a judgment here 



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Optimizing addition secret list perform scene
```
