### PR TITLE
pkg/alertmanager: sanitize configuration for v0.25.0

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -16,6 +16,7 @@ package alertmanager
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"path"
@@ -1344,7 +1345,7 @@ func (cb *configBuilder) convertHTTPConfig(ctx context.Context, in monitoringv1a
 	return out, nil
 }
 
-func (cb *configBuilder) convertTLSConfig(ctx context.Context, in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) tlsConfig {
+func (cb *configBuilder) convertTLSConfig(ctx context.Context, in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) *tlsConfig {
 	out := tlsConfig{
 		ServerName:         in.ServerName,
 		InsecureSkipVerify: in.InsecureSkipVerify,
@@ -1360,10 +1361,10 @@ func (cb *configBuilder) convertTLSConfig(ctx context.Context, in *monitoringv1.
 		out.KeyFile = path.Join(tlsAssetsDir, assets.TLSAssetKeyFromSecretSelector(crKey.Namespace, in.KeySecret).String())
 	}
 
-	return out
+	return &out
 }
 
-// sanitize the config against a specific AlertManager version
+// sanitize the config against a specific Alertmanager version
 // types may be sanitized in one of two ways:
 // 1. stripping the unsupported config and log a warning
 // 2. error which ensures that config will not be reconciled - this will be logged by a calling function
@@ -1418,51 +1419,139 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger log.Logger) er
 	}
 
 	// We need to sanitize the config for slack globally
-	// As of v0.22.0 AlertManager config supports passing URL via file name
-	fileURLAllowed := amVersion.GTE(semver.MustParse("0.22.0"))
+	// As of v0.22.0 Alertmanager config supports passing URL via file name
 	if gc.SlackAPIURLFile != "" {
-
 		if gc.SlackAPIURL != nil {
 			msg := "'slack_api_url' and 'slack_api_url_file' are mutually exclusive - 'slack_api_url' has taken precedence"
 			level.Warn(logger).Log("msg", msg)
 			gc.SlackAPIURLFile = ""
 		}
 
-		if !fileURLAllowed {
-			msg := "'slack_api_url_file' supported in AlertManager >= 0.22.0 only - dropping field from provided config"
+		if amVersion.LT(semver.MustParse("0.22.0")) {
+			msg := "'slack_api_url_file' supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
 			level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 			gc.SlackAPIURLFile = ""
 		}
 	}
 
-	if len(gc.OpsGenieAPIKeyFile) > 0 && !amVersion.GTE(semver.MustParse("0.24.0")) {
-		msg := "'opsgenie_api_key_file' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+	if gc.OpsGenieAPIKeyFile != "" && amVersion.LT(semver.MustParse("0.24.0")) {
+		msg := "'opsgenie_api_key_file' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		gc.OpsGenieAPIKeyFile = ""
+	}
+
+	if gc.SMTPAuthPasswordFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
+		msg := "'smtp_auth_password_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		gc.SMTPAuthPasswordFile = ""
+	}
+
+	if gc.SMTPAuthPassword != "" && gc.SMTPAuthPasswordFile != "" {
+		msg := "'smtp_auth_password' and 'smtp_auth_password_file' are mutually exclusive - 'smtp_auth_password' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
+		gc.SMTPAuthPasswordFile = ""
+	}
+
+	if gc.VictorOpsAPIKeyFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
+		msg := "'victorops_api_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		gc.VictorOpsAPIKeyFile = ""
+	}
+
+	if gc.VictorOpsAPIKey != "" && gc.VictorOpsAPIKeyFile != "" {
+		msg := "'victorops_api_key' and 'victorops_api_key_file' are mutually exclusive - 'victorops_api_key' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
+		gc.VictorOpsAPIKeyFile = ""
 	}
 
 	return nil
 }
 
-// sanitize httpClientConfig
 func (hc *httpClientConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
 	if hc == nil {
 		return nil
 	}
 
 	if hc.Authorization != nil && !amVersion.GTE(semver.MustParse("0.22.0")) {
-		return fmt.Errorf("'authorization' set in 'http_config' but supported in AlertManager >= 0.22.0 only")
+		return fmt.Errorf("'authorization' set in 'http_config' but supported in Alertmanager >= 0.22.0 only")
 	}
 
 	if hc.OAuth2 != nil && !amVersion.GTE(semver.MustParse("0.22.0")) {
-		return fmt.Errorf("'oauth2' set in 'http_config' but supported in AlertManager >= 0.22.0 only")
+		return fmt.Errorf("'oauth2' set in 'http_config' but supported in Alertmanager >= 0.22.0 only")
 	}
 
 	if hc.FollowRedirects != nil && !amVersion.GTE(semver.MustParse("0.22.0")) {
-		msg := "'follow_redirects' set in 'http_config' but supported in AlertManager >= 0.22.0 only - dropping field from provided config"
+		msg := "'follow_redirects' set in 'http_config' but supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		hc.FollowRedirects = nil
 	}
+
+	if hc.EnableHTTP2 != nil && !amVersion.GTE(semver.MustParse("0.25.0")) {
+		msg := "'enable_http2' set in 'http_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		hc.EnableHTTP2 = nil
+	}
+
+	if err := hc.TLSConfig.sanitize(amVersion, logger); err != nil {
+		return err
+	}
+
+	return hc.OAuth2.sanitize(amVersion, logger)
+}
+
+var tlsVersions = map[string]int{
+	"":      0x0000,
+	"TLS13": tls.VersionTLS13,
+	"TLS12": tls.VersionTLS12,
+	"TLS11": tls.VersionTLS11,
+	"TLS10": tls.VersionTLS10,
+}
+
+func (tc *tlsConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
+	if tc == nil {
+		return nil
+	}
+
+	if tc.MinVersion != "" && !amVersion.GTE(semver.MustParse("0.25.0")) {
+		msg := "'min_version' set in 'tls_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		tc.MinVersion = ""
+	}
+
+	if tc.MaxVersion != "" && !amVersion.GTE(semver.MustParse("0.25.0")) {
+		msg := "'max_version' set in 'tls_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		tc.MaxVersion = ""
+	}
+
+	minVersion, found := tlsVersions[tc.MinVersion]
+	if !found {
+		return fmt.Errorf("unknown TLS version: %s", tc.MinVersion)
+	}
+
+	maxVersion, found := tlsVersions[tc.MaxVersion]
+	if !found {
+		return fmt.Errorf("unknown TLS version: %s", tc.MaxVersion)
+	}
+
+	if minVersion != 0 && maxVersion != 0 && minVersion > maxVersion {
+		return fmt.Errorf("max TLS version %q must be greater than or equal to min TLS version %q", tc.MaxVersion, tc.MinVersion)
+	}
+
+	return nil
+}
+
+func (o *oauth2) sanitize(amVersion semver.Version, logger log.Logger) error {
+	if o == nil {
+		return nil
+	}
+
+	if o.ProxyURL != "" && !amVersion.GTE(semver.MustParse("0.25.0")) {
+		msg := "'proxy_url' set in 'oauth2' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		o.ProxyURL = ""
+	}
+
 	return nil
 }
 
@@ -1472,6 +1561,12 @@ func (r *receiver) sanitize(amVersion semver.Version, logger log.Logger) error {
 		return nil
 	}
 	withLogger := log.With(logger, "receiver", r.Name)
+
+	for _, conf := range r.EmailConfigs {
+		if err := conf.sanitize(amVersion, withLogger); err != nil {
+			return err
+		}
+	}
 
 	for _, conf := range r.OpsgenieConfigs {
 		if err := conf.sanitize(amVersion, withLogger); err != nil {
@@ -1527,6 +1622,33 @@ func (r *receiver) sanitize(amVersion semver.Version, logger log.Logger) error {
 		}
 	}
 
+	for _, conf := range r.DiscordConfigs {
+		if err := conf.sanitize(amVersion, withLogger); err != nil {
+			return err
+		}
+	}
+
+	for _, conf := range r.WebexConfigs {
+		if err := conf.sanitize(amVersion, withLogger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ec *emailConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
+	if ec.AuthPasswordFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
+		msg := "'auth_password_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		ec.AuthPasswordFile = ""
+	}
+
+	if ec.AuthPassword != "" && ec.AuthPasswordFile != "" {
+		level.Warn(logger).Log("msg", "'auth_password' and 'auth_password_file' are mutually exclusive for email receiver config - 'auth_password' has taken precedence")
+		ec.AuthPasswordFile = ""
+	}
+
 	return nil
 }
 
@@ -1538,18 +1660,18 @@ func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger log.Logger)
 	lessThanV0_24 := amVersion.LT(semver.MustParse("0.24.0"))
 
 	if ogc.Actions != "" && lessThanV0_24 {
-		msg := "opsgenie_config 'actions' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+		msg := "opsgenie_config 'actions' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.Actions = ""
 	}
 
 	if ogc.Entity != "" && lessThanV0_24 {
-		msg := "opsgenie_config 'entity' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+		msg := "opsgenie_config 'entity' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.Entity = ""
 	}
 	if ogc.UpdateAlerts != nil && lessThanV0_24 {
-		msg := "update_alerts 'entity' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+		msg := "update_alerts 'entity' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.UpdateAlerts = nil
 	}
@@ -1569,7 +1691,7 @@ func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger log.Logger)
 	}
 
 	if lessThanV0_24 {
-		msg := "'api_key_file' supported in AlertManager >= 0.24.0 only - dropping field from provided config"
+		msg := "'api_key_file' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
 		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		ogc.APIKeyFile = ""
 	}
@@ -1579,12 +1701,44 @@ func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger log.Logger)
 
 func (ops *opsgenieResponder) sanitize(amVersion semver.Version, logger log.Logger) error {
 	if ops.Type == "teams" && amVersion.LT(semver.MustParse("0.24.0")) {
-		return fmt.Errorf("'teams' set in 'opsgenieResponder' but supported in AlertManager >= 0.24.0 only")
+		return fmt.Errorf("'teams' set in 'opsgenieResponder' but supported in Alertmanager >= 0.24.0 only")
 	}
 	return nil
 }
 
 func (pdc *pagerdutyConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
+	lessThanV0_25 := amVersion.LT(semver.MustParse("0.25.0"))
+
+	if pdc.Source != "" && lessThanV0_25 {
+		msg := "'source' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		pdc.Source = ""
+	}
+
+	if pdc.RoutingKeyFile != "" && lessThanV0_25 {
+		msg := "'routing_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		pdc.RoutingKeyFile = ""
+	}
+
+	if pdc.ServiceKeyFile != "" && lessThanV0_25 {
+		msg := "'service_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		pdc.ServiceKeyFile = ""
+	}
+
+	if pdc.ServiceKey != "" && pdc.ServiceKeyFile != "" {
+		msg := "'service_key' and 'service_key_file' are mutually exclusive for pagerdury receiver config - 'service_key' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
+		pdc.ServiceKeyFile = ""
+	}
+
+	if pdc.RoutingKey != "" && pdc.RoutingKeyFile != "" {
+		msg := "'routing_key' and 'routing_key_file' are mutually exclusive for pagerdury receiver config - 'routing_key' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
+		pdc.RoutingKeyFile = ""
+	}
+
 	return pdc.HTTPConfig.sanitize(amVersion, logger)
 }
 
@@ -1602,17 +1756,16 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger log.Logger) err
 	}
 
 	// We need to sanitize the config for slack receivers
-	// As of v0.22.0 AlertManager config supports passing URL via file name
-	fileURLAllowed := amVersion.GTE(semver.MustParse("0.22.0"))
-	if sc.APIURL != "" {
-		msg := "'api_url' and 'api_url_file' are mutually exclusive for slack receiver config - 'api_url' has taken precedence"
-		level.Warn(logger).Log("msg", msg)
+	// As of v0.22.0 Alertmanager config supports passing URL via file name
+	if sc.APIURLFile != "" && amVersion.LT(semver.MustParse("0.22.0")) {
+		msg := "'api_url_file' supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
 		sc.APIURLFile = ""
 	}
 
-	if !fileURLAllowed {
-		msg := "'api_url_file' supported in AlertManager >= 0.22.0 only - dropping field from provided config"
-		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+	if sc.APIURL != "" && sc.APIURLFile != "" {
+		msg := "'api_url' and 'api_url_file' are mutually exclusive for slack receiver config - 'api_url' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
 		sc.APIURLFile = ""
 	}
 
@@ -1620,7 +1773,23 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger log.Logger) err
 }
 
 func (voc *victorOpsConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
-	return voc.HTTPConfig.sanitize(amVersion, logger)
+	if err := voc.HTTPConfig.sanitize(amVersion, logger); err != nil {
+		return err
+	}
+
+	if voc.APIKeyFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
+		msg := "'api_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
+		level.Warn(logger).Log("msg", msg, "current_version", amVersion.String())
+		voc.APIKeyFile = ""
+	}
+
+	if voc.APIKey != "" && voc.APIKeyFile != "" {
+		msg := "'api_key' and 'api_key_file' are mutually exclusive for victorops receiver config - 'api_url' has taken precedence"
+		level.Warn(logger).Log("msg", msg)
+		voc.APIKeyFile = ""
+	}
+
+	return nil
 }
 
 func (whc *webhookConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
@@ -1647,6 +1816,28 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger log.Logger) 
 
 	if tc.BotToken == "" {
 		return fmt.Errorf("mandatory field %q is empty", "botToken")
+	}
+
+	return tc.HTTPConfig.sanitize(amVersion, logger)
+}
+
+func (tc *discordConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
+	discordAllowed := amVersion.GTE(semver.MustParse("0.25.0"))
+	if !discordAllowed {
+		return fmt.Errorf(`invalid syntax in receivers config; discord integration is available in Alertmanager >= 0.25.0`)
+	}
+
+	return tc.HTTPConfig.sanitize(amVersion, logger)
+}
+
+func (tc *webexConfig) sanitize(amVersion semver.Version, logger log.Logger) error {
+	webexAllowed := amVersion.GTE(semver.MustParse("0.25.0"))
+	if !webexAllowed {
+		return fmt.Errorf(`invalid syntax in receivers config; webex integration is available in Alertmanager >= 0.25.0`)
+	}
+
+	if tc.RoomID == "" {
+		return errors.Errorf("mandatory field %q is empty", "room_id")
 	}
 
 	return tc.HTTPConfig.sanitize(amVersion, logger)

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -44,28 +44,30 @@ type globalConfig struct {
 
 	HTTPConfig *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	SMTPFrom           string          `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
-	SMTPHello          string          `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
-	SMTPSmarthost      config.HostPort `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
-	SMTPAuthUsername   string          `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
-	SMTPAuthPassword   string          `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
-	SMTPAuthSecret     string          `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
-	SMTPAuthIdentity   string          `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
-	SMTPRequireTLS     *bool           `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
-	SlackAPIURL        *config.URL     `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
-	SlackAPIURLFile    string          `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
-	PagerdutyURL       *config.URL     `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
-	HipchatAPIURL      *config.URL     `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`
-	HipchatAuthToken   string          `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
-	OpsGenieAPIURL     *config.URL     `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
-	OpsGenieAPIKey     string          `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
-	OpsGenieAPIKeyFile string          `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
-	WeChatAPIURL       *config.URL     `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
-	WeChatAPISecret    string          `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
-	WeChatAPICorpID    string          `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
-	VictorOpsAPIURL    *config.URL     `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
-	VictorOpsAPIKey    string          `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
-	TelegramAPIURL     *config.URL     `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
+	SMTPFrom             string          `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
+	SMTPHello            string          `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
+	SMTPSmarthost        config.HostPort `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
+	SMTPAuthUsername     string          `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
+	SMTPAuthPassword     string          `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
+	SMTPAuthPasswordFile string          `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
+	SMTPAuthSecret       string          `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
+	SMTPAuthIdentity     string          `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
+	SMTPRequireTLS       *bool           `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
+	SlackAPIURL          *config.URL     `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
+	SlackAPIURLFile      string          `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
+	PagerdutyURL         *config.URL     `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
+	HipchatAPIURL        *config.URL     `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`
+	HipchatAuthToken     string          `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
+	OpsGenieAPIURL       *config.URL     `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
+	OpsGenieAPIKey       string          `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	OpsGenieAPIKeyFile   string          `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
+	WeChatAPIURL         *config.URL     `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
+	WeChatAPISecret      string          `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
+	WeChatAPICorpID      string          `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
+	VictorOpsAPIURL      *config.URL     `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
+	VictorOpsAPIKey      string          `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKeyFile  string          `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
+	TelegramAPIURL       *config.URL     `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
 }
 
 type route struct {
@@ -105,6 +107,8 @@ type receiver struct {
 	VictorOpsConfigs []*victorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
 	SNSConfigs       []*snsConfig       `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
 	TelegramConfigs  []*telegramConfig  `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
+	DiscordConfigs   []*discordConfig   `yaml:"discord_configs,omitempty"`
+	WebexConfigs     []*webexConfig     `yaml:"webex_configs,omitempty"`
 }
 
 type webhookConfig struct {
@@ -115,21 +119,24 @@ type webhookConfig struct {
 }
 
 type pagerdutyConfig struct {
-	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
-	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	ServiceKey    string            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	RoutingKey    string            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
-	URL           string            `yaml:"url,omitempty" json:"url,omitempty"`
-	Client        string            `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL     string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description   string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Details       map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
-	Images        []pagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
-	Links         []pagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
-	Severity      string            `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Class         string            `yaml:"class,omitempty" json:"class,omitempty"`
-	Component     string            `yaml:"component,omitempty" json:"component,omitempty"`
-	Group         string            `yaml:"group,omitempty" json:"group,omitempty"`
+	VSendResolved  *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
+	HTTPConfig     *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	ServiceKey     string            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	ServiceKeyFile string            `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
+	RoutingKey     string            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	RoutingKeyFile string            `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
+	URL            string            `yaml:"url,omitempty" json:"url,omitempty"`
+	Client         string            `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL      string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description    string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Details        map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images         []pagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links          []pagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
+	Severity       string            `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Class          string            `yaml:"class,omitempty" json:"class,omitempty"`
+	Component      string            `yaml:"component,omitempty" json:"component,omitempty"`
+	Group          string            `yaml:"group,omitempty" json:"group,omitempty"`
+	Source         string            `yaml:"source,omitempty" json:"source,omitempty"`
 }
 
 type opsgenieConfig struct {
@@ -198,8 +205,9 @@ type httpClientConfig struct {
 	BearerToken     string         `yaml:"bearer_token,omitempty"`
 	BearerTokenFile string         `yaml:"bearer_token_file,omitempty"`
 	ProxyURL        string         `yaml:"proxy_url,omitempty"`
-	TLSConfig       tlsConfig      `yaml:"tls_config,omitempty"`
+	TLSConfig       *tlsConfig     `yaml:"tls_config,omitempty"`
 	FollowRedirects *bool          `yaml:"follow_redirects,omitempty"`
+	EnableHTTP2     *bool          `yaml:"enable_http2,omitempty"`
 }
 
 type tlsConfig struct {
@@ -208,6 +216,8 @@ type tlsConfig struct {
 	KeyFile            string `yaml:"key_file,omitempty"`
 	ServerName         string `yaml:"server_name,omitempty"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
+	MinVersion         string `yaml:"min_version,omitempty"`
+	MaxVersion         string `yaml:"max_version,omitempty"`
 }
 
 type authorization struct {
@@ -229,6 +239,7 @@ type oauth2 struct {
 	Scopes           []string          `yaml:"scopes,omitempty"`
 	TokenURL         string            `yaml:"token_url"`
 	EndpointParams   map[string]string `yaml:"endpoint_params,omitempty"`
+	ProxyURL         string            `yaml:"proxy_url,omitempty"`
 
 	TLSConfig *tlsConfig `yaml:"tls_config,omitempty"`
 }
@@ -275,20 +286,21 @@ type slackConfirmationField struct {
 }
 
 type emailConfig struct {
-	VSendResolved *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
-	To            string            `yaml:"to,omitempty" json:"to,omitempty"`
-	From          string            `yaml:"from,omitempty" json:"from,omitempty"`
-	Hello         string            `yaml:"hello,omitempty" json:"hello,omitempty"`
-	Smarthost     config.HostPort   `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
-	AuthUsername  string            `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
-	AuthPassword  string            `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
-	AuthSecret    string            `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
-	AuthIdentity  string            `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
-	Headers       map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
-	HTML          string            `yaml:"html,omitempty" json:"html,omitempty"`
-	Text          string            `yaml:"text,omitempty" json:"text,omitempty"`
-	RequireTLS    *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
-	TLSConfig     tlsConfig         `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	VSendResolved    *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
+	To               string            `yaml:"to,omitempty" json:"to,omitempty"`
+	From             string            `yaml:"from,omitempty" json:"from,omitempty"`
+	Hello            string            `yaml:"hello,omitempty" json:"hello,omitempty"`
+	Smarthost        config.HostPort   `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
+	AuthUsername     string            `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
+	AuthPassword     string            `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
+	AuthPasswordFile string            `yaml:"auth_password_file,omitempty" json:"auth_password_file,omitempty"`
+	AuthSecret       string            `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
+	AuthIdentity     string            `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
+	Headers          map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	HTML             string            `yaml:"html,omitempty" json:"html,omitempty"`
+	Text             string            `yaml:"text,omitempty" json:"text,omitempty"`
+	RequireTLS       *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+	TLSConfig        *tlsConfig        `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
 }
 
 type pushoverConfig struct {
@@ -331,6 +343,22 @@ type telegramConfig struct {
 	HTTPConfig           *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 }
 
+type discordConfig struct {
+	VSendResolved *bool             `yaml:"send_resolved,omitempty"`
+	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty"`
+	WebhookURL    string            `yaml:"webhook_url,omitempty"`
+	Title         string            `yaml:"title,omitempty"`
+	Message       string            `yaml:"message,omitempty"`
+}
+
+type webexConfig struct {
+	VSendResolved *bool             `yaml:"send_resolved,omitempty"`
+	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty"`
+	APIURL        string            `yaml:"api_url,omitempty"`
+	Message       string            `yaml:"message,omitempty"`
+	RoomID        string            `yaml:"room_id"`
+}
+
 type sigV4Config struct {
 	Region    string `yaml:"region,omitempty" json:"region,omitempty"`
 	AccessKey string `yaml:"access_key,omitempty" json:"access_key,omitempty"`
@@ -357,6 +385,7 @@ type victorOpsConfig struct {
 	VSendResolved     *bool             `yaml:"send_resolved,omitempty" json:"send_resolved,omitempty"`
 	HTTPConfig        *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	APIKey            string            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKeyFile        string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL            string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	RoutingKey        string            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
 	MessageType       string            `yaml:"message_type,omitempty" json:"message_type,omitempty"`


### PR DESCRIPTION
## Description

Alertmanager v0.25.0 introduces new notifiers (Discord, Webex) + configuration fields that the operator needs to sanitize.
    
Global configuration:
    * `smtp_auth_password_file`
    * `victorops_api_key_file`
    
HTTP client configuration:
    * `proxy_url` for OAuth2
    * `min_version` & `max_version` for TLS
    * `enable_http2`
    
Email configuration:
    * `auth_password_file`
    
PagerDuty configuration:
    * `routing_key_file`
    * `service_key_file`
    * `source`
    
VictorOps configuration:
    * `api_key_file`


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Supported new fields from Alertmanager v0.25.0
```
