### PR TITLE
Adds basicAuth to AlertmanagerEndpoints

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -3737,6 +3737,19 @@ TLSConfig
 </tr>
 <tr>
 <td>
+<code>basicAuth</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.BasicAuth">
+BasicAuth
+</a>
+</em>
+</td>
+<td>
+<p>BasicAuth allow an endpoint to authenticate over basic authentication</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bearerTokenFile</code><br/>
 <em>
 string
@@ -4770,7 +4783,7 @@ string
 <h3 id="monitoring.coreos.com/v1.BasicAuth">BasicAuth
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.APIServerConfig">APIServerConfig</a>, <a href="#monitoring.coreos.com/v1.Endpoint">Endpoint</a>, <a href="#monitoring.coreos.com/v1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1beta1.HTTPConfig">HTTPConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.APIServerConfig">APIServerConfig</a>, <a href="#monitoring.coreos.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>, <a href="#monitoring.coreos.com/v1.Endpoint">Endpoint</a>, <a href="#monitoring.coreos.com/v1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1beta1.HTTPConfig">HTTPConfig</a>)
 </p>
 <div>
 <p>BasicAuth allow an endpoint to authenticate over basic authentication

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -13730,6 +13730,53 @@ spec:
                                 Bearer, Basic will cause an error
                               type: string
                           type: object
+                        basicAuth:
+                          description: BasicAuth allow an endpoint to authenticate
+                            over basic authentication
+                          properties:
+                            password:
+                              description: The secret in the service monitor namespace
+                                that contains the password for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            username:
+                              description: The secret in the service monitor namespace
+                                that contains the username for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         bearerTokenFile:
                           description: BearerTokenFile to read from filesystem to
                             use when authenticating to Alertmanager.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1049,6 +1049,53 @@ spec:
                                 Bearer, Basic will cause an error
                               type: string
                           type: object
+                        basicAuth:
+                          description: BasicAuth allow an endpoint to authenticate
+                            over basic authentication
+                          properties:
+                            password:
+                              description: The secret in the service monitor namespace
+                                that contains the password for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            username:
+                              description: The secret in the service monitor namespace
+                                that contains the username for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         bearerTokenFile:
                           description: BearerTokenFile to read from filesystem to
                             use when authenticating to Alertmanager.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1049,6 +1049,53 @@ spec:
                                 Bearer, Basic will cause an error
                               type: string
                           type: object
+                        basicAuth:
+                          description: BasicAuth allow an endpoint to authenticate
+                            over basic authentication
+                          properties:
+                            password:
+                              description: The secret in the service monitor namespace
+                                that contains the password for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            username:
+                              description: The secret in the service monitor namespace
+                                that contains the username for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         bearerTokenFile:
                           description: BearerTokenFile to read from filesystem to
                             use when authenticating to Alertmanager.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -875,6 +875,56 @@
                               },
                               "type": "object"
                             },
+                            "basicAuth": {
+                              "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
+                              "properties": {
+                                "password": {
+                                  "description": "The secret in the service monitor namespace that contains the password for authentication.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "username": {
+                                  "description": "The secret in the service monitor namespace that contains the username for authentication.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
                             "bearerTokenFile": {
                               "description": "BearerTokenFile to read from filesystem to use when authenticating to Alertmanager.",
                               "type": "string"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1194,6 +1194,8 @@ type AlertmanagerEndpoints struct {
 	PathPrefix string `json:"pathPrefix,omitempty"`
 	// TLS Config to use for alertmanager connection.
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
+	// BasicAuth allow an endpoint to authenticate over basic authentication
+	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// BearerTokenFile to read from filesystem to use when authenticating to
 	// Alertmanager.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -136,6 +136,11 @@ func (in *AlertmanagerEndpoints) DeepCopyInto(out *AlertmanagerEndpoints) {
 		*out = new(TLSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.BasicAuth != nil {
+		in, out := &in.BasicAuth, &out.BasicAuth
+		*out = new(BasicAuth)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Authorization != nil {
 		in, out := &in.Authorization, &out.Authorization
 		*out = new(SafeAuthorization)

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1775,8 +1775,11 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 	if p.Spec.Alerting != nil {
 		for i, am := range p.Spec.Alerting.Alertmanagers {
+			if err := store.AddBasicAuth(ctx, p.GetNamespace(), am.BasicAuth, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
+				return errors.Wrapf(err, "alerting")
+			}
 			if err := store.AddSafeAuthorizationCredentials(ctx, p.GetNamespace(), am.Authorization, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
-				return errors.Wrapf(err, "apiserver config")
+				return errors.Wrapf(err, "alerting")
 			}
 		}
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1504,6 +1504,109 @@ alerting:
 	}
 }
 
+func TestAlertmanagerBasicAuth(t *testing.T) {
+	p := &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: "30s",
+			},
+			EvaluationInterval: "30s",
+			Alerting: &monitoringv1.AlertingSpec{
+				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
+					{
+						Name:      "alertmanager-main",
+						Namespace: "default",
+						Port:      intstr.FromString("web"),
+						BasicAuth: &monitoringv1.BasicAuth{
+							Username: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "username",
+							},
+							Password: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "password",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cg := mustNewConfigGenerator(t, p)
+
+	cfg, err := cg.Generate(
+		p,
+		nil,
+		nil,
+		nil,
+		&assets.Store{BasicAuthAssets: map[string]assets.BasicAuthCredentials{
+			"alertmanager/auth/0": {
+				Username: "bob",
+				Password: "alice",
+			},
+		}},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// If this becomes an endless sink of maintenance, then we should just
+	// change this to check that just the `bearer_token_file` is set with
+	// something like json-path.
+	expected := `global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - default
+    basic_auth:
+      username: bob
+      password: alice
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: alertmanager-main
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_endpoint_port_name
+      regex: web
+`
+
+	result := string(cfg)
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Logf("\n%s", diff)
+		t.Fatal("expected Prometheus configuration and actual configuration do not match")
+	}
+}
+
 func TestAlertmanagerAPIVersion(t *testing.T) {
 	p := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1505,68 +1505,15 @@ alerting:
 }
 
 func TestAlertmanagerBasicAuth(t *testing.T) {
-	p := &monitoringv1.Prometheus{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
-		Spec: monitoringv1.PrometheusSpec{
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ScrapeInterval: "30s",
-			},
-			EvaluationInterval: "30s",
-			Alerting: &monitoringv1.AlertingSpec{
-				Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
-					{
-						Name:      "alertmanager-main",
-						Namespace: "default",
-						Port:      intstr.FromString("web"),
-						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
-									Name: "foo",
-								},
-								Key: "username",
-							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
-									Name: "foo",
-								},
-								Key: "password",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	cg := mustNewConfigGenerator(t, p)
-
-	cfg, err := cg.Generate(
-		p,
-		nil,
-		nil,
-		nil,
-		&assets.Store{BasicAuthAssets: map[string]assets.BasicAuthCredentials{
-			"alertmanager/auth/0": {
-				Username: "bob",
-				Password: "alice",
-			},
-		}},
-		nil,
-		nil,
-		nil,
-		nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// If this becomes an endless sink of maintenance, then we should just
-	// change this to check that just the `bearer_token_file` is set with
-	// something like json-path.
-	expected := `global:
+	for _, tc := range []struct {
+		name           string
+		version        string
+		expectedConfig string
+	}{
+		{
+			name:    "Valid Prom Version",
+			version: "2.26.0",
+			expectedConfig: `global:
   evaluation_interval: 30s
   scrape_interval: 30s
   external_labels:
@@ -1597,13 +1544,108 @@ alerting:
       source_labels:
       - __meta_kubernetes_endpoint_port_name
       regex: web
-`
+`,
+		},
+		{
+			name:    "Invalid Prom Version",
+			version: "2.25.0",
+			expectedConfig: `global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - default
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: alertmanager-main
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_endpoint_port_name
+      regex: web
+`,
+		},
+	} {
 
-	result := string(cfg)
+		p := &monitoringv1.Prometheus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: monitoringv1.PrometheusSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					ScrapeInterval: "30s",
+					Version:        tc.version,
+				},
+				EvaluationInterval: "30s",
+				Alerting: &monitoringv1.AlertingSpec{
+					Alertmanagers: []monitoringv1.AlertmanagerEndpoints{
+						{
+							Name:      "alertmanager-main",
+							Namespace: "default",
+							Port:      intstr.FromString("web"),
+							BasicAuth: &monitoringv1.BasicAuth{
+								Username: v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "foo",
+									},
+									Key: "username",
+								},
+								Password: v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "foo",
+									},
+									Key: "password",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 
-	if diff := cmp.Diff(expected, result); diff != "" {
-		t.Logf("\n%s", diff)
-		t.Fatal("expected Prometheus configuration and actual configuration do not match")
+		cg := mustNewConfigGenerator(t, p)
+
+		cfg, err := cg.Generate(
+			p,
+			nil,
+			nil,
+			nil,
+			&assets.Store{BasicAuthAssets: map[string]assets.BasicAuthCredentials{
+				"alertmanager/auth/0": {
+					Username: "bob",
+					Password: "alice",
+				},
+			}},
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result := string(cfg)
+
+		if diff := cmp.Diff(tc.expectedConfig, result); diff != "" {
+			t.Logf("\n%s", diff)
+			t.Fatal("expected Prometheus configuration and actual configuration do not match")
+		}
 	}
 }
 
@@ -1687,6 +1729,7 @@ alerting:
 		fmt.Println(pretty.Compare(expected, result))
 		t.Fatal("expected Prometheus configuration and actual configuration do not match")
 	}
+
 }
 
 func TestAlertmanagerTimeoutConfig(t *testing.T) {


### PR DESCRIPTION
## Description

Close: https://github.com/prometheus-operator/prometheus-operator/issues/4892

Problem: prometheus-operator implements multiple authentication methods for Prometheus to authenticate with Alertmanager instances but it does support basicAuth

Solution: this PR introduces basicAuth to the type AlertmanagerEndpoints


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Adds basicAuth to AlertmanagerEndpoints
```
