### PR TITLE
feat : enable support for "hostNetwork" in Prometheus CRD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2125,6 +2125,19 @@ Applies only if enforcedNamespaceLabel set to true.</p>
 </tr>
 <tr>
 <td>
+<code>hostNetwork</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Use the host&rsquo;s network namespace if true.
+Make sure to understand the security implications if you want to enable it.
+When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code><br/>
 <em>
 string
@@ -5661,6 +5674,19 @@ to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>hostNetwork</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Use the host&rsquo;s network namespace if true.
+Make sure to understand the security implications if you want to enable it.
+When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.Duration">Duration
@@ -8856,6 +8882,19 @@ only available in versions of Prometheus &gt;= 2.11.0.</p>
 <p>List of references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
 to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostNetwork</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Use the host&rsquo;s network namespace if true.
+Make sure to understand the security implications if you want to enable it.
+When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15568,6 +15568,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - ip
                 x-kubernetes-list-type: map
+              hostNetwork:
+                description: Use the host's network namespace if true. Make sure to
+                  understand the security implications if you want to enable it. When
+                  hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                  automatically.
+                type: boolean
               ignoreNamespaceSelectors:
                 description: IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector
                   settings from all PodMonitor, ServiceMonitor and Probe objects.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -2888,6 +2888,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - ip
                 x-kubernetes-list-type: map
+              hostNetwork:
+                description: Use the host's network namespace if true. Make sure to
+                  understand the security implications if you want to enable it. When
+                  hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                  automatically.
+                type: boolean
               ignoreNamespaceSelectors:
                 description: IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector
                   settings from all PodMonitor, ServiceMonitor and Probe objects.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -2888,6 +2888,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - ip
                 x-kubernetes-list-type: map
+              hostNetwork:
+                description: Use the host's network namespace if true. Make sure to
+                  understand the security implications if you want to enable it. When
+                  hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                  automatically.
+                type: boolean
               ignoreNamespaceSelectors:
                 description: IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector
                   settings from all PodMonitor, ServiceMonitor and Probe objects.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2636,6 +2636,10 @@
                     ],
                     "x-kubernetes-list-type": "map"
                   },
+                  "hostNetwork": {
+                    "description": "Use the host's network namespace if true. Make sure to understand the security implications if you want to enable it. When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.",
+                    "type": "boolean"
+                  },
                   "ignoreNamespaceSelectors": {
                     "description": "IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector settings from all PodMonitor, ServiceMonitor and Probe objects. They will only discover endpoints within the namespace of the PodMonitor, ServiceMonitor and Probe objects. Defaults to false.",
                     "type": "boolean"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -336,6 +336,10 @@ type CommonPrometheusFields struct {
 	// to be excluded from enforcing a namespace label of origin.
 	// Applies only if enforcedNamespaceLabel set to true.
 	ExcludedFromEnforcement []ObjectReference `json:"excludedFromEnforcement,omitempty"`
+	// Use the host's network namespace if true.
+	// Make sure to understand the security implications if you want to enable it.
+	// When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 // +genclient

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -215,6 +215,10 @@ func makeStatefulSet(
 
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, p.Spec.Volumes...)
 
+	if p.Spec.HostNetwork {
+		statefulset.Spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	}
+
 	return statefulset, nil
 }
 
@@ -1011,6 +1015,7 @@ func makeStatefulSetSpec(
 				Affinity:                      p.Spec.Affinity,
 				TopologySpreadConstraints:     p.Spec.TopologySpreadConstraints,
 				HostAliases:                   operator.MakeHostAliases(p.Spec.HostAliases),
+				HostNetwork:                   p.Spec.HostNetwork,
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Description

Enabled support for "hostNetwork" in Prometheus Operator for Prometheus

Needed in many scenarios like:
1. To bypass the CNI network
2. In general to reduce the metrics traffic overhead on CNI network in clusters with large no of Nodes.


Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._


<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat : enable support for "hostNetwork" in Prometheus CRD
```

Fixes #2630 