### PR TITLE
Time interval location

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -13321,6 +13321,14 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1alpha1.Location">Location
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.TimeInterval">TimeInterval</a>)
+</p>
+<div>
+<p>Location defines an IANA Timezone</p>
+</div>
 <h3 id="monitoring.coreos.com/v1alpha1.MatchType">MatchType
 (<code>string</code> alias)</h3>
 <p>
@@ -15436,6 +15444,20 @@ HTTPConfig
 </tr>
 <tr>
 <td>
+<code>location</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1alpha1.Location">
+Location
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Location is a Timezone Location</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>weekdays</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1alpha1.WeekdayRange">
@@ -16630,6 +16652,14 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1beta1.Location">Location
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1beta1.TimePeriod">TimePeriod</a>)
+</p>
+<div>
+<p>Location defines an IANA Timezone</p>
+</div>
 <h3 id="monitoring.coreos.com/v1beta1.MatchType">MatchType
 (<code>string</code> alias)</h3>
 <p>
@@ -18755,6 +18785,20 @@ string
 <td>
 <em>(Optional)</em>
 <p>Times is a list of TimeRange</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>location</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1beta1.Location">
+Location
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Location is a Timezone Location</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is a Timezone Location
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -185,6 +185,10 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          location:
+                            description: Timezone of times. A string that matches a location in the IANA time zone database
+                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
+                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:
@@ -8862,6 +8866,10 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          location:
+                            description: Timezone of times. A string that matches a location in the IANA time zone database
+                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
+                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is a Timezone Location
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:
@@ -185,10 +188,6 @@ spec:
                                   type: string
                               type: object
                             type: array
-                          location:
-                            description: Timezone of times. A string that matches a location in the IANA time zone database
-                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
-                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:
@@ -8838,6 +8837,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is a Timezone Location
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:
@@ -8866,10 +8868,6 @@ spec:
                                   type: string
                               type: object
                             type: array
-                          location:
-                            description: Timezone of times. A string that matches a location in the IANA time zone database
-                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
-                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is a Timezone Location
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:
@@ -185,10 +188,6 @@ spec:
                                   type: string
                               type: object
                             type: array
-                          location:
-                            description: Timezone of times. A string that matches a location in the IANA time zone database
-                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
-                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -185,6 +185,10 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          location:
+                            description: Timezone of times. A string that matches a location in the IANA time zone database
+                              (i.e. 'Australia/Sydney'), 'Local', or 'UTC'
+                            type: string
                           weekdays:
                             description: Weekdays is a list of WeekdayRange
                             items:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -169,6 +169,10 @@
                                 },
                                 "type": "array"
                               },
+                              "location": {
+                                "description": "Location is a Timezone Location",
+                                "type": "string"
+                              },
                               "months": {
                                 "description": "Months is a list of MonthRange",
                                 "items": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -4570,6 +4570,10 @@
                             },
                             type: 'array',
                           },
+                          location: {
+                            description: 'Location is a Timezone Location',
+                            type: 'string',
+                          },
                           months: {
                             description: 'Months is a list of MonthRange',
                             items: {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1198,6 +1198,14 @@ func convertMuteTimeInterval(in *monitoringv1alpha1.MuteTimeInterval, crKey type
 			})
 		}
 
+		if timeInterval.Location != "" {
+			tz, err := time.LoadLocation(fmt.Sprintf("%s", timeInterval.Location))
+			if err != nil {
+				return nil, err
+			}
+			ti.Location = &timeinterval.Location{tz}
+		}
+
 		for _, wd := range timeInterval.Weekdays {
 			parsedWeekday, err := wd.Parse()
 			if err != nil {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1199,7 +1199,7 @@ func convertMuteTimeInterval(in *monitoringv1alpha1.MuteTimeInterval, crKey type
 		}
 
 		if timeInterval.Location != "" {
-			tz, err := time.LoadLocation(fmt.Sprintf("%s", timeInterval.Location))
+			tz, err := time.LoadLocation(string(timeInterval.Location))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1412,12 +1412,14 @@ func (c *alertmanagerConfig) sanitize(amVersion semver.Version, logger log.Logge
 
 	if len(c.TimeIntervals) > 0 && !amVersion.GTE(semver.MustParse("0.25.0")) {
 		// time interval locations are unsupported < 0.25.0, report and set to nil
-		for i, ti := range c.TimeIntervals {
-			if ti.Location != nil {
-				withLogger := log.With(logger, "component", "alertmanager")
-				msg := "time_interval location is supported in Alertmanager >= 0.25.0 only - dropping config"
-				level.Warn(withLogger).Log("msg", msg, "time_interval", ti)
-				ti.Location = nil
+		withLogger := log.With(logger, "component", "alertmanager")
+		for _, tip := range c.TimeIntervals {
+			for _, tic := range tip.TimeIntervals {
+				if tic.Location != nil {
+					msg := "time_interval location is supported in Alertmanager >= 0.25.0 only - dropping config"
+					level.Warn(withLogger).Log("msg", msg, "time_interval", tic)
+					tic.Location = nil
+				}
 			}
 		}
 	}

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1410,6 +1410,18 @@ func (c *alertmanagerConfig) sanitize(amVersion semver.Version, logger log.Logge
 		c.TimeIntervals = nil
 	}
 
+	if len(c.TimeIntervals) > 0 && !amVersion.GTE(semver.MustParse("0.25.0")) {
+		// time interval locations are unsupported < 0.25.0, report and set to nil
+		for i, ti := range c.TimeIntervals {
+			if ti.Location != nil {
+				withLogger := log.With(logger, "component", "alertmanager")
+				msg := "time_interval location is supported in Alertmanager >= 0.25.0 only - dropping config"
+				level.Warn(withLogger).Log("msg", msg, "time_interval", ti)
+				ti.Location = nil
+			}
+		}
+	}
+
 	return c.Route.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -1577,6 +1577,7 @@ templates: []
 												EndTime:   "17:00",
 											},
 										},
+										Location: monitoringv1alpha1.Location("UTC"),
 										Weekdays: []monitoringv1alpha1.WeekdayRange{
 											monitoringv1alpha1.WeekdayRange("Saturday"),
 											monitoringv1alpha1.WeekdayRange("Sunday"),
@@ -1655,6 +1656,7 @@ mute_time_intervals:
     days_of_month: ["1:10"]
     months: ["1:3"]
     years: ['2030:2050']
+    location: UTC
 templates: []
 `,
 		},
@@ -1693,6 +1695,7 @@ templates: []
 												EndTime:   "17:00",
 											},
 										},
+										Location: monitoringv1alpha1.Location("UTC"),
 										Weekdays: []monitoringv1alpha1.WeekdayRange{
 											monitoringv1alpha1.WeekdayRange("Saturday"),
 											monitoringv1alpha1.WeekdayRange("Sunday"),
@@ -1771,6 +1774,7 @@ mute_time_intervals:
     days_of_month: ["1:10"]
     months: ["1:3"]
     years: ['2030:2050']
+    location: UTC
 templates: []
 `,
 		},
@@ -1803,7 +1807,8 @@ templates: []
 
 			// Verify the generated yaml is as expected
 			if diff := cmp.Diff(tc.expected, string(cfgBytes)); diff != "" {
-				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+				//t.Errorf("Unexpected result (-want +got):\n%s", diff)
+				t.Errorf("%+v", cb.cfg)
 			}
 
 			// Verify the generated config is something that Alertmanager will be happy with

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -943,6 +943,9 @@ type TimeInterval struct {
 	// Times is a list of TimeRange
 	// +optional
 	Times []TimeRange `json:"times,omitempty"`
+	// Location is a Timezone Location
+	// +optional
+	Location Location `json:"location,omitempty"`
 	// Weekdays is a list of WeekdayRange
 	// +optional
 	Weekdays []WeekdayRange `json:"weekdays,omitempty"`
@@ -968,6 +971,9 @@ type TimeRange struct {
 	// EndTime is the end time in 24hr format.
 	EndTime Time `json:"endTime,omitempty"`
 }
+
+// Location defines an IANA Timezone
+type Location string
 
 // WeekdayRange is an inclusive range of days of the week beginning on Sunday
 // Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')

--- a/pkg/apis/monitoring/v1alpha1/validation.go
+++ b/pkg/apis/monitoring/v1alpha1/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (hc *HTTPConfig) Validate() error {
@@ -76,6 +77,11 @@ func (mti MuteTimeInterval) Validate() error {
 				return fmt.Errorf("time range at %d is invalid: %w", i, err)
 			}
 		}
+		if ti.Location != "" {
+			if err := ti.Location.Validate(); err != nil {
+				return fmt.Errorf("location at %d is invalid: %w", i, err)
+			}
+		}
 		for _, weekday := range ti.Weekdays {
 			if err := weekday.Validate(); err != nil {
 				return fmt.Errorf("weekday range at %d is invalid: %w", i, err)
@@ -130,6 +136,18 @@ func (tr TimeRange) Parse() (*ParsedRange, error) {
 		Start: start,
 		End:   end,
 	}, nil
+}
+
+// Validate the Location
+func (tz Location) Validate() error {
+	_, err := tz.Parse()
+	return err
+}
+
+// Parse returns a Location on a vaild timezone.
+func (tz Location) Parse() (Location, error) {
+	_, err := time.LoadLocation(fmt.Sprintf("%s", tz))
+	return tz, err
 }
 
 // Validate the WeekdayRange

--- a/pkg/apis/monitoring/v1alpha1/validation.go
+++ b/pkg/apis/monitoring/v1alpha1/validation.go
@@ -146,7 +146,7 @@ func (tz Location) Validate() error {
 
 // Parse returns a Location on a vaild timezone.
 func (tz Location) Parse() (Location, error) {
-	_, err := time.LoadLocation(fmt.Sprintf("%s", tz))
+	_, err := time.LoadLocation(string(tz))
 	return tz, err
 }
 

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -945,6 +945,9 @@ type TimePeriod struct {
 	// Times is a list of TimeRange
 	// +optional
 	Times []TimeRange `json:"times,omitempty"`
+	// Location is a Timezone Location
+	// +optional
+	Location Location `json:"location,omitempty"`
 	// Weekdays is a list of WeekdayRange
 	// +optional
 	Weekdays []WeekdayRange `json:"weekdays,omitempty"`
@@ -970,6 +973,9 @@ type TimeRange struct {
 	// EndTime is the end time in 24hr format.
 	EndTime Time `json:"endTime,omitempty"`
 }
+
+// Location defines an IANA Timezone
+type Location string
 
 // WeekdayRange is an inclusive range of days of the week beginning on Sunday
 // Days can be specified by name (e.g 'Sunday') or as an inclusive range (e.g 'Monday:Friday')

--- a/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -125,6 +125,7 @@ func convertTimeIntervalsFrom(in []v1alpha1.TimeInterval) []TimePeriod {
 			out,
 			TimePeriod{
 				Times:       trs,
+				Location:    Location(ti.Location),
 				Weekdays:    wds,
 				DaysOfMonth: doms,
 				Months:      mrs,

--- a/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -118,6 +118,7 @@ func convertTimeIntervalsTo(in []TimePeriod) []v1alpha1.TimeInterval {
 			out,
 			v1alpha1.TimeInterval{
 				Times:       trs,
+				Location:    v1alpha1.Location(ti.Location),
 				Weekdays:    wds,
 				DaysOfMonth: doms,
 				Months:      mrs,

--- a/pkg/apis/monitoring/v1beta1/validation.go
+++ b/pkg/apis/monitoring/v1beta1/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (hc *HTTPConfig) Validate() error {
@@ -76,6 +77,11 @@ func (ti TimeInterval) Validate() error {
 				return fmt.Errorf("time range at %d is invalid: %w", i, err)
 			}
 		}
+		if ti.Location != "" {
+			if err := ti.Location.Validate(); err != nil {
+				return fmt.Errorf("location at %d is invalid: %w", i, err)
+			}
+		}
 		for _, weekday := range ti.Weekdays {
 			if err := weekday.Validate(); err != nil {
 				return fmt.Errorf("weekday range at %d is invalid: %w", i, err)
@@ -130,6 +136,18 @@ func (tr TimeRange) Parse() (*ParsedRange, error) {
 		Start: start,
 		End:   end,
 	}, nil
+}
+
+// Validate the Location
+func (tz Location) Validate() error {
+	_, err := tz.Parse()
+	return err
+}
+
+// Parse returns a Location on a vaild timezone.
+func (tz Location) Parse() (Location, error) {
+	_, err := time.LoadLocation(fmt.Sprintf("%s", tz))
+	return tz, err
 }
 
 // Validate the WeekdayRange

--- a/pkg/apis/monitoring/v1beta1/validation.go
+++ b/pkg/apis/monitoring/v1beta1/validation.go
@@ -146,7 +146,7 @@ func (tz Location) Validate() error {
 
 // Parse returns a Location on a vaild timezone.
 func (tz Location) Parse() (Location, error) {
-	_, err := time.LoadLocation(fmt.Sprintf("%s", tz))
+	_, err := time.LoadLocation(string(tz))
 	return tz, err
 }
 

--- a/pkg/client/versioned/fake/register.go
+++ b/pkg/client/versioned/fake/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/versioned/scheme/register.go
+++ b/pkg/client/versioned/scheme/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1093,6 +1093,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 									EndTime:   "17:00",
 								},
 							},
+							Location: monitoringv1alpha1.Location("UTC"),
 							Weekdays: []monitoringv1alpha1.WeekdayRange{
 								"Saturday",
 								"Sunday",
@@ -1375,6 +1376,7 @@ mute_time_intervals:
   - times:
     - start_time: "08:00"
       end_time: "17:00"
+    location: UTC
     weekdays: [saturday, sunday]
     days_of_month: ["1:10"]
     months: ["1:3"]

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1376,11 +1376,11 @@ mute_time_intervals:
   - times:
     - start_time: "08:00"
       end_time: "17:00"
-    location: UTC
     weekdays: [saturday, sunday]
     days_of_month: ["1:10"]
     months: ["1:3"]
     years: ['2030:2050']
+    location: UTC
 templates: []
 `, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs, configNs)
 


### PR DESCRIPTION
## Description

Alertmanager 0.25.0 added a `location` field to the `time_interval`
object. This allows for active and muted ranges to be scoped to a
particular TZ rather than the default of UTC. This is not supported by
the operator and creates a failure mode if you try and use it. This PR
adds support for this new spec.

https://prometheus.io/docs/alerting/latest/configuration/#time_interval

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Add location support to time_interval object.