### PR TITLE
Documentation: update webhook guide

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -17,7 +17,7 @@ The admission webhook service is able to
 * Validate requests ensuring that `PrometheusRule` and `AlertmanagerConfig` objects
   are semantically valid.
 * Mutate requests enforcing that all annotations of `PrometheusRule` objects are
-  coerced into string values (.
+  coerced into string values.
 * Convert `AlertmanagerConfig` objects between `v1alpha1` and `v1beta1` versions.
 
 This guide assumes that you have already [deployed the Prometheus

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -86,7 +86,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
-    app.kubernetes.io/version: 0.61.0
+    app.kubernetes.io/version: 0.61.1
   name: prometheus-operator-admission-webhook
   namespace: default
 ```
@@ -97,7 +97,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
-    app.kubernetes.io/version: 0.61.0
+    app.kubernetes.io/version: 0.61.1
   name: prometheus-operator-admission-webhook
   namespace: default
 spec:
@@ -114,7 +114,7 @@ spec:
         kubectl.kubernetes.io/default-container: prometheus-operator-admission-webhook
       labels:
         app.kubernetes.io/name: prometheus-operator-admission-webhook
-        app.kubernetes.io/version: 0.61.0
+        app.kubernetes.io/version: 0.61.1
     spec:
       affinity:
         podAntiAffinity:
@@ -131,7 +131,7 @@ spec:
         - --web.enable-tls=true
         - --web.cert-file=/etc/tls/private/tls.crt
         - --web.key-file=/etc/tls/private/tls.key
-        image: quay.io/prometheus-operator/admission-webhook:v0.61.0
+        image: quay.io/prometheus-operator/admission-webhook:v0.61.1
         name: prometheus-operator-admission-webhook
         ports:
         - containerPort: 8443
@@ -177,7 +177,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
-    app.kubernetes.io/version: 0.61.0
+    app.kubernetes.io/version: 0.61.1
   name: prometheus-operator-admission-webhook
   namespace: default
 spec:

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -1,33 +1,41 @@
-# Admission webhooks
+---
+weight: 153
+toc: true
+title: Admission webhook
+menu:
+    docs:
+        parent: user-guides
+lead: ""
+images: []
+draft: false
+description: Guide to deploy and run the admission webhook service
+---
 
-This document describes how to deploy the Prometheus operator's admission webhook service.
+This guide describes how to deploy and use the Prometheus operator's admission webhook service.
 
-The admission webhook can be used to:
-* Ensure that all annotations of PrometheusRule objects are coerced into string values.
-* Check that PrometheusRule objects are semantically valid.
-* Check that AlertmanagerConfig objects are semantically valid.
-* Convert AlertmanagerConfig objects between v1alpha1 and v1beta1 versions.
-
-## Prerequisites
+The admission webhook service is able to
+* Validate requests ensuring that `PrometheusRule` and `AlertmanagerConfig` objects
+  are semantically valid.
+* Mutate requests enforcing that all annotations of `PrometheusRule` objects are
+  coerced into string values (.
+* Convert `AlertmanagerConfig` objects between `v1alpha1` and `v1beta1` versions.
 
 This guide assumes that you have already [deployed the Prometheus
-Operator](getting-started.md) and that [admission controllers are
+Operator]({{< ref "getting-started" >}}) and that [admission controllers are
 enabled](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-on-an-admission-controller)
 on your cluster.
 
-The Kubernetes API server expects admission webhooks to communicate over HTTPS
-so this guide also assumes the following:
-1. A valid TLS certificate and key has been provisioned for the admission webhook service.
-2. A secret holding the TLS certificate and key has been created.
+## Prerequisites
 
-If you don't want to manually provision the TLS materials,
-[cert-manager](https://cert-manager.io/) is a good option.
+The Kubernetes API server expects admission webhook services to communicate
+over HTTPS so we need:
+1. Valid TLS certificate and key provisioned for the admission webhook service.
+2. Kubernetes Secret containing the TLS certificate and key.
 
-## Admission webhook deployment
-
-Assuming that the following secret exists and contains the base64-encoded
-[PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) certificate
-(`tls.crt`) and key (`tls.key`) for the admission webhook service.
+For this guide, we assume that a Secret named `admission-webhook-certs` exists
+in the same namespace as the webhook deployment and that it contains the
+base64-encoded [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail)
+certificate (`tls.crt`) and key (`tls.key`) for the admission webhook service.
 
 ```yaml
 apiVersion: v1
@@ -40,67 +48,181 @@ metadata:
   namespace: default
 ```
 
-The admission webhook's pod template should be modified to mount the secret as a
-volume and the container arguments should be modified to include the
-certificate and key:
+The recommended approach is to use [cert-manager](https://cert-manager.io/)
+which manages both the lifecycle of the TLS certificates and the integration
+with the Kubernetes API with respect to the webhook configuration (e.g.
+automatic injection of the CA bundle).
+
+While installing cert-manager is beyond the scope of this guide, below is an
+example of a `Certificate` object which triggers the creation of the
+`admission-webhook-certs` secret using a [SelfSigned
+issuer](https://cert-manager.io/docs/configuration/selfsigned/).
 
 ```yaml
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: cert-manager.io/v1
+kind: Certificate
 metadata:
   name: prometheus-operator-admission-webhook
   namespace: default
 spec:
+  dnsNames:
+    - prometheus-operator-admission-webhook.default.svc
+  secretName: admission-webhook-certs
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+```
+
+## Deploying the admission webhook
+
+You can apply the following manifests to run a deployment of the webhook with 2 replicas.
+
+```yaml mdox-exec="cat example/admission-webhook/service-account.yaml"
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.61.0
+  name: prometheus-operator-admission-webhook
+  namespace: default
+```
+
+```yaml mdox-exec="cat example/admission-webhook/deployment.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.61.0
+  name: prometheus-operator-admission-webhook
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator-admission-webhook
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator-admission-webhook
+      labels:
+        app.kubernetes.io/name: prometheus-operator-admission-webhook
+        app.kubernetes.io/version: 0.61.0
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus-operator-admission-webhook
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
       containers:
-      - name: prometheus-operator-admission-webhook
-        args:
+      - args:
         - --web.enable-tls=true
         - --web.cert-file=/etc/tls/private/tls.crt
         - --web.key-file=/etc/tls/private/tls.key
+        image: quay.io/prometheus-operator/admission-webhook:v0.61.0
+        name: prometheus-operator-admission-webhook
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: tls-certificates
           readOnly: true
-     volumes:
-     - name: tls-certificates
-       secret:
-         secretName: admission-webhook-certs
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: prometheus-operator-admission-webhook
+      volumes:
+      - name: tls-certificates
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          secretName: admission-webhook-certs
 ```
 
-## Webhook endpoints
+You can now expose the webhook as a Kubernetes service by applying the following manifest.
 
-### caBundle note
+```yaml mdox-exec="cat example/admission-webhook/service.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+    app.kubernetes.io/version: 0.61.0
+  name: prometheus-operator-admission-webhook
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: prometheus-operator-admission-webhook
+```
 
-The `caBundle` field contains the base64-encoded CA certificate used to sign the
-webhook's certificate. It is used by the Kubernetes API server to validate the
-certificate of the webhook service.
+## Managing webhook configurations
 
-Certificate managers like [cert-manager](https://cert-manager.io/) supports CA
-injection into webhook configurations and custom resource definitions.
+Once the Prometheus operator's admission webhook service is up and running, you
+can create `ValidatingWebhookConfiguration` and/or `MutatingWebhookConfiguration`
+API objects that defines when/how the Kubernetes API should contact the service.
 
-### `/admission-prometheusrules/validate`
+For more details, refer to the [Kubernetes
+documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration).
 
-The endpoint `/admission-prometheusrules/validate` rejects `PrometheusRule`
-objects that are not valid.
+### PrometheusRule
 
-The following example deploys the validating admission webhook:
+#### Validating PrometheusRule resources
+
+The `/admission-prometheusrules/validate` endpoint of the admission webhook
+service ensures that `PrometheusRule` objects are semantically valid.
+
+The following example configures a validating admission webhook rejecting
+invalid PrometheusRule objects.
+
+> Note: If you're not using cert-manager, check the [CA Bundle]({{< ref "#ca-bundle" >}}) section.
 
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: prometheus-operator-rulesvalidation
+  annotations:
+    cert-manager.io/inject-ca-from: default/prometheus-operator-admission-webhook
 webhooks:
   - clientConfig:
-      caBundle: LS0tLS...LS0tCg==
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-prometheusrules/validate
     failurePolicy: Fail
-    name: prometheusrulemutate.monitoring.coreos.com
+    name: prometheusrulevalidate.monitoring.coreos.com
     namespaceSelector: {}
     rules:
       - apiGroups:
@@ -116,24 +238,27 @@ webhooks:
     sideEffects: None
 ```
 
-### `/admission-prometheusrules/mutate`
+#### Mutating PrometheusRule resources
 
-The endpoint `/admission-prometheusrules/mutate` mutates `PrometheusRule`
-objects so that integers and boolean yaml data elements are coerced into
+The `/admission-prometheusrules/mutate` endpoint mutates `PrometheusRule`
+objects so that integer and boolean YAML data elements are coerced into
 strings.
 
-The following example deploys the mutating admission webhook:
+The following example deploys a mutating admission webhook.
+
+> Note: If you're not using cert-manager, check the [CA Bundle]({{< ref "#ca-bundle" >}}) section.
 
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: prometheus-operator-rulesmutation
+  annotations:
+    cert-manager.io/inject-ca-from: default/prometheus-operator-admission-webhook
 webhooks:
   - clientConfig:
-      caBundle: LS0tLS...LS0tCg==
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-prometheusrules/mutate
     failurePolicy: Fail
@@ -153,23 +278,27 @@ webhooks:
     sideEffects: None
 ```
 
-### `/admission-alertmanagerconfigs/validate`
+### AlertmanagerConfig
 
-The endpoint `/admission-alertmanagerconfigs/validate` rejects
-`AlertmanagerConfig` objects that are not valid.
+The `/admission-alertmanagerconfigs/validate` endpoint rejects
+`AlertmanagerConfig` objects that are not semantically valid.
 
-The following example deploys the validating admission webhook:
+The following example configures a validating admission webhook rejecting
+invalid `AlertmanagerConfig` objects.
+
+> Note: If you're not using cert-manager, check the [CA Bundle]({{< ref "#ca-bundle" >}}) section.
 
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: prometheus-operator-alertmanager-config-validation
+  annotations:
+    cert-manager.io/inject-ca-from: default/prometheus-operator-admission-webhook
 webhooks:
   - clientConfig:
-      caBundle: LS0tLS...LS0tCg==
       service:
-        name: prometheus-operator
+        name: prometheus-operator-admission-webhook
         namespace: default
         path: /admission-alertmanagerconfigs/validate
     failurePolicy: Fail
@@ -189,22 +318,20 @@ webhooks:
     sideEffects: None
 ```
 
-### `/convert`
+## Converting AlertmanagerConfig resources
 
-The endpoint `/convert` convert `Alertmanagerconfig` objects between `v1alpha1`
+The `/convert` endpoint converts `Alertmanagerconfig` objects between `v1alpha1`
 and `v1beta1` versions.
 
-The following example is a patch for the
-`alertmanagerconfigs.monitoring.coreos.com` CRD to configure the conversion
-webhook.
+For more details, refer to the [Kubernetes
+documentation](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion).
 
-```json
+The following command patches the
+`alertmanagerconfigs.monitoring.coreos.com` CRD to enable the conversion.
+
+```bash
+cat <<EOF | kubectl patch crds/alertmanagerconfigs.monitoring.coreos.com --patch-file /dev/stdin
 {
-   "apiVersion": "apiextensions.k8s.io/v1",
-   "kind": "CustomResourceDefinition",
-   "metadata": {
-      "name": "alertmanagerconfigs.monitoring.coreos.com"
-   },
    "spec": {
       "conversion": {
          "strategy": "Webhook",
@@ -214,9 +341,8 @@ webhook.
                   "name": "prometheus-operator-admission-webhook",
                   "namespace": "default",
                   "path": "/convert",
-                  "port": 8443
-               },
-               "caBundle": "LS0tLS...LS0tCg=="
+                  "port": 443
+               }
             },
             "conversionReviewVersions": [
                "v1beta1",
@@ -226,4 +352,26 @@ webhook.
       }
    }
 }
+EOF
 ```
+
+Annotate the AlertmanagerConfig CRD to let cert-manager inject the service CA bundle.
+
+```bash
+kubectl annotate crds alertmanagerconfigs.monitoring.coreos.com cert-manager.io/inject-ca-from=default/prometheus-operator-admission-webhook
+```
+
+> Note: If you're not using cert-manager, check the [CA Bundle]({{< ref "#ca-bundle" >}}) section.
+
+## CA bundle
+
+When contacting the webhook service during request admissions or CRD
+conversion, the Kubernetes API verifies the server certificate using the
+`caBundle` field defined in `clientConfig`. The field should contain the
+base64-encoded CA certificate that signed the webhook's TLS certificate.
+
+Certificate managers like [cert-manager](https://cert-manager.io/) supports
+automatic CA injection into webhook configurations and custom resource
+definitions. If you are **not using** a certificate manager, you need to
+manually specify the `caBundle` field in `ValidatingWebhookConfiguration`,
+`MutatingWebhookConfiguration` and `CustomResourceDefinition`.

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -56,7 +56,9 @@ automatic injection of the CA bundle).
 While installing cert-manager is beyond the scope of this guide, below is an
 example of a `Certificate` object which triggers the creation of the
 `admission-webhook-certs` secret using a [SelfSigned
-issuer](https://cert-manager.io/docs/configuration/selfsigned/).
+issuer](https://cert-manager.io/docs/configuration/selfsigned/). The
+certificate is valid for the Kubernetes service
+`prometheus-operator-admission-webhook` in the `default` namespace.
 
 ```yaml
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
## Description

The goal of the change is:
* make it possible to include the webhook documentation on prometheus-operator.dev
* refresh the content
* encourage people to use cert-manager (or similar solution) to ease the deployment

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
