### PR TITLE
pkg/apis: Add Thanos version field to CRD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2834,6 +2834,17 @@ ThanosRulerSpec
 <table>
 <tr>
 <td>
+<code>version</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Version of Thanos to be deployed.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>podMetadata</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.EmbeddedObjectMetadata">
@@ -11156,6 +11167,17 @@ Prometheus &gt;= v2.39.0.</p>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>version</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Version of Thanos to be deployed.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>podMetadata</code><br/>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -27239,6 +27239,9 @@ spec:
                   file. When used alongside with TracingConfig, TracingConfigFile
                   takes precedence.
                 type: string
+              version:
+                description: Version of Thanos to be deployed.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4876,6 +4876,9 @@ spec:
                   file. When used alongside with TracingConfig, TracingConfigFile
                   takes precedence.
                 type: string
+              version:
+                description: Version of Thanos to be deployed.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4876,6 +4876,9 @@ spec:
                   file. When used alongside with TracingConfig, TracingConfigFile
                   takes precedence.
                 type: string
+              version:
+                description: Version of Thanos to be deployed.
+                type: string
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4352,6 +4352,10 @@
                     "description": "TracingConfig specifies the path of the tracing configuration file. When used alongside with TracingConfig, TracingConfigFile takes precedence.",
                     "type": "string"
                   },
+                  "version": {
+                    "description": "Version of Thanos to be deployed.",
+                    "type": "string"
+                  },
                   "volumes": {
                     "description": "Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects.",
                     "items": {

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -62,6 +62,8 @@ type ThanosRulerList struct {
 // https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +k8s:openapi-gen=true
 type ThanosRulerSpec struct {
+	// Version of Thanos to be deployed.
+	Version string `json:"version,omitempty"`
 	// PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Thanos container image URL.


### PR DESCRIPTION
Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added Thanos version field to CRD
```
