### PR TITLE
feat: enable support for "dnsPolicy" in Prometheus, AlertManager and Thanos CRD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -690,6 +690,21 @@ If defined, it takes precedence over the <code>configSecret</code> field.
 This field may change in future releases.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3723,6 +3738,21 @@ AlertmanagerConfiguration
 <p>EXPERIMENTAL: alertmanagerConfiguration specifies the configuration of Alertmanager.
 If defined, it takes precedence over the <code>configSecret</code> field.
 This field may change in future releases.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
 </td>
 </tr>
 </tbody>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2123,6 +2123,21 @@ Applies only if enforcedNamespaceLabel set to true.</p>
 </tr>
 <tr>
 <td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code><br/>
 <em>
 string
@@ -4964,6 +4979,21 @@ only available in versions of Prometheus &gt;= 2.11.0.</p>
 <p>List of references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
 to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
 </td>
 </tr>
 </tbody>
@@ -8149,6 +8179,21 @@ only available in versions of Prometheus &gt;= 2.11.0.</p>
 <p>List of references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
 to be excluded from enforcing a namespace label of origin.
 Applies only if enforcedNamespaceLabel set to true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -10981,6 +10981,21 @@ When used alongside with AlertRelabelConfigs, alertRelabelConfigFile takes prece
 <p>Pods&rsquo; hostAliases configuration</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -11630,6 +11645,21 @@ When used alongside with AlertRelabelConfigs, alertRelabelConfigFile takes prece
 </td>
 <td>
 <p>Pods&rsquo; hostAliases configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#dnspolicy-v1-core">
+Kubernetes core/v1.DNSPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Enable ability to add DNS policy. Kubernetes currently supports following &ldquo;Default&rdquo;, &ldquo;ClusterFirst&rdquo;, &ldquo;ClusterFirstWithHostNet&rdquo; and &ldquo;None&rdquo;.
+More details can be found at <a href="https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy">https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy</a>
+Note: &ldquo;Default&rdquo; is not the default DNS policy. If dnsPolicy is not explicitly specified, then &ldquo;ClusterFirst&rdquo; is used.</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -24455,6 +24455,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enforcedNamespaceLabel:
                 description: EnforcedNamespaceLabel enforces adding a namespace label
                   of origin for each alert and metric that is user created. The label

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15371,6 +15371,13 @@ spec:
               disableCompaction:
                 description: Disable prometheus compaction.
                 type: boolean
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enableAdminAPI:
                 description: 'Enable access to prometheus web admin API. Defaults
                   to the value of `false`. WARNING: Enabling the admin APIs enables

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7134,6 +7134,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               externalUrl:
                 description: The external URL the Alertmanager instances will be available
                   under. This is necessary to generate correct URLs. This is necessary

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2659,6 +2659,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               externalUrl:
                 description: The external URL the Alertmanager instances will be available
                   under. This is necessary to generate correct URLs. This is necessary

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -2700,6 +2700,13 @@ spec:
               disableCompaction:
                 description: Disable prometheus compaction.
                 type: boolean
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enableAdminAPI:
                 description: 'Enable access to prometheus web admin API. Defaults
                   to the value of `false`. WARNING: Enabling the admin APIs enables

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -2174,6 +2174,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enforcedNamespaceLabel:
                 description: EnforcedNamespaceLabel enforces adding a namespace label
                   of origin for each alert and metric that is user created. The label

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2659,6 +2659,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               externalUrl:
                 description: The external URL the Alertmanager instances will be available
                   under. This is necessary to generate correct URLs. This is necessary

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -2700,6 +2700,13 @@ spec:
               disableCompaction:
                 description: Disable prometheus compaction.
                 type: boolean
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enableAdminAPI:
                 description: 'Enable access to prometheus web admin API. Defaults
                   to the value of `false`. WARNING: Enabling the admin APIs enables

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -2174,6 +2174,13 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsPolicy:
+                description: 'Enable ability to add DNS policy. Kubernetes currently
+                  supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet"
+                  and "None". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+                  Note: "Default" is not the default DNS policy. If dnsPolicy is not
+                  explicitly specified, then "ClusterFirst" is used.'
+                type: string
               enforcedNamespaceLabel:
                 description: EnforcedNamespaceLabel enforces adding a namespace label
                   of origin for each alert and metric that is user created. The label

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2409,6 +2409,10 @@
                     },
                     "type": "array"
                   },
+                  "dnsPolicy": {
+                    "description": "Enable ability to add DNS policy. Kubernetes currently supports following \"Default\", \"ClusterFirst\", \"ClusterFirstWithHostNet\" and \"None\". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy Note: \"Default\" is not the default DNS policy. If dnsPolicy is not explicitly specified, then \"ClusterFirst\" is used.",
+                    "type": "string"
+                  },
                   "externalUrl": {
                     "description": "The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name.",
                     "type": "string"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2466,6 +2466,10 @@
                     "description": "Disable prometheus compaction.",
                     "type": "boolean"
                   },
+                  "dnsPolicy": {
+                    "description": "Enable ability to add DNS policy. Kubernetes currently supports following \"Default\", \"ClusterFirst\", \"ClusterFirstWithHostNet\" and \"None\". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy Note: \"Default\" is not the default DNS policy. If dnsPolicy is not explicitly specified, then \"ClusterFirst\" is used.",
+                    "type": "string"
+                  },
                   "enableAdminAPI": {
                     "description": "Enable access to prometheus web admin API. Defaults to the value of `false`. WARNING: Enabling the admin APIs enables mutating endpoints, to delete data, shutdown Prometheus, and more. Enabling this should be done with care and the user is advised to add additional authentication authorization via a proxy to ensure only clients authorized to perform these actions can do so. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis",
                     "type": "boolean"

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -1910,6 +1910,10 @@
                     },
                     "type": "array"
                   },
+                  "dnsPolicy": {
+                    "description": "Enable ability to add DNS policy. Kubernetes currently supports following \"Default\", \"ClusterFirst\", \"ClusterFirstWithHostNet\" and \"None\". More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy Note: \"Default\" is not the default DNS policy. If dnsPolicy is not explicitly specified, then \"ClusterFirst\" is used.",
+                    "type": "string"
+                  },
                   "enforcedNamespaceLabel": {
                     "description": "EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert and metric that is user created. The label value will always be the namespace of the object that is being created.",
                     "type": "string"

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -742,6 +742,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 				Affinity:                      a.Spec.Affinity,
 				TopologySpreadConstraints:     a.Spec.TopologySpreadConstraints,
 				HostAliases:                   operator.MakeHostAliases(a.Spec.HostAliases),
+				DNSPolicy:                     a.Spec.DNSPolicy,
 			},
 		},
 	}, nil

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1248,6 +1248,8 @@ func TestPodTemplateConfig(t *testing.T) {
 		},
 	}
 
+	dnsPolicy := v1.DNSPolicy("ClusterFirst")
+
 	sset, err := makeStatefulSet(&monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.AlertmanagerSpec{
@@ -1259,6 +1261,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			ServiceAccountName: serviceAccountName,
 			HostAliases:        hostAliases,
 			ImagePullSecrets:   imagePullSecrets,
+			DNSPolicy:          dnsPolicy,
 		},
 	}, defaultTestConfig, "", nil)
 	if err != nil {
@@ -1288,5 +1291,8 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)
+	}
+	if sset.Spec.Template.Spec.DNSPolicy != dnsPolicy {
+		t.Fatalf("expected dnsPolicy to match, want %s, got %s", dnsPolicy, sset.Spec.Template.Spec.DNSPolicy)
 	}
 }

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -217,6 +217,10 @@ type ThanosRulerSpec struct {
 	// +listType=map
 	// +listMapKey=ip
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`
+	// Enable ability to add DNS policy. Kubernetes currently supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet" and "None".
+	// More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+	// Note: "Default" is not the default DNS policy. If dnsPolicy is not explicitly specified, then "ClusterFirst" is used.
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // ThanosRulerStatus is the most recent observed status of the ThanosRuler. Read-only. Not

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1992,6 +1992,10 @@ type AlertmanagerSpec struct {
 	// If defined, it takes precedence over the `configSecret` field.
 	// This field may change in future releases.
 	AlertmanagerConfiguration *AlertmanagerConfiguration `json:"alertmanagerConfiguration,omitempty"`
+	// Enable ability to add DNS policy. Kubernetes currently supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet" and "None".
+	// More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+	// Note: "Default" is not the default DNS policy. If dnsPolicy is not explicitly specified, then "ClusterFirst" is used.
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // AlertmanagerConfiguration defines the Alertmanager configuration.

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -336,6 +336,10 @@ type CommonPrometheusFields struct {
 	// to be excluded from enforcing a namespace label of origin.
 	// Applies only if enforcedNamespaceLabel set to true.
 	ExcludedFromEnforcement []ObjectReference `json:"excludedFromEnforcement,omitempty"`
+	// Enable ability to add DNS policy. Kubernetes currently supports following "Default", "ClusterFirst", "ClusterFirstWithHostNet" and "None".
+	// More details can be found at https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+	// Note: "Default" is not the default DNS policy. If dnsPolicy is not explicitly specified, then "ClusterFirst" is used.
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // +genclient

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -1010,6 +1010,7 @@ func makeStatefulSetSpec(
 				Affinity:                      p.Spec.Affinity,
 				TopologySpreadConstraints:     p.Spec.TopologySpreadConstraints,
 				HostAliases:                   operator.MakeHostAliases(p.Spec.HostAliases),
+				DNSPolicy:                     p.Spec.DNSPolicy,
 			},
 		},
 	}, nil

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -2302,6 +2302,8 @@ func TestPodTemplateConfig(t *testing.T) {
 		},
 	}
 
+	dnsPolicy := v1.DNSPolicy("ClusterFirst")
+
 	sset, err := makeStatefulSet(newLogger(), "test", monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.PrometheusSpec{
@@ -2314,6 +2316,7 @@ func TestPodTemplateConfig(t *testing.T) {
 				ServiceAccountName: serviceAccountName,
 				HostAliases:        hostAliases,
 				ImagePullSecrets:   imagePullSecrets,
+				DNSPolicy:          dnsPolicy,
 			},
 		},
 	}, defaultTestConfig, nil, "", 0, nil)
@@ -2344,6 +2347,9 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)
+	}
+	if sset.Spec.Template.Spec.DNSPolicy != dnsPolicy {
+		t.Fatalf("expected dnsPolicy to match, want %s, got %s", dnsPolicy, sset.Spec.Template.Spec.DNSPolicy)
 	}
 }
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -491,6 +491,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 				Affinity:                      tr.Spec.Affinity,
 				TopologySpreadConstraints:     tr.Spec.TopologySpreadConstraints,
 				HostAliases:                   operator.MakeHostAliases(tr.Spec.HostAliases),
+				DNSPolicy:                     tr.Spec.DNSPolicy,
 			},
 		},
 	}, nil

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -701,6 +701,8 @@ func TestPodTemplateConfig(t *testing.T) {
 		},
 	}
 
+	dnsPolicy := v1.DNSPolicy("ClusterFirst")
+
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
@@ -713,6 +715,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			ServiceAccountName: serviceAccountName,
 			HostAliases:        hostAliases,
 			ImagePullSecrets:   imagePullSecrets,
+			DNSPolicy:          dnsPolicy,
 		},
 	}, defaultTestConfig, nil, "")
 	if err != nil {
@@ -742,6 +745,9 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)
+	}
+	if sset.Spec.Template.Spec.DNSPolicy != dnsPolicy {
+		t.Fatalf("expected dnsPolicy to match, want %s, got %s", dnsPolicy, sset.Spec.Template.Spec.DNSPolicy)
 	}
 }
 


### PR DESCRIPTION
## Description

Needed in scenarios like:
1. When using "hostNetwork"
2. for a Pod to ignore DNS settings from the Kubernetes environment

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry


```release-note
feat: enable support for "dnsPolicy" in Prometheus, AlertManager and Thanos CRD
```
