### PR TITLE
pkg/prometheus: fix tsdb config generation

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -8555,8 +8555,9 @@ scrape_configs: []
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
 scrape_configs: []
-tsdb:
-  out_of_order_time_window: 10m
+storage:
+  tsdb:
+    out_of_order_time_window: 10m
 `,
 		},
 	} {


### PR DESCRIPTION
## Description

Closes #5076 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed generated configuration when `spec.tsdb.outOfOrderTimeWindow` is set.
```
