### PR TITLE
pkg/prometheus: remove FOWNER capability for Thanos sidecar

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -824,9 +824,6 @@ func makeStatefulSetSpec(
 				},
 			)
 
-			// The Thanos sidecar needs the FOWNER capability because it links block files as hard link.
-			container.SecurityContext.Capabilities.Add = append(container.SecurityContext.Capabilities.Add, "FOWNER")
-
 			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
 			// to avoid races during upload, if the uploads are configured.
 			disableCompaction = true


### PR DESCRIPTION
After hearing from different users, it doesn't seem like the Thanos sidecar needs the `FOWNER` capability. From a security standpoint, it's better not to ask for a capability that isn't required. And even if it is needed in some environments, it can be added using the strategic merge patch technique.

Closes #5023

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Removed FOWNER capability from the Thanos sidecar.
```
