### PR TITLE
jsonnet: enforce TLS secret for the admission webhook

### DIFF
--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -33,7 +33,11 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - image: quay.io/prometheus-operator/admission-webhook:v0.60.1
+      - args:
+        - --web.enable-tls=true
+        - --web.cert-file=/etc/tls/private/tls.crt
+        - --web.key-file=/etc/tls/private/tls.key
+        image: quay.io/prometheus-operator/admission-webhook:v0.60.1
         name: prometheus-operator-admission-webhook
         ports:
         - containerPort: 8443
@@ -52,7 +56,20 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: tls-certificates
+          readOnly: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: prometheus-operator-admission-webhook
+      volumes:
+      - name: tls-certificates
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          secretName: admission-webhook-certs

--- a/example/admission-webhook/service.yaml
+++ b/example/admission-webhook/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - name: https
-    port: 8443
+    port: 443
     targetPort: https
   selector:
     app.kubernetes.io/name: prometheus-operator-admission-webhook

--- a/scripts/generate/admission-webhook.jsonnet
+++ b/scripts/generate/admission-webhook.jsonnet
@@ -2,6 +2,7 @@ local admissionWebhook = (import 'prometheus-operator/admission-webhook.libsonne
 local config = (import 'config.jsonnet');
 local aw = admissionWebhook(config {
   image: 'quay.io/prometheus-operator/admission-webhook:v' + config.version,
+  tlsSecretName: 'admission-webhook-certs',
 });
 
 {

--- a/test/framework/resources/prometheus-operator-mutatingwebhook.yaml
+++ b/test/framework/resources/prometheus-operator-mutatingwebhook.yaml
@@ -8,7 +8,6 @@ webhooks:
         name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-prometheusrules/mutate
-
     failurePolicy: Fail
     name: prometheusrulemutate.monitoring.coreos.com
     namespaceSelector: {}


### PR DESCRIPTION
## Description
The admission webhook service has to deployed with TLS enabled because the Kubernetes API only supports webhook URLs with a "https://" scheme.

This change also cleans up the end-to-end tests: there's no need to configure the Prometheus operator with TLS enabled since the Kubernetes API is configured to contact the dedicated admission webhook service.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
jsonnet: Enforced existence of the TLS secret for the admission webhook deployment.
jsonnet: Changed default port of the admission webhook service from 8443 to 443.
```
