### PR TITLE
docs: Add documentation of default labels for monitor objects

### DIFF
--- a/Documentation/user-guides/running-exporters.md
+++ b/Documentation/user-guides/running-exporters.md
@@ -74,27 +74,27 @@ By default, the `PodMonitor` and `ServiceMonitor` objects include runtime metada
 
 ### PodMonitors
 
-| Target Label | Source Label | Description |
-| ------------ | ------------ | ----------- |
-| instance | __param_target | The address of the scraped target |
-| job | - | `{metadata.namespace}/{metadata.name}`  of the `PodMonitor` or read from `jobLabel` if specified |
-| namespace | __meta_kubernetes_namespace | `{metadata.namespace}` of the scraped pod |
-| container | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod |
-| pod | __meta_kubernetes_pod_name | `{metadata.name}` of the scraped pod |
-| endpoint | - | `{spec.Port}` or `{spec.TargetPort}` if specified |
+| Target Label | Source Label                         | Description                                                                                     |
+|--------------|--------------------------------------|-------------------------------------------------------------------------------------------------|
+| instance     | __param_target                       | The address of the scraped target                                                               |
+| job          | -                                    | `{metadata.namespace}/{metadata.name}` of the `PodMonitor` or read from `jobLabel` if specified |
+| namespace    | __meta_kubernetes_namespace          | `{metadata.namespace}` of the scraped pod                                                       |
+| container    | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod                                                    |
+| pod          | __meta_kubernetes_pod_name           | `{metadata.name}` of the scraped pod                                                            |
+| endpoint     | -                                    | `{spec.Port}` or `{spec.TargetPort}` if specified                                               |
 
 ### ServiceMonitors
 
-| Target Label | Source Label | Description |
-| ------------ | ------------ | ----------- |
-| instance | __param_target | The address of the scraped target |
-| job | - | `{metadata.name}` of the scraped service or read from `jobLabel` if specified |
-| node/pod | - | Set depending on the endpoint responding to service request |
-| namespace | __meta_kubernetes_namespace | `{metadata.namespace}` of the scraped pod |
-| service | | `{metadata.name}` of the scraped service |
-| pod | __meta_kubernetes_pod_name | `{metadata.name}` of the scraped pod |
-| container | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod |
-| endpoint | - | `{spec.Port}` or `{spec.TargetPort}` if specified |
+| Target Label | Source Label                         | Description                                                                   |
+|--------------|--------------------------------------|-------------------------------------------------------------------------------|
+| instance     | __param_target                       | The address of the scraped target                                             |
+| job          | -                                    | `{metadata.name}` of the scraped service or read from `jobLabel` if specified |
+| node/pod     | -                                    | Set depending on the endpoint responding to service request                   |
+| namespace    | __meta_kubernetes_namespace          | `{metadata.namespace}` of the scraped pod                                     |
+| service      |                                      | `{metadata.name}` of the scraped service                                      |
+| pod          | __meta_kubernetes_pod_name           | `{metadata.name}` of the scraped pod                                          |
+| container    | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod                                  |
+| endpoint     | -                                    | `{spec.Port}` or `{spec.TargetPort}` if specified                             |
 
 ### Configuration
 

--- a/Documentation/user-guides/running-exporters.md
+++ b/Documentation/user-guides/running-exporters.md
@@ -68,6 +68,47 @@ spec:
     interval: 15s
 ```
 
+## Default Labels
+
+By default, the `PodMonitor` and `ServiceMonitor` objects include runtime metadata in the scraped results.
+
+### PodMonitors
+
+| Target Label | Source Label | Description |
+| ------------ | ------------ | ----------- |
+| instance | __param_target | The address of the scraped target |
+| job | - | `{metadata.namespace}/{metadata.name}`  of the `PodMonitor` or read from `jobLabel` if specified |
+| namespace | __meta_kubernetes_namespace | `{metadata.namespace}` of the scraped pod |
+| container | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod |
+| pod | __meta_kubernetes_pod_name | `{metadata.name}` of the scraped pod |
+| endpoint | - | `{spec.Port}` or `{spec.TargetPort}` if specified |
+
+### ServiceMonitors
+
+| Target Label | Source Label | Description |
+| ------------ | ------------ | ----------- |
+| instance | __param_target | The address of the scraped target |
+| job | - | `{metadata.name}` of the scraped service or read from `jobLabel` if specified |
+| node/pod | - | Set depending on the endpoint responding to service request |
+| namespace | __meta_kubernetes_namespace | `{metadata.namespace}` of the scraped pod |
+| service | | `{metadata.name}` of the scraped service |
+| pod | __meta_kubernetes_pod_name | `{metadata.name}` of the scraped pod |
+| container | __meta_kubernetes_pod_container_name | `{name}` of the container in the scraped pod |
+| endpoint | - | `{spec.Port}` or `{spec.TargetPort}` if specified |
+
+### Configuration
+
+These labels can be modified or disabled using the `relabelings` and `metricRelabelings` settings of the `PodMonitor` and `ServiceMonitor` specifications. The configuration below will drop all of the labels before being loaded into Prometheus.
+
+```
+relabelings:
+- action: labeldrop
+  regex: (container|endpoint|job|namespace|node|pod|service)
+metricRelabelings:
+- action: labeldrop
+  regex: instance
+```
+
 ## Troubleshooting
 
 ### Namespace "limits"/things to keep in mind


### PR DESCRIPTION
## Description

The change includes the current behavior of PodMonitor and ServiceMonitor objects. It also includes a reference of how to disable the behavior if needed. This should provide an answer to questions like #4065 and #4894 before they are opened.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add documentation of default monitor labels and how to configure them
```

Signed-off-by: Jeff Mace <jmace@vmware.com>
