### PR TITLE
Increase 'operations-per-run' for the stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,8 @@ jobs:
           days-before-stale: 60
           days-before-issue-close: 120
           days-before-pr-close: -1  # Prevent closing PRs
-          exempt-issue-labels: 'kind/feature,help-wanted,kind/bug'
+          exempt-issue-labels: 'kind/feature,help wanted,kind/bug'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           exempt-draft-pr: true
+          operations-per-run: 500


### PR DESCRIPTION
## Description

The default value of 30 is too low for the repository and the action fails to process all issues and pull requests.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
