### PR TITLE
More flexible resource name generation

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -63,6 +63,10 @@ Usage of ./operator:
     	Namespaces where Prometheus custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.
   -prometheus-instance-selector string
     	Label selector to filter Prometheus Custom Resources to watch.
+  -resource-naming-prefix
+    	Activate adding prefix to resources (default true)
+  -resource-naming-suffix
+    	Activate adding suffix to resources
   -secret-field-selector string
     	Field selector to filter Secrets to watch
   -short-version

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -175,6 +175,8 @@ func init() {
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-field-selector", "", "Field selector to filter Secrets to watch")
+	flagset.BoolVar(&cfg.ResourceNaming.Prefix, "resource-naming-prefix", true, "Activate adding prefix to resources")
+	flagset.BoolVar(&cfg.ResourceNaming.Suffix, "resource-naming-suffix", false, "Activate adding suffix to resources")
 }
 
 func Main() int {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,6 +35,7 @@ type API struct {
 	kclient *kubernetes.Clientset
 	mclient monitoringclient.Interface
 	logger  log.Logger
+	config  operator.Config
 }
 
 func New(conf operator.Config, l log.Logger) (*API, error) {
@@ -57,6 +58,7 @@ func New(conf operator.Config, l log.Logger) (*API, error) {
 		kclient: kclient,
 		mclient: mclient,
 		logger:  l,
+		config:  conf,
 	}, nil
 }
 
@@ -114,7 +116,7 @@ func (api *API) prometheusStatus(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	p.Status, _, err = prometheus.Status(req.Context(), api.kclient, p)
+	p.Status, _, err = prometheus.Status(req.Context(), api.kclient, p, api.config)
 	if err != nil {
 		api.logger.Log("error", err)
 	}

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	AlertManagerSelector         string
 	ThanosRulerSelector          string
 	SecretListWatchSelector      string
+	ResourceNaming               ResourceNaming
 }
 
 type ReloaderConfig struct {
@@ -98,4 +99,9 @@ type Namespaces struct {
 	AllowList, DenyList map[string]struct{}
 	// Allow list for prometheus/alertmanager custom resources.
 	PrometheusAllowList, AlertmanagerAllowList, AlertmanagerConfigAllowList, ThanosRulerAllowList map[string]struct{}
+}
+
+type ResourceNaming struct {
+	Prefix bool
+	Suffix bool
 }

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -329,7 +329,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 							Name: "config",
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
-									SecretName: configSecretName("volume-init-test"),
+									SecretName: configSecretName("volume-init-test", operator.Config{}),
 								},
 							},
 						},
@@ -341,7 +341,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 										{
 											Secret: &v1.SecretProjection{
 												LocalObjectReference: v1.LocalObjectReference{
-													Name: tlsAssetsSecretName("volume-init-test") + "-0",
+													Name: tlsAssetsSecretName("volume-init-test", operator.Config{}) + "-0",
 												},
 											},
 										},
@@ -404,7 +404,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 				},
 			},
 		},
-	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test") + "-0"})
+	}, defaultTestConfig, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test", operator.Config{}) + "-0"})
 
 	require.NoError(t, err)
 
@@ -2026,7 +2026,7 @@ func TestExpectedStatefulSetShardNames(t *testing.T) {
 				Replicas: &replicas,
 			},
 		},
-	})
+	}, operator.Config{})
 
 	expected := []string{
 		"prometheus-test",


### PR DESCRIPTION
## Description

For some, using the default prefix (`prometheus-`, etc.) for resources created by the operator results in cluster resource name convention/requirements non-compliance. Therefore, options to configure an alternative use of suffixed resource names should be present.

First commit contains roughly the changes that my team uses to resolve this issue for our use case.
Only the name generation for resources directly related to prometheus changed (still working on alertmanager and  thanos related resources).

### Subs-tasks

- [x] Add config entry's
- [x] Add cli option's
- [x] use config in promethues resource name generation
- [ ] use config in alertmanager resource name generation
- [ ] use config in thanos resource name generation
- [ ] add tests

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

add config flags for resource name prefix and suffix generation

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
