### PR TITLE
Adds field to Prometheus Rule AdmissionResponse in case of failure

### DIFF
--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -32,6 +32,7 @@ func TestMakeRulesConfigMaps(t *testing.T) {
 	t.Run("shouldRejectRuleWithInvalidLabels", shouldRejectRuleWithInvalidLabels)
 	t.Run("shouldRejectRuleWithInvalidExpression", shouldRejectRuleWithInvalidExpression)
 	t.Run("shouldResetRuleWithPartialResponseStrategySet", shouldResetRuleWithPartialResponseStrategySet)
+	t.Run("validateFieldInAdmissionError", validateFieldInAdmissionError)
 }
 
 func shouldRejectRuleWithInvalidPartialResponseStrategyValue(t *testing.T) {
@@ -149,5 +150,124 @@ func shouldResetRuleWithPartialResponseStrategySet(t *testing.T) {
 	content, _ := generateRulesConfiguration(PrometheusFormat, rules, log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)))
 	if strings.Contains(content, "partial_response_strategy") {
 		t.Fatalf("expected `partial_response_strategy` removed from PrometheusRule")
+	}
+}
+
+func validateFieldInAdmissionError(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		ruleSpec      monitoringv1.PrometheusRuleSpec
+		expectedField string
+	}{
+		{
+			name: "Invalid PartialResponseStrategy",
+			ruleSpec: monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+				{
+					Name:                    "group",
+					PartialResponseStrategy: "invalid",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+					},
+				},
+			}},
+			expectedField: "groups[0].partial_response_strategy",
+		},
+		{
+			name: "Invalid Rule",
+			ruleSpec: monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1"),
+						},
+					},
+				},
+			}},
+			expectedField: "groups[0].rules[0]",
+		},
+		{
+			name: "Invalid Rule in second rule",
+			ruleSpec: monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1"),
+						},
+					},
+				},
+			}},
+			expectedField: "groups[0].rules[1]",
+		},
+		{
+			name: "Invalid Rule in second group",
+			ruleSpec: monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "group 1",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+					},
+				},
+				{
+					Name: "group 2",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1"),
+						},
+					},
+				},
+			}},
+			expectedField: "groups[1].rules[0]",
+		},
+		{
+			name: "Repeated group name",
+			ruleSpec: monitoringv1.PrometheusRuleSpec{Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+					},
+				},
+				{
+					Name: "group",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "alert",
+							Expr:  intstr.FromString("vector(1)"),
+						},
+					},
+				},
+			}},
+			expectedField: "groups",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			admissionErrors := ValidateRule(tc.ruleSpec)
+			if len(admissionErrors) == 0 {
+				t.Fatalf("expected errors when parsing invalid rule")
+			}
+			for _, admissionError := range admissionErrors {
+				if tc.expectedField != admissionError.Field {
+					t.Fatalf("field in admissionError doesn't match expected value: expected %s got %s", tc.expectedField, admissionError.Field)
+				}
+			}
+		})
 	}
 }

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -20,6 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type RuleValidationError struct {
+	Field string
+	Error error
+}
+
 func MakeVolumeClaimTemplate(e monitoringv1.EmbeddedPersistentVolumeClaim) *v1.PersistentVolumeClaim {
 	pvc := v1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION

## Description

Issue: https://github.com/prometheus-operator/prometheus-operator/issues/5190

Problem: When the validation AdmissionWebhook rejects a PrometheusRule
resource, the error message sometimes might not indicate easily in the
resource where is the issue.

Solution: this commit aims at adding a field to the AdmissionResponse
when there is a issue with a PrometheusRule being created, it uses
reflection to build the path to the part of the resource where the issue
was found

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Adds fields to AdmissionResponse in case of failure
```
