### PR TITLE
fix: thanos-sidecar fowner capabilities

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -824,8 +824,8 @@ func makeStatefulSetSpec(
 				},
 			)
 
-			// The Thanos sidecar needs the CAP_FOWNER capability because it links block files as hard link.
-			container.SecurityContext.Capabilities.Add = append(container.SecurityContext.Capabilities.Add, "CAP_FOWNER")
+			// The Thanos sidecar needs the FOWNER capability because it links block files as hard link.
+			container.SecurityContext.Capabilities.Add = append(container.SecurityContext.Capabilities.Add, "FOWNER")
 
 			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
 			// to avoid races during upload, if the uploads are configured.

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1051,8 +1051,8 @@ func TestThanosNoObjectStorage(t *testing.T) {
 	}
 
 	for _, addCap := range sset.Spec.Template.Spec.Containers[2].SecurityContext.Capabilities.Add {
-		if addCap == "CAP_FOWNER" {
-			t.Fatal("Thanos sidecar shouldn't have the CAP_FOWNER capability")
+		if addCap == "FOWNER" {
+			t.Fatal("Thanos sidecar shouldn't have the FOWNER capability")
 		}
 	}
 }
@@ -1150,13 +1150,13 @@ func TestThanosObjectStorage(t *testing.T) {
 	{
 		var found bool
 		for _, addCap := range sset.Spec.Template.Spec.Containers[2].SecurityContext.Capabilities.Add {
-			if addCap == "CAP_FOWNER" {
+			if addCap == "FOWNER" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Fatal("Thanos sidecar should have CAP_FOWNER capability")
+			t.Fatal("Thanos sidecar should have FOWNER capability")
 		}
 	}
 }


### PR DESCRIPTION
## Description
The capability added for fixing #4928 is not working, since it needs to be specified without the `CAP_` prefix as stated on [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix: this remove the CAP_ prefix of the FOWNER capability on thanos-sidecar
```
