### PR TITLE
Adds comments to test related with AlertmanagerConfig

### DIFF
--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -200,6 +200,11 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 	}
 }
 
+// Test to exercise the function checkAlertmanagerConfigResource
+// and validate that semantic validation is in place for all the fields in the
+// AlertmanagerConfig CR. The validation is preformed by the operator
+// after selecting AlertmanagerConfig resources but before passing them to
+// addAlertmanagerConfigs
 func TestCheckAlertmanagerConfig(t *testing.T) {
 	version, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 	if err != nil {
@@ -993,6 +998,11 @@ func TestListOptions(t *testing.T) {
 	}
 }
 
+// Test to exercise the function provisionAlertmanagerConfiguration
+// and validate that the operator is able to generate an Alertmanager
+// configuration depending on the method chosen by the user.
+// Alertmanager can be configured using either the AlertmanagerConfig resource
+// or a Kubernetes secret.
 func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 	for _, tc := range []struct {
 		am      *monitoringv1.Alertmanager

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -797,11 +797,24 @@ func testAlertmanagerConfigVersions(t *testing.T) {
 	}
 }
 
+// e2e test to validate that all possible fields in an AlertmanagerConfig CR are
+// consumed by the operator and correctly passed to the Alertmanager
+// configuration.
 func testAlertmanagerConfigCRD(t *testing.T) {
 	// Don't run Alertmanager tests in parallel. See
 	// https://github.com/prometheus/alertmanager/issues/1835 for details.
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
+
+	// create 2 namespaces:
+	//
+	// 1. "ns" ns:
+	//   - hosts the Alertmanager CR which which should be reconciled
+	//
+	// 2. "configNs" ns:
+	//   - hosts the AlertmanagerConfig CRs which which should be reconciled
+	// 		thanks to the label monitored: "true" which is removed in the second
+	//		part of the test
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	configNs := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)


### PR DESCRIPTION


Signed-off-by: JoaoBraveCoding <jmarcal@redhat.com>

## Description

Goal is to try and clarify what each test is testing


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
