### PR TITLE
pkg/prometheus: Ignore PartialResponseStrategy for Prometheus

### DIFF
--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -28,7 +28,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
-	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/rulefmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	thanostypes "github.com/thanos-io/thanos/pkg/store/storepb"
+)
+
+func GenerateRulesConfiguration(promRule monitoringv1.PrometheusRuleSpec, logger log.Logger) (string, error) {
+	content, err := yaml.Marshal(promRule)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal content")
+	}
+	errs := ValidateRule(promRule)
+	if len(errs) != 0 {
+		const m = "Invalid rule"
+		level.Debug(logger).Log("msg", m, "content", content)
+		for _, err := range errs {
+			level.Info(logger).Log("msg", m, "err", err)
+		}
+		return "", errors.New(m)
+	}
+	return string(content), nil
+}
+
+// ValidateRule takes PrometheusRuleSpec and validates it using the upstream prometheus rule validator.
+func ValidateRule(promRule monitoringv1.PrometheusRuleSpec) []error {
+	for i, group := range promRule.Groups {
+		if group.PartialResponseStrategy == "" {
+			continue
+		}
+		// TODO(slashpai): Remove this validation after v0.65 since this is handled at CRD level
+		if _, ok := thanostypes.PartialResponseStrategy_value[strings.ToUpper(group.PartialResponseStrategy)]; !ok {
+			return []error{
+				fmt.Errorf("invalid partial_response_strategy %s value", group.PartialResponseStrategy),
+			}
+		}
+
+		// reset this as the upstream prometheus rule validator
+		// is not aware of the partial_response_strategy field.
+		promRule.Groups[i].PartialResponseStrategy = ""
+	}
+	content, err := yaml.Marshal(promRule)
+	if err != nil {
+		return []error{errors.Wrap(err, "failed to marshal content")}
+	}
+	_, errs := rulefmt.Parse(content)
+	return errs
+}

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestMakeRulesConfigMapsThanos(t *testing.T) {
+	t.Run("shouldAcceptRuleWithValidPartialResponseStrategyValue", shouldAcceptRuleWithValidPartialResponseStrategyValue)
+	t.Run("shouldRejectRuleWithInvalidPartialResponseStrategyValue", shouldRejectRuleWithInvalidPartialResponseStrategyValue)
+}
+
+func shouldRejectRuleWithInvalidPartialResponseStrategyValue(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name:                    "group",
+			PartialResponseStrategy: "invalid",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+				},
+			},
+		},
+	}}
+	_, err := GenerateRulesConfiguration(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if err == nil {
+		t.Fatalf("expected errors when parsing rule with invalid partial_response_strategy value")
+	}
+}
+
+func shouldAcceptRuleWithValidPartialResponseStrategyValue(t *testing.T) {
+	rules := monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+		{
+			Name:                    "group",
+			PartialResponseStrategy: "warn",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "alert",
+					Expr:  intstr.FromString("vector(1)"),
+				},
+			},
+		},
+	}}
+	content, _ := GenerateRulesConfiguration(rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
+	if !strings.Contains(content, "partial_response_strategy: warn") {
+		t.Fatalf("expected `partial_response_strategy` to be set in PrometheusRule as `warn`")
+
+	}
+}

--- a/pkg/prometheus/rules.go
+++ b/pkg/prometheus/rules.go
@@ -22,19 +22,17 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
-	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	namespacelabeler "github.com/prometheus-operator/prometheus-operator/pkg/namespace-labeler"
-	thanostypes "github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 const labelPrometheusName = "prometheus-name"
@@ -205,7 +203,7 @@ func (c *Operator) selectRules(p *monitoringv1.Prometheus, namespaces []string) 
 				return
 			}
 
-			content, err := GenerateContent(promRule.Spec, c.logger)
+			content, err := generateRulesConfiguration(promRule.Spec, c.logger)
 			if err != nil {
 				marshalErr = err
 				return
@@ -331,45 +329,11 @@ func prometheusRuleConfigMapName(prometheusName string) string {
 	return "prometheus-" + prometheusName + "-rulefiles"
 }
 
-// GenerateContent takes a PrometheusRuleSpec and generates the rule content
-func GenerateContent(promRule monitoringv1.PrometheusRuleSpec, logger log.Logger) (string, error) {
-	content, err := yaml.Marshal(promRule)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal content")
-	}
-	errs := ValidateRule(promRule)
-	if len(errs) != 0 {
-		const m = "Invalid rule"
-		level.Debug(logger).Log("msg", m, "content", content)
-		for _, err := range errs {
-			level.Info(logger).Log("msg", m, "err", err)
-		}
-		return "", errors.New(m)
-	}
-	return string(content), nil
-}
-
-// ValidateRule takes PrometheusRuleSpec and validates it using the upstream prometheus rule validator
-func ValidateRule(promRule monitoringv1.PrometheusRuleSpec) []error {
-	for i, group := range promRule.Groups {
-		if group.PartialResponseStrategy == "" {
-			continue
-		}
-		// TODO(slashpai): Remove this validation after v0.65 since this is handled at CRD level
-		if _, ok := thanostypes.PartialResponseStrategy_value[strings.ToUpper(group.PartialResponseStrategy)]; !ok {
-			return []error{
-				fmt.Errorf("invalid partial_response_strategy %s value", group.PartialResponseStrategy),
-			}
-		}
-
-		// reset this as the upstream prometheus rule validator
-		// is not aware of the partial_response_strategy field
+func generateRulesConfiguration(promRule monitoringv1.PrometheusRuleSpec, logger log.Logger) (string, error) {
+	// Unset partialResponseStrategy field.
+	for i := range promRule.Groups {
 		promRule.Groups[i].PartialResponseStrategy = ""
 	}
-	content, err := yaml.Marshal(promRule)
-	if err != nil {
-		return []error{errors.Wrap(err, "failed to marshal content")}
-	}
-	_, errs := rulefmt.Parse(content)
-	return errs
+
+	return operator.GenerateRulesConfiguration(promRule, logger)
 }

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -26,7 +26,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	namespacelabeler "github.com/prometheus-operator/prometheus-operator/pkg/namespace-labeler"
-	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -203,7 +203,7 @@ func (o *Operator) selectRules(t *monitoringv1.ThanosRuler, namespaces []string)
 				return
 			}
 
-			content, err := prometheus.GenerateContent(promRule.Spec, o.logger)
+			content, err := operator.GenerateRulesConfiguration(promRule.Spec, o.logger)
 			if err != nil {
 				marshalErr = err
 				return


### PR DESCRIPTION
partial_response_strategy field is only applicable for Thanos so if a user sets this by mistake in PrometheusRule object prometheus errors this field is not found in rule format.

This commit is to fix that and allow this field only for Thanos

Fixes #5124

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Ignore PartialResponseStrategy for Prometheus
```
