### PR TITLE
pkg/prometheus: add CAP_FOWNER capability to Thanos only if needed

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -779,8 +779,6 @@ func makeStatefulSetSpec(
 				AllowPrivilegeEscalation: &boolFalse,
 				ReadOnlyRootFilesystem:   &boolTrue,
 				Capabilities: &v1.Capabilities{
-					// The Thanos sidecar needs the CAP_FOWNER capability because it links block files as hard link.
-					Add:  []v1.Capability{"CAP_FOWNER"},
 					Drop: []v1.Capability{"ALL"},
 				},
 			},
@@ -825,6 +823,9 @@ func makeStatefulSetSpec(
 					SubPath:   subPathForStorage(p.Spec.Storage),
 				},
 			)
+
+			// The Thanos sidecar needs the CAP_FOWNER capability because it links block files as hard link.
+			container.SecurityContext.Capabilities.Add = append(container.SecurityContext.Capabilities.Add, "CAP_FOWNER")
 
 			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
 			// to avoid races during upload, if the uploads are configured.

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1050,9 +1050,9 @@ func TestThanosNoObjectStorage(t *testing.T) {
 		}
 	}
 
-	for _, vol := range sset.Spec.Template.Spec.Containers[2].VolumeMounts {
-		if vol.MountPath == storageDir {
-			t.Fatal("Prometheus data volume should not be mounted in the Thanos sidecar")
+	for _, addCap := range sset.Spec.Template.Spec.Containers[2].SecurityContext.Capabilities.Add {
+		if addCap == "CAP_FOWNER" {
+			t.Fatal("Thanos sidecar shouldn't have the CAP_FOWNER capability")
 		}
 	}
 }
@@ -1144,6 +1144,19 @@ func TestThanosObjectStorage(t *testing.T) {
 		}
 		if !found {
 			t.Fatal("Prometheus data volume should be mounted in the Thanos sidecar")
+		}
+	}
+
+	{
+		var found bool
+		for _, addCap := range sset.Spec.Template.Spec.Containers[2].SecurityContext.Capabilities.Add {
+			if addCap == "CAP_FOWNER" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("Thanos sidecar should have CAP_FOWNER capability")
 		}
 	}
 }


### PR DESCRIPTION
## Description

When configuring the Thanos sidecar to upload blocks to object storage, the container needs to the CAP_FOWNER capability. Otherwise it isn't required. This is a small improvement on top of #4931 to avoid granting more capabilities than needed.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Removed CAP_FOWNER capability for the Thanos sidecar if it isn't needed.
```
