### PR TITLE
replace non ascii apostrophe

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -12300,7 +12300,7 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>The Alertmanager route definition for alerts matching the resource’s
+<p>The Alertmanager route definition for alerts matching the resource&rsquo;s
 namespace. If present, it will be added to the generated Alertmanager
 configuration as a first-level route.</p>
 </td>
@@ -12331,7 +12331,7 @@ configuration as a first-level route.</p>
 <td>
 <em>(Optional)</em>
 <p>List of inhibition rules. The rules will only apply to alerts matching
-the resource’s namespace.</p>
+the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -12382,7 +12382,7 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>The Alertmanager route definition for alerts matching the resource’s
+<p>The Alertmanager route definition for alerts matching the resource&rsquo;s
 namespace. If present, it will be added to the generated Alertmanager
 configuration as a first-level route.</p>
 </td>
@@ -12413,7 +12413,7 @@ configuration as a first-level route.</p>
 <td>
 <em>(Optional)</em>
 <p>List of inhibition rules. The rules will only apply to alerts matching
-the resource’s namespace.</p>
+the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -12816,7 +12816,7 @@ See <a href="https://prometheus.io/docs/alerting/latest/configuration/#inhibit_r
 </td>
 <td>
 <p>Matchers that have to be fulfilled in the alerts to be muted. The
-operator enforces that the alert matches the resource’s namespace.</p>
+operator enforces that the alert matches the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -12831,7 +12831,7 @@ operator enforces that the alert matches the resource’s namespace.</p>
 <td>
 <p>Matchers for which one or more alerts have to exist for the inhibition
 to take effect. The operator enforces that the alert matches the
-resource’s namespace.</p>
+resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -13737,7 +13737,7 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>The secret&rsquo;s key that contains the recipient user’s user key.
+<p>The secret&rsquo;s key that contains the recipient user&rsquo;s user key.
 The secret needs to be in the same namespace as the AlertmanagerConfig
 object and accessible by the Prometheus Operator.</p>
 </td>
@@ -13752,7 +13752,7 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>The secret&rsquo;s key that contains the registered application’s API token, see <a href="https://pushover.net/apps">https://pushover.net/apps</a>.
+<p>The secret&rsquo;s key that contains the registered application&rsquo;s API token, see <a href="https://pushover.net/apps">https://pushover.net/apps</a>.
 The secret needs to be in the same namespace as the AlertmanagerConfig
 object and accessible by the Prometheus Operator.</p>
 </td>
@@ -14138,7 +14138,7 @@ Example: &ldquo;4h&rdquo;</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>List of matchers that the alert’s labels should match. For the first
+<p>List of matchers that the alert&rsquo;s labels should match. For the first
 level route, the operator removes any existing equality and regexp
 matcher on the <code>namespace</code> label and adds a <code>namespace: &lt;object
 namespace&gt;</code> matcher.</p>
@@ -15597,7 +15597,7 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>The Alertmanager route definition for alerts matching the resource’s
+<p>The Alertmanager route definition for alerts matching the resource&rsquo;s
 namespace. If present, it will be added to the generated Alertmanager
 configuration as a first-level route.</p>
 </td>
@@ -15628,7 +15628,7 @@ configuration as a first-level route.</p>
 <td>
 <em>(Optional)</em>
 <p>List of inhibition rules. The rules will only apply to alerts matching
-the resource’s namespace.</p>
+the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -15679,7 +15679,7 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>The Alertmanager route definition for alerts matching the resource’s
+<p>The Alertmanager route definition for alerts matching the resource&rsquo;s
 namespace. If present, it will be added to the generated Alertmanager
 configuration as a first-level route.</p>
 </td>
@@ -15710,7 +15710,7 @@ configuration as a first-level route.</p>
 <td>
 <em>(Optional)</em>
 <p>List of inhibition rules. The rules will only apply to alerts matching
-the resource’s namespace.</p>
+the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -16113,7 +16113,7 @@ See <a href="https://prometheus.io/docs/alerting/latest/configuration/#inhibit_r
 </td>
 <td>
 <p>Matchers that have to be fulfilled in the alerts to be muted. The
-operator enforces that the alert matches the resource’s namespace.</p>
+operator enforces that the alert matches the resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -16128,7 +16128,7 @@ operator enforces that the alert matches the resource’s namespace.</p>
 <td>
 <p>Matchers for which one or more alerts have to exist for the inhibition
 to take effect. The operator enforces that the alert matches the
-resource’s namespace.</p>
+resource&rsquo;s namespace.</p>
 </td>
 </tr>
 <tr>
@@ -16966,7 +16966,7 @@ SecretKeySelector
 </em>
 </td>
 <td>
-<p>The secret&rsquo;s key that contains the recipient user’s user key.
+<p>The secret&rsquo;s key that contains the recipient user&rsquo;s user key.
 The secret needs to be in the same namespace as the AlertmanagerConfig
 object and accessible by the Prometheus Operator.</p>
 </td>
@@ -16981,7 +16981,7 @@ SecretKeySelector
 </em>
 </td>
 <td>
-<p>The secret&rsquo;s key that contains the registered application’s API token, see <a href="https://pushover.net/apps">https://pushover.net/apps</a>.
+<p>The secret&rsquo;s key that contains the registered application&rsquo;s API token, see <a href="https://pushover.net/apps">https://pushover.net/apps</a>.
 The secret needs to be in the same namespace as the AlertmanagerConfig
 object and accessible by the Prometheus Operator.</p>
 </td>
@@ -17367,7 +17367,7 @@ Example: &ldquo;4h&rdquo;</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>List of matchers that the alert’s labels should match. For the first
+<p>List of matchers that the alert&rsquo;s labels should match. For the first
 level route, the operator removes any existing equality and regexp
 matcher on the <code>namespace</code> label and adds a <code>namespace: &lt;object
 namespace&gt;</code> matcher.</p>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45,7 +45,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -59,7 +59,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -92,7 +92,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -1778,7 +1778,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -1808,7 +1808,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -4379,7 +4379,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -4405,7 +4405,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -45,7 +45,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -59,7 +59,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -92,7 +92,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -1786,7 +1786,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -1817,7 +1817,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -4400,7 +4400,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -4426,7 +4426,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'
@@ -4519,7 +4519,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -4533,7 +4533,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -4562,7 +4562,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -6137,7 +6137,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -6165,7 +6165,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -8706,7 +8706,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -8732,7 +8732,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -45,7 +45,7 @@ spec:
             properties:
               inhibitRules:
                 description: List of inhibition rules. The rules will only apply to
-                  alerts matching the resource’s namespace.
+                  alerts matching the resource's namespace.
                 items:
                   description: InhibitRule defines an inhibition rule that allows
                     to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
@@ -59,7 +59,7 @@ spec:
                     sourceMatch:
                       description: Matchers for which one or more alerts have to exist
                         for the inhibition to take effect. The operator enforces that
-                        the alert matches the resource’s namespace.
+                        the alert matches the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -92,7 +92,7 @@ spec:
                     targetMatch:
                       description: Matchers that have to be fulfilled in the alerts
                         to be muted. The operator enforces that the alert matches
-                        the resource’s namespace.
+                        the resource's namespace.
                       items:
                         description: Matcher defines how to match on alert's labels.
                         properties:
@@ -1778,7 +1778,7 @@ spec:
                             type: string
                           token:
                             description: The secret's key that contains the registered
-                              application’s API token, see https://pushover.net/apps.
+                              application's API token, see https://pushover.net/apps.
                               The secret needs to be in the same namespace as the
                               AlertmanagerConfig object and accessible by the Prometheus
                               Operator.
@@ -1808,7 +1808,7 @@ spec:
                             type: string
                           userKey:
                             description: The secret's key that contains the recipient
-                              user’s user key. The secret needs to be in the same
+                              user's user key. The secret needs to be in the same
                               namespace as the AlertmanagerConfig object and accessible
                               by the Prometheus Operator.
                             properties:
@@ -4379,7 +4379,7 @@ spec:
                 type: array
               route:
                 description: The Alertmanager route definition for alerts matching
-                  the resource’s namespace. If present, it will be added to the generated
+                  the resource's namespace. If present, it will be added to the generated
                   Alertmanager configuration as a first-level route.
                 properties:
                   continue:
@@ -4405,7 +4405,7 @@ spec:
                       Example: "30s"'
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert’s labels should
+                    description: 'List of matchers that the alert''s labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -45,7 +45,7 @@
                 "description": "AlertmanagerConfigSpec is a specification of the desired behavior of the Alertmanager configuration. By definition, the Alertmanager configuration only applies to alerts for which the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.",
                 "properties": {
                   "inhibitRules": {
-                    "description": "List of inhibition rules. The rules will only apply to alerts matching the resource’s namespace.",
+                    "description": "List of inhibition rules. The rules will only apply to alerts matching the resource's namespace.",
                     "items": {
                       "description": "InhibitRule defines an inhibition rule that allows to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule",
                       "properties": {
@@ -57,7 +57,7 @@
                           "type": "array"
                         },
                         "sourceMatch": {
-                          "description": "Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource’s namespace.",
+                          "description": "Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource's namespace.",
                           "items": {
                             "description": "Matcher defines how to match on alert's labels.",
                             "properties": {
@@ -93,7 +93,7 @@
                           "type": "array"
                         },
                         "targetMatch": {
-                          "description": "Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource’s namespace.",
+                          "description": "Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource's namespace.",
                           "items": {
                             "description": "Matcher defines how to match on alert's labels.",
                             "properties": {
@@ -1878,7 +1878,7 @@
                                 "type": "string"
                               },
                               "token": {
-                                "description": "The secret's key that contains the registered application’s API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
+                                "description": "The secret's key that contains the registered application's API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
                                 "properties": {
                                   "key": {
                                     "description": "The key of the secret to select from.  Must be a valid secret key.",
@@ -1907,7 +1907,7 @@
                                 "type": "string"
                               },
                               "userKey": {
-                                "description": "The secret's key that contains the recipient user’s user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
+                                "description": "The secret's key that contains the recipient user's user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
                                 "properties": {
                                   "key": {
                                     "description": "The key of the secret to select from.  Must be a valid secret key.",
@@ -4599,7 +4599,7 @@
                     "type": "array"
                   },
                   "route": {
-                    "description": "The Alertmanager route definition for alerts matching the resource’s namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.",
+                    "description": "The Alertmanager route definition for alerts matching the resource's namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.",
                     "properties": {
                       "continue": {
                         "description": "Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.",
@@ -4621,7 +4621,7 @@
                         "type": "string"
                       },
                       "matchers": {
-                        "description": "List of matchers that the alert’s labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.",
+                        "description": "List of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.",
                         "items": {
                           "description": "Matcher defines how to match on alert's labels.",
                           "properties": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -21,7 +21,7 @@
             description: 'AlertmanagerConfigSpec is a specification of the desired behavior of the Alertmanager configuration. By definition, the Alertmanager configuration only applies to alerts for which the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.',
             properties: {
               inhibitRules: {
-                description: 'List of inhibition rules. The rules will only apply to alerts matching the resource’s namespace.',
+                description: "List of inhibition rules. The rules will only apply to alerts matching the resource's namespace.",
                 items: {
                   description: 'InhibitRule defines an inhibition rule that allows to mute alerts when other alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule',
                   properties: {
@@ -33,7 +33,7 @@
                       type: 'array',
                     },
                     sourceMatch: {
-                      description: 'Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource’s namespace.',
+                      description: "Matchers for which one or more alerts have to exist for the inhibition to take effect. The operator enforces that the alert matches the resource's namespace.",
                       items: {
                         description: "Matcher defines how to match on alert's labels.",
                         properties: {
@@ -65,7 +65,7 @@
                       type: 'array',
                     },
                     targetMatch: {
-                      description: 'Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource’s namespace.',
+                      description: "Matchers that have to be fulfilled in the alerts to be muted. The operator enforces that the alert matches the resource's namespace.",
                       items: {
                         description: "Matcher defines how to match on alert's labels.",
                         properties: {
@@ -1741,7 +1741,7 @@
                             type: 'string',
                           },
                           token: {
-                            description: "The secret's key that contains the registered application’s API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
+                            description: "The secret's key that contains the registered application's API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
                             properties: {
                               key: {
                                 description: 'The key of the secret to select from.  Must be a valid secret key.',
@@ -1769,7 +1769,7 @@
                             type: 'string',
                           },
                           userKey: {
-                            description: "The secret's key that contains the recipient user’s user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
+                            description: "The secret's key that contains the recipient user's user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.",
                             properties: {
                               key: {
                                 description: 'The key of the secret to select from.  Must be a valid secret key.',
@@ -4449,7 +4449,7 @@
                 type: 'array',
               },
               route: {
-                description: 'The Alertmanager route definition for alerts matching the resource’s namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.',
+                description: "The Alertmanager route definition for alerts matching the resource's namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.",
                 properties: {
                   continue: {
                     description: 'Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.',
@@ -4471,7 +4471,7 @@
                     type: 'string',
                   },
                   matchers: {
-                    description: 'List of matchers that the alert’s labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.',
+                    description: "List of matchers that the alert's labels should match. For the first level route, the operator removes any existing equality and regexp matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher.",
                     items: {
                       description: "Matcher defines how to match on alert's labels.",
                       properties: {

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -65,7 +65,7 @@ type AlertmanagerConfigList struct {
 // By definition, the Alertmanager configuration only applies to alerts for which
 // the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.
 type AlertmanagerConfigSpec struct {
-	// The Alertmanager route definition for alerts matching the resource’s
+	// The Alertmanager route definition for alerts matching the resource's
 	// namespace. If present, it will be added to the generated Alertmanager
 	// configuration as a first-level route.
 	// +optional
@@ -74,7 +74,7 @@ type AlertmanagerConfigSpec struct {
 	// +optional
 	Receivers []Receiver `json:"receivers"`
 	// List of inhibition rules. The rules will only apply to alerts matching
-	// the resource’s namespace.
+	// the resource's namespace.
 	// +optional
 	InhibitRules []InhibitRule `json:"inhibitRules,omitempty"`
 	// List of MuteTimeInterval specifying when the routes should be muted.
@@ -108,7 +108,7 @@ type Route struct {
 	// Example: "4h"
 	// +optional
 	RepeatInterval string `json:"repeatInterval,omitempty"`
-	// List of matchers that the alert’s labels should match. For the first
+	// List of matchers that the alert's labels should match. For the first
 	// level route, the operator removes any existing equality and regexp
 	// matcher on the `namespace` label and adds a `namespace: <object
 	// namespace>` matcher.
@@ -694,12 +694,12 @@ type PushoverConfig struct {
 	// Whether or not to notify about resolved alerts.
 	// +optional
 	SendResolved *bool `json:"sendResolved,omitempty"`
-	// The secret's key that contains the recipient user’s user key.
+	// The secret's key that contains the recipient user's user key.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
 	// +kubebuilder:validation:Required
 	UserKey *v1.SecretKeySelector `json:"userKey,omitempty"`
-	// The secret's key that contains the registered application’s API token, see https://pushover.net/apps.
+	// The secret's key that contains the registered application's API token, see https://pushover.net/apps.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
 	// +kubebuilder:validation:Required
@@ -815,11 +815,11 @@ type TelegramConfig struct {
 // See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
 type InhibitRule struct {
 	// Matchers that have to be fulfilled in the alerts to be muted. The
-	// operator enforces that the alert matches the resource’s namespace.
+	// operator enforces that the alert matches the resource's namespace.
 	TargetMatch []Matcher `json:"targetMatch,omitempty"`
 	// Matchers for which one or more alerts have to exist for the inhibition
 	// to take effect. The operator enforces that the alert matches the
-	// resource’s namespace.
+	// resource's namespace.
 	SourceMatch []Matcher `json:"sourceMatch,omitempty"`
 	// Labels that must have an equal value in the source and target alert for
 	// the inhibition to take effect.

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -63,7 +63,7 @@ type AlertmanagerConfigList struct {
 // By definition, the Alertmanager configuration only applies to alerts for which
 // the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.
 type AlertmanagerConfigSpec struct {
-	// The Alertmanager route definition for alerts matching the resource’s
+	// The Alertmanager route definition for alerts matching the resource's
 	// namespace. If present, it will be added to the generated Alertmanager
 	// configuration as a first-level route.
 	// +optional
@@ -72,7 +72,7 @@ type AlertmanagerConfigSpec struct {
 	// +optional
 	Receivers []Receiver `json:"receivers"`
 	// List of inhibition rules. The rules will only apply to alerts matching
-	// the resource’s namespace.
+	// the resource's namespace.
 	// +optional
 	InhibitRules []InhibitRule `json:"inhibitRules,omitempty"`
 	// List of TimeInterval specifying when the routes should be muted or active.
@@ -106,7 +106,7 @@ type Route struct {
 	// Example: "4h"
 	// +optional
 	RepeatInterval string `json:"repeatInterval,omitempty"`
-	// List of matchers that the alert’s labels should match. For the first
+	// List of matchers that the alert's labels should match. For the first
 	// level route, the operator removes any existing equality and regexp
 	// matcher on the `namespace` label and adds a `namespace: <object
 	// namespace>` matcher.
@@ -688,12 +688,12 @@ type PushoverConfig struct {
 	// Whether or not to notify about resolved alerts.
 	// +optional
 	SendResolved *bool `json:"sendResolved,omitempty"`
-	// The secret's key that contains the recipient user’s user key.
+	// The secret's key that contains the recipient user's user key.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
 	// +kubebuilder:validation:Required
 	UserKey *SecretKeySelector `json:"userKey,omitempty"`
-	// The secret's key that contains the registered application’s API token, see https://pushover.net/apps.
+	// The secret's key that contains the registered application's API token, see https://pushover.net/apps.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
 	// +kubebuilder:validation:Required
@@ -809,11 +809,11 @@ type TelegramConfig struct {
 // See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
 type InhibitRule struct {
 	// Matchers that have to be fulfilled in the alerts to be muted. The
-	// operator enforces that the alert matches the resource’s namespace.
+	// operator enforces that the alert matches the resource's namespace.
 	TargetMatch []Matcher `json:"targetMatch,omitempty"`
 	// Matchers for which one or more alerts have to exist for the inhibition
 	// to take effect. The operator enforces that the alert matches the
-	// resource’s namespace.
+	// resource's namespace.
 	SourceMatch []Matcher `json:"sourceMatch,omitempty"`
 	// Labels that must have an equal value in the source and target alert for
 	// the inhibition to take effect.


### PR DESCRIPTION
## Description

The current non-ascii apostrophe in API description for alertmanagerconfigs is using a non-ascii character as apostrophe in several places. This leads to certain tools having issues parsing/decoding the resulting CRD yamls.

*Before update*
```sh
file monitoring.coreos.com_alertmanagerconfigs.yaml
monitoring.coreos.com_alertmanagerconfigs.yaml: Unicode text, UTF-8 text
```

*After update*
```sh
file monitoring.coreos.com_alertmanagerconfigs.yaml 
monitoring.coreos.com_alertmanagerconfigs.yaml: ASCII text
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._


<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
replace non ascii characters in descriptions
```
