### PR TITLE
apis/v1: Add tests from #4222

### DIFF
--- a/pkg/apis/monitoring/v1/podmonitor_types_test.go
+++ b/pkg/apis/monitoring/v1/podmonitor_types_test.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMarshallPodMonitor(t *testing.T) {
+	sm := &PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group1",
+			},
+		},
+		Spec: PodMonitorSpec{
+			NamespaceSelector: NamespaceSelector{
+				MatchNames: []string{"test"},
+			},
+			PodMetricsEndpoints: []PodMetricsEndpoint{
+				{
+					Port: "metric",
+				},
+			},
+		},
+	}
+	expected := `{"metadata":{"name":"test","namespace":"default","creationTimestamp":null,"labels":{"group":"group1"}},"spec":{"podMetricsEndpoints":[{"port":"metric","bearerTokenSecret":{"key":""}}],"selector":{},"namespaceSelector":{"matchNames":["test"]}}}`
+
+	r, err := json.Marshal(sm)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	rs := string(r)
+	if rs != expected {
+		t.Fatalf("Got %s expected: %s ", rs, expected)
+	}
+}

--- a/pkg/apis/monitoring/v1/probe_types_test.go
+++ b/pkg/apis/monitoring/v1/probe_types_test.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,5 +66,37 @@ func TestValidateProbeTargets(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestMarshallProbe(t *testing.T) {
+	sm := &Probe{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"group": "group1",
+			},
+		},
+		Spec: ProbeSpec{
+			Targets: ProbeTargets{
+				StaticConfig: &ProbeTargetStaticConfig{
+					Targets: []string{"prometheus.io"},
+					Labels: map[string]string{
+						"env": "prometheus",
+					},
+				},
+			},
+		},
+	}
+	expected := `{"metadata":{"name":"test","namespace":"default","creationTimestamp":null,"labels":{"group":"group1"}},"spec":{"prober":{"url":""},"targets":{"staticConfig":{"static":["prometheus.io"],"labels":{"env":"prometheus"}}},"bearerTokenSecret":{"key":""}}}`
+
+	r, err := json.Marshal(sm)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	rs := string(r)
+	if rs != expected {
+		t.Fatalf("Got %s expected: %s ", rs, expected)
 	}
 }


### PR DESCRIPTION
## Description

Re-adding tests from #4222 

Closes #4222 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note

```
