### PR TITLE
Generate Prometheus configuration through interface

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -8228,11 +8228,6 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="monitoring.coreos.com/v1.PrometheusInterface">PrometheusInterface
-</h3>
-<div>
-<p>PrometheusInterface is used by Prometheus and PrometheusAgent to share common methods, e.g. config generation.</p>
-</div>
 <h3 id="monitoring.coreos.com/v1.PrometheusRuleExcludeConfig">PrometheusRuleExcludeConfig
 </h3>
 <p>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -8228,6 +8228,11 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1.PrometheusInterface">PrometheusInterface
+</h3>
+<div>
+<p>PrometheusInterface is used by Prometheus and PrometheusAgent to share common methods, e.g. config generation.</p>
+</div>
 <h3 id="monitoring.coreos.com/v1.PrometheusRuleExcludeConfig">PrometheusRuleExcludeConfig
 </h3>
 <p>

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -28,6 +28,17 @@ const (
 	PrometheusKindKey = "prometheus"
 )
 
+// PrometheusInterface is used by Prometheus and PrometheusAgent to share common methods, e.g. config generation.
+// +k8s:deepcopy-gen=false
+type PrometheusInterface interface {
+	metav1.ObjectMetaAccessor
+	GetCommonPrometheusFields() CommonPrometheusFields
+}
+
+func (l *Prometheus) GetCommonPrometheusFields() CommonPrometheusFields {
+	return l.Spec.CommonPrometheusFields
+}
+
 // CommonPrometheusFields are the options available to both the Prometheus server and agent.
 // +k8s:deepcopy-gen=true
 type CommonPrometheusFields struct {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1700,7 +1700,13 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 
 	// Update secret based on the most recent configuration.
 	conf, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		smons,
 		pmons,
 		bmons,

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -126,10 +126,10 @@ scrape_configs: []
 			Expected: `global:
   evaluation_interval: 30s
   scrape_interval: 60s
+  scrape_timeout: 10s
   external_labels:
     prometheus: /
     prometheus_replica: $(POD_NAME)
-  scrape_timeout: 10s
 scrape_configs: []
 `,
 		},
@@ -188,7 +188,13 @@ scrape_configs: []
 		cg := mustNewConfigGenerator(t, p)
 		t.Run(fmt.Sprintf("case %s", tc.Scenario), func(t *testing.T) {
 			cfg, err := cg.Generate(
-				p,
+				p.Spec.EvaluationInterval,
+				p.Spec.QueryLogFile,
+				p.Spec.RuleSelector,
+				p.Spec.Exemplars,
+				p.Spec.TSDB,
+				p.Spec.Alerting,
+				p.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{},
 				nil,
 				nil,
@@ -436,7 +442,13 @@ func TestProbeStaticTargetsConfigGeneration(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -557,7 +569,13 @@ func TestProbeStaticTargetsConfigGenerationWithLabelEnforce(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -678,7 +696,13 @@ func TestProbeStaticTargetsConfigGenerationWithJobName(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -785,7 +809,13 @@ func TestProbeStaticTargetsConfigGenerationWithoutModule(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -888,7 +918,13 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -1036,7 +1072,13 @@ func TestProbeIngressSDConfigGenerationWithShards(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -1184,7 +1226,13 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		map[string]*monitoringv1.Probe{
@@ -1442,7 +1490,13 @@ func TestAlertmanagerBearerToken(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		nil,
@@ -1615,7 +1669,13 @@ alerting:
 		cg := mustNewConfigGenerator(t, p)
 
 		cfg, err := cg.Generate(
-			p,
+			p.Spec.EvaluationInterval,
+			p.Spec.QueryLogFile,
+			p.Spec.RuleSelector,
+			p.Spec.Exemplars,
+			p.Spec.TSDB,
+			p.Spec.Alerting,
+			p.Spec.RemoteRead,
 			nil,
 			nil,
 			nil,
@@ -1669,7 +1729,13 @@ func TestAlertmanagerAPIVersion(t *testing.T) {
 	}
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		nil,
@@ -1752,7 +1818,13 @@ func TestAlertmanagerTimeoutConfig(t *testing.T) {
 	}
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		nil,
@@ -1960,7 +2032,13 @@ alerting:
 
 			cg := mustNewConfigGenerator(t, p)
 			cfg, err := cg.Generate(
-				p,
+				p.Spec.EvaluationInterval,
+				p.Spec.QueryLogFile,
+				p.Spec.RuleSelector,
+				p.Spec.Exemplars,
+				p.Spec.TSDB,
+				p.Spec.Alerting,
+				p.Spec.RemoteRead,
 				nil,
 				nil,
 				nil,
@@ -2003,19 +2081,13 @@ func TestAdditionalScrapeConfigs(t *testing.T) {
 		cg := mustNewConfigGenerator(t, p)
 
 		cfg, err := cg.Generate(
-			&monitoringv1.Prometheus{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Spec: monitoringv1.PrometheusSpec{
-					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-						Shards:         shards,
-						ScrapeInterval: "30s",
-					},
-					EvaluationInterval: "30s",
-				},
-			},
+			p.Spec.EvaluationInterval,
+			p.Spec.QueryLogFile,
+			p.Spec.RuleSelector,
+			p.Spec.Exemplars,
+			p.Spec.TSDB,
+			p.Spec.Alerting,
+			p.Spec.RemoteRead,
 			nil,
 			nil,
 			nil,
@@ -2191,7 +2263,13 @@ func TestAdditionalAlertRelabelConfigs(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		nil,
@@ -2268,7 +2346,13 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -2439,7 +2523,13 @@ func TestServiceMonitorWithEndpointSliceEnable(t *testing.T) {
 	cg.endpointSliceSupported = true
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -2616,7 +2706,13 @@ func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -2773,7 +2869,13 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -2923,7 +3025,13 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -3107,7 +3215,13 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -3283,7 +3397,13 @@ func TestAdditionalAlertmanagers(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		nil,
 		nil,
@@ -3362,7 +3482,13 @@ func TestSettingHonorTimestampsInServiceMonitor(t *testing.T) {
 	}
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -3507,7 +3633,13 @@ func TestSettingHonorTimestampsInPodMonitor(t *testing.T) {
 	}
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -3635,7 +3767,13 @@ func TestHonorTimestampsOverriding(t *testing.T) {
 
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -3781,7 +3919,13 @@ func TestSettingHonorLabels(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -3926,7 +4070,13 @@ func TestHonorLabelsOverriding(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -4072,7 +4222,13 @@ func TestTargetLabels(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -4384,7 +4540,13 @@ oauth2:
 		t.Run(tt.name, func(t *testing.T) {
 			cg := mustNewConfigGenerator(t, tt.p)
 			cfg, err := cg.Generate(
-				tt.p,
+				tt.p.Spec.EvaluationInterval,
+				tt.p.Spec.QueryLogFile,
+				tt.p.Spec.RuleSelector,
+				tt.p.Spec.Exemplars,
+				tt.p.Spec.TSDB,
+				tt.p.Spec.Alerting,
+				tt.p.Spec.RemoteRead,
 				tt.sMons,
 				tt.pMons,
 				tt.probes,
@@ -4433,7 +4595,13 @@ func TestPodTargetLabels(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"testservicemonitor1": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -4577,7 +4745,13 @@ func TestPodTargetLabelsFromPodMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -4703,7 +4877,13 @@ func TestPodTargetLabelsFromPodMonitorAndGlobal(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -4823,7 +5003,13 @@ func TestEmptyEndpointPorts(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -4991,7 +5177,13 @@ func generateTestConfig(t *testing.T, version string) ([]byte, error) {
 	cg := mustNewConfigGenerator(t, p)
 
 	return cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		makeServiceMonitors(),
 		makePodMonitors(),
 		nil,
@@ -5643,7 +5835,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -5914,7 +6112,13 @@ scrape_configs:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -6127,7 +6331,13 @@ remote_read:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				nil,
 				nil,
@@ -6580,7 +6790,13 @@ remote_write:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				nil,
 				nil,
@@ -6853,7 +7069,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -7087,7 +7309,13 @@ scrape_configs:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				map[string]*monitoringv1.PodMonitor{
 					"testpodmonitor1": &podMonitor,
@@ -7302,7 +7530,13 @@ scrape_configs:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				nil,
 				map[string]*monitoringv1.Probe{
@@ -7537,7 +7771,13 @@ scrape_configs:
 
 			cg := mustNewConfigGenerator(t, &prometheus)
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -7583,7 +7823,13 @@ func TestMatchExpressionsServiceMonitor(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -7987,7 +8233,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -8239,7 +8491,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				map[string]*monitoringv1.PodMonitor{
 					"testpodmonitor1": &podMonitor,
@@ -8548,7 +8806,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				map[string]*monitoringv1.ServiceMonitor{
 					"testservicemonitor1": &serviceMonitor,
 				},
@@ -8595,7 +8859,13 @@ func TestPodMonitorPhaseFilter(t *testing.T) {
 	}
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		nil,
 		map[string]*monitoringv1.PodMonitor{
 			"testpodmonitor1": {
@@ -8908,7 +9178,13 @@ scrape_configs:
 			cg := mustNewConfigGenerator(t, &prometheus)
 
 			cfg, err := cg.Generate(
-				&prometheus,
+				prometheus.Spec.EvaluationInterval,
+				prometheus.Spec.QueryLogFile,
+				prometheus.Spec.RuleSelector,
+				prometheus.Spec.Exemplars,
+				prometheus.Spec.TSDB,
+				prometheus.Spec.Alerting,
+				prometheus.Spec.RemoteRead,
 				nil,
 				map[string]*monitoringv1.PodMonitor{
 					"testpodmonitor1": &podMonitor,
@@ -9025,7 +9301,13 @@ scrape_configs: []
 			cg := mustNewConfigGenerator(t, tc.Prometheus)
 
 			cfg, err := cg.Generate(
-				tc.Prometheus,
+				tc.Prometheus.Spec.EvaluationInterval,
+				tc.Prometheus.Spec.QueryLogFile,
+				tc.Prometheus.Spec.RuleSelector,
+				tc.Prometheus.Spec.Exemplars,
+				tc.Prometheus.Spec.TSDB,
+				tc.Prometheus.Spec.Alerting,
+				tc.Prometheus.Spec.RemoteRead,
 				nil,
 				nil,
 				nil,
@@ -9140,7 +9422,13 @@ storage:
 			cg := mustNewConfigGenerator(t, tc.p)
 
 			cfg, err := cg.Generate(
-				tc.p,
+				tc.p.Spec.EvaluationInterval,
+				tc.p.Spec.QueryLogFile,
+				tc.p.Spec.RuleSelector,
+				tc.p.Spec.Exemplars,
+				tc.p.Spec.TSDB,
+				tc.p.Spec.Alerting,
+				tc.p.Spec.RemoteRead,
 				nil,
 				nil,
 				nil,
@@ -9181,7 +9469,13 @@ func TestGenerateRelabelConfig(t *testing.T) {
 	cg := mustNewConfigGenerator(t, p)
 
 	cfg, err := cg.Generate(
-		p,
+		p.Spec.EvaluationInterval,
+		p.Spec.QueryLogFile,
+		p.Spec.RuleSelector,
+		p.Spec.Exemplars,
+		p.Spec.TSDB,
+		p.Spec.Alerting,
+		p.Spec.RemoteRead,
 		map[string]*monitoringv1.ServiceMonitor{
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -485,7 +485,7 @@ func makeStatefulSetSpec(
 		},
 	}
 
-	if volume, ok := queryLogFileVolume(&p); ok {
+	if volume, ok := queryLogFileVolume(p.Spec.QueryLogFile); ok {
 		volumes = append(volumes, volume)
 	}
 
@@ -535,7 +535,7 @@ func makeStatefulSetSpec(
 		})
 	}
 
-	if vmount, ok := queryLogFileVolumeMount(&p); ok {
+	if vmount, ok := queryLogFileVolumeMount(p.Spec.QueryLogFile); ok {
 		promVolumeMounts = append(promVolumeMounts, vmount)
 	}
 
@@ -1037,12 +1037,12 @@ func subPathForStorage(s *monitoringv1.StorageSpec) string {
 	return "prometheus-db"
 }
 
-func usesDefaultQueryLogVolume(p *monitoringv1.Prometheus) bool {
-	return p.Spec.QueryLogFile != "" && filepath.Dir(p.Spec.QueryLogFile) == "."
+func usesDefaultQueryLogVolume(queryLogFile string) bool {
+	return queryLogFile != "" && filepath.Dir(queryLogFile) == "."
 }
 
-func queryLogFileVolumeMount(p *monitoringv1.Prometheus) (v1.VolumeMount, bool) {
-	if !usesDefaultQueryLogVolume(p) {
+func queryLogFileVolumeMount(queryLogFile string) (v1.VolumeMount, bool) {
+	if !usesDefaultQueryLogVolume(queryLogFile) {
 		return v1.VolumeMount{}, false
 	}
 
@@ -1053,8 +1053,8 @@ func queryLogFileVolumeMount(p *monitoringv1.Prometheus) (v1.VolumeMount, bool) 
 	}, true
 }
 
-func queryLogFileVolume(p *monitoringv1.Prometheus) (v1.Volume, bool) {
-	if !usesDefaultQueryLogVolume(p) {
+func queryLogFileVolume(queryLogFile string) (v1.Volume, bool) {
+	if !usesDefaultQueryLogVolume(queryLogFile) {
 		return v1.Volume{}, false
 	}
 
@@ -1066,10 +1066,10 @@ func queryLogFileVolume(p *monitoringv1.Prometheus) (v1.Volume, bool) {
 	}, true
 }
 
-func queryLogFilePath(p *monitoringv1.Prometheus) string {
-	if !usesDefaultQueryLogVolume(p) {
-		return p.Spec.QueryLogFile
+func queryLogFilePath(queryLogFile string) string {
+	if !usesDefaultQueryLogVolume(queryLogFile) {
+		return queryLogFile
 	}
 
-	return filepath.Join(defaultQueryLogDirectory, p.Spec.QueryLogFile)
+	return filepath.Join(defaultQueryLogDirectory, queryLogFile)
 }

--- a/scripts/docs/config.json
+++ b/scripts/docs/config.json
@@ -4,7 +4,8 @@
   ],
   "hideTypePatterns": [
     "ParseError$",
-    "List$"
+    "List$",
+    "Interface$"
   ],
   "externalPackages": [
     {


### PR DESCRIPTION
## Description

This PR creates a common interface that can be used by `Prometheus` and, in the future, by `PrometheusAgent` CRDs. I'm also refactoring the config generation to use the new interface instead of the Prometheus object, as discussed in https://github.com/prometheus-operator/prometheus-operator/issues/3989#issuecomment-1408948890.

This is probably one of many PRs needed for us to finally introduce the PrometheusAgent CRD

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
