### PR TITLE
pkg/prometheus: add `{grpc,http}ListenLocal` for Thanos sidecar

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -11769,8 +11769,36 @@ bool
 </em>
 </td>
 <td>
-<p>ListenLocal makes the Thanos sidecar listen on loopback, so that it
-does not bind against the Pod IP.</p>
+<p>If true, the Thanos sidecar listens on the loopback interface
+for the HTTP and gRPC endpoints.
+It takes precedence over <code>grpcListenLocal</code> and <code>httpListenLocal</code>.
+Deprecated: use <code>grpcListenLocal</code> and <code>httpListenLocal</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>grpcListenLocal</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>If true, the Thanos sidecar listens on the loopback interface
+for the gRPC endpoints.
+It has no effect if <code>listenLocal</code> is true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpListenLocal</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>If true, the Thanos sidecar listens on the loopback interface
+for the HTTP endpoints.
+It has no effect if <code>listenLocal</code> is true.</p>
 </td>
 </tr>
 <tr>
@@ -11808,8 +11836,8 @@ TLSConfig
 </em>
 </td>
 <td>
-<p>GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads
-recorded rule data.
+<p>GRPCServerTLSConfig configures the TLS parameters for the gRPC server
+providing the StoreAPI.
 Note: Currently only the CAFile, CertFile, and KeyFile fields are supported.
 Maps to the &lsquo;&ndash;grpc-server-tls-*&rsquo; CLI args.</p>
 </td>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -19073,9 +19073,14 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  grpcListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the gRPC endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   grpcServerTlsConfig:
-                    description: 'GRPCServerTLSConfig configures the gRPC server from
-                      which Thanos Querier reads recorded rule data. Note: Currently
+                    description: 'GRPCServerTLSConfig configures the TLS parameters
+                      for the gRPC server providing the StoreAPI. Note: Currently
                       only the CAFile, CertFile, and KeyFile fields are supported.
                       Maps to the ''--grpc-server-tls-*'' CLI args.'
                     properties:
@@ -19208,6 +19213,11 @@ spec:
                         description: Used to verify the hostname for the targets.
                         type: string
                     type: object
+                  httpListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   image:
                     description: Image if specified has precedence over baseImage,
                       tag and sha combinations. Specifying the version is still necessary
@@ -19215,8 +19225,10 @@ spec:
                       is being configured.
                     type: string
                   listenLocal:
-                    description: ListenLocal makes the Thanos sidecar listen on loopback,
-                      so that it does not bind against the Pod IP.
+                    description: 'If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP and gRPC endpoints. It takes precedence
+                      over `grpcListenLocal` and `httpListenLocal`. Deprecated: use
+                      `grpcListenLocal` and `httpListenLocal` instead.'
                     type: boolean
                   logFormat:
                     description: LogFormat for Thanos sidecar to be configured with.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6402,9 +6402,14 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  grpcListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the gRPC endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   grpcServerTlsConfig:
-                    description: 'GRPCServerTLSConfig configures the gRPC server from
-                      which Thanos Querier reads recorded rule data. Note: Currently
+                    description: 'GRPCServerTLSConfig configures the TLS parameters
+                      for the gRPC server providing the StoreAPI. Note: Currently
                       only the CAFile, CertFile, and KeyFile fields are supported.
                       Maps to the ''--grpc-server-tls-*'' CLI args.'
                     properties:
@@ -6537,6 +6542,11 @@ spec:
                         description: Used to verify the hostname for the targets.
                         type: string
                     type: object
+                  httpListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   image:
                     description: Image if specified has precedence over baseImage,
                       tag and sha combinations. Specifying the version is still necessary
@@ -6544,8 +6554,10 @@ spec:
                       is being configured.
                     type: string
                   listenLocal:
-                    description: ListenLocal makes the Thanos sidecar listen on loopback,
-                      so that it does not bind against the Pod IP.
+                    description: 'If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP and gRPC endpoints. It takes precedence
+                      over `grpcListenLocal` and `httpListenLocal`. Deprecated: use
+                      `grpcListenLocal` and `httpListenLocal` instead.'
                     type: boolean
                   logFormat:
                     description: LogFormat for Thanos sidecar to be configured with.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6402,9 +6402,14 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  grpcListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the gRPC endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   grpcServerTlsConfig:
-                    description: 'GRPCServerTLSConfig configures the gRPC server from
-                      which Thanos Querier reads recorded rule data. Note: Currently
+                    description: 'GRPCServerTLSConfig configures the TLS parameters
+                      for the gRPC server providing the StoreAPI. Note: Currently
                       only the CAFile, CertFile, and KeyFile fields are supported.
                       Maps to the ''--grpc-server-tls-*'' CLI args.'
                     properties:
@@ -6537,6 +6542,11 @@ spec:
                         description: Used to verify the hostname for the targets.
                         type: string
                     type: object
+                  httpListenLocal:
+                    description: If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP endpoints. It has no effect if `listenLocal`
+                      is true.
+                    type: boolean
                   image:
                     description: Image if specified has precedence over baseImage,
                       tag and sha combinations. Specifying the version is still necessary
@@ -6544,8 +6554,10 @@ spec:
                       is being configured.
                     type: string
                   listenLocal:
-                    description: ListenLocal makes the Thanos sidecar listen on loopback,
-                      so that it does not bind against the Pod IP.
+                    description: 'If true, the Thanos sidecar listens on the loopback
+                      interface for the HTTP and gRPC endpoints. It takes precedence
+                      over `grpcListenLocal` and `httpListenLocal`. Deprecated: use
+                      `grpcListenLocal` and `httpListenLocal` instead.'
                     type: boolean
                   logFormat:
                     description: LogFormat for Thanos sidecar to be configured with.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5961,8 +5961,12 @@
                         "description": "Thanos base image if other than default. Deprecated: use 'image' instead",
                         "type": "string"
                       },
+                      "grpcListenLocal": {
+                        "description": "If true, the Thanos sidecar listens on the loopback interface for the gRPC endpoints. It has no effect if `listenLocal` is true.",
+                        "type": "boolean"
+                      },
                       "grpcServerTlsConfig": {
-                        "description": "GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads recorded rule data. Note: Currently only the CAFile, CertFile, and KeyFile fields are supported. Maps to the '--grpc-server-tls-*' CLI args.",
+                        "description": "GRPCServerTLSConfig configures the TLS parameters for the gRPC server providing the StoreAPI. Note: Currently only the CAFile, CertFile, and KeyFile fields are supported. Maps to the '--grpc-server-tls-*' CLI args.",
                         "properties": {
                           "ca": {
                             "description": "Struct containing the CA cert to use for the targets.",
@@ -6109,12 +6113,16 @@
                         },
                         "type": "object"
                       },
+                      "httpListenLocal": {
+                        "description": "If true, the Thanos sidecar listens on the loopback interface for the HTTP endpoints. It has no effect if `listenLocal` is true.",
+                        "type": "boolean"
+                      },
                       "image": {
                         "description": "Image if specified has precedence over baseImage, tag and sha combinations. Specifying the version is still necessary to ensure the Prometheus Operator knows what version of Thanos is being configured.",
                         "type": "string"
                       },
                       "listenLocal": {
-                        "description": "ListenLocal makes the Thanos sidecar listen on loopback, so that it does not bind against the Pod IP.",
+                        "description": "If true, the Thanos sidecar listens on the loopback interface for the HTTP and gRPC endpoints. It takes precedence over `grpcListenLocal` and `httpListenLocal`. Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.",
                         "type": "boolean"
                       },
                       "logFormat": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -934,16 +934,26 @@ type ThanosSpec struct {
 	// ObjectStorageConfigFile specifies the path of the object storage configuration file.
 	// When used alongside with ObjectStorageConfig, ObjectStorageConfigFile takes precedence.
 	ObjectStorageConfigFile *string `json:"objectStorageConfigFile,omitempty"`
-	// ListenLocal makes the Thanos sidecar listen on loopback, so that it
-	// does not bind against the Pod IP.
+	// If true, the Thanos sidecar listens on the loopback interface
+	// for the HTTP and gRPC endpoints.
+	// It takes precedence over `grpcListenLocal` and `httpListenLocal`.
+	// Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.
 	ListenLocal bool `json:"listenLocal,omitempty"`
+	// If true, the Thanos sidecar listens on the loopback interface
+	// for the gRPC endpoints.
+	// It has no effect if `listenLocal` is true.
+	GRPCListenLocal bool `json:"grpcListenLocal,omitempty"`
+	// If true, the Thanos sidecar listens on the loopback interface
+	// for the HTTP endpoints.
+	// It has no effect if `listenLocal` is true.
+	HTTPListenLocal bool `json:"httpListenLocal,omitempty"`
 	// TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.
 	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// TracingConfig specifies the path of the tracing configuration file.
 	// When used alongside with TracingConfig, TracingConfigFile takes precedence.
 	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
-	// GRPCServerTLSConfig configures the gRPC server from which Thanos Querier reads
-	// recorded rule data.
+	// GRPCServerTLSConfig configures the TLS parameters for the gRPC server
+	// providing the StoreAPI.
 	// Note: Currently only the CAFile, CertFile, and KeyFile fields are supported.
 	// Maps to the '--grpc-server-tls-*' CLI args.
 	GRPCServerTLSConfig *TLSConfig `json:"grpcServerTlsConfig,omitempty"`

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -744,16 +744,20 @@ func makeStatefulSetSpec(
 			return nil, errors.Wrap(err, "failed to build image path")
 		}
 
-		bindAddress := "" // Listen to all available IP addresses by default
-		if p.Spec.Thanos.ListenLocal {
-			bindAddress = "127.0.0.1"
+		var grpcBindAddress, httpBindAddress string
+		if p.Spec.Thanos.ListenLocal || p.Spec.Thanos.GRPCListenLocal {
+			grpcBindAddress = "127.0.0.1"
+		}
+
+		if p.Spec.Thanos.ListenLocal || p.Spec.Thanos.HTTPListenLocal {
+			httpBindAddress = "127.0.0.1"
 		}
 
 		thanosArgs := []monitoringv1.Argument{
 			{Name: "prometheus.url", Value: fmt.Sprintf("%s://%s:9090%s", prometheusURIScheme, c.LocalHost, path.Clean(webRoutePrefix))},
 			{Name: "prometheus.http-client", Value: `{"tls_config": {"insecure_skip_verify":true}}`},
-			{Name: "grpc-address", Value: fmt.Sprintf("%s:10901", bindAddress)},
-			{Name: "http-address", Value: fmt.Sprintf("%s:10902", bindAddress)},
+			{Name: "grpc-address", Value: fmt.Sprintf("%s:10901", grpcBindAddress)},
+			{Name: "http-address", Value: fmt.Sprintf("%s:10902", httpBindAddress)},
 		}
 
 		if p.Spec.Thanos.GRPCServerTLSConfig != nil {


### PR DESCRIPTION
## Description

When `spec.thanos.listenLocal` is true, both gRPC and HTTP endpoints are configured to listen on the loopback interface. It is sometimes needed to listen on all interfaces for gRPC and on the loopback interface only for HTTP.

This commit introduces the `spec.thanos.grpcListenLocal` and `spec.thanos.httpListenLocal` fields to enable all possible use cases. `spec.thanos.listenLocal` is marked as deprecated since the new fields offer equivalent possibilities with fine-grained controls.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added `grpcListenLocal` and `httpListenLocal` fields to the Thanos sidecar configuration.
```
