### PR TITLE
Prometheus hostnetwork: specify listen address on pod ip

### DIFF
--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -460,6 +460,9 @@ func makeStatefulSetSpec(
 	if p.Spec.ListenLocal {
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.listen-address", Value: "127.0.0.1:9090"})
 	} else {
+		if p.Spec.HostNetwork {
+			promArgs = append(promArgs, monitoringv1.Argument{Name: "web.listen-address", Value: "[$(POD_IP)]:9090"})
+		}
 		ports = []v1.ContainerPort{
 			{
 				Name:          p.Spec.PortName,
@@ -956,6 +959,16 @@ func makeStatefulSetSpec(
 				AllowPrivilegeEscalation: &boolFalse,
 				Capabilities: &v1.Capabilities{
 					Drop: []v1.Capability{"ALL"},
+				},
+			},
+			Env: []v1.EnvVar{
+				{
+					Name: "POD_IP",
+					ValueFrom: &v1.EnvVarSource{
+						FieldRef: &v1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -2821,4 +2821,19 @@ func TestPodHostNetworkConfig(t *testing.T) {
 	if sset.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirstWithHostNet {
 		t.Fatalf("expected DNSPolicy configuration to match due to hostNetwork but failed")
 	}
+
+	if len(sset.Spec.Template.Spec.Containers[0].Env) <= 0 {
+		t.Fatalf("expect prometheus POD_IP env but failed")
+	}
+
+	var listenAddrFound bool
+	for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
+		if arg == "--web.listen-address=[$(POD_IP)]:9090" {
+			listenAddrFound = true
+			break
+		}
+	}
+	if !listenAddrFound {
+		t.Fatalf("expect prometheus listen on pod ip but failed")
+	}
 }


### PR DESCRIPTION
## Description

when prometheus.spec.hostNetwork=true, it will listen on 0.0.0.0:9090 of the node by default, which is not security.

To reduce the problem, just specify it only listen on the pod ip.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```
prometheus hostnetwork: specify listen address on pod ip
```
