### PR TITLE
Documentation/user-guides/storage.md: fix typo

### DIFF
--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -165,7 +165,8 @@ issue](https://github.com/kubernetes/enhancements/issues/661)).
 
 It is still possible to fix the situation manually.
 
-First, update the storage request in the `spec.storage` field of the custom resource (assuming a Prometheus resource named `example`):
+First, update the storage request in the `spec.storage` field of the custom
+resource (assuming a Prometheus resource named `example`):
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -182,11 +183,11 @@ spec:
             storage: 10Gi
 ```
 
-Next, patch every PVC with the updated storage request:
+Next, patch every PVC with the updated storage request (10Gi in this example):
 
 ```bash
 for p in $(kubectl get pvc -l operator.prometheus.io/name=example -o jsonpath='{range .items[*]}{.metadata.name} {end}'); do \
-  kubectl patch pvc/${p} --patch '{"spec": {"resources": {"requests": {"storage":"10Gi"}}}}' \
+  kubectl patch pvc/${p} --patch '{"spec": {"resources": {"requests": {"storage":"10Gi"}}}}'; \
 done
 ```
 


### PR DESCRIPTION
## Description

The kubectl command had a typo.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
