### PR TITLE
pkg/apis: Support empty relabelConfig separator

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -11913,6 +11913,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -11933,6 +11935,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -12097,6 +12101,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -12117,6 +12123,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:
@@ -12536,6 +12544,8 @@ spec:
                         groups are available. Default is '$1'
                       type: string
                     separator:
+                      default:
+                      - ;
                       description: Separator placed between concatenated source label
                         values. default is ';'.
                       type: string
@@ -12555,6 +12565,8 @@ spec:
                         a replace action. It is mandatory for replace actions. Regex
                         capture groups are available.
                       type: string
+                  required:
+                  - separator
                   type: object
                 type: array
               module:
@@ -12761,6 +12773,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -12781,6 +12795,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       selector:
@@ -12894,6 +12910,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -12914,6 +12932,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       static:
@@ -17727,6 +17747,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -17747,6 +17769,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:
@@ -26375,6 +26399,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -26395,6 +26421,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:
@@ -30469,6 +30497,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -30489,6 +30519,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -30653,6 +30685,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -30673,6 +30707,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -260,6 +260,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -280,6 +282,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -444,6 +448,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -464,6 +470,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -209,6 +209,8 @@ spec:
                         groups are available. Default is '$1'
                       type: string
                     separator:
+                      default:
+                      - ;
                       description: Separator placed between concatenated source label
                         values. default is ';'.
                       type: string
@@ -228,6 +230,8 @@ spec:
                         a replace action. It is mandatory for replace actions. Regex
                         capture groups are available.
                       type: string
+                  required:
+                  - separator
                   type: object
                 type: array
               module:
@@ -434,6 +438,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -454,6 +460,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       selector:
@@ -567,6 +575,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -587,6 +597,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       static:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4683,6 +4683,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -4703,6 +4705,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5456,6 +5456,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -5476,6 +5478,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -229,6 +229,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -249,6 +251,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -413,6 +417,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -433,6 +439,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -260,6 +260,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -280,6 +282,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -444,6 +448,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -464,6 +470,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -209,6 +209,8 @@ spec:
                         groups are available. Default is '$1'
                       type: string
                     separator:
+                      default:
+                      - ;
                       description: Separator placed between concatenated source label
                         values. default is ';'.
                       type: string
@@ -228,6 +230,8 @@ spec:
                         a replace action. It is mandatory for replace actions. Regex
                         capture groups are available.
                       type: string
+                  required:
+                  - separator
                   type: object
                 type: array
               module:
@@ -434,6 +438,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -454,6 +460,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       selector:
@@ -567,6 +575,8 @@ spec:
                                 Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
+                              default:
+                              - ;
                               description: Separator placed between concatenated source
                                 label values. default is ';'.
                               type: string
@@ -587,6 +597,8 @@ spec:
                                 in a replace action. It is mandatory for replace actions.
                                 Regex capture groups are available.
                               type: string
+                          required:
+                          - separator
                           type: object
                         type: array
                       static:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4683,6 +4683,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -4703,6 +4705,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5456,6 +5456,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -5476,6 +5478,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                   required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -229,6 +229,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -249,6 +251,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     oauth2:
@@ -413,6 +417,8 @@ spec:
                               capture groups are available. Default is '$1'
                             type: string
                           separator:
+                            default:
+                            - ;
                             description: Separator placed between concatenated source
                               label values. default is ';'.
                             type: string
@@ -433,6 +439,8 @@ spec:
                               in a replace action. It is mandatory for replace actions.
                               Regex capture groups are available.
                             type: string
+                        required:
+                        - separator
                         type: object
                       type: array
                     scheme:

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -272,6 +272,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -289,6 +292,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"
@@ -465,6 +471,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -482,6 +491,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -220,6 +220,9 @@
                           "type": "string"
                         },
                         "separator": {
+                          "default": [
+                            ";"
+                          ],
                           "description": "Separator placed between concatenated source label values. default is ';'.",
                           "type": "string"
                         },
@@ -237,6 +240,9 @@
                           "type": "string"
                         }
                       },
+                      "required": [
+                        "separator"
+                      ],
                       "type": "object"
                     },
                     "type": "array"
@@ -459,6 +465,9 @@
                                   "type": "string"
                                 },
                                 "separator": {
+                                  "default": [
+                                    ";"
+                                  ],
                                   "description": "Separator placed between concatenated source label values. default is ';'.",
                                   "type": "string"
                                 },
@@ -476,6 +485,9 @@
                                   "type": "string"
                                 }
                               },
+                              "required": [
+                                "separator"
+                              ],
                               "type": "object"
                             },
                             "type": "array"
@@ -584,6 +596,9 @@
                                   "type": "string"
                                 },
                                 "separator": {
+                                  "default": [
+                                    ";"
+                                  ],
                                   "description": "Separator placed between concatenated source label values. default is ';'.",
                                   "type": "string"
                                 },
@@ -601,6 +616,9 @@
                                   "type": "string"
                                 }
                               },
+                              "required": [
+                                "separator"
+                              ],
                               "type": "object"
                             },
                             "type": "array"

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4331,6 +4331,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -4348,6 +4351,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5155,6 +5155,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -5172,6 +5175,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -240,6 +240,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -257,6 +260,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"
@@ -433,6 +439,9 @@
                                 "type": "string"
                               },
                               "separator": {
+                                "default": [
+                                  ";"
+                                ],
                                 "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
@@ -450,6 +459,9 @@
                                 "type": "string"
                               }
                             },
+                            "required": [
+                              "separator"
+                            ],
                             "type": "object"
                           },
                           "type": "array"

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -821,7 +821,8 @@ type RelabelConfig struct {
 	// for the replace, keep, and drop actions.
 	SourceLabels []LabelName `json:"sourceLabels,omitempty"`
 	// Separator placed between concatenated source label values. default is ';'.
-	Separator string `json:"separator,omitempty"`
+	//+kubebuilder:default=;
+	Separator string `json:"separator"`
 	// Label to which the resulting value is written in a replace action.
 	// It is mandatory for replace actions. Regex capture groups are available.
 	TargetLabel string `json:"targetLabel,omitempty"`


### PR DESCRIPTION
Fixes #5003

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Allow empty separator in relabelConfig
```
