### PR TITLE
add defaultxxxLimit support

### DIFF
--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -272,6 +272,36 @@ type CommonPrometheusFields struct {
 	// Label name is this field's value.
 	// Label value is the namespace of the created object (mentioned above).
 	EnforcedNamespaceLabel string `json:"enforcedNamespaceLabel,omitempty"`
+	// DefaultSampleLimit defines the default limit on number of scraped
+	// samples that will be accepted. This sets the default value for
+	// SampleLimit set per ServiceMonitor or/and PodMonitor.
+	DefaultSampleLimit *uint64 `json:"defaultSampleLimit,omitempty"`
+	// DefaultTargetLimit defines the default limit on number of scraped
+	// targets  that will be accepted. This sets the default value for
+	// SampleLimit set per ServiceMonitor or/and PodMonitor.
+	DefaultTargetLimit *uint64 `json:"defaultTargetLimit,omitempty"`
+	// DefaultLabelLimit defines the default per-scrape limit on number
+	// of labels that will be accepted for a sample. This sets the default
+	// value for SampleLimit set per ServiceMonitor or/and PodMonitor.
+	// Only valid in Prometheus versions 2.27.0 and newer.
+	DefaultLabelLimit *uint64 `json:"defaultLabelLimit,omitempty"`
+	// DefaultLabelNameLengthLimit defines the default limit on length of
+	// labels name that will be accepted for a sample. This sets the default
+	// value for SampleLimit set per ServiceMonitor or/and PodMonitor.
+	// Only valid in Prometheus versions 2.27.0 and newer.
+	DefaultLabelNameLengthLimit *uint64 `json:"defaultLabelNameLengthLimit,omitempty"`
+	// DefaultLabelValueLengthLimit defines the default limit on length of
+	// labels value that will be accepted for a sample. This sets the default
+	// value for SampleLimit set per ServiceMonitor or/and PodMonitor.
+	// Only valid in Prometheus versions 2.27.0 and newer.
+	DefaultLabelValueLengthLimit *uint64 `json:"defaultLabelValueLengthLimit,omitempty"`
+	// DefaultBodySizeLimit defines the default limit of the maximum size of
+	// uncompressed response body that will be accepted by Prometheus.
+	// Targets responding with a body larger than this many bytes will cause
+	// the scrape to fail. Example: 100MB. This sets the default
+	// value for SampleLimit set per ServiceMonitor or/and PodMonitor.
+	// Only valid in Prometheus versions 2.28.0 and newer.
+	DefaultBodySizeLimit ByteSize `json:"defaultBodySizeLimit,omitempty"`
 	// EnforcedSampleLimit defines global limit on number of scraped samples
 	// that will be accepted. This overrides any SampleLimit set per
 	// ServiceMonitor or/and PodMonitor. It is meant to be used by admins to

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -180,7 +180,12 @@ var (
 
 // AddLimitsToYAML appends the given limit key to the configuration if
 // supported by the Prometheus version.
-func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit uint64, enforcedLimit *uint64) yaml.MapSlice {
+func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit uint64, defaultLimit *uint64, enforcedLimit *uint64) yaml.MapSlice {
+	// use defaultLimit if default is set and limit is 0
+	if defaultLimit != nil && limit == 0 {
+		limit = *defaultLimit
+	}
+
 	if limit == 0 && enforcedLimit == nil {
 		return cfg
 	}
@@ -937,11 +942,11 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 	relabelings = generateAddressShardingRelabelingRules(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
-	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.EnforcedSampleLimit)
-	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.EnforcedTargetLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.EnforcedLabelLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.DefaultSampleLimit, cg.spec.EnforcedSampleLimit)
+	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.DefaultTargetLimit, cg.spec.EnforcedTargetLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.DefaultLabelLimit, cg.spec.EnforcedLabelLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.DefaultLabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.DefaultLabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
 
 	if cg.spec.EnforcedBodySizeLimit != "" {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", cg.spec.EnforcedBodySizeLimit)
@@ -996,11 +1001,11 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		}})
 	}
 
-	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.EnforcedSampleLimit)
-	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.EnforcedTargetLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.EnforcedLabelLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.DefaultSampleLimit, cg.spec.EnforcedSampleLimit)
+	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.DefaultTargetLimit, cg.spec.EnforcedTargetLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.DefaultLabelLimit, cg.spec.EnforcedLabelLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.DefaultLabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.DefaultLabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
 
 	if cg.spec.EnforcedBodySizeLimit != "" {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", cg.spec.EnforcedBodySizeLimit)
@@ -1441,11 +1446,11 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 	relabelings = generateAddressShardingRelabelingRules(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
-	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.EnforcedSampleLimit)
-	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.EnforcedTargetLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.EnforcedLabelLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
-	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cg.spec.DefaultSampleLimit, cg.spec.EnforcedSampleLimit)
+	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, m.Spec.TargetLimit, cg.spec.DefaultTargetLimit, cg.spec.EnforcedTargetLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelLimitKey, m.Spec.LabelLimit, cg.spec.DefaultLabelLimit, cg.spec.EnforcedLabelLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelNameLengthLimitKey, m.Spec.LabelNameLengthLimit, cg.spec.DefaultLabelNameLengthLimit, cg.spec.EnforcedLabelNameLengthLimit)
+	cfg = cg.AddLimitsToYAML(cfg, labelValueLengthLimitKey, m.Spec.LabelValueLengthLimit, cg.spec.DefaultLabelValueLengthLimit, cg.spec.EnforcedLabelValueLengthLimit)
 
 	if cg.spec.EnforcedBodySizeLimit != "" {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", cg.spec.EnforcedBodySizeLimit)


### PR DESCRIPTION
## Description
adds `defaultSampleLimit` and other default limits which is just a default is samplesLimit is 0 and doesn't limit the value in any kind #5119 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- adds `defaultSampleLimit`  in Prometheuses spec
- adds `defaultTargetLimit` in Prometheuses spec
- adds `defaultLabelLimit` in Prometheuses spec
- adds `defaultLabelNameLengthLimit` in Prometheuses spec
- adds `defaultBodySizeLimit` in Prometheuses spec
```
