### PR TITLE
Renames ReloaderConfig to ReloaderOperatorConfig and refactors pkg/*/statefulset_test

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -92,7 +92,7 @@ type Config struct {
 	Host                         string
 	LocalHost                    string
 	ClusterDomain                string
-	ReloaderConfig               operator.ReloaderConfig
+	ReloaderConfig               operator.ContainerConfig
 	AlertmanagerDefaultBaseImage string
 	Namespaces                   operator.Namespaces
 	Labels                       operator.Labels

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -686,7 +686,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 		},
 		operator.CreateConfigReloader(
 			"config-reloader",
-			operator.ReloaderResources(config.ReloaderConfig),
+			operator.ReloaderConfig(config.ReloaderConfig),
 			operator.ReloaderURL(url.URL{
 				Scheme: alertmanagerURIScheme,
 				Host:   config.LocalHost + ":9093",

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	TLSInsecure                  bool
 	TLSConfig                    rest.TLSClientConfig
 	ServerTLSConfig              server.TLSServerConfig
-	ReloaderConfig               ReloaderConfig
+	ReloaderConfig               ContainerConfig
 	AlertmanagerDefaultBaseImage string
 	PrometheusDefaultBaseImage   string
 	ThanosDefaultBaseImage       string
@@ -46,7 +46,9 @@ type Config struct {
 	SecretListWatchSelector      string
 }
 
-type ReloaderConfig struct {
+// ContainerConfig holds some configuration for the ConfigReloader sidecar
+// that can be set through prometheus-operator command line arguments
+type ContainerConfig struct {
 	CPURequest    string
 	CPULimit      string
 	MemoryRequest string

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -29,7 +29,7 @@ const configReloaderPort = 8080
 // a config-reloader container
 type ConfigReloader struct {
 	name               string
-	config             ReloaderConfig
+	config             ContainerConfig
 	configFile         string
 	configEnvsubstFile string
 	imagePullPolicy    v1.PullPolicy
@@ -75,7 +75,7 @@ func ConfigEnvsubstFile(configEnvsubstFile string) ReloaderOption {
 }
 
 // ReloaderResources sets the config option for the config-reloader container
-func ReloaderResources(rc ReloaderConfig) ReloaderOption {
+func ReloaderConfig(rc ContainerConfig) ReloaderOption {
 	return func(c *ConfigReloader) {
 		c.config = rc
 	}

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var reloaderConfig = ReloaderConfig{
+var reloaderConfig = ContainerConfig{
 	CPURequest:    "100m",
 	CPULimit:      "100m",
 	MemoryRequest: "50Mi",
@@ -36,7 +36,7 @@ func TestCreateInitConfigReloader(t *testing.T) {
 	expectedImagePullPolicy := v1.PullAlways
 	var container = CreateConfigReloader(
 		initContainerName,
-		ReloaderResources(reloaderConfig),
+		ReloaderConfig(reloaderConfig),
 		ReloaderRunOnce(),
 		ImagePullPolicy(v1.PullAlways),
 	)
@@ -62,7 +62,7 @@ func TestCreateConfigReloader(t *testing.T) {
 	expectedImagePullPolicy := v1.PullAlways
 	var container = CreateConfigReloader(
 		containerName,
-		ReloaderResources(reloaderConfig),
+		ReloaderConfig(reloaderConfig),
 		ReloaderURL(url.URL{
 			Scheme: "http",
 			Host:   "localhost:9093",

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -1,0 +1,224 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	DefaultReloaderTestConfig = &Config{
+		ReloaderConfig: ContainerConfig{
+			CPURequest:    "100m",
+			CPULimit:      "100m",
+			MemoryRequest: "50Mi",
+			MemoryLimit:   "50Mi",
+			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
+		},
+	}
+)
+
+func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig ContainerConfig) *appsv1.StatefulSet) {
+	for _, tc := range []struct {
+		name              string
+		reloaderConfig    ContainerConfig
+		expectedResources v1.ResourceRequirements
+	}{
+		{
+			name: "no_resources",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "0",
+				CPULimit:      "0",
+				MemoryRequest: "0",
+				MemoryLimit:   "0",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits:   v1.ResourceList{},
+				Requests: v1.ResourceList{},
+			},
+		},
+		{
+			name: "no_requests",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "0",
+				CPULimit:      "100m",
+				MemoryRequest: "0",
+				MemoryLimit:   "50Mi",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: v1.ResourceList{},
+			},
+		},
+		{
+			name: "no_limits",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "100m",
+				CPULimit:      "0",
+				MemoryRequest: "50Mi",
+				MemoryLimit:   "0",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+		},
+		{
+			name: "no_CPU_resources",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "0",
+				CPULimit:      "0",
+				MemoryRequest: "50Mi",
+				MemoryLimit:   "50Mi",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+		},
+		{
+			name: "no_CPU_requests",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "0",
+				CPULimit:      "100m",
+				MemoryRequest: "50Mi",
+				MemoryLimit:   "50Mi",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+		},
+		{
+			name: "no_CPU_limits",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "100m",
+				CPULimit:      "0",
+				MemoryRequest: "50Mi",
+				MemoryLimit:   "50Mi",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+		},
+		{
+			name: "no_memory_resources",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "100m",
+				CPULimit:      "100m",
+				MemoryRequest: "0",
+				MemoryLimit:   "0",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+		},
+		{
+			name: "no_memory_requests",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "100m",
+				CPULimit:      "100m",
+				MemoryRequest: "0",
+				MemoryLimit:   "50Mi",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+		},
+		{
+			name: "no_memory_limits",
+			reloaderConfig: ContainerConfig{
+				CPURequest:    "100m",
+				CPULimit:      "100m",
+				MemoryRequest: "50Mi",
+				MemoryLimit:   "0",
+				Image:         DefaultReloaderTestConfig.ReloaderConfig.Image,
+			},
+			expectedResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sset := makeStatefulSet(tc.reloaderConfig)
+			foundContainer := false
+
+			for _, c := range sset.Spec.Template.Spec.Containers {
+				if strings.HasSuffix(c.Name, "config-reloader") {
+					foundContainer = true
+				}
+				if strings.HasSuffix(c.Name, "config-reloader") && !reflect.DeepEqual(c.Resources, tc.expectedResources) {
+					t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", tc.expectedResources.String(), c.Resources.String())
+				}
+			}
+
+			if !foundContainer {
+				t.Fatalf("Expected to find a config-reloader container but it did")
+			}
+		})
+	}
+}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -901,7 +901,7 @@ func makeStatefulSetSpec(
 	operatorInitContainers = append(operatorInitContainers,
 		operator.CreateConfigReloader(
 			"init-config-reloader",
-			operator.ReloaderResources(c.ReloaderConfig),
+			operator.ReloaderConfig(c.ReloaderConfig),
 			operator.ReloaderRunOnce(),
 			operator.LogFormat(p.Spec.LogFormat),
 			operator.LogLevel(p.Spec.LogLevel),
@@ -950,7 +950,7 @@ func makeStatefulSetSpec(
 		},
 		operator.CreateConfigReloader(
 			"config-reloader",
-			operator.ReloaderResources(c.ReloaderConfig),
+			operator.ReloaderConfig(c.ReloaderConfig),
 			operator.ReloaderURL(url.URL{
 				Scheme: prometheusURIScheme,
 				Host:   c.LocalHost + ":9090",

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -38,16 +38,10 @@ import (
 
 var (
 	defaultTestConfig = &operator.Config{
-		LocalHost: "localhost",
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos",
+		LocalHost:                  "localhost",
+		ReloaderConfig:             operator.DefaultReloaderTestConfig.ReloaderConfig,
+		PrometheusDefaultBaseImage: operator.DefaultPrometheusBaseImage,
+		ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
 	}
 )
 
@@ -826,13 +820,7 @@ func TestTagAndShaAndVersion(t *testing.T) {
 
 func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 	operatorConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
+		ReloaderConfig:             defaultTestConfig.ReloaderConfig,
 		PrometheusDefaultBaseImage: "nondefaultuseflag/quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "nondefaultuseflag/quay.io/thanos/thanos",
 	}
@@ -866,13 +854,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 
 func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	thanosBaseImageConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
+		ReloaderConfig:             defaultTestConfig.ReloaderConfig,
 		PrometheusDefaultBaseImage: "nondefaultuseflag/quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "nondefaultuseflag/quay.io/thanos/thanos",
 	}
@@ -1390,13 +1372,7 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 
 func TestReplicasConfigurationWithSharding(t *testing.T) {
 	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "0",
-			CPULimit:      "0",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
+		ReloaderConfig:             defaultTestConfig.ReloaderConfig,
 		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
 		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
 	}
@@ -1437,344 +1413,26 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 	}
 }
 
-func TestSidecarsNoResources(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "0",
-			CPULimit:      "0",
-			MemoryRequest: "0",
-			MemoryLimit:   "0",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits:   v1.ResourceList{},
-		Requests: v1.ResourceList{},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+func TestSidecarResources(t *testing.T) {
+	operator.TestSidecarsResources(t, func(reloaderConfig operator.ContainerConfig) *appsv1.StatefulSet {
+		testConfig := &operator.Config{
+			ReloaderConfig:             reloaderConfig,
+			PrometheusDefaultBaseImage: defaultTestConfig.PrometheusDefaultBaseImage,
+			ThanosDefaultBaseImage:     defaultTestConfig.ThanosDefaultBaseImage,
 		}
-	}
-}
-
-func TestSidecarsNoRequests(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "0",
-			CPULimit:      "100m",
-			MemoryRequest: "0",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-		Requests: v1.ResourceList{},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
+		logger := newLogger()
+		p := monitoringv1.Prometheus{
+			Spec: monitoringv1.PrometheusSpec{},
 		}
-	}
-}
 
-func TestSidecarsNoLimits(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "0",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "0",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
+		cg, err := NewConfigGenerator(logger, &p, false)
+		require.NoError(t, err)
 
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
+		sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
+		require.NoError(t, err)
+		return sset
+	})
 
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoCPUResources(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "0",
-			CPULimit:      "0",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoCPURequests(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "0",
-			CPULimit:      "100m",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoCPULimits(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "0",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoMemoryResources(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "0",
-			MemoryLimit:   "0",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("100m"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("100m"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoMemoryRequests(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "0",
-			MemoryLimit:   "50Mi",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("100m"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
-}
-
-func TestSidecarsNoMemoryLimits(t *testing.T) {
-	testConfig := &operator.Config{
-		ReloaderConfig: operator.ReloaderConfig{
-			CPURequest:    "100m",
-			CPULimit:      "100m",
-			MemoryRequest: "50Mi",
-			MemoryLimit:   "0",
-			Image:         "quay.io/prometheus-operator/prometheus-config-reloader:latest",
-		},
-		PrometheusDefaultBaseImage: "quay.io/prometheus/prometheus",
-		ThanosDefaultBaseImage:     "quay.io/thanos/thanos:v0.7.0",
-	}
-	logger := newLogger()
-	p := monitoringv1.Prometheus{
-		Spec: monitoringv1.PrometheusSpec{},
-	}
-
-	cg, err := NewConfigGenerator(logger, &p, false)
-	require.NoError(t, err)
-
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
-	require.NoError(t, err)
-
-	expectedResources := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU: resource.MustParse("100m"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
-		},
-	}
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if (c.Name == "prometheus-config-reloader" || c.Name == "rules-configmap-reloader") && !reflect.DeepEqual(c.Resources, expectedResources) {
-			t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", expectedResources.String(), c.Resources.String())
-		}
-	}
 }
 
 func TestAdditionalContainers(t *testing.T) {

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -78,7 +78,7 @@ type Config struct {
 	Host                   string
 	TLSInsecure            bool
 	TLSConfig              rest.TLSClientConfig
-	ReloaderConfig         operator.ReloaderConfig
+	ReloaderConfig         operator.ContainerConfig
 	ThanosDefaultBaseImage string
 	Namespaces             operator.Namespaces
 	Labels                 operator.Labels

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -321,7 +321,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			additionalContainers,
 			operator.CreateConfigReloader(
 				"config-reloader",
-				operator.ReloaderResources(config.ReloaderConfig),
+				operator.ReloaderConfig(config.ReloaderConfig),
 				operator.ReloaderURL(url.URL{
 					Scheme: "http",
 					Host:   config.LocalHost + ":10902",


### PR DESCRIPTION
## Description

Problem: The name ReloaderConfig conflicted with the function under pkg/operator/config_reloader.go that would set ReloaderConfig, this function was previously called ReloaderResources which did not indicate clearly that other fields like image were also being configured. Furthermore each pkg/*/statefulset_test.go file was testing extensively the resources for the ReloadConfig sidecar which created a lot of code duplication.

Solution: Rename the type ReloaderConfig to ReloaderOperatorConfig since the config comes from the operator and refactor tests to extract the logic to the resources tests for ReloadConfig sidecar into a dedicated lib under pkg/operator/config_reloader_test_lib.go

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
