### PR TITLE
test: re-add e2e test for Prometheus Operator upgrade path

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,31 +14,42 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: [alertmanager, prometheus, prometheusAllNS, thanosruler]
+        suite: [alertmanager, prometheus, prometheusAllNS, thanosruler, operatorUpgrade]
         include:
           - suite: alertmanager
             prometheus: "exclude"
             prometheusAllNS: "exclude"
             alertmanager: ""
             thanosruler: "exclude"
+            operatorUpgrade: "exclude"
             featureGated: "include"
           - suite: prometheus
             prometheus: ""
             prometheusAllNS: "exclude"
             alertmanager: "exclude"
             thanosruler: "exclude"
+            operatorUpgrade: "exclude"
             featureGated: "include"
           - suite: prometheusAllNS
             prometheus: "exclude"
             prometheusAllNS: ""
             alertmanager: "exclude"
             thanosruler: "exclude"
+            operatorUpgrade: "exclude"
             featureGated: "include"
           - suite: thanosruler
             prometheus: "exclude"
             prometheusAllNS: "exclude"
             alertmanager: "exclude"
             thanosruler: ""
+            operatorUpgrade: "exclude"
+            featureGated: "include"
+          - suite: operatorUpgrade
+            prometheus: "exclude"
+            prometheusAllNS: "exclude"
+            alertmanager: "exclude"
+            thanosruler: "exclude"
+            operatorUpgrade: ""
             featureGated: "include"
     steps:
     - uses: actions/checkout@v3
@@ -76,6 +87,7 @@ jobs:
         EXCLUDE_PROMETHEUS_TESTS=${{ matrix.prometheus }}
         EXCLUDE_PROMETHEUS_ALL_NS_TESTS=${{ matrix.prometheusAllNS }}
         EXCLUDE_THANOSRULER_TESTS=${{ matrix.thanosruler }}
+        EXCLUDE_OPERATOR_UPGRADE_TESTS=${{ matrix.operatorUpgrade }}
         FEATURE_GATED_TESTS=${{ matrix.featureGated }}
         make test-e2e
 

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -45,7 +45,7 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 	nonInstanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, nil, nil, []string{instanceNs}, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, nil, nil, []string{instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func testAlertmanagerInstanceNamespacesDenyNs(t *testing.T) {
 	instanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, []string{instanceNs}, nil, []string{instanceNs}, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, []string{instanceNs}, nil, []string{instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 	}
 
 	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{"notfound", allowedNs}, nil, nil, []string{"notfound", instanceNs}, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, []string{"notfound", allowedNs}, nil, nil, []string{"notfound", instanceNs}, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -198,7 +198,7 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,7 +240,7 @@ func testAMClusterInitialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, alertmanagerService); err != nil {
 		t.Fatal(err)
 	}
 
@@ -562,7 +562,7 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	if err := framework.CreateDeployment(context.Background(), ns, whdpl); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, whsvc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, whsvc); err != nil {
 		t.Fatal(err)
 	}
 	err := framework.WaitForPodsReady(context.Background(), ns, time.Minute*5, 1,
@@ -620,7 +620,7 @@ inhibit_rules:
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1821,7 +1821,7 @@ func testAMWeb(t *testing.T) {
 	}
 
 	kubeClient := framework.KubeClient
-	if err := framework.CreateSecretWithCert(context.Background(), certBytes, keyBytes, ns, "web-tls"); err != nil {
+	if err := framework.CreateOrUpdateSecretWithCert(context.Background(), certBytes, keyBytes, ns, "web-tls"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -37,7 +37,7 @@ func testDenyPrometheus(t *testing.T) {
 
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNamespace, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func testDenyServiceMonitor(t *testing.T) {
 
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNamespace, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func testDenyServiceMonitor(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), denied, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), denied, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -155,7 +155,7 @@ func testDenyServiceMonitor(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("allowed", "allowed", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowed, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowed, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -204,7 +204,7 @@ func testDenyThanosRuler(t *testing.T) {
 
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, operatorNamespace)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNamespace, *opImage, nil, deniedNamespaces, nil, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNamespace, nil, deniedNamespaces, nil, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -17,10 +17,14 @@ package e2e
 import (
 	"context"
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +32,9 @@ import (
 )
 
 var (
-	framework *operatorFramework.Framework
-	opImage   *string
+	previousVersionFramework *operatorFramework.Framework
+	framework                *operatorFramework.Framework
+	opImage                  *string
 )
 
 func skipPrometheusAllNSTests(t *testing.T) {
@@ -53,6 +58,12 @@ func skipAlertmanagerTests(t *testing.T) {
 func skipThanosRulerTests(t *testing.T) {
 	if os.Getenv("EXCLUDE_THANOSRULER_TESTS") != "" {
 		t.Skip("Skipping ThanosRuler tests")
+	}
+}
+
+func skipOperatorUpgradeTests(t *testing.T) {
+	if os.Getenv("EXCLUDE_OPERATOR_UPGRADE_TESTS") != "" {
+		t.Skip("Skipping Operator upgrade tests")
 	}
 }
 
@@ -81,8 +92,53 @@ func TestMain(m *testing.M) {
 		exitCode int
 	)
 
-	if framework, err = operatorFramework.New(*kubeconfig, *opImage); err != nil {
-		log.Printf("failed to setup framework: %v\n", err)
+	logger := log.New(os.Stdout, "", log.Lshortfile)
+
+	currentVersion, err := os.ReadFile("../../VERSION")
+	if err != nil {
+		logger.Printf("failed to read version file: %v\n", err)
+		os.Exit(1)
+	}
+	currentSemVer, err := semver.ParseTolerant(string(currentVersion))
+	if err != nil {
+		logger.Printf("failed to parse current version: %v\n", err)
+		os.Exit(1)
+	}
+
+	prevStableVersionURL := fmt.Sprintf("https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-%d.%d/VERSION", currentSemVer.Major, currentSemVer.Minor-1)
+	reader, err := operatorFramework.URLToIOReader(prevStableVersionURL)
+	if err != nil {
+		logger.Printf("failed to get previous version file content: %v\n", err)
+		os.Exit(1)
+	}
+
+	prevStableVersion, err := io.ReadAll(reader)
+	if err != nil {
+		logger.Printf("failed to read previous stable version: %v\n", err)
+		os.Exit(1)
+	}
+
+	prometheusOperatorGithubBranchURL := "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator"
+
+	prevSemVer, err := semver.ParseTolerant(string(prevStableVersion))
+	if err != nil {
+		logger.Printf("failed to parse previous stable version: %v\n", err)
+		os.Exit(1)
+	}
+	prevStableOpImage := fmt.Sprintf("%s:v%s", "quay.io/prometheus-operator/prometheus-operator", strings.TrimSpace(string(prevStableVersion)))
+	prevExampleDir := fmt.Sprintf("%s/release-%d.%d/example", prometheusOperatorGithubBranchURL, prevSemVer.Major, prevSemVer.Minor)
+	prevResourcesDir := fmt.Sprintf("%s/release-%d.%d/test/framework/resources", prometheusOperatorGithubBranchURL, prevSemVer.Major, prevSemVer.Minor)
+
+	if previousVersionFramework, err = operatorFramework.New(*kubeconfig, prevStableOpImage, prevExampleDir, prevResourcesDir, prevSemVer); err != nil {
+		logger.Printf("failed to setup previous version framework: %v\n", err)
+		os.Exit(1)
+	}
+
+	exampleDir := "../../example"
+	resourcesDir := "../framework/resources"
+
+	if framework, err = operatorFramework.New(*kubeconfig, *opImage, exampleDir, resourcesDir, currentSemVer); err != nil {
+		logger.Printf("failed to setup framework: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -99,7 +155,7 @@ func TestAllNS(t *testing.T) {
 
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 
-	finalizers, err := framework.CreatePrometheusOperator(context.Background(), ns, *opImage, nil, nil, nil, nil, true, true)
+	finalizers, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, nil, nil, nil, nil, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,6 +348,18 @@ func TestAlertmanagerInstanceNs(t *testing.T) {
 		"AllNs":     testAlertmanagerInstanceNamespacesAllNs,
 		"AllowList": testAlertmanagerInstanceNamespacesAllowList,
 		"DenyNs":    testAlertmanagerInstanceNamespacesDenyNs,
+	}
+
+	for name, f := range testFuncs {
+		t.Run(name, f)
+	}
+}
+
+// TestOperatorUpgrade tests the prometheus upgrade from previous stable minor version to current version
+func TestOperatorUpgrade(t *testing.T) {
+	skipOperatorUpgradeTests(t)
+	testFuncs := map[string]func(t *testing.T){
+		"OperatorUpgrade": testOperatorUpgrade,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -137,7 +137,14 @@ func TestMain(m *testing.M) {
 	exampleDir := "../../example"
 	resourcesDir := "../framework/resources"
 
-	if framework, err = operatorFramework.New(*kubeconfig, *opImage, exampleDir, resourcesDir, currentSemVer); err != nil {
+	nextSemVer, err := semver.ParseTolerant(fmt.Sprintf("0.%d.0", currentSemVer.Minor))
+	if err != nil {
+		logger.Printf("failed to parse next version: %v\n", err)
+		os.Exit(1)
+	}
+
+	// init with next minor version since we are developing toward it.
+	if framework, err = operatorFramework.New(*kubeconfig, *opImage, exampleDir, resourcesDir, nextSemVer); err != nil {
 		logger.Printf("failed to setup framework: %v\n", err)
 		os.Exit(1)
 	}

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -33,7 +33,7 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 	nonInstanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, nil, []string{instanceNs}, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, nil, []string{instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), deniedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), deniedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -162,7 +162,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -215,7 +215,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{allowedNs}, nil, []string{instanceNs}, nil, false, false)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, []string{allowedNs}, nil, []string{instanceNs}, nil, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -280,7 +280,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -369,7 +369,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	}
 
 	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
-	_, err := framework.CreatePrometheusOperator(context.Background(), operatorNs, *opImage, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -419,7 +419,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 		}
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -235,7 +235,7 @@ func createK8sSampleApp(t *testing.T, name, ns string) {
 		},
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -288,7 +288,7 @@ func createK8sAppMonitoring(name, ns string, prwtc testFramework.PromRemoteWrite
 		return nil, "", err
 	}
 	prometheusReceiverSvc := framework.MakePrometheusService(receiverName, receiverName, v1.ServiceTypeClusterIP)
-	if _, err = framework.CreateServiceAndWaitUntilReady(context.Background(), ns, prometheusReceiverSvc); err != nil {
+	if _, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, prometheusReceiverSvc); err != nil {
 		return nil, "", err
 	}
 	prometheusReceiverURL := "https://" + prometheusReceiverSvc.Name + ":9090/api/v1/write"
@@ -301,7 +301,7 @@ func createK8sAppMonitoring(name, ns string, prwtc testFramework.PromRemoteWrite
 	}
 
 	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
-	if _, err = framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
+	if _, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
 		return nil, "", err
 	}
 
@@ -1117,7 +1117,7 @@ scrape_configs:
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1205,7 +1205,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1263,7 +1263,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1321,7 +1321,7 @@ func testPromReloadRules(t *testing.T) {
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1379,7 +1379,7 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1435,7 +1435,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 	}
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), rootNS, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), rootNS, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1506,7 +1506,7 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 	}()
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -1758,7 +1758,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 	}
 
 	pSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2049,7 +2049,7 @@ func testPromDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2087,7 +2087,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 		}
 
 		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 			t.Fatal(err)
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -2142,7 +2142,7 @@ func testShardingProvisioning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2213,7 +2213,7 @@ func testResharding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2298,7 +2298,7 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2318,7 +2318,7 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating Alertmanager service failed"))
 	}
 
@@ -2342,7 +2342,7 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 		t.Fatal("Creating prometheus failed: ", err)
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, service); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, service); err != nil {
 		t.Fatal("Creating prometheus service failed: ", err)
 	}
 
@@ -2396,7 +2396,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2452,7 +2452,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), prometheusNSName, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), prometheusNSName, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -2518,7 +2518,7 @@ func testThanos(t *testing.T) {
 	}
 
 	qrySvc := framework.MakeThanosQuerierService(qryDep.Name)
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, qrySvc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, qrySvc); err != nil {
 		t.Fatal("Creating Thanos query service failed: ", err)
 	}
 
@@ -2690,7 +2690,7 @@ func testPromGetAuthSecret(t *testing.T) {
 			}
 
 			sm := test.serviceMonitor()
-			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), testNamespace, svc); err != nil {
+			if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), testNamespace, svc); err != nil {
 				t.Fatal(err)
 			} else {
 				testCtx.AddFinalizerFn(finalizerFn)
@@ -2739,7 +2739,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches single namespace mainNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(context.Background(), operatorNS, *opImage, []string{mainNS}, nil, nil, nil, false, true)
+		_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNS, []string{mainNS}, nil, nil, nil, false, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2767,7 +2767,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), mainNS, pSVC); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), mainNS, pSVC); err != nil {
 			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -2810,7 +2810,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		// Prometheus Operator only watches prometheusNS and ruleNS, not arbitraryNS.
-		_, err := framework.CreatePrometheusOperator(context.Background(), operatorNS, *opImage, []string{prometheusNS, ruleNS}, nil, nil, nil, false, true)
+		_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNS, []string{prometheusNS, ruleNS}, nil, nil, nil, false, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2838,7 +2838,7 @@ func testOperatorNSScope(t *testing.T) {
 		}
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
-		if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), prometheusNS, pSVC); err != nil {
+		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), prometheusNS, pSVC); err != nil {
 			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
@@ -3093,7 +3093,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 			}
 
 			svc := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
-			if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+			if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3234,7 +3234,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3282,7 +3282,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 
 	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
 
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3329,7 +3329,7 @@ func testPromStaticProbe(t *testing.T) {
 	}
 
 	blackboxSvc := framework.MakeBlackBoxExporterService(ns, blackboxExporterName)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, blackboxSvc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, blackboxSvc); err != nil {
 		t.Fatal("creating blackbox exporter service failed ", err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -3357,7 +3357,7 @@ func testPromStaticProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
@@ -3635,7 +3635,7 @@ func testPromWebWithThanosSidecar(t *testing.T) {
 	}
 
 	kubeClient := framework.KubeClient
-	if err := framework.CreateSecretWithCert(context.Background(), certBytes, keyBytes, ns, "web-tls"); err != nil {
+	if err := framework.CreateOrUpdateSecretWithCert(context.Background(), certBytes, keyBytes, ns, "web-tls"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3947,7 +3947,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+			if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 				t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 			} else {
 				ctx.AddFinalizerFn(finalizerFn)
@@ -4099,7 +4099,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+			if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 				t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
 			} else {
 				ctx.AddFinalizerFn(finalizerFn)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -60,7 +60,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	}
 
 	svc := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
-	if _, err := framework.CreateServiceAndWaitUntilReady(context.Background(), thanosNamespace, svc); err != nil {
+	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), thanosNamespace, svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,7 +91,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	}
 
 	thanosService := framework.MakeThanosRulerService(thanos.Name, "not-relevant", v1.ServiceTypeClusterIP)
-	if finalizerFn, err := framework.CreateServiceAndWaitUntilReady(context.Background(), thanosNamespace, thanosService); err != nil {
+	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), thanosNamespace, thanosService); err != nil {
 		t.Fatalf("creating Thanos ruler service failed: %v", err)
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)

--- a/test/e2e/upgradepath_test.go
+++ b/test/e2e/upgradepath_test.go
@@ -1,0 +1,197 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func testOperatorUpgrade(t *testing.T) {
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+
+	// Delete cluster wide resources to make sure the environment is clean
+	err := framework.DeletePrometheusOperatorClusterResource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Prometheus Operator with previous stable minor version
+	_, err = previousVersionFramework.CreateOrUpdatePrometheusOperator(context.Background(), ns, nil, nil, nil, nil, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := "operator-upgrade"
+
+	// Create Alertmanager, Prometheus, Thanosruler services with selector labels promised by Prometheus Operator
+	alertmanagerService := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("alertmanager-%s", name),
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9093,
+					TargetPort: intstr.FromString("web"),
+				},
+			},
+			Selector: map[string]string{
+				"app.kubernetes.io/name":       "alertmanager",
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+				"app.kubernetes.io/instance":   name,
+				"alertmanager":                 name,
+			},
+		},
+	}
+
+	prometheusService := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("prometheus-%s", name),
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+			},
+			Selector: map[string]string{
+				"app.kubernetes.io/name":       "prometheus",
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+				"app.kubernetes.io/instance":   name,
+				"prometheus":                   name,
+				"operator.prometheus.io/shard": "0",
+				"operator.prometheus.io/name":  name,
+			},
+		},
+	}
+
+	thanosRulerService := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("thanos-ruler-%s", name),
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+			},
+			Selector: map[string]string{
+				"app.kubernetes.io/name":       "thanos-ruler",
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+				"app.kubernetes.io/instance":   name,
+				"thanos-ruler":                 name,
+			},
+		},
+	}
+
+	alertmanager := previousVersionFramework.MakeBasicAlertmanager(name, 1)
+	_, err = previousVersionFramework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, alertmanager)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = previousVersionFramework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, &alertmanagerService)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousVersionFramework.SetupPrometheusRBAC(context.Background(), t, nil, ns)
+	prometheus := previousVersionFramework.MakeBasicPrometheus(ns, name, name, 1)
+
+	_, err = previousVersionFramework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, previousVersionFramework.MakeBasicPrometheus(ns, name, name, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = previousVersionFramework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, &prometheusService)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	thanosRuler := previousVersionFramework.MakeBasicThanosRuler(name, 1, "http://test.example.com")
+	_, err = previousVersionFramework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanosRuler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = previousVersionFramework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, &thanosRulerService)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+	// Update Prometheus Operator to current version
+	finalizers, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, nil, nil, nil, nil, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range finalizers {
+		testCtx.AddFinalizerFn(f)
+	}
+
+	// Wait for the updated Prometheus Operator to take effect on Alertmanager, Prometheus, and ThanosRuler.
+	time.Sleep(time.Minute)
+
+	err = framework.WaitForAlertmanagerReady(context.Background(), ns, alertmanager, int(*alertmanager.Spec.Replicas))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = framework.WaitForServiceReady(context.Background(), ns, alertmanagerService.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = framework.WaitForPrometheusReady(context.Background(), prometheus, 5*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = framework.WaitForServiceReady(context.Background(), ns, prometheusService.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = framework.WaitForThanosRulerReady(thanosRuler, 5*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = framework.WaitForServiceReady(context.Background(), ns, thanosRulerService.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/framework/admission-webhooks.go
+++ b/test/framework/admission-webhooks.go
@@ -19,44 +19,79 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) createMutatingHook(ctx context.Context, certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
-	h, err := parseMutatingHookYaml(yamlPath)
+func (f *Framework) createOrUpdateMutatingHook(ctx context.Context, certBytes []byte, namespace, source string) (FinalizerFn, error) {
+	hook, err := parseMutatingHookYaml(source)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed parsing mutating webhook")
 	}
 
-	h.Webhooks[0].ClientConfig.Service.Namespace = namespace
-	h.Webhooks[0].ClientConfig.CABundle = certBytes
+	hook.Webhooks[0].ClientConfig.Service.Namespace = namespace
+	hook.Webhooks[0].ClientConfig.CABundle = certBytes
 
-	_, err = f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, h, metav1.CreateOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create mutating webhook %s", h.Name)
+	h, err := f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, hook.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, errors.Wrapf(err, "failed to get mutating webhook %s", hook.Name)
 	}
 
-	finalizerFn := func() error { return f.deleteMutatingWebhook(ctx, h.Name) }
+	if apierrors.IsNotFound(err) {
+		// MutatingWebhookConfiguration doesn't exists -> Create
+		_, err = f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, hook, metav1.CreateOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create mutating webhook %s", hook.Name)
+		}
+	} else {
+		// must set this field from existing MutatingWebhookConfiguration to prevent update fail
+		hook.ObjectMeta.ResourceVersion = h.ObjectMeta.ResourceVersion
+
+		// MutatingWebhookConfiguration already exists -> Update
+		_, err = f.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, hook, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update mutating webhook %s", hook.Name)
+		}
+	}
+
+	finalizerFn := func() error { return f.deleteMutatingWebhook(ctx, hook.Name) }
 
 	return finalizerFn, nil
 }
 
-func (f *Framework) createValidatingHook(ctx context.Context, certBytes []byte, namespace, yamlPath string) (FinalizerFn, error) {
-	h, err := parseValidatingHookYaml(yamlPath)
+func (f *Framework) createOrUpdateValidatingHook(ctx context.Context, certBytes []byte, namespace, source string) (FinalizerFn, error) {
+	hook, err := parseValidatingHookYaml(source)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed parsing validating webhook")
 	}
 
-	h.Webhooks[0].ClientConfig.Service.Namespace = namespace
-	h.Webhooks[0].ClientConfig.CABundle = certBytes
+	hook.Webhooks[0].ClientConfig.Service.Namespace = namespace
+	hook.Webhooks[0].ClientConfig.CABundle = certBytes
 
-	_, err = f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, h, metav1.CreateOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create validating webhook %s", h.Name)
+	h, err := f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, hook.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, errors.Wrapf(err, "failed to get validating webhook %s", hook.Name)
 	}
 
-	finalizerFn := func() error { return f.deleteValidatingWebhook(ctx, h.Name) }
+	if apierrors.IsNotFound(err) {
+		// ValidatingWebhookConfiguration doesn't exists -> Create
+		_, err = f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, hook, metav1.CreateOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create validating webhook %s", hook.Name)
+		}
+	} else {
+		// must set this field from existing ValidatingWebhookConfiguration to prevent update fail
+		hook.ObjectMeta.ResourceVersion = h.ObjectMeta.ResourceVersion
+
+		// ValidatingWebhookConfiguration already exists -> Update
+		_, err = f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(ctx, hook, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update validating webhook %s", hook.Name)
+		}
+	}
+
+	finalizerFn := func() error { return f.deleteValidatingWebhook(ctx, hook.Name) }
 
 	return finalizerFn, nil
 }
@@ -69,29 +104,29 @@ func (f *Framework) deleteValidatingWebhook(ctx context.Context, name string) er
 	return f.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-func parseValidatingHookYaml(pathToYaml string) (*v1.ValidatingWebhookConfiguration, error) {
-	manifest, err := PathToOSFile(pathToYaml)
+func parseValidatingHookYaml(source string) (*v1.ValidatingWebhookConfiguration, error) {
+	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
 
 	resource := v1.ValidatingWebhookConfiguration{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&resource); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode file %s", pathToYaml)
+		return nil, errors.Wrapf(err, "failed to decode file %s", source)
 	}
 
 	return &resource, nil
 }
 
-func parseMutatingHookYaml(pathToYaml string) (*v1.MutatingWebhookConfiguration, error) {
-	manifest, err := PathToOSFile(pathToYaml)
+func parseMutatingHookYaml(source string) (*v1.MutatingWebhookConfiguration, error) {
+	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
 
 	resource := v1.MutatingWebhookConfiguration{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&resource); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode file %s", pathToYaml)
+		return nil, errors.Wrapf(err, "failed to decode file %s", source)
 	}
 
 	return &resource, nil

--- a/test/framework/cluster_role_binding.go
+++ b/test/framework/cluster_role_binding.go
@@ -16,14 +16,16 @@ package framework
 
 import (
 	"context"
+
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) createClusterRoleBinding(ctx context.Context, ns string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return f.DeleteClusterRoleBinding(ctx, ns, relativePath) }
-	clusterRoleBinding, err := parseClusterRoleBindingYaml(relativePath)
+func (f *Framework) createOrUpdateClusterRoleBinding(ctx context.Context, ns string, source string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteClusterRoleBinding(ctx, ns, source) }
+	clusterRoleBinding, err := parseClusterRoleBindingYaml(source)
 	if err != nil {
 		return finalizerFn, err
 	}
@@ -35,16 +37,19 @@ func (f *Framework) createClusterRoleBinding(ctx context.Context, ns string, rel
 	clusterRoleBinding.Subjects[0].Namespace = ns
 
 	_, err = f.KubeClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return finalizerFn, err
+	}
 
-	if err == nil {
-		// ClusterRoleBinding already exists -> Update
-		_, err = f.KubeClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
+	if apierrors.IsNotFound(err) {
+		// ClusterRoleBinding doesn't exists -> Create
+		_, err = f.KubeClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
 	} else {
-		// ClusterRoleBinding doesn't exists -> Create
-		_, err = f.KubeClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		// ClusterRoleBinding already exists -> Update
+		_, err = f.KubeClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
 		if err != nil {
 			return finalizerFn, err
 		}
@@ -53,8 +58,8 @@ func (f *Framework) createClusterRoleBinding(ctx context.Context, ns string, rel
 	return finalizerFn, err
 }
 
-func (f *Framework) DeleteClusterRoleBinding(ctx context.Context, ns string, relativePath string) error {
-	clusterRoleBinding, err := parseClusterRoleYaml(relativePath)
+func (f *Framework) DeleteClusterRoleBinding(ctx context.Context, ns string, source string) error {
+	clusterRoleBinding, err := parseClusterRoleYaml(source)
 	if err != nil {
 		return err
 	}
@@ -66,8 +71,8 @@ func (f *Framework) DeleteClusterRoleBinding(ctx context.Context, ns string, rel
 	return f.KubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{})
 }
 
-func parseClusterRoleBindingYaml(relativePath string) (*rbacv1.ClusterRoleBinding, error) {
-	manifest, err := PathToOSFile(relativePath)
+func parseClusterRoleBindingYaml(source string) (*rbacv1.ClusterRoleBinding, error) {
+	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
@@ -129,14 +128,7 @@ func WaitForCRDReady(listFunc func(opts metav1.ListOptions) (runtime.Object, err
 func (f *Framework) CreateOrUpdateCRDAndWaitUntilReady(ctx context.Context, crdName string, listFunc func(opts metav1.ListOptions) (runtime.Object, error)) error {
 	crdName = strings.ToLower(crdName)
 	group := monitoring.GroupName
-
-	var assetPath string
-
-	if f.operatorVersion.GTE(semver.MustParse("0.57.0")) {
-		assetPath = f.exampleDir + "/prometheus-operator-crd-full/" + group + "_" + crdName + ".yaml"
-	} else {
-		assetPath = f.exampleDir + "/prometheus-operator-crd/" + group + "_" + crdName + ".yaml"
-	}
+	assetPath := f.exampleDir + "/prometheus-operator-crd-full/" + group + "_" + crdName + ".yaml"
 
 	crd, err := f.MakeCRD(assetPath)
 	if err != nil {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -305,13 +305,11 @@ func (f *Framework) CreateOrUpdatePrometheusOperator(ctx context.Context, ns str
 		return nil, errors.Wrap(err, "initialize AlertmanagerConfig v1alpha1 CRD")
 	}
 
-	if f.operatorVersion.GTE(semver.MustParse("0.57.0")) {
-		err = WaitForCRDReady(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return f.MonClientV1beta1.AlertmanagerConfigs(v1.NamespaceAll).List(ctx, opts)
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "wait for AlertmanagerConfig v1beta1 CRD")
-		}
+	err = WaitForCRDReady(func(opts metav1.ListOptions) (runtime.Object, error) {
+		return f.MonClientV1beta1.AlertmanagerConfigs(v1.NamespaceAll).List(ctx, opts)
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "wait for AlertmanagerConfig v1beta1 CRD")
 	}
 
 	deploy, err := MakeDeployment(fmt.Sprintf("%s/rbac/prometheus-operator/prometheus-operator-deployment.yaml", f.exampleDir))
@@ -439,13 +437,11 @@ func (f *Framework) CreateOrUpdatePrometheusOperator(ctx context.Context, ns str
 		}
 		finalizers = append(finalizers, finalizer)
 
-		if f.operatorVersion.GTE(semver.MustParse("0.57.0")) {
-			finalizer, err = f.configureAlertmanagerConfigConversion(ctx, webhookService, b)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to configure conversion webhook for AlertManagerConfigs")
-			}
-			finalizers = append(finalizers, finalizer)
+		finalizer, err = f.configureAlertmanagerConfigConversion(ctx, webhookService, b)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to configure conversion webhook for AlertManagerConfigs")
 		}
+		finalizers = append(finalizers, finalizer)
 	}
 
 	return finalizers, nil

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -17,9 +17,11 @@ package framework
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +35,14 @@ import (
 	"github.com/prometheus/prometheus/model/textparse"
 )
 
+func SourceToIOReader(source string) (io.Reader, error) {
+	if strings.HasPrefix(source, "http") {
+		return URLToIOReader(source)
+	} else {
+		return PathToOSFile(source)
+	}
+}
+
 func PathToOSFile(relativePath string) (*os.File, error) {
 	path, err := filepath.Abs(relativePath)
 	if err != nil {
@@ -45,6 +55,30 @@ func PathToOSFile(relativePath string) (*os.File, error) {
 	}
 
 	return manifest, nil
+}
+
+func URLToIOReader(url string) (io.Reader, error) {
+	var resp *http.Response
+	timeout := 30 * time.Second
+
+	err := wait.Poll(time.Second, timeout, func() (bool, error) {
+		var err error
+		resp, err = http.Get(url)
+		if err == nil && resp.StatusCode == 200 {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(
+			"waiting for %v to return a successful status code timed out. Last response from server was: %v",
+			url,
+			resp,
+		))
+	}
+
+	return resp.Body, nil
 }
 
 // WaitForPodsReady waits for a selection of Pods to be running and each

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
@@ -405,7 +406,7 @@ func (f *Framework) WaitForPrometheusReady(ctx context.Context, p *monitoringv1.
 			if cond.Type == monitoringv1.PrometheusReconciled {
 				reconciled = &cond
 			}
-			if cond.ObservedGeneration != current.Generation {
+			if f.operatorVersion.GTE(semver.MustParse("0.60.0")) && cond.ObservedGeneration != current.Generation {
 				pollErr = errors.Errorf("observed generation %d for condition %s isn't equal to the state generation %d",
 					cond.ObservedGeneration,
 					cond.Type,

--- a/test/framework/service.go
+++ b/test/framework/service.go
@@ -21,29 +21,49 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func MakeService(pathToYaml string) (*v1.Service, error) {
-	manifest, err := PathToOSFile(pathToYaml)
+func MakeService(source string) (*v1.Service, error) {
+	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
 	resource := v1.Service{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&resource); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to decode file %s", pathToYaml))
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to decode file %s", source))
 	}
 
 	return &resource, nil
 }
 
-func (f *Framework) CreateServiceAndWaitUntilReady(ctx context.Context, namespace string, service *v1.Service) (FinalizerFn, error) {
+func (f *Framework) CreateOrUpdateServiceAndWaitUntilReady(ctx context.Context, namespace string, service *v1.Service) (FinalizerFn, error) {
 	finalizerFn := func() error { return f.DeleteServiceAndWaitUntilGone(ctx, namespace, service.Name) }
 
-	if _, err := f.KubeClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{}); err != nil {
-		return finalizerFn, errors.Wrap(err, fmt.Sprintf("creating service %v failed", service.Name))
+	s, err := f.KubeClient.CoreV1().Services(namespace).Get(ctx, service.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return finalizerFn, errors.Wrap(err, fmt.Sprintf("getting service %v failed", service.Name))
+	}
+
+	if apierrors.IsNotFound(err) {
+		// Service doesn't exists -> Create
+		if _, err := f.KubeClient.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{}); err != nil {
+			return finalizerFn, errors.Wrap(err, fmt.Sprintf("creating service %v failed", service.Name))
+		}
+	} else {
+		// must set these immutable fields from the existing service to prevent update fail
+		service.ObjectMeta.ResourceVersion = s.ObjectMeta.ResourceVersion
+		service.Spec.ClusterIP = s.Spec.ClusterIP
+		service.Spec.ClusterIPs = s.Spec.ClusterIPs
+		service.Spec.IPFamilies = s.Spec.IPFamilies
+
+		// Service already exists -> Update
+		if _, err := f.KubeClient.CoreV1().Services(namespace).Update(ctx, service, metav1.UpdateOptions{}); err != nil {
+			return finalizerFn, errors.Wrap(err, fmt.Sprintf("updating service %v failed", service.Name))
+		}
 	}
 
 	if err := f.WaitForServiceReady(ctx, namespace, service.Name); err != nil {

--- a/test/framework/service_account.go
+++ b/test/framework/service_account.go
@@ -16,29 +16,45 @@ package framework
 
 import (
 	"context"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (f *Framework) createServiceAccount(ctx context.Context, namespace string, relativePath string) (FinalizerFn, error) {
-	finalizerFn := func() error { return f.DeleteServiceAccount(ctx, namespace, relativePath) }
+func (f *Framework) createOrUpdateServiceAccount(ctx context.Context, namespace string, source string) (FinalizerFn, error) {
+	finalizerFn := func() error { return f.DeleteServiceAccount(ctx, namespace, source) }
 
-	serviceAccount, err := parseServiceAccountYaml(relativePath)
+	serviceAccount, err := parseServiceAccountYaml(source)
 	if err != nil {
 		return finalizerFn, err
 	}
 	serviceAccount.Namespace = namespace
-	_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
-	if err != nil {
+	_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, serviceAccount.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
 		return finalizerFn, err
+	}
+
+	if apierrors.IsNotFound(err) {
+		// ServiceAccount doesn't exists -> Create
+		_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
+		if err != nil {
+			return finalizerFn, err
+		}
+	} else {
+		// ServiceAccount already exists -> Update
+		_, err = f.KubeClient.CoreV1().ServiceAccounts(namespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+		if err != nil {
+			return finalizerFn, err
+		}
 	}
 
 	return finalizerFn, nil
 }
 
-func parseServiceAccountYaml(relativePath string) (*v1.ServiceAccount, error) {
-	manifest, err := PathToOSFile(relativePath)
+func parseServiceAccountYaml(source string) (*v1.ServiceAccount, error) {
+	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +67,8 @@ func parseServiceAccountYaml(relativePath string) (*v1.ServiceAccount, error) {
 	return &serviceAccount, nil
 }
 
-func (f *Framework) DeleteServiceAccount(ctx context.Context, namespace string, relativePath string) error {
-	serviceAccount, err := parseServiceAccountYaml(relativePath)
+func (f *Framework) DeleteServiceAccount(ctx context.Context, namespace string, source string) error {
+	serviceAccount, err := parseServiceAccountYaml(source)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

PR #4758 was reverted because it broke CI. CI failed because it was out of sync with the main branch for a long time and some of the function signature changed.

This commit is based on PR #4758 and fix CI function signature error.

Fixes: #4067

Signed-off-by: heylongdacoder <heylongdacoder@gmail.com>



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
