### PR TITLE
Fixes nil pointer when roleARN is used instead of access and secret keys

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1049,23 +1049,25 @@ func (cb *configBuilder) convertSnsConfig(ctx context.Context, in monitoringv1al
 	}
 
 	if in.Sigv4 != nil {
-		accessKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Sigv4.AccessKey)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get access key")
-		}
-
-		secretKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Sigv4.SecretKey)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get AWS secret key")
-
-		}
-
 		out.Sigv4 = sigV4Config{
-			Region:    in.Sigv4.Region,
-			AccessKey: accessKey,
-			SecretKey: secretKey,
-			Profile:   in.Sigv4.Profile,
-			RoleARN:   in.Sigv4.RoleArn,
+			Region:  in.Sigv4.Region,
+			Profile: in.Sigv4.Profile,
+			RoleARN: in.Sigv4.RoleArn,
+		}
+
+		if in.Sigv4.AccessKey != nil && in.Sigv4.SecretKey != nil {
+			accessKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Sigv4.AccessKey)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get access key")
+			}
+
+			secretKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Sigv4.SecretKey)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get AWS secret key")
+
+			}
+			out.Sigv4.AccessKey = accessKey
+			out.Sigv4.SecretKey = secretKey
 		}
 	}
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -1308,7 +1308,7 @@ templates: []
 		},
 		{
 
-			name: "CR with SNS Receiver",
+			name: "CR with SNS Receiver with Access and Key",
 			kclient: fake.NewSimpleClientset(
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1379,6 +1379,71 @@ receivers:
       region: us-east-2
       access_key: xyz
       secret_key: "123"
+    topic_arn: test-topicARN
+templates: []
+`,
+		},
+		{
+
+			name: "CR with SNS Receiver with roleARN",
+			kclient: fake.NewSimpleClientset(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "am-sns-test",
+						Namespace: "mynamespace",
+					},
+					Data: map[string][]byte{
+						"key":    []byte("xyz"),
+						"secret": []byte("123"),
+					},
+				}),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{
+							Name: "test",
+							SNSConfigs: []monitoringv1alpha1.SNSConfig{
+								{
+									ApiURL: "https://sns.us-east-2.amazonaws.com",
+									Sigv4: &monitoringingv1.Sigv4{
+										Region:  "us-east-2",
+										RoleArn: "test-roleARN",
+									},
+									TopicARN: "test-topicARN",
+								},
+							},
+						}},
+					},
+				},
+			},
+			expected: `route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  sns_configs:
+  - api_url: https://sns.us-east-2.amazonaws.com
+    sigv4:
+      region: us-east-2
+      role_arn: test-roleARN
     topic_arn: test-topicARN
 templates: []
 `,


### PR DESCRIPTION
## Description

Issue: https://github.com/prometheus-operator/prometheus-operator/issues/5130

Problem: Alertmanager supports both roleARN and access and secret keys for Sigv4 authentication, however in the current implementation of prometheus-operator the code does not check if the user has provided access and secret keys and simply calls GetSecretKey, if the user uses roleARN this will generate access to a nil pointer

Solution: Before calling GetSecretKey validate that the user has indeed provided access and a secret key


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixes nil pointer when roleARN is used instead of access and secret keys in Alertmanager Config
```
