### PR TITLE
Update alerting.md

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -143,5 +143,5 @@ spec:
   receivers:
   - name: 'webhook'
     webhookConfigs:
-    - api: 'http://example.com/'
+    - url: 'http://example.com/'
 ```

--- a/Documentation/user-guides/alerting.md
+++ b/Documentation/user-guides/alerting.md
@@ -60,7 +60,7 @@ spec:
 Wait for all Alertmanager pods to be ready:
 
 ```bash
-kubectl get pods -l alertmanager=main -w
+kubectl get pods -l alertmanager=example -w
 ```
 
 ## Managing Alertmanager configuration
@@ -137,7 +137,7 @@ templates:
 ### Using AlertmanagerConfig Resources
 
 The following example configuration creates an AlertmanagerConfig resource that
-sends notifications to a fictuous webhook service.
+sends notifications to a fictitious webhook service.
 
 ```yaml mdox-exec="cat example/user-guides/alerting/alertmanager-config-example.yaml"
 apiVersion: monitoring.coreos.com/v1alpha1
@@ -156,7 +156,7 @@ spec:
   receivers:
   - name: 'webhook'
     webhookConfigs:
-    - api: 'http://example.com/'
+    - url: 'http://example.com/'
 ```
 
 Create the AlertmanagerConfig resource in your cluster:
@@ -186,7 +186,7 @@ spec:
 
 The following example configuration creates an Alertmanager resource that uses
 an AlertmanagerConfig resource to be used for the Alertmanager configuration
-instead of the `alertmanager-main` secret.
+instead of the `alertmanager-example` secret.
 
 ```yaml mdox-exec="cat example/user-guides/alerting/alertmanager-example-alertmanager-configuration.yaml"
 apiVersion: monitoring.coreos.com/v1
@@ -197,13 +197,13 @@ metadata:
 spec:
   replicas: 3
   alertmanagerConfiguration:
-    name: example-config
+    name: config-example
 ```
 
 The AlertmanagerConfig resource named `example-config` in namespace `default`
 will be a global AlertmanagerConfig. When the operator generates the
 Alertmanager configuration from it, the namespace label will not be enforced
-for routes and inhibittion rules.
+for routes and inhibition rules.
 
 ## Exposing the Alertmanager service
 
@@ -247,6 +247,7 @@ kind: Prometheus
 metadata:
   name: example
 spec:
+  serviceAccountName: prometheus
   replicas: 2
   alerting:
     alertmanagers:
@@ -292,6 +293,7 @@ kind: Prometheus
 metadata:
   name: example
 spec:
+  serviceAccountName: prometheus
   replicas: 2
   alerting:
     alertmanagers:

--- a/example/user-guides/alerting/alertmanager-config-example.yaml
+++ b/example/user-guides/alerting/alertmanager-config-example.yaml
@@ -14,4 +14,4 @@ spec:
   receivers:
   - name: 'webhook'
     webhookConfigs:
-    - api: 'http://example.com/'
+    - url: 'http://example.com/'

--- a/example/user-guides/alerting/alertmanager-example-alertmanager-configuration.yaml
+++ b/example/user-guides/alerting/alertmanager-example-alertmanager-configuration.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   replicas: 3
   alertmanagerConfiguration:
-    name: example-config
+    name: config-example

--- a/example/user-guides/alerting/prometheus-example-rule-namespace-selector.yaml
+++ b/example/user-guides/alerting/prometheus-example-rule-namespace-selector.yaml
@@ -3,6 +3,7 @@ kind: Prometheus
 metadata:
   name: example
 spec:
+  serviceAccountName: prometheus
   replicas: 2
   alerting:
     alertmanagers:

--- a/example/user-guides/alerting/prometheus-example.yaml
+++ b/example/user-guides/alerting/prometheus-example.yaml
@@ -3,6 +3,7 @@ kind: Prometheus
 metadata:
   name: example
 spec:
+  serviceAccountName: prometheus
   replicas: 2
   alerting:
     alertmanagers:


### PR DESCRIPTION
## Description

1. alertmanager name is example, not main
2. we create a AlertManagerConfig named `config-example` not `example-config`
3. webhookConfig doesn't have a field named `api` but `url`, see line 159
4. statefulset alertmanager name is alertmanager-example, not alertmanager-main
5. must specify service account when createing prometheus obj, or else default sa doesn't have permission to get/list pod,svc,ep...


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix typo in alerting.md
```
