### PR TITLE
pkg/alertmanager: sanitize Location field

### DIFF
--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -28,13 +28,13 @@ import (
 // marshalling. See the following issue for details:
 // https://github.com/prometheus/alertmanager/issues/1985
 type alertmanagerConfig struct {
-	Global            *globalConfig       `yaml:"global,omitempty" json:"global,omitempty"`
-	Route             *route              `yaml:"route,omitempty" json:"route,omitempty"`
-	InhibitRules      []*inhibitRule      `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
-	Receivers         []*receiver         `yaml:"receivers,omitempty" json:"receivers,omitempty"`
-	MuteTimeIntervals []*muteTimeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
-	TimeIntervals     []*timeInterval     `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
-	Templates         []string            `yaml:"templates" json:"templates"`
+	Global            *globalConfig   `yaml:"global,omitempty" json:"global,omitempty"`
+	Route             *route          `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules      []*inhibitRule  `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	Receivers         []*receiver     `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	MuteTimeIntervals []*timeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
+	TimeIntervals     []*timeInterval `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
+	Templates         []string        `yaml:"templates" json:"templates"`
 }
 
 type globalConfig struct {
@@ -395,7 +395,4 @@ type victorOpsConfig struct {
 	CustomFields      map[string]string `yaml:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 }
 
-type (
-	muteTimeInterval config.MuteTimeInterval
-	timeInterval     config.TimeInterval
-)
+type timeInterval config.TimeInterval


### PR DESCRIPTION
## Description

Alertmanager v0.25.0 introduces a new `location` field for time intervals. This change strips the field if the Alertmanager version isn't compatible.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support Location field for Alertmanager >= v0.25.0
```
