### PR TITLE
docs: Reword deprecation notices on *MonitorSelector

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1298,9 +1298,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p>ServiceMonitors to be selected for target discovery. <em>Deprecated:</em> if
-neither this nor podMonitorSelector are specified, configuration is
-unmanaged.</p>
+<p>ServiceMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -1327,9 +1333,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery.
-<em>Deprecated:</em> if neither this nor serviceMonitorSelector are specified,
-configuration is unmanaged.</p>
+<p><em>Experimental</em> PodMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -1357,6 +1369,14 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p><em>Experimental</em> Probes to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -5044,9 +5064,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p>ServiceMonitors to be selected for target discovery. <em>Deprecated:</em> if
-neither this nor podMonitorSelector are specified, configuration is
-unmanaged.</p>
+<p>ServiceMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -5073,9 +5099,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery.
-<em>Deprecated:</em> if neither this nor serviceMonitorSelector are specified,
-configuration is unmanaged.</p>
+<p><em>Experimental</em> PodMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -5103,6 +5135,14 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p><em>Experimental</em> Probes to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -8300,9 +8340,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p>ServiceMonitors to be selected for target discovery. <em>Deprecated:</em> if
-neither this nor podMonitorSelector are specified, configuration is
-unmanaged.</p>
+<p>ServiceMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -8329,9 +8375,15 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery.
-<em>Deprecated:</em> if neither this nor serviceMonitorSelector are specified,
-configuration is unmanaged.</p>
+<p><em>Experimental</em> PodMonitors to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -8359,6 +8411,14 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p><em>Experimental</em> Probes to be selected for target discovery.</p>
+<p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code> and
+<code>spec.probeSelector</code> are null, the Prometheus configuration is unmanaged.
+The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
+Secret exists, but it is the responsibility of the user to provide the raw
+gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
+This behavior is deprecated and will be removed in the next major version
+of the custom resource definition. It is recommended to use
+<code>spec.additionalScrapeConfigs</code> instead.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -17343,9 +17343,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: '*Experimental* PodMonitors to be selected for target
-                  discovery. *Deprecated:* if neither this nor serviceMonitorSelector
-                  are specified, configuration is unmanaged.'
+                description: "*Experimental* PodMonitors to be selected for target
+                  discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`
+                  and `spec.probeSelector` are null, the Prometheus configuration
+                  is unmanaged. The Prometheus operator will ensure that the Prometheus
+                  configuration's Secret exists, but it is the responsibility of the
+                  user to provide the raw gzipped Prometheus configuration under the
+                  `prometheus.yaml.gz` key. This behavior is deprecated and will be
+                  removed in the next major version of the custom resource definition.
+                  It is recommended to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -17449,7 +17455,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: '*Experimental* Probes to be selected for target discovery.'
+                description: "*Experimental* Probes to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -18859,9 +18873,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               serviceMonitorSelector:
-                description: ServiceMonitors to be selected for target discovery.
-                  *Deprecated:* if neither this nor podMonitorSelector are specified,
-                  configuration is unmanaged.
+                description: "ServiceMonitors to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4379,9 +4379,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: '*Experimental* PodMonitors to be selected for target
-                  discovery. *Deprecated:* if neither this nor serviceMonitorSelector
-                  are specified, configuration is unmanaged.'
+                description: "*Experimental* PodMonitors to be selected for target
+                  discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`
+                  and `spec.probeSelector` are null, the Prometheus configuration
+                  is unmanaged. The Prometheus operator will ensure that the Prometheus
+                  configuration's Secret exists, but it is the responsibility of the
+                  user to provide the raw gzipped Prometheus configuration under the
+                  `prometheus.yaml.gz` key. This behavior is deprecated and will be
+                  removed in the next major version of the custom resource definition.
+                  It is recommended to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4485,7 +4491,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: '*Experimental* Probes to be selected for target discovery.'
+                description: "*Experimental* Probes to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -5895,9 +5909,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               serviceMonitorSelector:
-                description: ServiceMonitors to be selected for target discovery.
-                  *Deprecated:* if neither this nor podMonitorSelector are specified,
-                  configuration is unmanaged.
+                description: "ServiceMonitors to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4379,9 +4379,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: '*Experimental* PodMonitors to be selected for target
-                  discovery. *Deprecated:* if neither this nor serviceMonitorSelector
-                  are specified, configuration is unmanaged.'
+                description: "*Experimental* PodMonitors to be selected for target
+                  discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`
+                  and `spec.probeSelector` are null, the Prometheus configuration
+                  is unmanaged. The Prometheus operator will ensure that the Prometheus
+                  configuration's Secret exists, but it is the responsibility of the
+                  user to provide the raw gzipped Prometheus configuration under the
+                  `prometheus.yaml.gz` key. This behavior is deprecated and will be
+                  removed in the next major version of the custom resource definition.
+                  It is recommended to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4485,7 +4491,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: '*Experimental* Probes to be selected for target discovery.'
+                description: "*Experimental* Probes to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -5895,9 +5909,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               serviceMonitorSelector:
-                description: ServiceMonitors to be selected for target discovery.
-                  *Deprecated:* if neither this nor podMonitorSelector are specified,
-                  configuration is unmanaged.
+                description: "ServiceMonitors to be selected for target discovery.
+                  \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+                  `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+                  The Prometheus operator will ensure that the Prometheus configuration's
+                  Secret exists, but it is the responsibility of the user to provide
+                  the raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
+                  key. This behavior is deprecated and will be removed in the next
+                  major version of the custom resource definition. It is recommended
+                  to use `spec.additionalScrapeConfigs` instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4015,7 +4015,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "podMonitorSelector": {
-                    "description": "*Experimental* PodMonitors to be selected for target discovery. *Deprecated:* if neither this nor serviceMonitorSelector are specified, configuration is unmanaged.",
+                    "description": "*Experimental* PodMonitors to be selected for target discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and `spec.probeSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is deprecated and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -4116,7 +4116,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "probeSelector": {
-                    "description": "*Experimental* Probes to be selected for target discovery.",
+                    "description": "*Experimental* Probes to be selected for target discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and `spec.probeSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is deprecated and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5557,7 +5557,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "serviceMonitorSelector": {
-                    "description": "ServiceMonitors to be selected for target discovery. *Deprecated:* if neither this nor podMonitorSelector are specified, configuration is unmanaged.",
+                    "description": "ServiceMonitors to be selected for target discovery. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and `spec.probeSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is deprecated and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -33,21 +33,44 @@ const (
 type CommonPrometheusFields struct {
 	// PodMetadata configures Labels and Annotations which are propagated to the prometheus pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
-	// ServiceMonitors to be selected for target discovery. *Deprecated:* if
-	// neither this nor podMonitorSelector are specified, configuration is
-	// unmanaged.
+	// ServiceMonitors to be selected for target discovery.
+	//
+	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+	// `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+	// The Prometheus operator will ensure that the Prometheus configuration's
+	// Secret exists, but it is the responsibility of the user to provide the raw
+	// gzipped Prometheus configuration under the `prometheus.yaml.gz` key.
+	// This behavior is deprecated and will be removed in the next major version
+	// of the custom resource definition. It is recommended to use
+	// `spec.additionalScrapeConfigs` instead.
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 	// Namespace's labels to match for ServiceMonitor discovery. If nil, only
 	// check own namespace.
 	ServiceMonitorNamespaceSelector *metav1.LabelSelector `json:"serviceMonitorNamespaceSelector,omitempty"`
 	// *Experimental* PodMonitors to be selected for target discovery.
-	// *Deprecated:* if neither this nor serviceMonitorSelector are specified,
-	// configuration is unmanaged.
+	//
+	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+	// `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+	// The Prometheus operator will ensure that the Prometheus configuration's
+	// Secret exists, but it is the responsibility of the user to provide the raw
+	// gzipped Prometheus configuration under the `prometheus.yaml.gz` key.
+	// This behavior is deprecated and will be removed in the next major version
+	// of the custom resource definition. It is recommended to use
+	// `spec.additionalScrapeConfigs` instead.
 	PodMonitorSelector *metav1.LabelSelector `json:"podMonitorSelector,omitempty"`
 	// Namespace's labels to match for PodMonitor discovery. If nil, only
 	// check own namespace.
 	PodMonitorNamespaceSelector *metav1.LabelSelector `json:"podMonitorNamespaceSelector,omitempty"`
 	// *Experimental* Probes to be selected for target discovery.
+	//
+	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector` and
+	// `spec.probeSelector` are null, the Prometheus configuration is unmanaged.
+	// The Prometheus operator will ensure that the Prometheus configuration's
+	// Secret exists, but it is the responsibility of the user to provide the raw
+	// gzipped Prometheus configuration under the `prometheus.yaml.gz` key.
+	// This behavior is deprecated and will be removed in the next major version
+	// of the custom resource definition. It is recommended to use
+	// `spec.additionalScrapeConfigs` instead.
 	ProbeSelector *metav1.LabelSelector `json:"probeSelector,omitempty"`
 	// *Experimental* Namespaces to be selected for Probe discovery. If nil, only check own namespace.
 	ProbeNamespaceSelector *metav1.LabelSelector `json:"probeNamespaceSelector,omitempty"`


### PR DESCRIPTION
Fixes #5300

## Description

Rewording deprecation notices on `serviceMonitorSelector` and `podMonitorSelector` as per #5300.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note

```
