### PR TITLE
Introduces e2e test testTRAlertmanagerConfig

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -302,6 +302,7 @@ func testAllNSThanosRuler(t *testing.T) {
 		"ThanosRulerPrometheusRuleInDifferentNamespace": testThanosRulerPrometheusRuleInDifferentNamespace,
 		"ThanosRulerPreserveUserAddedMetadata":          testTRPreserveUserAddedMetadata,
 		"ThanosRulerMinReadySeconds":                    testTRMinReadySeconds,
+		"ThanosRulerAlertmanagerConfig":                 testTRAlertmanagerConfig,
 	}
 	for name, f := range testFuncs {
 		t.Run(name, f)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,7 +66,6 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 	}
 
 	thanos := framework.MakeBasicThanosRuler(name, 1, fmt.Sprintf("http://%s:%d/", svc.Name, svc.Spec.Ports[0].Port))
-	thanos.Spec.RuleSelector = &metav1.LabelSelector{}
 	thanos.Spec.RuleNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"monitored": "true",
@@ -257,4 +257,80 @@ func testTRMinReadySeconds(t *testing.T) {
 	if trSS.Spec.MinReadySeconds != int32(updated) {
 		t.Fatalf("expected MinReadySeconds to be %d but got %d", updated, trSS.Spec.MinReadySeconds)
 	}
+}
+
+// Tests Thanos ruler -> Alertmanger path
+// This is done by creating a firing rule that will be picked up by
+// Thanos Ruler which will send it to Alertmanager, finally we will
+// use the Alertmanager API to validate that the alert is there
+func testTRAlertmanagerConfig(t *testing.T) {
+	const (
+		name       = "test"
+		group      = "thanos-alertmanager-test"
+		secretName = "thanos-ruler-alertmanagers-config"
+		configKey  = "alertmanagers.yaml"
+		testAlert  = "alert1"
+	)
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	// Create Alertmanager resource and service
+	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), ns, framework.MakeBasicAlertmanager(name, 1))
+	assert.NoError(t, err)
+
+	amSVC := framework.MakeAlertmanagerService(alertmanager.Name, group, v1.ServiceTypeClusterIP)
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, amSVC)
+	assert.NoError(t, err)
+
+	// Create a Prometheus resource because Thanos ruler needs a query API.
+	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, framework.MakeBasicPrometheus(ns, name, name, 1))
+	assert.NoError(t, err)
+
+	svc := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc)
+	assert.NoError(t, err)
+
+	// Create Secret with Alermanager config,
+	trAmConfigSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: map[string][]byte{
+			configKey: []byte(fmt.Sprintf(`
+alertmanagers:
+- scheme: http
+  api_version: v2
+  static_configs:
+    - dnssrv+_web._tcp.%s.%s.svc.cluster.local
+`, amSVC.Name, ns)),
+		},
+	}
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), trAmConfigSecret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create Thanos ruler resource and service
+	thanos := framework.MakeBasicThanosRuler(name, 1, fmt.Sprintf("http://%s:%d/", svc.Name, svc.Spec.Ports[0].Port))
+	thanos.Spec.EvaluationInterval = "1s"
+	thanos.Spec.AlertManagersConfig = &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: secretName,
+		},
+		Key: configKey,
+	}
+
+	_, err = framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanos)
+	assert.NoError(t, err)
+
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, framework.MakeThanosRulerService(thanos.Name, group, v1.ServiceTypeClusterIP))
+	assert.NoError(t, err)
+
+	// Create firing rule
+	_, err = framework.MakeAndCreateFiringRule(context.Background(), ns, "rule1", testAlert)
+	assert.NoError(t, err)
+
+	err = framework.WaitForAlertmanagerFiringAlert(context.Background(), ns, amSVC.Name, testAlert)
+	assert.NoError(t, err)
 }

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -40,6 +40,7 @@ func (f *Framework) MakeBasicThanosRuler(name string, replicas int32, queryEndpo
 			Replicas:       &replicas,
 			QueryEndpoints: []string{queryEndpoint},
 			LogLevel:       "debug",
+			RuleSelector:   &metav1.LabelSelector{},
 		},
 	}
 }


### PR DESCRIPTION


## Description

Issue: https://github.com/prometheus-operator/prometheus-operator/issues/5187

The goal of the test is to validate the path TR -> Alertmanager.
We will create a firing alert that Thanos Ruler should propagate to
alertmanger.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
