### PR TITLE
Modifies ThanosRuler arguments to be read from secrets instead of using ENV vars

### DIFF
--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -32,6 +32,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	containerName = "thanos-ruler"
+)
+
 var (
 	defaultTestConfig = Config{
 		ReloaderConfig: operator.ReloaderConfig{
@@ -200,14 +204,22 @@ func TestStatefulSetVolumes(t *testing.T) {
 }
 
 func TestTracing(t *testing.T) {
-	testKey := "thanos-tracing-config-secret"
+	const (
+		secretName = "thanos-tracing-config-secret"
+		secretKey  = "config.yaml"
+		volumeName = "tracing-config"
+		mountPath  = "/etc/thanos/config/tracing-config.yaml"
+	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 			TracingConfig: &v1.SecretKeySelector{
-				Key: testKey,
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
 			},
 		},
 	}, defaultTestConfig, nil, "")
@@ -215,26 +227,37 @@ func TestTracing(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	if sset.Spec.Template.Spec.Containers[0].Name != "thanos-ruler" {
+	if sset.Spec.Template.Spec.Containers[0].Name != containerName {
 		t.Fatalf("expected 1st containers to be thanos-ruler, got %s", sset.Spec.Template.Spec.Containers[0].Name)
 	}
-
-	var containsEnvVar bool
-	for _, env := range sset.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "TRACING_CONFIG" {
-			if env.ValueFrom.SecretKeyRef.Key == testKey {
-				containsEnvVar = true
-				break
+	{
+		var containsVolume bool
+		for _, volume := range sset.Spec.Template.Spec.Volumes {
+			if volume.Name == volumeName {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+					containsVolume = true
+					break
+				}
 			}
 		}
+		if !containsVolume {
+			t.Fatalf("Thanos ruler is missing tracing-config volume with correct secret name and key")
+		}
 	}
-	if !containsEnvVar {
-		t.Fatalf("Thanos ruler is missing expected TRACING_CONFIG env var with correct value")
-	}
-
 	{
+		var containsVolumeMount bool
+		for _, volumeMount := range sset.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if volumeMount.Name == volumeName && volumeMount.MountPath == mountPath {
+				containsVolumeMount = true
+			}
+		}
+		if !containsVolumeMount {
+			t.Fatalf("Thanos ruler is missing tracing-config volume mount with correct name and mountPath")
+		}
+	}
+	{
+		const expectedArg = "--tracing.config-file=" + mountPath
 		var containsArg bool
-		const expectedArg = "--tracing.config=$(TRACING_CONFIG)"
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {
 				containsArg = true
@@ -291,14 +314,22 @@ func TestTracingFile(t *testing.T) {
 }
 
 func TestObjectStorage(t *testing.T) {
-	testKey := "thanos-objstore-config-secret"
+	const (
+		secretName = "thanos-objstore-config-secret"
+		secretKey  = "config.yaml"
+		volumeName = "objstorage-config"
+		mountPath  = "/etc/thanos/config/objstorage-config.yaml"
+	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 			ObjectStorageConfig: &v1.SecretKeySelector{
-				Key: testKey,
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
 			},
 		},
 	}, defaultTestConfig, nil, "")
@@ -306,26 +337,37 @@ func TestObjectStorage(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	if sset.Spec.Template.Spec.Containers[0].Name != "thanos-ruler" {
+	if sset.Spec.Template.Spec.Containers[0].Name != containerName {
 		t.Fatalf("expected 1st containers to be thanos-ruler, got %s", sset.Spec.Template.Spec.Containers[0].Name)
 	}
-
-	var containsEnvVar bool
-	for _, env := range sset.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "OBJSTORE_CONFIG" {
-			if env.ValueFrom.SecretKeyRef.Key == testKey {
-				containsEnvVar = true
-				break
+	{
+		var containsVolume bool
+		for _, volume := range sset.Spec.Template.Spec.Volumes {
+			if volume.Name == volumeName {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+					containsVolume = true
+					break
+				}
 			}
 		}
+		if !containsVolume {
+			t.Fatalf("Thanos ruler is missing objstorage-config volume with correct secret name and key")
+		}
 	}
-	if !containsEnvVar {
-		t.Fatalf("Thanos ruler is missing expected OBJSTORE_CONFIG env var with correct value")
-	}
-
 	{
+		var containsVolumeMount bool
+		for _, volumeMount := range sset.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if volumeMount.Name == volumeName && volumeMount.MountPath == mountPath {
+				containsVolumeMount = true
+			}
+		}
+		if !containsVolumeMount {
+			t.Fatalf("Thanos ruler is missing objstorage-config volume mount with correct name and mountPath")
+		}
+	}
+	{
+		const expectedArg = "--objstore.config-file=" + mountPath
 		var containsArg bool
-		const expectedArg = "--objstore.config=$(OBJSTORE_CONFIG)"
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {
 				containsArg = true
@@ -382,14 +424,22 @@ func TestObjectStorageFile(t *testing.T) {
 }
 
 func TestAlertRelabel(t *testing.T) {
-	testKey := "thanos-alertrelabel-config-secret"
+	const (
+		secretName = "thanos-alertrelabel-config-secret"
+		secretKey  = "config.yaml"
+		volumeName = "alertrelabel-config"
+		mountPath  = "/etc/thanos/config/alertrelabel-config.yaml"
+	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
 			AlertRelabelConfigs: &v1.SecretKeySelector{
-				Key: testKey,
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
 			},
 		},
 	}, defaultTestConfig, nil, "")
@@ -397,26 +447,37 @@ func TestAlertRelabel(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	if sset.Spec.Template.Spec.Containers[0].Name != "thanos-ruler" {
+	if sset.Spec.Template.Spec.Containers[0].Name != containerName {
 		t.Fatalf("expected 1st containers to be thanos-ruler, got %s", sset.Spec.Template.Spec.Containers[0].Name)
 	}
-
-	var containsEnvVar bool
-	for _, env := range sset.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "ALERT_RELABEL_CONFIG" {
-			if env.ValueFrom.SecretKeyRef.Key == testKey {
-				containsEnvVar = true
-				break
+	{
+		var containsVolume bool
+		for _, volume := range sset.Spec.Template.Spec.Volumes {
+			if volume.Name == volumeName {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+					containsVolume = true
+					break
+				}
 			}
 		}
+		if !containsVolume {
+			t.Fatalf("Thanos ruler is missing alertrelabel-config volume with correct secret name and key")
+		}
 	}
-	if !containsEnvVar {
-		t.Fatalf("Thanos ruler is missing expected ALERT_RELABEL_CONFIG env var with correct value")
-	}
-
 	{
+		var containsVolumeMount bool
+		for _, volumeMount := range sset.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if volumeMount.Name == volumeName && volumeMount.MountPath == mountPath {
+				containsVolumeMount = true
+			}
+		}
+		if !containsVolumeMount {
+			t.Fatalf("Thanos ruler is missing alertrelabel-config volume mount with correct name and mountPath")
+		}
+	}
+	{
+		const expectedArg = "--alert.relabel-config-file=" + mountPath
 		var containsArg bool
-		const expectedArg = "--alert.relabel-config=$(ALERT_RELABEL_CONFIG)"
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {
 				containsArg = true
@@ -756,7 +817,7 @@ func TestExternalQueryURL(t *testing.T) {
 		t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 	}
 
-	if sset.Spec.Template.Spec.Containers[0].Name != "thanos-ruler" {
+	if sset.Spec.Template.Spec.Containers[0].Name != containerName {
 		t.Fatalf("expected 1st containers to be thanos-ruler, got %s", sset.Spec.Template.Spec.Containers[0].Name)
 	}
 


### PR DESCRIPTION

## Description
Issue: https://issues.redhat.com/browse/OCPBUGS-2778

Problem: Some arguments are currently being passed to ThanosRuler using ENV vars. Those arguments are QueryConfig, AlertManagerConfig, ObjectStorageConfig and TracingConfig. These arguments should instead be read directly from the secrets instead of using ENV vars.

Solution: Modify the code to mount the secrets in the SecretKeySelector instead of assigning them to ENV variables

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
-  ThanosRuler arguments (QueryConfig, AlertManagerConfig, ObjectStorageConfig and TracingConfig) are now directly read from the secrets instead of using ENV vars
```
