### PR TITLE
Fixes regression introduced in thanos/statefulset.go when reading arguments from secrets

### DIFF
--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -208,7 +208,8 @@ func TestTracing(t *testing.T) {
 		secretName = "thanos-tracing-config-secret"
 		secretKey  = "config.yaml"
 		volumeName = "tracing-config"
-		mountPath  = "/etc/thanos/config/tracing-config.yaml"
+		mountPath  = "/etc/thanos/config/tracing-config"
+		fullPath   = "/etc/thanos/config/tracing-config/config.yaml"
 	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -234,7 +235,7 @@ func TestTracing(t *testing.T) {
 		var containsVolume bool
 		for _, volume := range sset.Spec.Template.Spec.Volumes {
 			if volume.Name == volumeName {
-				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey && volume.Secret.Items[0].Path == secretKey {
 					containsVolume = true
 					break
 				}
@@ -256,7 +257,7 @@ func TestTracing(t *testing.T) {
 		}
 	}
 	{
-		const expectedArg = "--tracing.config-file=" + mountPath
+		const expectedArg = "--tracing.config-file=" + fullPath
 		var containsArg bool
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {
@@ -318,7 +319,8 @@ func TestObjectStorage(t *testing.T) {
 		secretName = "thanos-objstore-config-secret"
 		secretKey  = "config.yaml"
 		volumeName = "objstorage-config"
-		mountPath  = "/etc/thanos/config/objstorage-config.yaml"
+		mountPath  = "/etc/thanos/config/objstorage-config"
+		fullPath   = "/etc/thanos/config/objstorage-config/config.yaml"
 	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -344,7 +346,7 @@ func TestObjectStorage(t *testing.T) {
 		var containsVolume bool
 		for _, volume := range sset.Spec.Template.Spec.Volumes {
 			if volume.Name == volumeName {
-				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey && volume.Secret.Items[0].Path == secretKey {
 					containsVolume = true
 					break
 				}
@@ -366,7 +368,7 @@ func TestObjectStorage(t *testing.T) {
 		}
 	}
 	{
-		const expectedArg = "--objstore.config-file=" + mountPath
+		const expectedArg = "--objstore.config-file=" + fullPath
 		var containsArg bool
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {
@@ -428,7 +430,8 @@ func TestAlertRelabel(t *testing.T) {
 		secretName = "thanos-alertrelabel-config-secret"
 		secretKey  = "config.yaml"
 		volumeName = "alertrelabel-config"
-		mountPath  = "/etc/thanos/config/alertrelabel-config.yaml"
+		mountPath  = "/etc/thanos/config/alertrelabel-config"
+		fullPath   = "/etc/thanos/config/alertrelabel-config/config.yaml"
 	)
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -454,7 +457,7 @@ func TestAlertRelabel(t *testing.T) {
 		var containsVolume bool
 		for _, volume := range sset.Spec.Template.Spec.Volumes {
 			if volume.Name == volumeName {
-				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey {
+				if volume.Secret.SecretName == secretName && volume.Secret.Items[0].Key == secretKey && volume.Secret.Items[0].Path == secretKey {
 					containsVolume = true
 					break
 				}
@@ -476,7 +479,7 @@ func TestAlertRelabel(t *testing.T) {
 		}
 	}
 	{
-		const expectedArg = "--alert.relabel-config-file=" + mountPath
+		const expectedArg = "--alert.relabel-config-file=" + fullPath
 		var containsArg bool
 		for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
 			if arg == expectedArg {


### PR DESCRIPTION
## Description

PR that introduced the regression: https://github.com/prometheus-operator/prometheus-operator/pull/5122

In the PR above Thanos started reading arguments from secrets instead of ENV vars, however, in the change, we forgot to specify a Path that is necessary when working with projection of secret keys to specific paths as can be seen in the k8s documentation [1]

[1] https://kubernetes.io/docs/concepts/configuration/secret/#projection-of-secret-keys-to-specific-paths

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixes regression introduced in thanos/statefulset.go when reading arguments from secrets
```
