### PR TITLE
Fix architecture image URL

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture](/img/architecture.png)
+![Prometheus Operator Architecture](/Documentation/img/architecture.png)
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 


### PR DESCRIPTION
## Description
This PR intends to fix an invalid URL in the docs that points to the architecture image.

## Type of change
_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry
```release-note
Fix an invalid URL in the getting-started docs that points to the right architecture image
```
