### PR TITLE
jsonnet: improve admission webhook deployment to avoid down-time on updates

### DIFF
--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -11,6 +11,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus-operator-admission-webhook
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:
@@ -19,6 +22,15 @@ spec:
         app.kubernetes.io/name: prometheus-operator-admission-webhook
         app.kubernetes.io/version: 0.60.1
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus-operator-admission-webhook
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
       - image: quay.io/prometheus-operator/admission-webhook:v0.60.1
@@ -35,6 +47,9 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -693,6 +693,8 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 
 	// Only 1 replica needed for the tests.
 	deploy.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+	deploy.Spec.Template.Spec.Affinity = nil
+	deploy.Spec.Strategy = appsv1.DeploymentStrategy{}
 
 	deploy.Spec.Template.Spec.Containers[0].Args = append(deploy.Spec.Template.Spec.Containers[0].Args, "--log-level=debug")
 


### PR DESCRIPTION
## Description

Enables good default values (hard anti-affinity + rolling update maxUnavailable) ensuring no downtime on update when replicas > 1.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Updated admission webhook deployment's jsonnet to avoid down-time on updates. 
```
