### PR TITLE
remove setting empty defalt value in CRD PrometheusRule.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21673,7 +21673,6 @@ spec:
                       minLength: 1
                       type: string
                     partial_response_strategy:
-                      default: ""
                       description: 'PartialResponseStrategy is only used by ThanosRuler
                         and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
                       pattern: ^(?i)(abort|warn)?$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
@@ -56,7 +56,6 @@ spec:
                       minLength: 1
                       type: string
                     partial_response_strategy:
-                      default: ""
                       description: 'PartialResponseStrategy is only used by ThanosRuler
                         and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
                       pattern: ^(?i)(abort|warn)?$

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -56,7 +56,6 @@ spec:
                       minLength: 1
                       type: string
                     partial_response_strategy:
-                      default: ""
                       description: 'PartialResponseStrategy is only used by ThanosRuler
                         and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
                       pattern: ^(?i)(abort|warn)?$

--- a/jsonnet/prometheus-operator/prometheusrules-crd.json
+++ b/jsonnet/prometheus-operator/prometheusrules-crd.json
@@ -60,7 +60,6 @@
                           "type": "string"
                         },
                         "partial_response_strategy": {
-                          "default": "",
                           "description": "PartialResponseStrategy is only used by ThanosRuler and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response",
                           "pattern": "^(?i)(abort|warn)?$",
                           "type": "string"

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1840,7 +1840,6 @@ type RuleGroup struct {
 	// be ignored by Prometheus instances.
 	// More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response
 	// +kubebuilder:validation:Pattern="^(?i)(abort|warn)?$"
-	// +kubebuilder:default:=""
 	PartialResponseStrategy string `json:"partial_response_strategy,omitempty"`
 }
 


### PR DESCRIPTION
## Description

In PrometheusRule->RuleGroup structure, the property `PartialResponseStrategy` has an explicit default value set to an empty string, which is unnecessary and may cause some non-semantic comparator functions to return inequality when the property `PartialResponseStrategy` is omitted on either side. 

In the example below,  when applying a PrometheusRule object without the property `PartialResponseStrategy`, kubernetes will add that field with default value. 
```yaml
kind: PrometheusRule
metadata:
  creationTimestamp: "2022-11-28T15:40:10Z"
  generation: 1
  labels:
    app.kubernetes.io/component: exporter
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/part-of: openshift-monitoring
    app.kubernetes.io/version: 2.6.0
    prometheus: k8s
    role: alert-rules
  name: kube-state-metrics-rules
  namespace: openshift-monitoring
  resourceVersion: "21469"
  uid: 8ba53406-c41c-4357-9e6c-268edcb037b3
spec:
  groups:
  - name: kube-state-metrics
    partial_response_strategy: ""
    rules:
    - alert: KubeStateMetricsListErrors
      annotations:
        description: kube-state-metrics is experiencing errors at an elevated rate
          in list operations. This is likely causing it to not be able to expose metrics
          about Kubernetes objects correctly or at all.
        summary: kube-state-metrics is experiencing errors in list operations.
      expr: |
        (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
          /
        sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
        > 0.01
      for: 15m
      labels:
        severity: warning
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

The change is not user-facing, so no release note is required. 

```release-note

```
