### PR TITLE
Fix the ThanosRuler Thanos Section link in Design

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -45,7 +45,7 @@ The `ThanosRuler` custom resource definition (CRD) declaratively defines a desir
 
 A `ThanosRuler` instance requires at least one query endpoint which points to the location of Thanos Queriers or Prometheus instances.
 
-Further information can also be found in the [Thanos section](thanos.md).
+Further information can also be found in the [Thanos section](/Documentation/thanos).
 
 ## ServiceMonitor
 


### PR DESCRIPTION
## Description

The 404 error in the link of ThanosRuler section https://prometheus-operator.dev/docs/operator/design/#thanosruler . To fix this we need to follow a few rules for navigating the internal links: 
1.  By using the relative path for the section.
2.  By not using the .md suffix. 
As https://prometheus-operator.dev/docs/operator/thanos/ is the provided section we want in ThanosRuler section  which is present in the same page.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._
Fixes the ThanosRuler section link.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
