### PR TITLE
pkg: Remove validations which is already covered at CRD level

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -817,10 +817,6 @@ func (c *Operator) loadConfigurationFromSecret(ctx context.Context, am *monitori
 func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.Store) error {
 	namespacedLogger := log.With(c.logger, "alertmanager", am.Name, "namespace", am.Namespace)
 
-	if err := validation.ValidateAlertmanager(am); err != nil {
-		return err
-	}
-
 	// If no AlertmanagerConfig selectors and AlertmanagerConfiguration are
 	// configured, the user wants to manage configuration themselves.
 	if am.Spec.AlertmanagerConfigSelector == nil && am.Spec.AlertmanagerConfiguration == nil {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1221,30 +1221,6 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			ok:           true,
 			expectedKeys: []string{"key1"},
 		},
-		{
-			am: &monitoringv1.Alertmanager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid cluster gossip interval",
-					Namespace: "test",
-				},
-				Spec: monitoringv1.AlertmanagerSpec{
-					ClusterGossipInterval: "30k",
-				},
-			},
-			ok: false,
-		},
-		{
-			am: &monitoringv1.Alertmanager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "correct cluster gossip interval",
-					Namespace: "test",
-				},
-				Spec: monitoringv1.AlertmanagerSpec{
-					ClusterGossipInterval: "30s",
-				},
-			},
-			ok: true,
-		},
 	} {
 		t.Run(tc.am.Name, func(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.objects...)

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -18,47 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus/alertmanager/config"
 )
-
-// ValidateAlertmanager runs extra validation on the AlertManager fields which
-// can't be done at the CRD schema validation level.
-func ValidateAlertmanager(am *monitoringv1.Alertmanager) error {
-	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
-	if am.Spec.Retention != "" {
-		if err := operator.ValidateDurationField(string(am.Spec.Retention)); err != nil {
-			return errors.Wrap(err, "invalid retention value specified")
-		}
-	}
-
-	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
-	if am.Spec.ClusterGossipInterval != "" {
-		if err := operator.ValidateDurationField(string(am.Spec.ClusterGossipInterval)); err != nil {
-			return errors.Wrap(err, "invalid clusterGossipInterval value specified")
-		}
-	}
-
-	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
-	if am.Spec.ClusterPushpullInterval != "" {
-		if err := operator.ValidateDurationField(string(am.Spec.ClusterPushpullInterval)); err != nil {
-			return errors.Wrap(err, "invalid clusterPushpullInterval value specified")
-		}
-	}
-
-	// TODO(slashpai): Remove this validation after v0.60 since this is handled at CRD level
-	if am.Spec.ClusterPeerTimeout != "" {
-		if err := operator.ValidateDurationField(string(am.Spec.ClusterPeerTimeout)); err != nil {
-			return errors.Wrap(err, "invalid clusterPeerTimeout value specified")
-		}
-	}
-
-	return nil
-}
-
-// ValidateAlertmanagerConfig checks that the given resource complies with the
 
 // ValidateURL against the config.URL
 // This could potentially become a regex and be validated via OpenAPI

--- a/pkg/operator/validations.go
+++ b/pkg/operator/validations.go
@@ -16,8 +16,6 @@ package operator
 
 import (
 	"github.com/alecthomas/units"
-	"github.com/pkg/errors"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -34,31 +32,5 @@ func ValidateDurationField(durationField string) error {
 	if _, err := model.ParseDuration(durationField); err != nil {
 		return err
 	}
-	return nil
-}
-
-// CompareScrapeTimeoutToScrapeInterval validates value of scrapeTimeout based on scrapeInterval
-func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval monitoringv1.Duration) error {
-	var err error
-	var si, st model.Duration
-
-	// since default scrapeInterval set by operator is 30s
-	if scrapeInterval == "" {
-		scrapeInterval = "30s"
-	}
-
-	// TODO(slashpai): Remove this validation after v0.57 since this is set at CRD level
-	if si, err = model.ParseDuration(string(scrapeInterval)); err != nil {
-		return errors.Wrapf(err, "invalid scrapeInterval %q", scrapeInterval)
-	}
-	// TODO(slashpai): Remove this validation after v0.57 since this is set at CRD level
-	if st, err = model.ParseDuration(string(scrapeTimeout)); err != nil {
-		return errors.Wrapf(err, "invalid scrapeTimeout: %q", scrapeTimeout)
-	}
-
-	if st > si {
-		return errors.Errorf("scrapeTimeout %q greater than scrapeInterval %q", scrapeTimeout, scrapeInterval)
-	}
-
 	return nil
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -2437,5 +2437,5 @@ func validateScrapeIntervalAndTimeout(p *monitoringv1.Prometheus, scrapeInterval
 	if scrapeInterval == "" {
 		scrapeInterval = p.Spec.ScrapeInterval
 	}
-	return operator.CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval)
+	return compareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval)
 }

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -16,7 +16,6 @@ package prometheus
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -97,72 +96,18 @@ func TestGlobalSettings(t *testing.T) {
 		ExpectError        bool
 	}{
 		{
-			Scenario: "valid config",
-			Version:  "v2.15.2",
+			Scenario:           "valid config",
+			Version:            "v2.15.2",
+			ScrapeInterval:     "15s",
+			EvaluationInterval: "30s",
 			Expected: `global:
   evaluation_interval: 30s
-  scrape_interval: 30s
+  scrape_interval: 15s
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
 scrape_configs: []
 `,
-		},
-		{
-			Scenario:           "valid evaluation interval specified",
-			Version:            "v2.15.2",
-			EvaluationInterval: "60s",
-			Expected: `global:
-  evaluation_interval: 60s
-  scrape_interval: 30s
-  external_labels:
-    prometheus: /
-    prometheus_replica: $(POD_NAME)
-scrape_configs: []
-`,
-		},
-		{
-			Scenario:           "invalid evaluation interval specified #1",
-			Version:            "v2.15.2",
-			EvaluationInterval: "60 s",
-			ExpectError:        true,
-		},
-		{
-			Scenario:           "invalid evaluation interval specified #2",
-			Version:            "v2.28.0",
-			EvaluationInterval: "randomvalue",
-			ExpectError:        true,
-		},
-		{
-			Scenario:       "valid scrape interval",
-			Version:        "v2.15.2",
-			ScrapeInterval: "60s",
-			Expected: `global:
-  evaluation_interval: 30s
-  scrape_interval: 60s
-  external_labels:
-    prometheus: /
-    prometheus_replica: $(POD_NAME)
-scrape_configs: []
-`,
-		},
-		{
-			Scenario:       "invalid scrape interval",
-			Version:        "v2.28.0",
-			ScrapeInterval: "30 k",
-			ExpectError:    true,
-		},
-		{
-			Scenario:      "invalid scrape timeout",
-			Version:       "v2.29.0",
-			ScrapeTimeout: "some value",
-			ExpectError:   true,
-		},
-		{
-			Scenario:      "invalid scrape timeout specified when scrape interval not specified to compare with default value",
-			Version:       "v2.30.0",
-			ScrapeTimeout: "120s",
-			ExpectError:   true,
 		},
 		{
 			Scenario:       "invalid scrape timeout specified when scrape interval specified",
@@ -172,10 +117,11 @@ scrape_configs: []
 			ExpectError:    true,
 		},
 		{
-			Scenario:       "valid scrape timeout along with valid scrape interval specified",
-			Version:        "v2.15.2",
-			ScrapeInterval: "60s",
-			ScrapeTimeout:  "10s",
+			Scenario:           "valid scrape timeout along with valid scrape interval specified",
+			Version:            "v2.15.2",
+			ScrapeInterval:     "60s",
+			ScrapeTimeout:      "10s",
+			EvaluationInterval: "30s",
 			Expected: `global:
   evaluation_interval: 30s
   scrape_interval: 60s
@@ -187,8 +133,10 @@ scrape_configs: []
 `,
 		},
 		{
-			Scenario: "external label specified",
-			Version:  "v2.15.2",
+			Scenario:           "external label specified",
+			Version:            "v2.15.2",
+			ScrapeInterval:     "30s",
+			EvaluationInterval: "30s",
 			ExternalLabels: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -205,9 +153,11 @@ scrape_configs: []
 `,
 		},
 		{
-			Scenario:     "query log file",
-			Version:      "v2.16.0",
-			QueryLogFile: "test.log",
+			Scenario:           "query log file",
+			Version:            "v2.16.0",
+			ScrapeInterval:     "30s",
+			EvaluationInterval: "30s",
+			QueryLogFile:       "test.log",
 			Expected: `global:
   evaluation_interval: 30s
   scrape_interval: 30s
@@ -459,8 +409,10 @@ func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -579,8 +531,10 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -699,8 +653,10 @@ func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -805,8 +761,10 @@ func TestProbeStaticTargetsConfigGenerationWithoutModule(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -907,8 +865,10 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -1053,9 +1013,11 @@ func TestProbeIngressSDConfigGenerationWithShards(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
-				Shards:  pointer.Int32Ptr(2),
+				Version:        operator.DefaultPrometheusVersion,
+				Shards:         pointer.Int32Ptr(2),
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -1200,8 +1162,10 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 						"group": "group1",
 					},
 				},
-				Version: operator.DefaultPrometheusVersion,
+				Version:        operator.DefaultPrometheusVersion,
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -1439,6 +1403,10 @@ func TestAlertmanagerBearerToken(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
 			Alerting: &monitoringv1.AlertingSpec{
 				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 					{
@@ -1519,8 +1487,10 @@ func TestAlertmanagerAPIVersion(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: "v2.11.0",
+				Version:        "v2.11.0",
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 			Alerting: &monitoringv1.AlertingSpec{
 				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 					{
@@ -1599,8 +1569,10 @@ func TestAlertmanagerTimeoutConfig(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: "v2.11.0",
+				Version:        "v2.11.0",
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 			Alerting: &monitoringv1.AlertingSpec{
 				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 					{
@@ -1685,8 +1657,10 @@ func TestAdditionalScrapeConfigs(t *testing.T) {
 			},
 			Spec: monitoringv1.PrometheusSpec{
 				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					Shards: shards,
+					Shards:         shards,
+					ScrapeInterval: "30s",
 				},
+				EvaluationInterval: "30s",
 			},
 		}
 
@@ -1700,8 +1674,10 @@ func TestAdditionalScrapeConfigs(t *testing.T) {
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Shards: shards,
+						Shards:         shards,
+						ScrapeInterval: "30s",
 					},
+					EvaluationInterval: "30s",
 				},
 			},
 			nil,
@@ -1860,6 +1836,10 @@ func TestAdditionalAlertRelabelConfigs(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
 			Alerting: &monitoringv1.AlertingSpec{
 				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 					{
@@ -1941,7 +1921,12 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 			Name:      "test",
 			Namespace: "ns-value",
 		},
-		Spec: monitoringv1.PrometheusSpec{},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
+		},
 	}
 
 	cg := mustNewConfigGenerator(t, p)
@@ -2104,7 +2089,9 @@ func TestServiceMonitorWithEndpointSliceEnable(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				EnforcedNamespaceLabel: "ns-key",
+				ScrapeInterval:         "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -2276,7 +2263,9 @@ func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				EnforcedNamespaceLabel: "ns-key",
+				ScrapeInterval:         "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -2432,7 +2421,9 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 						Name:      "testpodmonitor1",
 					},
 				},
+				ScrapeInterval: "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -2579,7 +2570,9 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				EnforcedNamespaceLabel: "ns-key",
+				ScrapeInterval:         "30s",
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -2749,6 +2742,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval:         "30s",
 				EnforcedNamespaceLabel: "ns-key",
 				ExcludedFromEnforcement: []monitoringv1.ObjectReference{
 					{
@@ -2759,6 +2753,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -2917,6 +2912,10 @@ func TestAdditionalAlertmanagers(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
 			Alerting: &monitoringv1.AlertingSpec{
 				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
 					{
@@ -2998,13 +2997,15 @@ func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: "v2.9.0",
+				Version:        "v2.9.0",
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -3137,13 +3138,15 @@ func TestSettingHonorTimestampsInPodMonitor(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: "v2.9.0",
+				Version:        "v2.9.0",
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -3262,6 +3265,7 @@ func TestHonorTimestampsOverriding(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				Version:                 "v2.9.0",
+				ScrapeInterval:          "30s",
 				OverrideHonorTimestamps: true,
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -3269,6 +3273,7 @@ func TestHonorTimestampsOverriding(t *testing.T) {
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -3402,12 +3407,14 @@ func TestSettingHonorLabels(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -3541,6 +3548,7 @@ func TestHonorLabelsOverriding(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval:      "30s",
 				OverrideHonorLabels: true,
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -3548,6 +3556,7 @@ func TestHonorLabelsOverriding(t *testing.T) {
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -3680,6 +3689,7 @@ func TestTargetLabels(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval:      "30s",
 				OverrideHonorLabels: false,
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -3687,6 +3697,7 @@ func TestTargetLabels(t *testing.T) {
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -4036,12 +4047,14 @@ func TestPodTargetLabels(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -4174,12 +4187,14 @@ func TestPodTargetLabelsFromPodMonitor(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -4294,6 +4309,12 @@ func TestEmptyEndointPorts(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -5068,13 +5089,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: "v2.20.0",
+						Version:        "v2.20.0",
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 			if tc.enforcedLimit >= 0 {
@@ -5330,13 +5353,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 			if tc.enforcedLimit >= 0 {
@@ -5479,19 +5504,6 @@ remote_read:
     credentials: secret
 `,
 		},
-		{
-			version: "v2.26.0",
-			remoteRead: monitoringv1.RemoteReadSpec{
-				URL: "http://example.com",
-				OAuth2: &monitoringv1.OAuth2{
-					TokenURL:       "http://token-url",
-					Scopes:         []string{"scope1"},
-					EndpointParams: map[string]string{"param": "value"},
-				},
-				RemoteTimeout: "30 g",
-			},
-			expectedErr: errors.New("invalid remoteRead[0].remoteTimeout value specified: not a valid duration string: \"30 g\""),
-		},
 	} {
 		t.Run(fmt.Sprintf("version=%s", tc.version), func(t *testing.T) {
 			prometheus := monitoringv1.Prometheus{
@@ -5501,14 +5513,16 @@ remote_read:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
-					RemoteRead: []monitoringv1.RemoteReadSpec{tc.remoteRead},
+					EvaluationInterval: "30s",
+					RemoteRead:         []monitoringv1.RemoteReadSpec{tc.remoteRead},
 				},
 			}
 
@@ -5883,30 +5897,6 @@ remote_write:
 `,
 		},
 		{
-			version: "v2.27.1",
-			remoteWrite: monitoringv1.RemoteWriteSpec{
-				URL: "http://example.com",
-				OAuth2: &monitoringv1.OAuth2{
-					TokenURL:       "http://token-url",
-					Scopes:         []string{"scope1"},
-					EndpointParams: map[string]string{"param": "value"},
-				},
-				RemoteTimeout: "30ss",
-			},
-			expectedErr: errors.New("invalid remoteWrite[0].remoteTimeout value specified: not a valid duration string: \"30ss\""),
-		},
-		{
-			version: "v2.26.0",
-			remoteWrite: monitoringv1.RemoteWriteSpec{
-				URL: "http://example.com",
-				MetadataConfig: &monitoringv1.MetadataConfig{
-					Send:         false,
-					SendInterval: "1p",
-				},
-			},
-			expectedErr: errors.New("invalid remoteWrite[0].metadataConfig.sendInterval value specified: not a valid duration string: \"1p\""),
-		},
-		{
 			version: "v2.30.0",
 			remoteWrite: monitoringv1.RemoteWriteSpec{
 				URL: "http://example.com",
@@ -5952,7 +5942,8 @@ remote_write:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
@@ -5961,6 +5952,7 @@ remote_write:
 						RemoteWrite: []monitoringv1.RemoteWriteSpec{tc.remoteWrite},
 						Secrets:     []string{"sigv4-secret"},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -6211,13 +6203,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -6444,13 +6438,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -6646,13 +6642,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 			if tc.enforcedLabelValueLengthLimit >= 0 {
@@ -6877,26 +6875,6 @@ scrape_configs:
 			enforcedBodySizeLimit: "",
 			expected:              expectNoLimit,
 		},
-		{
-			version:               "v2.28.0",
-			enforcedBodySizeLimit: "100",
-			expectedErr:           errors.New("invalid enforcedBodySizeLimit value specified: units: unknown unit  in 100"),
-		},
-		{
-			version:               "v2.28.0",
-			enforcedBodySizeLimit: "200kb",
-			expectedErr:           errors.New("invalid enforcedBodySizeLimit value specified: units: unknown unit kb in 200kb"),
-		},
-		{
-			version:               "v2.28.0",
-			enforcedBodySizeLimit: "300 MB",
-			expectedErr:           errors.New("invalid enforcedBodySizeLimit value specified: units: unknown unit  MB in 300 MB"),
-		},
-		{
-			version:               "v2.28.0",
-			enforcedBodySizeLimit: "150M",
-			expectedErr:           errors.New("invalid enforcedBodySizeLimit value specified: units: unknown unit M in 150M"),
-		},
 	} {
 		t.Run(fmt.Sprintf("%s enforcedBodySizeLimit(%s)", tc.version, tc.enforcedBodySizeLimit), func(t *testing.T) {
 			prometheus := monitoringv1.Prometheus{
@@ -6906,13 +6884,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 			if tc.enforcedBodySizeLimit != "" {
@@ -6974,6 +6954,12 @@ func TestMatchExpressionsServiceMonitor(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "ns-value",
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
 		},
 	}
 
@@ -7334,13 +7320,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -7605,13 +7593,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -7921,13 +7911,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -8008,13 +8000,15 @@ func TestPodMonitorPhaseFilter(t *testing.T) {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: "v2.9.0",
+				Version:        "v2.9.0",
+				ScrapeInterval: "30s",
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
 					},
 				},
 			},
+			EvaluationInterval: "30s",
 		},
 	}
 	cg := mustNewConfigGenerator(t, p)
@@ -8298,13 +8292,15 @@ scrape_configs:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: tc.version,
+						Version:        tc.version,
+						ScrapeInterval: "30s",
 						ServiceMonitorSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
 								"group": "group1",
 							},
 						},
 					},
+					EvaluationInterval: "30s",
 				},
 			}
 
@@ -8394,6 +8390,10 @@ func TestStorageSettingMaxExemplars(t *testing.T) {
 					Exemplars: &monitoringv1.Exemplars{
 						MaxSize: getInt64Pointer(5000000),
 					},
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeInterval: "30s",
+					},
+					EvaluationInterval: "30s",
 				},
 			},
 			ExpectedConfig: `global:
@@ -8417,11 +8417,13 @@ storage:
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: "v2.28.0",
+						Version:        "v2.28.0",
+						ScrapeInterval: "30s",
 					},
 					Exemplars: &monitoringv1.Exemplars{
 						MaxSize: getInt64Pointer(5000000),
 					},
+					EvaluationInterval: "30s",
 				},
 			},
 			ExpectedConfig: `global:
@@ -8442,8 +8444,10 @@ scrape_configs: []
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeInterval: "30s",
 						EnableFeatures: []string{"exemplar-storage"},
 					},
+					EvaluationInterval: "30s",
 				},
 			},
 			ExpectedConfig: `global:
@@ -8496,7 +8500,12 @@ func TestTSDBConfig(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
-				Spec: monitoringv1.PrometheusSpec{},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeInterval: "30s",
+					},
+					EvaluationInterval: "30s",
+				},
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -8516,8 +8525,10 @@ scrape_configs: []
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: "v2.38.0",
+						Version:        "v2.38.0",
+						ScrapeInterval: "30s",
 					},
+					EvaluationInterval: "30s",
 					TSDB: monitoringv1.TSDBSpec{
 						OutOfOrderTimeWindow: monitoringv1.Duration("10m"),
 					},
@@ -8541,8 +8552,10 @@ scrape_configs: []
 				},
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Version: "v2.39.0",
+						Version:        "v2.39.0",
+						ScrapeInterval: "30s",
 					},
+					EvaluationInterval: "30s",
 					TSDB: monitoringv1.TSDBSpec{
 						OutOfOrderTimeWindow: monitoringv1.Duration("10m"),
 					},
@@ -8595,7 +8608,12 @@ func TestGenerateRelabelConfig(t *testing.T) {
 			Name:      "test",
 			Namespace: "test-relabel",
 		},
-		Spec: monitoringv1.PrometheusSpec{},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
+		},
 	}
 
 	cg := mustNewConfigGenerator(t, p)

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -165,30 +165,6 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		return nil, errors.Wrap(err, "failed to build image path")
 	}
 
-	// TODO(slashpai): Remove this assignment after v0.57 since this is handled at CRD level
-	if tr.Spec.EvaluationInterval == "" {
-		tr.Spec.EvaluationInterval = defaultEvaluationInterval
-	}
-
-	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
-	if tr.Spec.EvaluationInterval != "" {
-		if err := operator.ValidateDurationField(string(tr.Spec.EvaluationInterval)); err != nil {
-			return nil, errors.Wrap(err, "invalid evaluationInterval value specified")
-		}
-	}
-
-	// TODO(slashpai): Remove this assignment after v0.57 since this is handled at CRD level
-	if tr.Spec.Retention == "" {
-		tr.Spec.Retention = defaultRetention
-	}
-
-	// TODO(slashpai): Remove this validation after v0.57 since this is handled at CRD level
-	if tr.Spec.Retention != "" {
-		if err := operator.ValidateDurationField(string(tr.Spec.Retention)); err != nil {
-			return nil, errors.Wrap(err, "invalid retention value specified")
-		}
-	}
-
 	trCLIArgs := []string{
 		"rule",
 		fmt.Sprintf("--data-dir=%s", storageDir),

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -616,12 +616,8 @@ func TestRetention(t *testing.T) {
 	for _, tc := range []struct {
 		specRetention     monitoringv1.Duration
 		expectedRetention monitoringv1.Duration
-		ok                bool
 	}{
-		{"", "24h", true},
-		{"1d", "1d", true},
-		{"1k", "", false},
-		{"somevalue", "", false},
+		{"1d", "1d"},
 	} {
 		t.Run(string(tc.specRetention), func(t *testing.T) {
 			sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -630,13 +626,6 @@ func TestRetention(t *testing.T) {
 					QueryEndpoints: emptyQueryEndpoints,
 				},
 			}, defaultTestConfig, nil, "")
-
-			if !tc.ok {
-				if err == nil {
-					t.Fatal("expecting error but got none")
-				}
-				return
-			}
 
 			if err != nil {
 				t.Fatalf("expecting no error but got %q", err)


### PR DESCRIPTION
pkg: Remove validations which is already covered at CRD level

Update unit tests as well to incorporate this change

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
pkg: Remove validations which is already covered at CRD level
```
