### PR TITLE
Update webhook examples and docs to always use service port 443

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -63,10 +63,10 @@ spec:
         - mountPath: /etc/tls/private
           name: tls-certificates
           readOnly: true
-     volumes:
-     - name: tls-certificates
-       secret:
-         secretName: admission-webhook-certs
+      volumes:
+      - name: tls-certificates
+        secret:
+          secretName: admission-webhook-certs
 ```
 
 ## Webhook endpoints
@@ -213,8 +213,7 @@ webhook.
                "service": {
                   "name": "prometheus-operator-admission-webhook",
                   "namespace": "default",
-                  "path": "/convert",
-                  "port": 8443
+                  "path": "/convert"
                },
                "caBundle": "LS0tLS...LS0tCg=="
             },

--- a/example/admission-webhook/config-validating-webhook-configuration.yaml
+++ b/example/admission-webhook/config-validating-webhook-configuration.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: prometheus-operator-alertmanager-config-validation
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.59.0
+  annotations:
+    # If you're using cert-manager, this annotation injects the caBundle from the given certificate
+    cert-manager.io/inject-ca-from: "prometheus/prometheus-operator-admission-webhook-certs"
+webhooks:
+  - clientConfig:
+      service:
+        name: prometheus-operator-admission-webhook
+        namespace: prometheus
+        path: /admission-alertmanagerconfigs/validate
+    failurePolicy: Fail
+    name: alertmanagerconfigsvalidate.monitoring.coreos.com
+    namespaceSelector: {}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - alertmanagerconfigs
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None

--- a/example/admission-webhook/mutating-webhook-configuration.yaml
+++ b/example/admission-webhook/mutating-webhook-configuration.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prometheus-operator-rulesmutation
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.59.0
+  annotations:
+    # If you're using cert-manager, this annotation injects the caBundle from the given certificate
+    cert-manager.io/inject-ca-from: "prometheus/prometheus-operator-admission-webhook-certs"
+webhooks:
+  - clientConfig:
+      service:
+        name: prometheus-operator-admission-webhook
+        namespace: prometheus
+        path: /admission-prometheusrules/mutate
+    failurePolicy: Fail
+    name: prometheusrulemutate.monitoring.coreos.com
+    namespaceSelector: {}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - prometheusrules
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None

--- a/example/admission-webhook/rules-validating-webhook-configuration.yaml
+++ b/example/admission-webhook/rules-validating-webhook-configuration.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: prometheus-operator-rulesvalidation
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.59.0
+  annotations:
+    # If you're using cert-manager, this annotation injects the caBundle from the given certificate
+    cert-manager.io/inject-ca-from: "prometheus/prometheus-operator-admission-webhook-certs"
+webhooks:
+  - clientConfig:
+      service:
+        name: prometheus-operator-admission-webhook
+        namespace: prometheus
+        path: /admission-prometheusrules/validate
+    failurePolicy: Fail
+    name: prometheusrulemutate.monitoring.coreos.com
+    namespaceSelector: {}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - prometheusrules
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None

--- a/example/admission-webhook/service.yaml
+++ b/example/admission-webhook/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - name: https
-    port: 8443
+    port: 443
     targetPort: https
   selector:
     app.kubernetes.io/name: prometheus-operator-admission-webhook

--- a/example/alertmanager-crd-conversion/patch.json
+++ b/example/alertmanager-crd-conversion/patch.json
@@ -3,7 +3,8 @@
    "kind": "CustomResourceDefinition",
    "metadata": {
       "annotations": {
-         "controller-gen.kubebuilder.io/version": "v0.9.2"
+         "controller-gen.kubebuilder.io/version": "v0.9.2",
+         "cert-manager.io/inject-ca-from": "prometheus/prometheus-operator-admission-webhook-certs"
       },
       "creationTimestamp": null,
       "name": "alertmanagerconfigs.monitoring.coreos.com"
@@ -16,8 +17,7 @@
                "service": {
                   "name": "prometheus-operator-admission-webhook",
                   "namespace": "default",
-                  "path": "/convert",
-                  "port": 8443
+                  "path": "/convert"
                }
             },
             "conversionReviewVersions": [


### PR DESCRIPTION
## Description

While setting this up I noticed that the examples used a mix of not specifying the port (meaning apiserver uses port 443) and specifying port 8443.  

This meant that following the examples resulted in a broken setup because api server was connecting to an undefined port 443 on the service for the webhooks.

Since there were more cases of the default port, my suggestion here is to standardize on that for the docs and examples.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `BUGFIX` (non-breaking change which fixes an issue)

## Changelog entry

```release-note
- Fix examples / docs for webhook to consistently use the same service port (443)
```
