### PR TITLE
Improves comment on field MinReadySeconds for CommonPrometheusFields and AlertmanagerSpec

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -647,7 +647,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -2059,7 +2059,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -3401,7 +3401,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -4402,7 +4402,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -5639,7 +5639,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -8861,7 +8861,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -11714,7 +11714,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -647,7 +647,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -2059,7 +2059,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -4402,7 +4402,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -5639,7 +5639,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -8861,7 +8861,7 @@ uint32
 <p>Minimum number of seconds for which a newly created pod should be ready
 without any of its container crashing for it to be considered available.
 Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.</p>
+This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8450,8 +8450,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -16858,8 +16859,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8451,8 +8451,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -16860,8 +16860,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:
@@ -26021,8 +26021,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -3976,8 +3976,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -3975,8 +3975,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4178,8 +4178,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4177,8 +4177,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -3659,8 +3659,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -3976,8 +3976,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -3975,8 +3975,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4178,8 +4178,8 @@ spec:
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
                   as soon as it is ready) This is an alpha field from kubernetes 1.22
-                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
-                  gate.
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4177,8 +4177,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling StatefulSetMinReadySeconds feature
+                  gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -3659,8 +3659,9 @@ spec:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing for it to
                   be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready) This is an alpha field and requires enabling
-                  StatefulSetMinReadySeconds feature gate.
+                  as soon as it is ready) This is an alpha field from kubernetes 1.22
+                  until 1.24 which requires enabling the StatefulSetMinReadySeconds
+                  feature gate.
                 format: int32
                 type: integer
               nodeSelector:

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3627,7 +3627,7 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3627,7 +3627,7 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3818,7 +3818,7 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3818,7 +3818,7 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3330,7 +3330,7 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -204,7 +204,7 @@ type ThanosRulerSpec struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.
+	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
 	// +optional
 	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
 	// AlertRelabelConfigs configures alert relabeling in ThanosRuler.

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -313,7 +313,7 @@ type CommonPrometheusFields struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.
+	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.
 	// +optional
 	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
 	// Pods' hostAliases configuration
@@ -2037,7 +2037,7 @@ type AlertmanagerSpec struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field and requires enabling StatefulSetMinReadySeconds feature gate.
+	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.
 	// +optional
 	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
 	// Pods' hostAliases configuration

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -313,7 +313,7 @@ type CommonPrometheusFields struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.
+	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
 	// +optional
 	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
 	// Pods' hostAliases configuration
@@ -2037,7 +2037,7 @@ type AlertmanagerSpec struct {
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling StatefulSetMinReadySeconds feature gate.
+	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
 	// +optional
 	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
 	// Pods' hostAliases configuration


### PR DESCRIPTION
## Description

Close: https://github.com/prometheus-operator/prometheus-operator/issues/5067

Problem: the field StatefulSetMinReadySeconds was introduced in 1.22 and until 1.25 when it stopped being alpha this field is not reset in the statefulset code, this makes it so if the field is specified and the feature gate is not enabled the stateful will just crash loop

Solution: improve the field comments to prevent users from using it if the feature is not enabled


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Improves comment on field MinReadySeconds for CommonPrometheusFields and AlertmanagerSpec
```
