### PR TITLE
Adds e2e test to validate ThanosRuler queryConfig field

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -303,6 +303,7 @@ func testAllNSThanosRuler(t *testing.T) {
 		"ThanosRulerPreserveUserAddedMetadata":          testTRPreserveUserAddedMetadata,
 		"ThanosRulerMinReadySeconds":                    testTRMinReadySeconds,
 		"ThanosRulerAlertmanagerConfig":                 testTRAlertmanagerConfig,
+		"ThanosRulerQueryConfig":                        testTRQueryConfig,
 	}
 	for name, f := range testFuncs {
 		t.Run(name, f)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -334,3 +334,72 @@ alertmanagers:
 	err = framework.WaitForAlertmanagerFiringAlert(context.Background(), ns, amSVC.Name, testAlert)
 	assert.NoError(t, err)
 }
+
+// Tests Thanos ruler query Config
+// This is done by creating a firing rule that will be picked up by
+// Thanos Ruler which will only fire the rule if it's able to query prometheus
+// it has to pull configuration from queryConfig file
+func testTRQueryConfig(t *testing.T) {
+	const (
+		name       = "test"
+		group      = "thanos-ruler-query-config"
+		secretName = "thanos-ruler-query-config"
+		configKey  = "query.yaml"
+		testAlert  = "alert1"
+	)
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	// Create a Prometheus resource because Thanos ruler needs a query API.
+	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, framework.MakeBasicPrometheus(ns, name, name, 1))
+	assert.NoError(t, err)
+
+	promSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, promSVC)
+	assert.NoError(t, err)
+
+	// Create Secret with query config,
+	trQueryConfSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: map[string][]byte{
+			configKey: []byte(fmt.Sprintf(`
+- scheme: http
+  static_configs:
+  - %s.%s.svc:%d
+`, promSVC.Name, ns, promSVC.Spec.Ports[0].Port)),
+		},
+	}
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), trQueryConfSecret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create Thanos ruler resource and service
+	// setting queryEndpoint to "" as it will be ignored because we set QueryConfig
+	thanos := framework.MakeBasicThanosRuler(name, 1, "")
+	thanos.Spec.EvaluationInterval = "1s"
+	thanos.Spec.QueryConfig = &v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: secretName,
+		},
+		Key: configKey,
+	}
+
+	_, err = framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanos)
+	assert.NoError(t, err)
+
+	svc := framework.MakeThanosRulerService(thanos.Name, group, v1.ServiceTypeClusterIP)
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc)
+	assert.NoError(t, err)
+
+	// Create firing rule
+	_, err = framework.MakeAndCreateFiringRule(context.Background(), ns, "rule1", testAlert)
+	assert.NoError(t, err)
+
+	if err := framework.WaitForThanosFiringAlert(context.Background(), ns, svc.Name, testAlert); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION


## Description

Closes https://github.com/prometheus-operator/prometheus-operator/issues/5187

Problem: Before this commit, the code path used by the field queryConfig was not being tested in e2e tests

Solution: This commit adds a test that validates that if queryConfig is set, then the operator will configure the ThanosRuler deployment correctly




## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
