### PR TITLE
Fixes ThanoRuler StatefulSet re-creation bug

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"sort"
 	"strings"
 
 	"k8s.io/client-go/rest"
@@ -91,6 +92,16 @@ func (labels *Labels) Set(value string) error {
 	(*labels).LabelsMap = m
 	(*labels).LabelsString = value
 	return nil
+}
+
+// Returns an arrary with the keys of the label map sorted
+func (labels *Labels) SortedKeys() []string {
+	keys := make([]string, 0, len(labels.LabelsMap))
+	for key := range labels.LabelsMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 type Namespaces struct {

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -192,8 +192,9 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	trVolumeMounts := []v1.VolumeMount{}
 
 	trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "label", Value: fmt.Sprintf(`%s="$(POD_NAME)"`, defaultReplicaLabelName)})
-	for k, v := range tr.Spec.Labels {
-		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "label", Value: fmt.Sprintf(`%s="%s"`, k, v)})
+	labels := operator.Labels{LabelsMap: tr.Spec.Labels}
+	for _, k := range labels.SortedKeys() {
+		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "label", Value: fmt.Sprintf(`%s="%s"`, k, labels.LabelsMap[k])})
 	}
 
 	trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "alert.label-drop", Value: defaultReplicaLabelName})


### PR DESCRIPTION


Signed-off-by: JoaoBraveCoding <jmarcal@redhat.com>

## Description

Issue: fixes #5317

Problem: see issue #5317

Solution: add arguments to Thanos container by iterating over the sorted list of the keys of the map ThanosRuler.Spec.Labels

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- fixes ThanoRuler StatefulSet re-creation bug if labels specified
```
