### PR TITLE
Remove "replace" directive of github.com/prometheus/prometheus in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,7 @@ require (
 	github.com/prometheus/alertmanager v0.24.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
-	// This version is replaced using replace directive below
-	github.com/prometheus/prometheus v1.99.0
+	github.com/prometheus/prometheus v0.39.1
 	github.com/stretchr/testify v1.8.1
 	github.com/thanos-io/thanos v0.28.1
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
@@ -124,7 +123,5 @@ require (
 replace (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => ./pkg/apis/monitoring
 	github.com/prometheus-operator/prometheus-operator/pkg/client => ./pkg/client
-	// A replace directive is needed for github.com/prometheus/prometheus to ensure running against the latest version of prometheus.
-	github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.38.1-0.20221005044927-6d7f26c46ff7
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/prometheus/prometheus v0.38.1-0.20221005044927-6d7f26c46ff7 h1:z1fBltqKbTyXSfhaKcbYNqEDHnkP8JGTR4cbUY19/ts=
-github.com/prometheus/prometheus v0.38.1-0.20221005044927-6d7f26c46ff7/go.mod h1:GjQjgLhHMc0oo4Ko7qt/yBSJMY4hUoiAZwsYQgjaePA=
+github.com/prometheus/prometheus v0.39.1 h1:abZM6A+sKAv2eKTbRIaHq4amM/nT07MuxRm0+QTaTj0=
+github.com/prometheus/prometheus v0.39.1/go.mod h1:GjQjgLhHMc0oo4Ko7qt/yBSJMY4hUoiAZwsYQgjaePA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
## Description

In the `go.mod` file it uses replace directive for github.com/prometheus/prometheus to replace the placeholder version of 1.99 with the latest version 0.38.1.

This PR will remove the prometheus package out of the replace directive, so that we can use directly the version 0.x.y which follows the real version 2.x.y. Next time when we update go packages using `go get -u github.com/prometheus/prometheus`, it will pick the latest version without modifying the replace directive.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
```
