### PR TITLE
docs: Fix wrong containerPort for alertmanager svc

### DIFF
--- a/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
+++ b/Documentation/user-guides/exposing-prometheus-and-alertmanager.md
@@ -198,7 +198,7 @@ spec:
   type: ClusterIP
   ports:
   - name: web
-    port: 9090
+    port: 9093
     protocol: TCP
     targetPort: web
   selector:


### PR DESCRIPTION
Only a single occurence in Documentation/user-guides/exposing-prometheus-and-alertmanager.md

## Description

Correct a single occurence of wrong containerPort number for alertmanager service in Documentation,
in the file Documentation/user-guides/exposing-prometheus-and-alertmanager.md

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Correct a typo with a single occurence in user-guides Documentation.
```
