### PR TITLE
feat: add observedGeneration attribute to the status conditions

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -7108,6 +7108,19 @@ string
 <p>Human-readable message indicating details for the condition&rsquo;s last transition.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>observedGeneration</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>observedGeneration represents the .metadata.generation that the condition was set based upon.
+For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.PrometheusConditionStatus">PrometheusConditionStatus

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -7116,7 +7116,7 @@ int64
 </em>
 </td>
 <td>
-<p>observedGeneration represents the .metadata.generation that the condition was set based upon.
+<p>ObservedGeneration represents the .metadata.generation that the condition was set based upon.
 For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
 with respect to the current state of the instance.</p>
 </td>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21375,6 +21375,14 @@ spec:
                       description: Human-readable message indicating details for the
                         condition's last transition.
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: Reason for the condition's last transition.
                       type: string

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21376,7 +21376,7 @@ spec:
                         condition's last transition.
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
+                      description: ObservedGeneration represents the .metadata.generation
                         that the condition was set based upon. For instance, if .metadata.generation
                         is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8709,6 +8709,14 @@ spec:
                       description: Human-readable message indicating details for the
                         condition's last transition.
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: Reason for the condition's last transition.
                       type: string

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8710,7 +8710,7 @@ spec:
                         condition's last transition.
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
+                      description: ObservedGeneration represents the .metadata.generation
                         that the condition was set based upon. For instance, if .metadata.generation
                         is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8709,6 +8709,14 @@ spec:
                       description: Human-readable message indicating details for the
                         condition's last transition.
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: Reason for the condition's last transition.
                       type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8710,7 +8710,7 @@ spec:
                         condition's last transition.
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
+                      description: ObservedGeneration represents the .metadata.generation
                         that the condition was set based upon. For instance, if .metadata.generation
                         is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -8004,7 +8004,7 @@
                           "type": "string"
                         },
                         "observedGeneration": {
-                          "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                          "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
                           "format": "int64",
                           "type": "integer"
                         },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -8003,6 +8003,11 @@
                           "description": "Human-readable message indicating details for the condition's last transition.",
                           "type": "string"
                         },
+                        "observedGeneration": {
+                          "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
                         "reason": {
                           "description": "Reason for the condition's last transition.",
                           "type": "string"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -630,6 +630,10 @@ type PrometheusCondition struct {
 	// Human-readable message indicating details for the condition's last transition.
 	// +optional
 	Message string `json:"message,omitempty"`
+	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the instance.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type PrometheusConditionType string

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -630,7 +630,7 @@ type PrometheusCondition struct {
 	// Human-readable message indicating details for the condition's last transition.
 	// +optional
 	Message string `json:"message,omitempty"`
-	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// ObservedGeneration represents the .metadata.generation that the condition was set based upon.
 	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
 	// with respect to the current state of the instance.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1565,6 +1565,7 @@ func (c *Operator) status(ctx context.Context, key string) error {
 			LastTransitionTime: metav1.Time{
 				Time: time.Now().UTC(),
 			},
+			ObservedGeneration: p.Generation,
 		}
 		messages []string
 	)
@@ -1639,6 +1640,7 @@ func (c *Operator) status(ctx context.Context, key string) error {
 		LastTransitionTime: metav1.Time{
 			Time: time.Now().UTC(),
 		},
+		ObservedGeneration: p.Generation,
 	}
 	reconciliationStatus, found := c.reconciliations.GetStatus(key)
 	if !found {

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -406,7 +406,10 @@ func (f *Framework) WaitForPrometheusReady(ctx context.Context, p *monitoringv1.
 				reconciled = &cond
 			}
 			if cond.ObservedGeneration != current.Generation {
-				pollErr = errors.Errorf("prometheus generation is not equal to conditions observed generation")
+				pollErr = errors.Errorf("observed generation %d for condition %s isn't equal to the state generation %d",
+					cond.ObservedGeneration,
+					cond.Type,
+					current.Generation)
 				return false, nil
 			}
 		}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -405,6 +405,10 @@ func (f *Framework) WaitForPrometheusReady(ctx context.Context, p *monitoringv1.
 			if cond.Type == monitoringv1.PrometheusReconciled {
 				reconciled = &cond
 			}
+			if cond.ObservedGeneration != current.Generation {
+				pollErr = errors.Errorf("prometheus generation is not equal to conditions observed generation")
+				return false, nil
+			}
 		}
 
 		if reconciled == nil {
@@ -427,12 +431,12 @@ func (f *Framework) WaitForPrometheusReady(ctx context.Context, p *monitoringv1.
 			return false, nil
 		}
 
-		if reconciled.Status != monitoringv1.PrometheusConditionTrue {
+		if available.Status != monitoringv1.PrometheusConditionTrue {
 			pollErr = errors.Errorf(
 				"expected Available condition to be 'True', got %q (reason %s, %q)",
-				reconciled.Status,
-				reconciled.Reason,
-				reconciled.Message,
+				available.Status,
+				available.Reason,
+				available.Message,
 			)
 			return false, nil
 		}


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._
This is adding a new `ObservedGeneration int64 `json:"observedGeneration,omitempty"` to the `PrometheusCondition`. 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
