### PR TITLE
docs: ScrapeConfig proposal

### DIFF
--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -26,8 +26,9 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 ## Audience
 * Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
-* Users who want to manage scrape configs the same way as for services runnings within the kubernetes cluster
-* Users who want a supported Kubernetes way of scraping targets outside of the cluster
+* Users who want to manage scrape configs the same way as for services running within the kubernetes cluster
+* Users who want a supported Kubernetes way of scraping targets outside the cluster
+
 # Non-Goals
 * this proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
 * refactoring of the other CRDs is not in scope for the first version

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -64,9 +64,10 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 As described by
 [@aulig in #2787](https://github.com/prometheus-operator/prometheus-operator/issues/2787#issuecomment-559776221), we
-will create a new `ScrapeConfig` CRD, this config will act the same as the other CRDs and append scrape configurations
-to the configuration. `ScrapeConfig` will allow for any scraping configuration, while the other CRDs provide sane
-defaults. This will allow for isolated testing of the new `ScrapeConfig` CRD.
+will create a new ScrapeConfig CRD, this new CRD will act the same as the other CRDs and append scrape configurations to
+the configuration. Usage of ScrapeConfig doesn't exclude the use of the other CRDs, they are not mutually exclusive.
+`ScrapeConfig` will allow for any scraping configuration, while the other CRDs provide sane defaults. This will allow
+for isolated testing of the new `ScrapeConfig` CRD.
 
 ```mermaid
 graph TD;

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -95,7 +95,7 @@ spec:
   httpSDConfigs:
     - <httpSDConfig>[] # new resource
   relabelConfigs:
-    - <RelabelConfig>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1150
+    - <relabelConfig>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1150
   metricsPath: /metrics
 ```
 

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -26,7 +26,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 ## Audience
 * Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
-* Users who want to manage scrape configs the same way as for services running within the kubernetes cluster
+* Users who want to manage scrape configs the same way as for services running within the Kubernetes cluster
 * Users who want a supported Kubernetes way of scraping targets outside the Kubernetes cluster
 
 # Non-Goals

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -89,7 +89,7 @@ metadata:
     test: value
 spec:
   staticConfigs:
-    - <StaticConfig>[] # new resource
+    - <staticConfig>[] # new resource
   fileSDConfigs:
     - <fileSDConfig>[] # new resource
   httpSDConfigs:

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -7,7 +7,7 @@
 * Other docs:
   * n/a
 
-This document aims at creating a lower level `ScrapeConfig` Custom Resource that defines additional scrape configurations the kubernetes way.
+This document aims at creating a lower level `ScrapeConfig` Custom Resource  Definition that defines additional scrape configurations the Kubernetes way.
 
 # Why
 

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -1,4 +1,5 @@
 # ScrapeConfig CRD
+
 * Owners:
   * [xiu](https://github.com/xiu)
 * Related Tickets:
@@ -21,15 +22,18 @@ Using `additionalScrapeConfig` comes with drawbacks:
 * There is no input validation, which can lead to an invalid prometheus configuration
 
 # Goals
+
 * Provide a way for users to self-service adding scrape targets
 * Consolidate the scrape configuration generation logic in a central point for other resources to use
 
 ## Audience
+
 * Users who serve Prometheus as a service and want to have their customers autonomous in defining scrape configs
 * Users who want to manage scrape configs the same way as for services running within the Kubernetes cluster
 * Users who want a supported Kubernetes way of scraping targets outside the Kubernetes cluster
 
 # Non-Goals
+
 * This proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
 * refactoring of the other CRDs is not in scope for the first version
 
@@ -93,8 +97,10 @@ graph TD;
 ```
 
 # Alternatives
+
 * Use `additionalScrapeConfig` secrets, with the pitfalls described earlier
 
 # Action Plan
+
 1. Create the `ScrapeConfig` CRD, covering `file_sd_configs` and `static_configs`
 2. Once released, refactor the configuration generation logic to reuse `ScrapeConfig`

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -1,0 +1,60 @@
+# ScrapeConfig CRD
+* Owners:
+  * [xiu](https://github.com/xiu)
+* Related Tickets:
+  * [#2787](https://github.com/prometheus-operator/prometheus-operator/issues/2787)
+  * [#3447](https://github.com/prometheus-operator/prometheus-operator/issues/3447)
+* Other docs:
+  * n/a
+
+This document aims at creating a lower level `ScrapeConfig` Custom Resource that defines additional scrape configurations the kubernetes way.
+
+# Why
+
+prometheus-operator misses a way to scrape external targets using CRD. Users have either been abusing the `Probe` CRD (#3447) or `additionalScrapeConfig` to do so.
+
+## Pitfalls of the current solution
+
+Using `additionalScrapeConfig` comes with drawbacks:
+* it becomes a bottleneck as teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a team becomes responsible for the configuration
+* there is no input validation, which can lead to an invalid prometheus configuration
+
+# Goals
+* Provide a way for users to self-service adding scrape targets
+
+## Audience
+* Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
+* Users who want to manage scrape configs the same way as for services runnings within the kubernetes cluster
+
+# Non-Goals
+* this proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
+* refactoring of the other CRDs is not in scope for the first version
+
+# How
+
+As described by [@aulig in #2787](https://github.com/prometheus-operator/prometheus-operator/issues/2787#issuecomment-559776221), we will create a new `ScrapeConfig` CRD, this config will act the same as the other CRDs and append scrape configurations to the configuration. `ScrapeConfig` will allow for any scraping configuration, while the other CRDs provide sane defaults. This will allow for isolated testing of the new `ScrapeConfig` CRD.
+
+```mermaid
+graph TD;
+    ServiceMonitor-->prometheusConfig
+    PodMonitor-->prometheusConfig
+    ScrapeConfig-->prometheusConfig
+    prometheusConfig
+```
+
+Once the CRD is released, we will start refactoring the other CRDs. Since `ScrapeConfig` will allow for any configuration, it can also generate scrape configuration for the other CRDs.
+
+```mermaid
+graph TD;
+    ServiceMonitor-->ScrapeConfig
+    PodMonitor-->ScrapeConfig
+    ScrapeConfig-->prometheusConfig
+    prometheusConfig
+```
+
+# Alternatives
+* Use `additionalScrapeConfig` secrets, with the pitfalls described earlier
+
+# Action Plan
+1. Create the `ScrapeConfig` CRD, covering `file_sd_configs` and `static_configs`
+2. Once released, refactor the configuration generation logic to reuse `ScrapeConfig`

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -115,7 +115,7 @@ labels:
 ```yaml
 files:
   - <SecretOrConfigMap>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1644
-refresh_interval: 5m
+refreshInterval: 5m
 ```
 
 * `httpSDConfig`:

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -57,7 +57,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 * This proposal doesn't aim at covering all the fields in
   [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
-  Specifically, it focuses first on `static_configs`, `file_sd_configs`  and `http_sd_configs`.
+  Specifically, it focuses first on `static_configs`, `file_sd_configs` and `http_sd_configs`.
 * Refactoring of the other CRDs is not in scope for the first version
 
 # How
@@ -131,7 +131,7 @@ refreshInterval: 60s
 This example doesn't list all the fields that are offered by prometheus. The implementation of all the fields will be
 done in an iterative process and as such, the expectation is not for all of them to be implemented in the first version.
 
-Also, to help selecting `ScrapeConfig`, a new field will be added to the Prometheus CRD, same as for `ServiceMonitor` , 
+Also, to help selecting `ScrapeConfig`, a new field will be added to the Prometheus CRD, same as for `ServiceMonitor`,
 `PodMonitor` and `Probe` objects:
 
 ```yaml

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -27,7 +27,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 ## Audience
 * Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
 * Users who want to manage scrape configs the same way as for services runnings within the kubernetes cluster
-
+* Users who want a supported Kubernetes way of scraping targets outside of the cluster
 # Non-Goals
 * this proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
 * refactoring of the other CRDs is not in scope for the first version

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -18,7 +18,7 @@ Furthermore, currently, there is a lot of code duplication due to the operator s
 
 Using `additionalScrapeConfig` comes with drawbacks:
 * teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a single team becomes responsible for the configuration
-* there is no input validation, which can lead to an invalid prometheus configuration
+* There is no input validation, which can lead to an invalid prometheus configuration
 
 # Goals
 * Provide a way for users to self-service adding scrape targets

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -30,7 +30,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 * Users who want a supported Kubernetes way of scraping targets outside the Kubernetes cluster
 
 # Non-Goals
-* this proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
+* This proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
 * refactoring of the other CRDs is not in scope for the first version
 
 # How

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -17,7 +17,7 @@ Furthermore, currently, there is a lot of code duplication due to the operator s
 ## Pitfalls of the current solution
 
 Using `additionalScrapeConfig` comes with drawbacks:
-* it becomes a bottleneck as teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a team becomes responsible for the configuration
+* teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a single team becomes responsible for the configuration
 * there is no input validation, which can lead to an invalid prometheus configuration
 
 # Goals

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -25,7 +25,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 * Consolidate the scrape configuration generation logic in a central point for other resources to use
 
 ## Audience
-* Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
+* Users who serve Prometheus as a service and want to have their customers autonomous in defining scrape configs
 * Users who want to manage scrape configs the same way as for services running within the Kubernetes cluster
 * Users who want a supported Kubernetes way of scraping targets outside the Kubernetes cluster
 

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -114,7 +114,10 @@ labels:
 
 ```yaml
 files:
-  - <SecretOrConfigMap>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1644
+  # Files here are string referencing a file existing in the Prometheus Pod. prometheus-operator is not responsible for
+  # these SD files. The operator should use Prometheus.ConfigMaps to mount these files in the pods and have them usable
+  # by ScrapeConfig. No validation on the content of the SD files is expected from prometheus-operator.
+  - /etc/prometheus/configmaps/inventory/file.json
 refreshInterval: 5m
 ```
 

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -27,7 +27,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 ## Audience
 * Users who serve prometheus as a service and want to have their customers autonomous in defining scrape configs
 * Users who want to manage scrape configs the same way as for services running within the kubernetes cluster
-* Users who want a supported Kubernetes way of scraping targets outside the cluster
+* Users who want a supported Kubernetes way of scraping targets outside the Kubernetes cluster
 
 # Non-Goals
 * this proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -57,7 +57,7 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 * This proposal doesn't aim at covering all the fields in
   [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
-  Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
+  Specifically, it focuses first on `static_configs`, `file_sd_configs`  and `http_sd_configs`.
 * Refactoring of the other CRDs is not in scope for the first version
 
 # How

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -17,7 +17,7 @@ Furthermore, currently, there is a lot of code duplication due to the operator s
 ## Pitfalls of the current solution
 
 Using `additionalScrapeConfig` comes with drawbacks:
-* teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a single team becomes responsible for the configuration
+* Teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a single team becomes responsible for the configuration
 * There is no input validation, which can lead to an invalid prometheus configuration
 
 # Goals

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -131,8 +131,8 @@ refreshInterval: 60s
 This example doesn't list all the fields that are offered by prometheus. The implementation of all the fields will be
 done in an iterative process and as such, the expectation is not for all of them to be implemented in the first version.
 
-Also, to help selecting `ScrapeConfig`, a new field will be added to the Prometheus CRD, same as for `ServiceMontor` or
-`PodMonitor`:
+Also, to help selecting `ScrapeConfig`, a new field will be added to the Prometheus CRD, same as for `ServiceMonitor` , 
+`PodMonitor` and `Probe` objects:
 
 ```yaml
 [...]

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -94,8 +94,8 @@ spec:
     - <fileSDConfig>[] # new resource
   httpSDConfigs:
     - <httpSDConfig>[] # new resource
-  relabelConfigs:
-    - <relabelConfig>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1150
+  relabelings: # relabel_configs
+    - <RelabelConfig>[] # https://github.com/prometheus-operator/prometheus-operator/blob/e4e27052f57040f073c6c1e4aedaecaaec77d170/pkg/apis/monitoring/v1/types.go#L1150
   metricsPath: /metrics
 ```
 
@@ -128,6 +128,19 @@ url: http://localhost:1234
 refreshInterval: 60s
 ```
 
+This example doesn't list all the fields that are offered by prometheus. The implementation of all the fields will be
+done in an iterative process and as such, the expectation is not for all of them to be implemented in the first version.
+
+Also, to help selecting `ScrapeConfig`, a new field will be added to the Prometheus CRD, same as for `ServiceMontor` or
+`PodMonitor`:
+
+```yaml
+[...]
+spec:
+  scrapeConfigSelector: ...
+  scrapeConfigNamespaceSelector: ...
+```
+
 Once the CRD is released, we will start refactoring the other CRDs. Since `ScrapeConfig` will allow for any
 configuration, it can also generate scrape configuration for the other CRDs.
 
@@ -145,6 +158,9 @@ prometheusConfig
 
 # Action Plan
 
-1. Create the `ScrapeConfig` CRD, covering `file_sd_configs`, `static_configs` and `http_sd_configs`
+1. Create the `ScrapeConfig` CRD, covering `file_sd_configs`, `static_configs` and `http_sd_configs`. The implementation
+   of every field in each service discovery mechanism is left to the implementation. The expectation is not for all of
+   them to be implemented.
 2. Once released, refactor the configuration generation logic to reuse `ScrapeConfig`. In parallel, add other service
-   discovery mechanisms to the CRD.
+   discovery mechanisms to the CRD and complete the implementation of `file_sd_configs`, `static_configs` and
+   `http_sd_configs`.

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -8,7 +8,7 @@
 * Other docs:
   * n/a
 
-This document aims at creating a lower level `ScrapeConfig` Custom Resource  Definition that defines additional scrape configurations the Kubernetes way.
+This document aims at creating a lower level `ScrapeConfig` Custom Resource Definition that defines additional scrape configurations the Kubernetes way.
 
 # Why
 

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -8,17 +8,23 @@
 * Other docs:
   * n/a
 
-This document aims at creating a lower level `ScrapeConfig` Custom Resource Definition that defines additional scrape configurations the Kubernetes way.
+This document aims at creating a lower level `ScrapeConfig` Custom Resource Definition that defines additional scrape 
+configurations the Kubernetes way.
 
 # Why
 
-prometheus-operator misses a way to scrape external targets using CRD. Users have either been abusing the Probe CRD (#3447) or additionalScrapeConfig to do so.
-Furthermore, currently, there is a lot of code duplication due to the operator supporting several CRDs that generate scrape configurations. With the new `ScrapeConfig` CRD, it would be possible to consolidate some of that logic, where the other `*Monitor` CRDs could be migrated so that they create a ScrapeConfig resource that would ultimately be used by the operator to generate scrape configuration.
+prometheus-operator misses a way to scrape external targets using CRD. Users have either been abusing the Probe CRD 
+(#3447) or additionalScrapeConfig to do so.
+Furthermore, currently, there is a lot of code duplication due to the operator supporting several CRDs that generate 
+scrape configurations. With the new `ScrapeConfig` CRD, it would be possible to consolidate some of that logic, where 
+the other `*Monitor` CRDs could be migrated so that they create a ScrapeConfig resource that would ultimately be used by
+the operator to generate scrape configuration.
 
 ## Pitfalls of the current solution
 
 Using `additionalScrapeConfig` comes with drawbacks:
-* Teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a single team becomes responsible for the configuration
+* Teams have to build an infrastructure to add scrape rules in a centralized manner, which creates a bottleneck since a 
+single team becomes responsible for the configuration
 * There is no input validation, which can lead to an invalid prometheus configuration
 
 # Goals
@@ -34,12 +40,18 @@ Using `additionalScrapeConfig` comes with drawbacks:
 
 # Non-Goals
 
-* This proposal doesn't aim at covering all the fields in [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
+* This proposal doesn't aim at covering all the fields in 
+[`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). 
+Specifically, no service discovery other than `static_configs` or `file_sd_configs` should be implemented at first.
 * refactoring of the other CRDs is not in scope for the first version
 
 # How
 
-As described by [@aulig in #2787](https://github.com/prometheus-operator/prometheus-operator/issues/2787#issuecomment-559776221), we will create a new `ScrapeConfig` CRD, this config will act the same as the other CRDs and append scrape configurations to the configuration. `ScrapeConfig` will allow for any scraping configuration, while the other CRDs provide sane defaults. This will allow for isolated testing of the new `ScrapeConfig` CRD.
+As described by 
+[@aulig in #2787](https://github.com/prometheus-operator/prometheus-operator/issues/2787#issuecomment-559776221), we 
+will create a new `ScrapeConfig` CRD, this config will act the same as the other CRDs and append scrape configurations
+to the configuration. `ScrapeConfig` will allow for any scraping configuration, while the other CRDs provide sane
+defaults. This will allow for isolated testing of the new `ScrapeConfig` CRD.
 
 ```mermaid
 graph TD;
@@ -86,7 +98,8 @@ files:
 refresh_interval: 5m
 ```
 
-Once the CRD is released, we will start refactoring the other CRDs. Since `ScrapeConfig` will allow for any configuration, it can also generate scrape configuration for the other CRDs.
+Once the CRD is released, we will start refactoring the other CRDs. Since `ScrapeConfig` will allow for any
+configuration, it can also generate scrape configuration for the other CRDs.
 
 ```mermaid
 graph TD;

--- a/Documentation/proposals/202212-scrape-config.md
+++ b/Documentation/proposals/202212-scrape-config.md
@@ -122,7 +122,7 @@ refresh_interval: 5m
 
 ```yaml
 url: http://localhost:1234
-refresh_interval: 60s
+refreshInterval: 60s
 ```
 
 Once the CRD is released, we will start refactoring the other CRDs. Since `ScrapeConfig` will allow for any


### PR DESCRIPTION
## Description
This is a first shot at a proposal for ScrapeConfig, opening it early to take feedback in.

Related tickets:
* #2787 
* #3447

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
