### PR TITLE
Documentation/thanos.md: update deprecated config example

### DIFF
--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -28,18 +28,15 @@ Other Thanos components such the Querier, the Receiver, the Compactor and the St
 ## Prometheus Custom Resource with Thanos Sidecar
 
 The `Prometheus` CRD has support for adding a Thanos sidecar to the Prometheus
-Pod. To enable the sidecar, reference the following example.
-
-This is the simplest configuration change that needs to be made to your
-Prometheus resource.
+Pod. To enable the sidecar, the `thanos` section must be set to a non empty value.
+For example, the simplest configuration is to just set a valid thanos container image url.
 
 ```yaml
 ...
 spec:
   ...
   thanos:
-    baseImage: quay.io/thanos/thanos
-    version: v0.8.1
+    image: quay.io/thanos/thanos:v0.28.1
 ...
 ```
 
@@ -74,8 +71,7 @@ Then you can specify this secret inside the Thanos field of the Prometheus spec 
 spec:
   ...
   thanos:
-    baseImage: quay.io/thanos/thanos
-    version: v0.8.1
+    image: quay.io/thanos/thanos:v0.28.1
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objstore-config


### PR DESCRIPTION
Replace deprecated usage of `baseImage` and `version` with the `image` field. Minor improvement to example text.

Signed-off-by: Paul Gier <paul.gier@datastax.com>

## Description

Updating the docs to remove use of deprecated API in the example.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ X ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

update deprecated API usage in thanos readme

```release-note
update deprecated API usage in thanos readme
```
