### PR TITLE
Added ability to specify imagePullPolicy

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2919,7 +2919,7 @@ Kubernetes core/v1.PullPolicy
 </em>
 </td>
 <td>
-<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+<p>Image pull policy for the &lsquo;thanos&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
 See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
@@ -11369,7 +11369,7 @@ Kubernetes core/v1.PullPolicy
 </em>
 </td>
 <td>
-<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+<p>Image pull policy for the &lsquo;thanos&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
 See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -125,6 +125,20 @@ configured.</p>
 </tr>
 <tr>
 <td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>version</code><br/>
 <em>
 string
@@ -1394,6 +1408,20 @@ string
 combinations. Specifying the version is still necessary to ensure the
 Prometheus Operator knows what version of Prometheus is being
 configured.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
 <tr>
@@ -2883,6 +2911,20 @@ string
 </tr>
 <tr>
 <td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>imagePullSecrets</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#localobjectreference-v1-core">
@@ -3956,6 +3998,20 @@ string
 combinations. Specifying the version is still necessary to ensure the
 Prometheus Operator knows what version of Alertmanager is being
 configured.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
 <tr>
@@ -5054,6 +5110,20 @@ string
 combinations. Specifying the version is still necessary to ensure the
 Prometheus Operator knows what version of Prometheus is being
 configured.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
 <tr>
@@ -8280,6 +8350,20 @@ configured.</p>
 </tr>
 <tr>
 <td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>imagePullSecrets</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#localobjectreference-v1-core">
@@ -11273,6 +11357,20 @@ string
 </td>
 <td>
 <p>Thanos container image URL.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#pullpolicy-v1-core">
+Kubernetes core/v1.PullPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -133,7 +133,7 @@ Kubernetes core/v1.PullPolicy
 </em>
 </td>
 <td>
-<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+<p>Image pull policy for the &lsquo;alertmanager&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
 See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>
@@ -4010,7 +4010,7 @@ Kubernetes core/v1.PullPolicy
 </em>
 </td>
 <td>
-<p>Image pull policy for the &lsquo;prometheus&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
+<p>Image pull policy for the &lsquo;alertmanager&rsquo;, &lsquo;init-config-reloader&rsquo; and &lsquo;config-reloader&rsquo; containers.
 See <a href="https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy">https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy</a> for more details.</p>
 </td>
 </tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7195,6 +7195,16 @@ spec:
                   to ensure the Prometheus Operator knows what version of Alertmanager
                   is being configured.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling prometheus and alertmanager images
@@ -15655,6 +15665,16 @@ spec:
                   and sha combinations. Specifying the version is still necessary
                   to ensure the Prometheus Operator knows what version of Prometheus
                   is being configured.
+                type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
@@ -24814,6 +24834,16 @@ spec:
                 x-kubernetes-list-type: map
               image:
                 description: Thanos container image URL.
+                type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
                 type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7196,7 +7196,7 @@ spec:
                   is being configured.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'alertmanager', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -24836,7 +24836,7 @@ spec:
                 description: Thanos container image URL.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'thanos', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2721,7 +2721,7 @@ spec:
                   is being configured.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'alertmanager', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2720,6 +2720,16 @@ spec:
                   to ensure the Prometheus Operator knows what version of Alertmanager
                   is being configured.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling prometheus and alertmanager images

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -2955,6 +2955,16 @@ spec:
                   to ensure the Prometheus Operator knows what version of Prometheus
                   is being configured.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling prometheus and alertmanager images

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -2383,7 +2383,7 @@ spec:
                 description: Thanos container image URL.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'thanos', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -2382,6 +2382,16 @@ spec:
               image:
                 description: Thanos container image URL.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling thanos images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2721,7 +2721,7 @@ spec:
                   is being configured.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'alertmanager', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2720,6 +2720,16 @@ spec:
                   to ensure the Prometheus Operator knows what version of Alertmanager
                   is being configured.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling prometheus and alertmanager images

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -2955,6 +2955,16 @@ spec:
                   to ensure the Prometheus Operator knows what version of Prometheus
                   is being configured.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling prometheus and alertmanager images

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -2383,7 +2383,7 @@ spec:
                 description: Thanos container image URL.
                 type: string
               imagePullPolicy:
-                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                description: Image pull policy for the 'thanos', 'init-config-reloader'
                   and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
                   for more details.
                 enum:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -2382,6 +2382,16 @@ spec:
               image:
                 description: Thanos container image URL.
                 type: string
+              imagePullPolicy:
+                description: Image pull policy for the 'prometheus', 'init-config-reloader'
+                  and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                  for more details.
+                enum:
+                - ""
+                - Always
+                - Never
+                - IfNotPresent
+                type: string
               imagePullSecrets:
                 description: An optional list of references to secrets in the same
                   namespace to use for pulling thanos images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2473,7 +2473,7 @@
                     "type": "string"
                   },
                   "imagePullPolicy": {
-                    "description": "Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
+                    "description": "Image pull policy for the 'alertmanager', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
                     "enum": [
                       "",
                       "Always",

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2472,6 +2472,16 @@
                     "description": "Image if specified has precedence over baseImage, tag and sha combinations. Specifying the version is still necessary to ensure the Prometheus Operator knows what version of Alertmanager is being configured.",
                     "type": "string"
                   },
+                  "imagePullPolicy": {
+                    "description": "Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
+                    "enum": [
+                      "",
+                      "Always",
+                      "Never",
+                      "IfNotPresent"
+                    ],
+                    "type": "string"
+                  },
                   "imagePullSecrets": {
                     "description": "An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
                     "items": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2702,6 +2702,16 @@
                     "description": "Image if specified has precedence over baseImage, tag and sha combinations. Specifying the version is still necessary to ensure the Prometheus Operator knows what version of Prometheus is being configured.",
                     "type": "string"
                   },
+                  "imagePullPolicy": {
+                    "description": "Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
+                    "enum": [
+                      "",
+                      "Always",
+                      "Never",
+                      "IfNotPresent"
+                    ],
+                    "type": "string"
+                  },
                   "imagePullSecrets": {
                     "description": "An optional list of references to secrets in the same namespace to use for pulling prometheus and alertmanager images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
                     "items": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -2154,7 +2154,7 @@
                     "type": "string"
                   },
                   "imagePullPolicy": {
-                    "description": "Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
+                    "description": "Image pull policy for the 'thanos', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
                     "enum": [
                       "",
                       "Always",

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -2153,6 +2153,16 @@
                     "description": "Thanos container image URL.",
                     "type": "string"
                   },
+                  "imagePullPolicy": {
+                    "description": "Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers. See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.",
+                    "enum": [
+                      "",
+                      "Always",
+                      "Never",
+                      "IfNotPresent"
+                    ],
+                    "type": "string"
+                  },
                   "imagePullSecrets": {
                     "description": "An optional list of references to secrets in the same namespace to use for pulling thanos images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
                     "items": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -698,6 +698,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 			operator.Shard(-1),
 			operator.ConfigFile(path.Join(alertmanagerConfigDir, alertmanagerConfigFileCompressed)),
 			operator.ConfigEnvsubstFile(path.Join(alertmanagerConfigOutDir, alertmanagerConfigEnvsubstFilename)),
+			operator.ImagePullPolicy(a.Spec.ImagePullPolicy),
 		),
 	}
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -652,14 +652,15 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 
 	defaultContainers := []v1.Container{
 		{
-			Args:           amArgs,
-			Name:           "alertmanager",
-			Image:          amImagePath,
-			Ports:          ports,
-			VolumeMounts:   amVolumeMounts,
-			LivenessProbe:  livenessProbe,
-			ReadinessProbe: readinessProbe,
-			Resources:      a.Spec.Resources,
+			Args:            amArgs,
+			Name:            "alertmanager",
+			Image:           amImagePath,
+			ImagePullPolicy: a.Spec.ImagePullPolicy,
+			Ports:           ports,
+			VolumeMounts:    amVolumeMounts,
+			LivenessProbe:   livenessProbe,
+			ReadinessProbe:  readinessProbe,
+			Resources:       a.Spec.Resources,
 			SecurityContext: &v1.SecurityContext{
 				AllowPrivilegeEscalation: &boolFalse,
 				ReadOnlyRootFilesystem:   &boolTrue,

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1247,6 +1247,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			Name: "registry-secret",
 		},
 	}
+	imagePullPolicy := v1.PullAlways
 
 	sset, err := makeStatefulSet(&monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{},
@@ -1259,6 +1260,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			ServiceAccountName: serviceAccountName,
 			HostAliases:        hostAliases,
 			ImagePullSecrets:   imagePullSecrets,
+			ImagePullPolicy:    imagePullPolicy,
 		},
 	}, defaultTestConfig, "", nil)
 	if err != nil {
@@ -1288,5 +1290,15 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)
+	}
+	for _, initContainer := range sset.Spec.Template.Spec.InitContainers {
+		if !reflect.DeepEqual(initContainer.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
+	}
+	for _, container := range sset.Spec.Template.Spec.Containers {
+		if !reflect.DeepEqual(container.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
 	}
 }

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -68,6 +68,10 @@ type ThanosRulerSpec struct {
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Thanos container image URL.
 	Image string `json:"image,omitempty"`
+	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
+	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
+	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling thanos images from registries
 	// see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -68,7 +68,7 @@ type ThanosRulerSpec struct {
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Thanos container image URL.
 	Image string `json:"image,omitempty"`
-	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
+	// Image pull policy for the 'thanos', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -96,6 +96,10 @@ type CommonPrometheusFields struct {
 	// Prometheus Operator knows what version of Prometheus is being
 	// configured.
 	Image *string `json:"image,omitempty"`
+	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
+	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
+	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling prometheus and alertmanager images from registries
 	// see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
@@ -1897,6 +1901,10 @@ type AlertmanagerSpec struct {
 	// Prometheus Operator knows what version of Alertmanager is being
 	// configured.
 	Image *string `json:"image,omitempty"`
+	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
+	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
+	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Version the cluster should be on.
 	Version string `json:"version,omitempty"`
 	// Tag of Alertmanager container image to be deployed. Defaults to the value of `version`.

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -1901,7 +1901,7 @@ type AlertmanagerSpec struct {
 	// Prometheus Operator knows what version of Alertmanager is being
 	// configured.
 	Image *string `json:"image,omitempty"`
-	// Image pull policy for the 'prometheus', 'init-config-reloader' and 'config-reloader' containers.
+	// Image pull policy for the 'alertmanager', 'init-config-reloader' and 'config-reloader' containers.
 	// See https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy for more details.
 	// +kubebuilder:validation:Enum="";Always;Never;IfNotPresent
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/pkg/operator/config-reloader.go
+++ b/pkg/operator/config-reloader.go
@@ -32,6 +32,7 @@ type ConfigReloader struct {
 	config             ReloaderConfig
 	configFile         string
 	configEnvsubstFile string
+	imagePullPolicy    v1.PullPolicy
 	listenLocal        bool
 	localHost          string
 	logFormat          string
@@ -126,6 +127,13 @@ func VolumeMounts(mounts []v1.VolumeMount) ReloaderOption {
 func Shard(shard int32) ReloaderOption {
 	return func(c *ConfigReloader) {
 		c.shard = &shard
+	}
+}
+
+// ImagePullPolicy sets the imagePullPolicy option for the config-reloader container
+func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
+	return func(c *ConfigReloader) {
+		c.imagePullPolicy = imagePullPolicy
 	}
 }
 
@@ -225,6 +233,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 	return v1.Container{
 		Name:                     name,
 		Image:                    configReloader.config.Image,
+		ImagePullPolicy:          configReloader.config.ImagePullPolicy,
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		Env:                      envVars,
 		Command:                  []string{"/bin/prometheus-config-reloader"},

--- a/pkg/operator/config-reloader.go
+++ b/pkg/operator/config-reloader.go
@@ -32,7 +32,6 @@ type ConfigReloader struct {
 	config             ReloaderConfig
 	configFile         string
 	configEnvsubstFile string
-	imagePullPolicy    v1.PullPolicy
 	listenLocal        bool
 	localHost          string
 	logFormat          string
@@ -133,7 +132,7 @@ func Shard(shard int32) ReloaderOption {
 // ImagePullPolicy sets the imagePullPolicy option for the config-reloader container
 func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	return func(c *ConfigReloader) {
-		c.imagePullPolicy = imagePullPolicy
+		c.config.ImagePullPolicy = imagePullPolicy
 	}
 }
 

--- a/pkg/operator/config-reloader.go
+++ b/pkg/operator/config-reloader.go
@@ -32,6 +32,7 @@ type ConfigReloader struct {
 	config             ReloaderConfig
 	configFile         string
 	configEnvsubstFile string
+	imagePullPolicy    v1.PullPolicy
 	listenLocal        bool
 	localHost          string
 	logFormat          string
@@ -132,7 +133,7 @@ func Shard(shard int32) ReloaderOption {
 // ImagePullPolicy sets the imagePullPolicy option for the config-reloader container
 func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	return func(c *ConfigReloader) {
-		c.config.ImagePullPolicy = imagePullPolicy
+		c.imagePullPolicy = imagePullPolicy
 	}
 }
 
@@ -232,7 +233,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 	return v1.Container{
 		Name:                     name,
 		Image:                    configReloader.config.Image,
-		ImagePullPolicy:          configReloader.config.ImagePullPolicy,
+		ImagePullPolicy:          configReloader.imagePullPolicy,
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		Env:                      envVars,
 		Command:                  []string{"/bin/prometheus-config-reloader"},

--- a/pkg/operator/config-reloader_test.go
+++ b/pkg/operator/config-reloader_test.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"net/url"
 	"strconv"
 	"testing"
@@ -27,7 +28,7 @@ var reloaderConfig = ReloaderConfig{
 	MemoryRequest:   "50Mi",
 	MemoryLimit:     "50Mi",
 	Image:           "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-	ImagePullPolicy: "Always",
+	ImagePullPolicy: v1.PullAlways,
 }
 
 func TestCreateInitConfigReloader(t *testing.T) {
@@ -35,14 +36,16 @@ func TestCreateInitConfigReloader(t *testing.T) {
 	var container = CreateConfigReloader(
 		initContainerName,
 		ReloaderResources(reloaderConfig),
-		ReloaderRunOnce())
+		ReloaderRunOnce(),
+		ImagePullPolicy(v1.PullAlways),
+	)
 	if container.Name != "init-config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", initContainerName, container.Name)
 	}
 	if !contains(container.Args, "--watch-interval=0") {
 		t.Errorf("Expected '--watch-interval=0' does not exist in container arguments")
 	}
-	if container.ImagePullPolicy != "Always" {
+	if container.ImagePullPolicy != reloaderConfig.ImagePullPolicy {
 		t.Errorf("Expected imagePullPolicy %s, but found %s", reloaderConfig.ImagePullPolicy, container.ImagePullPolicy)
 	}
 }
@@ -107,6 +110,10 @@ func TestCreateConfigReloader(t *testing.T) {
 	}
 	if !flag {
 		t.Errorf("Expected shard value '%d' not found in %s", shard, container.Env)
+	}
+
+	if container.ImagePullPolicy != v1.PullAlways {
+		t.Errorf("Expected imagePullPolicy %s, but found %s", v1.PullAlways, container.ImagePullPolicy)
 	}
 }
 

--- a/pkg/operator/config-reloader_test.go
+++ b/pkg/operator/config-reloader_test.go
@@ -22,11 +22,12 @@ import (
 )
 
 var reloaderConfig = ReloaderConfig{
-	CPURequest:    "100m",
-	CPULimit:      "100m",
-	MemoryRequest: "50Mi",
-	MemoryLimit:   "50Mi",
-	Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+	CPURequest:      "100m",
+	CPULimit:        "100m",
+	MemoryRequest:   "50Mi",
+	MemoryLimit:     "50Mi",
+	Image:           "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+	ImagePullPolicy: "Always",
 }
 
 func TestCreateInitConfigReloader(t *testing.T) {
@@ -40,6 +41,9 @@ func TestCreateInitConfigReloader(t *testing.T) {
 	}
 	if !contains(container.Args, "--watch-interval=0") {
 		t.Errorf("Expected '--watch-interval=0' does not exist in container arguments")
+	}
+	if container.ImagePullPolicy != "Always" {
+		t.Errorf("Expected imagePullPolicy %s, but found %s", reloaderConfig.ImagePullPolicy, container.ImagePullPolicy)
 	}
 }
 

--- a/pkg/operator/config-reloader_test.go
+++ b/pkg/operator/config-reloader_test.go
@@ -16,23 +16,24 @@ package operator
 
 import (
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"net/url"
 	"strconv"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 var reloaderConfig = ReloaderConfig{
-	CPURequest:      "100m",
-	CPULimit:        "100m",
-	MemoryRequest:   "50Mi",
-	MemoryLimit:     "50Mi",
-	Image:           "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-	ImagePullPolicy: v1.PullAlways,
+	CPURequest:    "100m",
+	CPULimit:      "100m",
+	MemoryRequest: "50Mi",
+	MemoryLimit:   "50Mi",
+	Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
 }
 
 func TestCreateInitConfigReloader(t *testing.T) {
 	initContainerName := "init-config-reloader"
+	expectedImagePullPolicy := v1.PullAlways
 	var container = CreateConfigReloader(
 		initContainerName,
 		ReloaderResources(reloaderConfig),
@@ -45,8 +46,8 @@ func TestCreateInitConfigReloader(t *testing.T) {
 	if !contains(container.Args, "--watch-interval=0") {
 		t.Errorf("Expected '--watch-interval=0' does not exist in container arguments")
 	}
-	if container.ImagePullPolicy != reloaderConfig.ImagePullPolicy {
-		t.Errorf("Expected imagePullPolicy %s, but found %s", reloaderConfig.ImagePullPolicy, container.ImagePullPolicy)
+	if container.ImagePullPolicy != expectedImagePullPolicy {
+		t.Errorf("Expected imagePullPolicy %s, but found %s", expectedImagePullPolicy, container.ImagePullPolicy)
 	}
 }
 
@@ -58,6 +59,7 @@ func TestCreateConfigReloader(t *testing.T) {
 	configEnvsubstFile := "configEnvsubstFile"
 	watchedDirectories := []string{"directory1", "directory2"}
 	shard := int32(1)
+	expectedImagePullPolicy := v1.PullAlways
 	var container = CreateConfigReloader(
 		containerName,
 		ReloaderResources(reloaderConfig),
@@ -74,6 +76,7 @@ func TestCreateConfigReloader(t *testing.T) {
 		ConfigEnvsubstFile(configEnvsubstFile),
 		WatchedDirectories(watchedDirectories),
 		Shard(shard),
+		ImagePullPolicy(expectedImagePullPolicy),
 	)
 	if container.Name != "config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", containerName, container.Name)
@@ -112,8 +115,8 @@ func TestCreateConfigReloader(t *testing.T) {
 		t.Errorf("Expected shard value '%d' not found in %s", shard, container.Env)
 	}
 
-	if container.ImagePullPolicy != v1.PullAlways {
-		t.Errorf("Expected imagePullPolicy %s, but found %s", v1.PullAlways, container.ImagePullPolicy)
+	if container.ImagePullPolicy != expectedImagePullPolicy {
+		t.Errorf("Expected imagePullPolicy %s, but found %s", expectedImagePullPolicy, container.ImagePullPolicy)
 	}
 }
 

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -17,7 +17,6 @@ package operator
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/server"
@@ -48,12 +47,11 @@ type Config struct {
 }
 
 type ReloaderConfig struct {
-	CPURequest      string
-	CPULimit        string
-	MemoryRequest   string
-	MemoryLimit     string
-	Image           string
-	ImagePullPolicy v1.PullPolicy
+	CPURequest    string
+	CPULimit      string
+	MemoryRequest string
+	MemoryLimit   string
+	Image         string
 }
 
 type Labels struct {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -17,6 +17,7 @@ package operator
 import (
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/server"
@@ -47,11 +48,12 @@ type Config struct {
 }
 
 type ReloaderConfig struct {
-	CPURequest    string
-	CPULimit      string
-	MemoryRequest string
-	MemoryLimit   string
-	Image         string
+	CPURequest      string
+	CPULimit        string
+	MemoryRequest   string
+	MemoryLimit     string
+	Image           string
+	ImagePullPolicy v1.PullPolicy
 }
 
 type Labels struct {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -781,6 +781,7 @@ func makeStatefulSetSpec(
 		container := v1.Container{
 			Name:                     "thanos-sidecar",
 			Image:                    thanosImage,
+			ImagePullPolicy:          p.Spec.ImagePullPolicy,
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 			SecurityContext: &v1.SecurityContext{
 				AllowPrivilegeEscalation: &boolFalse,
@@ -922,6 +923,7 @@ func makeStatefulSetSpec(
 			operator.ConfigEnvsubstFile(path.Join(confOutDir, configEnvsubstFilename)),
 			operator.WatchedDirectories(watchedDirectories),
 			operator.Shard(shard),
+			operator.ImagePullPolicy(p.Spec.ImagePullPolicy),
 		),
 	)
 
@@ -942,6 +944,7 @@ func makeStatefulSetSpec(
 		{
 			Name:                     "prometheus",
 			Image:                    pImagePath,
+			ImagePullPolicy:          p.Spec.ImagePullPolicy,
 			Ports:                    ports,
 			Args:                     containerArgs,
 			VolumeMounts:             promVolumeMounts,
@@ -974,6 +977,7 @@ func makeStatefulSetSpec(
 			operator.ConfigEnvsubstFile(path.Join(confOutDir, configEnvsubstFilename)),
 			operator.WatchedDirectories(watchedDirectories), operator.VolumeMounts(configReloaderVolumeMounts),
 			operator.Shard(shard),
+			operator.ImagePullPolicy(p.Spec.ImagePullPolicy),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -2317,6 +2317,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			IP:        "1.1.1.1",
 		},
 	}
+	imagePullPolicy := v1.PullAlways
 	imagePullSecrets := []v1.LocalObjectReference{
 		{
 			Name: "registry-secret",
@@ -2336,6 +2337,7 @@ func TestPodTemplateConfig(t *testing.T) {
 				PriorityClassName:  priorityClassName,
 				ServiceAccountName: serviceAccountName,
 				HostAliases:        hostAliases,
+				ImagePullPolicy:    imagePullPolicy,
 				ImagePullSecrets:   imagePullSecrets,
 				HostNetwork:        hostNetwork,
 			},
@@ -2365,6 +2367,16 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if len(sset.Spec.Template.Spec.HostAliases) != len(hostAliases) {
 		t.Fatalf("expected length of host aliases to match, want %d, got %d", len(hostAliases), len(sset.Spec.Template.Spec.HostAliases))
+	}
+	for _, initContainer := range sset.Spec.Template.Spec.InitContainers {
+		if !reflect.DeepEqual(initContainer.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
+	}
+	for _, container := range sset.Spec.Template.Spec.Containers {
+		if !reflect.DeepEqual(container.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -390,6 +390,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		{
 			Name:                     "thanos-ruler",
 			Image:                    trImagePath,
+			ImagePullPolicy:          tr.Spec.ImagePullPolicy,
 			Args:                     trCLIArgs,
 			Env:                      trEnvVars,
 			VolumeMounts:             trVolumeMounts,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -753,6 +753,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			Name: "registry-secret",
 		},
 	}
+	imagePullPolicy := v1.PullAlways
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		ObjectMeta: metav1.ObjectMeta{},
@@ -766,6 +767,7 @@ func TestPodTemplateConfig(t *testing.T) {
 			ServiceAccountName: serviceAccountName,
 			HostAliases:        hostAliases,
 			ImagePullSecrets:   imagePullSecrets,
+			ImagePullPolicy:    imagePullPolicy,
 		},
 	}, defaultTestConfig, nil, "")
 	if err != nil {
@@ -795,6 +797,16 @@ func TestPodTemplateConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sset.Spec.Template.Spec.ImagePullSecrets, imagePullSecrets) {
 		t.Fatalf("expected image pull secrets to match, want %s, got %s", imagePullSecrets, sset.Spec.Template.Spec.ImagePullSecrets)
+	}
+	for _, initContainer := range sset.Spec.Template.Spec.InitContainers {
+		if !reflect.DeepEqual(initContainer.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
+	}
+	for _, container := range sset.Spec.Template.Spec.Containers {
+		if !reflect.DeepEqual(container.ImagePullPolicy, imagePullPolicy) {
+			t.Fatalf("expected imagePullPolicy to match, want %s, got %s", imagePullPolicy, sset.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Should be able to set imagePullPolicy for pods.

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/2747

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Added ability to specify imagePullPolicy
```
