### PR TITLE
fix: path of custom metrics image

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -51,7 +51,7 @@ A common problem related to `ServiceMonitor` identification by Prometheus is rel
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![flow diagram](/img/custom-metrics-elements.png)
+![flow diagram](./img/custom-metrics-elements.png)
 
 Note: The `ServiceMonitor` references a `Service` (not a `Deployment`, or a `Pod`), by labels *and* by the port name in the `Service`. This *port name* is optional in Kubernetes, but must be specified for the `ServiceMonitor` to work. It is not the same as the port name on the `Pod` or container, although it can be.
 


### PR DESCRIPTION
## Description

The preview of the image at [overview-of-servicemonitor-tagging-and-related-elements](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/troubleshooting.md#overview-of-servicemonitor-tagging-and-related-elements) section wasn't working because of incorrect path.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Using correct the image path to fix the preview [overview-of-servicemonitor-tagging-and-related-elements](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/troubleshooting.md#overview-of-servicemonitor-tagging-and-related-elements) section.

