### PR TITLE
Standardize how the Prometheus and Alertmanager versions are calculated

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -218,7 +218,6 @@ func makeStatefulSetService(p *monitoringv1.Alertmanager, config Config) *v1.Ser
 
 func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSecrets []string) (*appsv1.StatefulSetSpec, error) {
 	amVersion := operator.StringValOrDefault(a.Spec.Version, operator.DefaultAlertmanagerVersion)
-
 	amImagePath, err := operator.BuildImagePath(
 		operator.StringPtrValOrDefault(a.Spec.Image, ""),
 		operator.StringValOrDefault(a.Spec.BaseImage, config.AlertmanagerDefaultBaseImage),

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -832,7 +832,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 }
 
 func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
-	prometheusBaseImageConfig := &operator.Config{
+	operatorConfig := &operator.Config{
 		ReloaderConfig: operator.ReloaderConfig{
 			CPURequest:    "100m",
 			CPULimit:      "100m",
@@ -855,12 +855,12 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 			Labels:      labels,
 			Annotations: annotations,
 		},
-	}, prometheusBaseImageConfig, nil, "", 0, nil)
+	}, operatorConfig, nil, "", 0, nil)
 
 	require.NoError(t, err)
 
 	image := sset.Spec.Template.Spec.Containers[0].Image
-	expected := "nondefaultuseflag/quay.io/prometheus/prometheus"
+	expected := "nondefaultuseflag/quay.io/prometheus/prometheus" + ":" + operator.DefaultPrometheusVersion
 	if image != expected {
 		t.Fatalf("Unexpected container image.\n\nExpected: %s\n\nGot: %s", expected, image)
 	}


### PR DESCRIPTION
## Description

Close: https://github.com/prometheus-operator/prometheus-operator/issues/4893

Problem: since the inception of the operator a lot of options were introduced to customize the image ran by the statefulset for both Prometheus and Alertmanager, this made it so some inconsistencies on how the version is calculated were introduced between the two.

Solution: this commit introduces the function GetVersion which has the goal of returning the tag of the image that will be used in the statefulsets. If the image is tagless or uses a SHA256 it will instead return the DefaultVersion for that component if Spec.Version is not defined.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Standardize how the Prometheus and Alertmanager versions are calculated
```
