### PR TITLE
Fixed secret and configmap volume names that need to be mounted in additional containers

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -514,7 +514,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 
 	rn := k8sutil.NewResourceNamerWithPrefix("secret")
 	for _, s := range a.Spec.Secrets {
-		name, err := rn.UniqueVolumeName(s)
+		name, err := rn.VolumeName(s)
 		if err != nil {
 			return nil, err
 		}
@@ -540,7 +540,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 
 	rn = k8sutil.NewResourceNamerWithPrefix("configmap")
 	for _, c := range a.Spec.ConfigMaps {
-		name, err := rn.UniqueVolumeName(c)
+		name, err := rn.VolumeName(c)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -569,10 +569,10 @@ func TestAdditionalSecretsMounted(t *testing.T) {
 	secret1Found = false
 	secret2Found = false
 	for _, v := range sset.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if strings.HasPrefix(v.Name, "secret-secret1-") && v.MountPath == "/etc/alertmanager/secrets/secret1" {
+		if v.Name == "secret-secret1" && v.MountPath == "/etc/alertmanager/secrets/secret1" {
 			secret1Found = true
 		}
-		if strings.HasPrefix(v.Name, "secret-secret2-") && v.MountPath == "/etc/alertmanager/secrets/secret2" {
+		if v.Name == "secret-secret2" && v.MountPath == "/etc/alertmanager/secrets/secret2" {
 			secret2Found = true
 		}
 	}
@@ -722,7 +722,7 @@ func TestAdditionalConfigMap(t *testing.T) {
 
 	cmVolumeFound := false
 	for _, v := range sset.Spec.Template.Spec.Volumes {
-		if strings.HasPrefix(v.Name, "configmap-test-cm1-") {
+		if v.Name == "configmap-test-cm1" {
 			cmVolumeFound = true
 			break
 		}
@@ -733,7 +733,7 @@ func TestAdditionalConfigMap(t *testing.T) {
 
 	cmMounted := false
 	for _, v := range sset.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if strings.HasPrefix(v.Name, "configmap-test-cm1-") && v.MountPath == "/etc/alertmanager/configmaps/test-cm1" {
+		if v.Name == "configmap-test-cm1" && v.MountPath == "/etc/alertmanager/configmaps/test-cm1" {
 			cmMounted = true
 			break
 		}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -43,19 +43,19 @@ func TestUniqueVolumeName(t *testing.T) {
 		},
 		{
 			name:     "NAME",
-			expected: "name-6c5f7b2e",
+			expected: "name-4cfd3574",
 		},
 		{
 			name:     "foo--",
-			expected: "foo-33bf00a8",
+			expected: "foo-e705c7c8",
 		},
 		{
 			name:     "foo^%#$bar",
-			expected: "foo-bar-6ab521af",
+			expected: "foo-bar-f3e212b1",
 		},
 		{
 			name:     "fOo^%#$bar",
-			expected: "foo-bar-6ab521af",
+			expected: "foo-bar-ee5c3c18",
 		},
 		{
 			name: strings.Repeat("a", validation.DNS1123LabelMaxLength*2),
@@ -65,18 +65,17 @@ func TestUniqueVolumeName(t *testing.T) {
 		{
 			prefix:   "with-prefix",
 			name:     "name",
-			expected: "with-prefix-name-fa429965",
+			expected: "with-prefix-name-6c5f7b2e",
 		},
 		{
 			prefix:   "with-prefix-",
 			name:     "name",
-			expected: "with-prefix-name-fa429965",
+			expected: "with-prefix-name-6c5f7b2e",
 		},
 		{
-			prefix: "with-prefix",
-			name:   strings.Repeat("a", validation.DNS1123LabelMaxLength*2),
-			expected: "with-prefix-" + strings.Repeat("a", 42) +
-				"-c183166e",
+			prefix:   "with-prefix",
+			name:     strings.Repeat("a", validation.DNS1123LabelMaxLength*2),
+			expected: "with-prefix-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-4ed69ce2",
 		},
 	}
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -582,7 +582,7 @@ func makeStatefulSetSpec(
 
 	rn := k8sutil.NewResourceNamerWithPrefix("secret")
 	for _, s := range p.Spec.Secrets {
-		name, err := rn.UniqueVolumeName(s)
+		name, err := rn.VolumeName(s)
 		if err != nil {
 			return nil, err
 		}
@@ -604,7 +604,7 @@ func makeStatefulSetSpec(
 
 	rn = k8sutil.NewResourceNamerWithPrefix("configmap")
 	for _, c := range p.Spec.ConfigMaps {
-		name, err := rn.UniqueVolumeName(c)
+		name, err := rn.VolumeName(c)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -316,7 +316,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 									SubPath:   "web-config.yaml",
 								},
 								{
-									Name:      "secret-test-secret1-df14634a",
+									Name:      "secret-test-secret1",
 									ReadOnly:  true,
 									MountPath: "/etc/prometheus/secrets/test-secret1",
 									SubPath:   "",
@@ -374,7 +374,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 							},
 						},
 						{
-							Name: "secret-test-secret1-df14634a",
+							Name: "secret-test-secret1",
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "test-secret1",

--- a/pkg/webconfig/config_test.go
+++ b/pkg/webconfig/config_test.go
@@ -293,7 +293,7 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 				{
-					Name: "web-config-tls-secret-key-some-secret-38b2f493",
+					Name: "web-config-tls-secret-key-some-secret-3556f148",
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
 							SecretName: "some-secret",
@@ -301,7 +301,7 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 				{
-					Name: "web-config-tls-secret-cert-some-secret-a60e0a56",
+					Name: "web-config-tls-secret-cert-some-secret-3556f148",
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
 							SecretName: "some-secret",
@@ -309,7 +309,7 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 				{
-					Name: "web-config-tls-secret-client-ca-some-secret-3ec4509b",
+					Name: "web-config-tls-secret-client-ca-some-secret-3556f148",
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
 							SecretName: "some-secret",
@@ -327,7 +327,7 @@ func TestGetMountParameters(t *testing.T) {
 					SubPathExpr:      "",
 				},
 				{
-					Name:             "web-config-tls-secret-key-some-secret-38b2f493",
+					Name:             "web-config-tls-secret-key-some-secret-3556f148",
 					ReadOnly:         true,
 					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.key",
 					SubPath:          "tls.key",
@@ -335,7 +335,7 @@ func TestGetMountParameters(t *testing.T) {
 					SubPathExpr:      "",
 				},
 				{
-					Name:             "web-config-tls-secret-cert-some-secret-a60e0a56",
+					Name:             "web-config-tls-secret-cert-some-secret-3556f148",
 					ReadOnly:         true,
 					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.crt",
 					SubPath:          "tls.crt",
@@ -343,7 +343,7 @@ func TestGetMountParameters(t *testing.T) {
 					SubPathExpr:      "",
 				},
 				{
-					Name:             "web-config-tls-secret-client-ca-some-secret-3ec4509b",
+					Name:             "web-config-tls-secret-client-ca-some-secret-3556f148",
 					ReadOnly:         true,
 					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.client_ca",
 					SubPath:          "tls.client_ca",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -222,6 +222,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromNamespaceEnforcementExclusion":      testPromNamespaceEnforcementExclusion,
 		"PromQueryLogFile":                       testPromQueryLogFile,
 		"PromDegradedCondition":                  testPromDegradedConditionStatus,
+		"PromStrategicMergePatch":                testPromStrategicMergePatch,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -4486,6 +4486,53 @@ func testPromDegradedConditionStatus(t *testing.T) {
 	}
 }
 
+func testPromStrategicMergePatch(t *testing.T) {
+	t.Parallel()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: ns},
+		Type:       v1.SecretType("Opaque"),
+		Data:       map[string][]byte{},
+	}
+	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create secret: %s", err)
+	}
+
+	configmap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "configmap", Namespace: ns},
+		Data:       map[string]string{},
+	}
+	_, err = framework.KubeClient.CoreV1().ConfigMaps(ns).Create(context.Background(), configmap, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create configmap: %s", err)
+	}
+
+	p := framework.MakeBasicPrometheus(ns, "test", "", 1)
+	p.Spec.Secrets = []string{secret.Name}
+	p.Spec.ConfigMaps = []string{configmap.Name}
+	p.Spec.Containers = []v1.Container{{
+		Name:  "sidecar",
+		Image: "nginx",
+		// Ensure that the sidecar container can mount the additional secret and configmap.
+		VolumeMounts: []v1.VolumeMount{{
+			Name:      "secret-" + secret.Name,
+			MountPath: "/tmp/secret",
+		}, {
+			Name:      "configmap-" + configmap.Name,
+			MountPath: "/tmp/configmap",
+		}},
+	}}
+
+	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func isAlertmanagerDiscoveryWorking(ctx context.Context, ns, promSVCName, alertmanagerName string) func() (bool, error) {
 	return func() (bool, error) {
 		pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), alertmanager.ListOptions(alertmanagerName))


### PR DESCRIPTION
## Description

#4988 (84ffc50f68f619c0cb2e3e6999ea267a259b4635) introduced a change breaking users that pass additional secrets & configmaps and want to mount them in additional containers. In practice, the aforementioned commit appends a hash suffix to the volume name which makes it impossible for a user to reference the volume in a sidecar container.

This PR reverts to the old behavior for user-provided secrets/configmaps: the volume name is identical to the object name, except that invalid characters are replaced by `-` and the string is truncated to 63 chars.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed secret and configmap volume names that need to be mounted in additional containers.
```
