### PR TITLE
Refactor: Use PrometheusInterface to generate statefulset

### DIFF
--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -32,11 +32,21 @@ const (
 // +k8s:deepcopy-gen=false
 type PrometheusInterface interface {
 	metav1.ObjectMetaAccessor
+	GetTypeMeta() metav1.TypeMeta
 	GetCommonPrometheusFields() CommonPrometheusFields
+	SetCommonPrometheusFields(CommonPrometheusFields)
 }
 
 func (l *Prometheus) GetCommonPrometheusFields() CommonPrometheusFields {
 	return l.Spec.CommonPrometheusFields
+}
+
+func (l *Prometheus) SetCommonPrometheusFields(f CommonPrometheusFields) {
+	l.Spec.CommonPrometheusFields = f
+}
+
+func (l *Prometheus) GetTypeMeta() metav1.TypeMeta {
+	return l.TypeMeta
 }
 
 // CommonPrometheusFields are the options available to both the Prometheus server and agent.

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -1224,7 +1224,26 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			return err
 		}
 
-		sset, err := makeStatefulSet(logger, ssetName, *p, &c.config, cg, ruleConfigMapNames, newSSetInputHash, int32(shard), tlsAssets.ShardNames())
+		sset, err := makeStatefulSet(
+			logger,
+			ssetName,
+			p,
+			p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+			p.Spec.Retention,
+			p.Spec.RetentionSize,
+			p.Spec.Rules,
+			p.Spec.Query,
+			p.Spec.AllowOverlappingBlocks,
+			p.Spec.EnableAdminAPI,
+			p.Spec.QueryLogFile,
+			p.Spec.Thanos,
+			p.Spec.DisableCompaction,
+			&c.config,
+			cg,
+			ruleConfigMapNames,
+			newSSetInputHash,
+			int32(shard),
+			tlsAssets.ShardNames())
 		if err != nil {
 			return errors.Wrap(err, "making statefulset failed")
 		}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -472,7 +472,7 @@ func makeStatefulSetSpec(
 	if disableCompaction {
 		thanosBlockDuration := "2h"
 		if thanos != nil {
-			thanosBlockDuration = string(thanos.BlockDuration)
+			thanosBlockDuration = operator.StringValOrDefault(string(thanos.BlockDuration), thanosBlockDuration)
 		}
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: thanosBlockDuration})
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: thanosBlockDuration})

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -470,7 +470,10 @@ func makeStatefulSetSpec(
 	}
 
 	if disableCompaction {
-		thanosBlockDuration := operator.StringValOrDefault(string(thanos.BlockDuration), "2h")
+		thanosBlockDuration := "2h"
+		if thanos != nil {
+			thanosBlockDuration = string(thanos.BlockDuration)
+		}
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: thanosBlockDuration})
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: thanosBlockDuration})
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -96,7 +96,17 @@ func prometheusNameByShard(name string, shard int32) string {
 func makeStatefulSet(
 	logger log.Logger,
 	name string,
-	p monitoringv1.Prometheus,
+	p monitoringv1.PrometheusInterface,
+	baseImage, tag, sha string,
+	retention monitoringv1.Duration,
+	retentionSize monitoringv1.ByteSize,
+	rules monitoringv1.Rules,
+	query *monitoringv1.QuerySpec,
+	allowOverlappingBlocks bool,
+	enableAdminAPI bool,
+	queryLogFile string,
+	thanos *monitoringv1.ThanosSpec,
+	disableCompaction bool,
 	config *operator.Config,
 	cg *ConfigGenerator,
 	ruleConfigMapNames []string,
@@ -104,19 +114,26 @@ func makeStatefulSet(
 	shard int32,
 	tlsAssetSecrets []string,
 ) (*appsv1.StatefulSet, error) {
-	if p.Spec.PortName == "" {
-		p.Spec.PortName = defaultPortName
+	cpf := p.GetCommonPrometheusFields()
+	objMeta := p.GetObjectMeta()
+	typeMeta := p.GetTypeMeta()
+
+	if cpf.PortName == "" {
+		cpf.PortName = defaultPortName
 	}
 
-	if p.Spec.Replicas == nil {
-		p.Spec.Replicas = &minReplicas
+	if cpf.Replicas == nil {
+		cpf.Replicas = &minReplicas
 	}
 	intZero := int32(0)
-	if p.Spec.Replicas != nil && *p.Spec.Replicas < 0 {
-		p.Spec.Replicas = &intZero
+	if cpf.Replicas != nil && *cpf.Replicas < 0 {
+		cpf.Replicas = &intZero
 	}
 
-	spec, err := makeStatefulSetSpec(logger, p, config, cg, shard, ruleConfigMapNames, tlsAssetSecrets)
+	// We need to re-set the common fields because cpf is only a copy of the original object.
+	// We set some defaults if some fields are not present, and we want those fields set in the original Prometheus object before building the StatefulSetSpec.
+	p.SetCommonPrometheusFields(cpf)
+	spec, err := makeStatefulSetSpec(logger, baseImage, tag, sha, retention, retentionSize, rules, query, allowOverlappingBlocks, enableAdminAPI, queryLogFile, thanos, disableCompaction, p, config, cg, shard, ruleConfigMapNames, tlsAssetSecrets)
 	if err != nil {
 		return nil, errors.Wrap(err, "make StatefulSet spec")
 	}
@@ -125,17 +142,17 @@ func makeStatefulSet(
 	// do not transfer kubectl annotations to the statefulset so it is not
 	// pruned by kubectl
 	annotations := make(map[string]string)
-	for key, value := range p.ObjectMeta.Annotations {
+	for key, value := range objMeta.GetAnnotations() {
 		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
 			annotations[key] = value
 		}
 	}
 	labels := make(map[string]string)
-	for key, value := range p.ObjectMeta.Labels {
+	for key, value := range objMeta.GetLabels() {
 		labels[key] = value
 	}
 	labels[shardLabelName] = fmt.Sprintf("%d", shard)
-	labels[prometheusNameLabelName] = p.Name
+	labels[prometheusNameLabelName] = objMeta.GetName()
 
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -144,12 +161,12 @@ func makeStatefulSet(
 			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         p.APIVersion,
+					APIVersion:         typeMeta.APIVersion,
 					BlockOwnerDeletion: &boolTrue,
 					Controller:         &boolTrue,
-					Kind:               p.Kind,
-					Name:               p.Name,
-					UID:                p.UID,
+					Kind:               typeMeta.Kind,
+					Name:               objMeta.GetName(),
+					UID:                objMeta.GetUID(),
 				},
 			},
 		},
@@ -164,13 +181,13 @@ func makeStatefulSet(
 		statefulset.ObjectMeta.Annotations[sSetInputHashName] = inputHash
 	}
 
-	if p.Spec.ImagePullSecrets != nil && len(p.Spec.ImagePullSecrets) > 0 {
-		statefulset.Spec.Template.Spec.ImagePullSecrets = p.Spec.ImagePullSecrets
+	if cpf.ImagePullSecrets != nil && len(cpf.ImagePullSecrets) > 0 {
+		statefulset.Spec.Template.Spec.ImagePullSecrets = cpf.ImagePullSecrets
 	}
-	storageSpec := p.Spec.Storage
+	storageSpec := cpf.Storage
 	if storageSpec == nil {
 		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: volumeName(p.Name),
+			Name: volumeName(objMeta.GetName()),
 			VolumeSource: v1.VolumeSource{
 				EmptyDir: &v1.EmptyDirVolumeSource{},
 			},
@@ -178,7 +195,7 @@ func makeStatefulSet(
 	} else if storageSpec.EmptyDir != nil {
 		emptyDir := storageSpec.EmptyDir
 		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: volumeName(p.Name),
+			Name: volumeName(objMeta.GetName()),
 			VolumeSource: v1.VolumeSource{
 				EmptyDir: emptyDir,
 			},
@@ -186,7 +203,7 @@ func makeStatefulSet(
 	} else if storageSpec.Ephemeral != nil {
 		ephemeral := storageSpec.Ephemeral
 		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: volumeName(p.Name),
+			Name: volumeName(objMeta.GetName()),
 			VolumeSource: v1.VolumeSource{
 				Ephemeral: ephemeral,
 			},
@@ -194,7 +211,7 @@ func makeStatefulSet(
 	} else {
 		pvcTemplate := operator.MakeVolumeClaimTemplate(storageSpec.VolumeClaimTemplate)
 		if pvcTemplate.Name == "" {
-			pvcTemplate.Name = volumeName(p.Name)
+			pvcTemplate.Name = volumeName(objMeta.GetName())
 		}
 		if storageSpec.VolumeClaimTemplate.Spec.AccessModes == nil {
 			pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
@@ -206,9 +223,9 @@ func makeStatefulSet(
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)
 	}
 
-	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, p.Spec.Volumes...)
+	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, cpf.Volumes...)
 
-	if p.Spec.HostNetwork {
+	if cpf.HostNetwork {
 		statefulset.Spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 
@@ -298,7 +315,17 @@ func makeStatefulSetService(p *monitoringv1.Prometheus, config operator.Config) 
 
 func makeStatefulSetSpec(
 	logger log.Logger,
-	p monitoringv1.Prometheus,
+	baseImage, tag, sha string,
+	retention monitoringv1.Duration,
+	retentionSize monitoringv1.ByteSize,
+	rules monitoringv1.Rules,
+	query *monitoringv1.QuerySpec,
+	allowOverlappingBlocks bool,
+	enableAdminAPI bool,
+	queryLogFile string,
+	thanos *monitoringv1.ThanosSpec,
+	disableCompaction bool,
+	p monitoringv1.PrometheusInterface,
 	c *operator.Config,
 	cg *ConfigGenerator,
 	shard int32,
@@ -308,14 +335,15 @@ func makeStatefulSetSpec(
 	// Prometheus may take quite long to shut down to checkpoint existing data.
 	// Allow up to 10 minutes for clean termination.
 	terminationGracePeriod := int64(600)
+	cpf := p.GetCommonPrometheusFields()
+	promName := p.GetObjectMeta().GetName()
 
-	promVersion := operator.StringValOrDefault(p.Spec.Version, operator.DefaultPrometheusVersion)
 	pImagePath, err := operator.BuildImagePath(
-		operator.StringPtrValOrDefault(p.Spec.Image, ""),
-		operator.StringValOrDefault(p.Spec.BaseImage, c.PrometheusDefaultBaseImage),
-		promVersion,
-		operator.StringValOrDefault(p.Spec.Tag, ""),
-		operator.StringValOrDefault(p.Spec.SHA, ""),
+		operator.StringPtrValOrDefault(cpf.Image, ""),
+		operator.StringValOrDefault(baseImage, c.PrometheusDefaultBaseImage),
+		operator.StringValOrDefault(cpf.Version, operator.DefaultPrometheusVersion),
+		operator.StringValOrDefault(tag, ""),
+		operator.StringValOrDefault(sha, ""),
 	)
 	if err != nil {
 		return nil, err
@@ -325,222 +353,29 @@ func makeStatefulSetSpec(
 		return nil, errors.Errorf("unsupported Prometheus major version %s", cg.version)
 	}
 
-	promArgs := []monitoringv1.Argument{
-		{Name: "web.console.templates", Value: "/etc/prometheus/consoles"},
-		{Name: "web.console.libraries", Value: "/etc/prometheus/console_libraries"},
-	}
-
-	var (
-		retentionTimeFlagName  = "storage.tsdb.retention.time"
-		retentionTimeFlagValue = string(p.Spec.Retention)
-	)
-	if cg.WithMaximumVersion("2.7.0").IsCompatible() {
-		retentionTimeFlagName = "storage.tsdb.retention"
-		if p.Spec.Retention == "" {
-			retentionTimeFlagValue = defaultRetention
-		}
-	} else if p.Spec.Retention == "" && p.Spec.RetentionSize == "" {
-		retentionTimeFlagValue = defaultRetention
-	}
-
-	if retentionTimeFlagValue != "" {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: retentionTimeFlagName, Value: retentionTimeFlagValue})
-	}
-	if p.Spec.RetentionSize != "" {
-		retentionSizeFlag := monitoringv1.Argument{Name: "storage.tsdb.retention.size", Value: string(p.Spec.RetentionSize)}
-		promArgs = cg.WithMinimumVersion("2.7.0").AppendCommandlineArgument(promArgs, retentionSizeFlag)
-	}
-
-	promArgs = append(promArgs,
-		monitoringv1.Argument{Name: "config.file", Value: path.Join(confOutDir, configEnvsubstFilename)},
-		monitoringv1.Argument{Name: "storage.tsdb.path", Value: storageDir},
-		monitoringv1.Argument{Name: "web.enable-lifecycle"},
-	)
-
-	if p.Spec.Rules.Alert.ForOutageTolerance != "" {
-		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.for-outage-tolerance", Value: p.Spec.Rules.Alert.ForOutageTolerance})
-	}
-	if p.Spec.Rules.Alert.ForGracePeriod != "" {
-		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.for-grace-period", Value: p.Spec.Rules.Alert.ForGracePeriod})
-	}
-	if p.Spec.Rules.Alert.ResendDelay != "" {
-		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.resend-delay", Value: p.Spec.Rules.Alert.ResendDelay})
-	}
-
-	if p.Spec.Query != nil {
-		if p.Spec.Query.LookbackDelta != nil {
-			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.lookback-delta", Value: *p.Spec.Query.LookbackDelta})
-		}
-
-		if p.Spec.Query.MaxSamples != nil && *p.Spec.Query.MaxSamples > 0 {
-			promArgs = cg.WithMinimumVersion("2.5.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "query.max-samples", Value: fmt.Sprintf("%d", *p.Spec.Query.MaxSamples)})
-		}
-
-		if p.Spec.Query.MaxConcurrency != nil && *p.Spec.Query.MaxConcurrency > 1 {
-			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.max-concurrency", Value: fmt.Sprintf("%d", *p.Spec.Query.MaxConcurrency)})
-		}
-
-		if p.Spec.Query.Timeout != nil {
-			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.timeout", Value: string(*p.Spec.Query.Timeout)})
-		}
-	}
-
-	if p.Spec.Web != nil {
-		if p.Spec.Web.PageTitle != nil {
-			promArgs = cg.WithMinimumVersion("2.6.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "web.page-title", Value: *p.Spec.Web.PageTitle})
-		}
-
-		if p.Spec.Web.MaxConnections != nil {
-			promArgs = append(promArgs, monitoringv1.Argument{Name: "web.max-connections", Value: fmt.Sprintf("%d", *p.Spec.Web.MaxConnections)})
-		}
-	}
-
-	if p.Spec.EnableAdminAPI {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.enable-admin-api"})
-	}
-
-	if p.Spec.EnableRemoteWriteReceiver {
-		promArgs = cg.WithMinimumVersion("2.33.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "web.enable-remote-write-receiver"})
-	}
-
-	if len(p.Spec.EnableFeatures) > 0 {
-		promArgs = cg.WithMinimumVersion("2.25.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "enable-feature", Value: strings.Join(p.Spec.EnableFeatures[:], ",")})
-	}
-
-	if p.Spec.ExternalURL != "" {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.external-url", Value: p.Spec.ExternalURL})
-	}
-
 	webRoutePrefix := "/"
-	if p.Spec.RoutePrefix != "" {
-		webRoutePrefix = p.Spec.RoutePrefix
+	if cpf.RoutePrefix != "" {
+		webRoutePrefix = cpf.RoutePrefix
 	}
-	promArgs = append(promArgs, monitoringv1.Argument{Name: "web.route-prefix", Value: webRoutePrefix})
-
-	if p.Spec.LogLevel != "" && p.Spec.LogLevel != "info" {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "log.level", Value: p.Spec.LogLevel})
-	}
-
-	if p.Spec.LogFormat != "" && p.Spec.LogFormat != "logfmt" {
-		promArgs = cg.WithMinimumVersion("2.6.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "log.format", Value: p.Spec.LogFormat})
-	}
-
-	if p.Spec.WALCompression != nil {
-		arg := monitoringv1.Argument{Name: "no-storage.tsdb.wal-compression"}
-		if *p.Spec.WALCompression {
-			arg.Name = "storage.tsdb.wal-compression"
-		}
-		promArgs = cg.WithMinimumVersion("2.11.0").AppendCommandlineArgument(promArgs, arg)
-	}
-
-	if p.Spec.AllowOverlappingBlocks {
-		promArgs = cg.WithMinimumVersion("2.11.0").WithMaximumVersion("2.39.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "storage.tsdb.allow-overlapping-blocks"})
-	}
+	promArgs := buildCommonPrometheusArgs(cpf, cg, webRoutePrefix)
+	promArgs = appendServerArgs(promArgs, cg, retention, retentionSize, rules, query, allowOverlappingBlocks, enableAdminAPI)
 
 	var ports []v1.ContainerPort
-	if p.Spec.ListenLocal {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.listen-address", Value: "127.0.0.1:9090"})
-	} else {
+	if !cpf.ListenLocal {
 		ports = []v1.ContainerPort{
 			{
-				Name:          p.Spec.PortName,
+				Name:          cpf.PortName,
 				ContainerPort: 9090,
 				Protocol:      v1.ProtocolTCP,
 			},
 		}
 	}
 
-	assetsVolume := v1.Volume{
-		Name: "tls-assets",
-		VolumeSource: v1.VolumeSource{
-			Projected: &v1.ProjectedVolumeSource{
-				Sources: []v1.VolumeProjection{},
-			},
-		},
+	volumes, promVolumeMounts, err := buildCommonVolumes(p, tlsAssetSecrets)
+	if err != nil {
+		return nil, err
 	}
-	for _, assetShard := range tlsAssetSecrets {
-		assetsVolume.Projected.Sources = append(assetsVolume.Projected.Sources,
-			v1.VolumeProjection{
-				Secret: &v1.SecretProjection{
-					LocalObjectReference: v1.LocalObjectReference{Name: assetShard},
-				},
-			})
-	}
-
-	volumes := []v1.Volume{
-		{
-			Name: "config",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: configSecretName(p.Name),
-				},
-			},
-		},
-		assetsVolume,
-		{
-			Name: "config-out",
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{
-					// tmpfs is used here to avoid writing sensitive data into disk.
-					Medium: v1.StorageMediumMemory,
-				},
-			},
-		},
-	}
-
-	if volume, ok := queryLogFileVolume(p.Spec.QueryLogFile); ok {
-		volumes = append(volumes, volume)
-	}
-
-	for _, name := range ruleConfigMapNames {
-		volumes = append(volumes, v1.Volume{
-			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: name,
-					},
-				},
-			},
-		})
-	}
-
-	volName := volumeName(p.Name)
-	if p.Spec.Storage != nil {
-		if p.Spec.Storage.VolumeClaimTemplate.Name != "" {
-			volName = p.Spec.Storage.VolumeClaimTemplate.Name
-		}
-	}
-
-	promVolumeMounts := []v1.VolumeMount{
-		{
-			Name:      "config-out",
-			ReadOnly:  true,
-			MountPath: confOutDir,
-		},
-		{
-			Name:      "tls-assets",
-			ReadOnly:  true,
-			MountPath: tlsAssetsDir,
-		},
-		{
-			Name:      volName,
-			MountPath: storageDir,
-			SubPath:   subPathForStorage(p.Spec.Storage),
-		},
-	}
-
-	promVolumeMounts = append(promVolumeMounts, p.Spec.VolumeMounts...)
-	for _, name := range ruleConfigMapNames {
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
-			Name:      name,
-			MountPath: rulesDir + "/" + name,
-		})
-	}
-
-	if vmount, ok := queryLogFileVolumeMount(p.Spec.QueryLogFile); ok {
-		promVolumeMounts = append(promVolumeMounts, vmount)
-	}
+	volumes, promVolumeMounts = appendServerVolumes(volumes, promVolumeMounts, queryLogFile, ruleConfigMapNames)
 
 	// Mount web config and web TLS credentials as volumes.
 	// We always mount the web config file for versions greater than 2.24.0.
@@ -549,11 +384,11 @@ func makeStatefulSetSpec(
 	webConfigGenerator := cg.WithMinimumVersion("2.24.0")
 	if webConfigGenerator.IsCompatible() {
 		var fields monitoringv1.WebConfigFileFields
-		if p.Spec.Web != nil {
-			fields = p.Spec.Web.WebConfigFileFields
+		if cpf.Web != nil {
+			fields = cpf.Web.WebConfigFileFields
 		}
 
-		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(p.Name), fields)
+		webConfig, err := webconfig.New(webConfigDir, webConfigSecretName(promName), fields)
 		if err != nil {
 			return nil, err
 		}
@@ -565,88 +400,8 @@ func makeStatefulSetSpec(
 		promArgs = append(promArgs, confArg)
 		volumes = append(volumes, configVol...)
 		promVolumeMounts = append(promVolumeMounts, configMount...)
-	} else if p.Spec.Web != nil {
+	} else if cpf.Web != nil {
 		webConfigGenerator.Warn("web.config.file")
-	}
-
-	// Mount related secrets
-	rn := k8sutil.NewResourceNamerWithPrefix("secret")
-	for _, s := range p.Spec.Secrets {
-		name, err := rn.DNS1123Label(s)
-		if err != nil {
-			return nil, err
-		}
-
-		volumes = append(volumes, v1.Volume{
-			Name: name,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: s,
-				},
-			},
-		})
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
-			Name:      name,
-			ReadOnly:  true,
-			MountPath: secretsDir + s,
-		})
-	}
-
-	rn = k8sutil.NewResourceNamerWithPrefix("configmap")
-	for _, c := range p.Spec.ConfigMaps {
-		name, err := rn.DNS1123Label(c)
-		if err != nil {
-			return nil, err
-		}
-
-		volumes = append(volumes, v1.Volume{
-			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: c,
-					},
-				},
-			},
-		})
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
-			Name:      name,
-			ReadOnly:  true,
-			MountPath: configmapsDir + c,
-		})
-	}
-
-	probeHandler := func(probePath string) v1.ProbeHandler {
-		probePath = path.Clean(webRoutePrefix + probePath)
-		handler := v1.ProbeHandler{}
-		if p.Spec.ListenLocal {
-			probeURL := url.URL{
-				Scheme: "http",
-				Host:   "localhost:9090",
-				Path:   probePath,
-			}
-			handler.Exec = &v1.ExecAction{
-				Command: []string{
-					"sh",
-					"-c",
-					fmt.Sprintf(
-						`if [ -x "$(command -v curl)" ]; then exec %s; elif [ -x "$(command -v wget)" ]; then exec %s; else exit 1; fi`,
-						operator.CurlProber(probeURL.String()),
-						operator.WgetProber(probeURL.String()),
-					),
-				},
-			}
-			return handler
-		}
-
-		handler.HTTPGet = &v1.HTTPGetAction{
-			Path: probePath,
-			Port: intstr.FromString(p.Spec.PortName),
-		}
-		if p.Spec.Web != nil && p.Spec.Web.TLSConfig != nil && webConfigGenerator.IsCompatible() {
-			handler.HTTPGet.Scheme = v1.URISchemeHTTPS
-		}
-		return handler
 	}
 
 	// The /-/ready handler returns OK only after the TSDB initialization has
@@ -656,31 +411,29 @@ func makeStatefulSetSpec(
 	// Prometheus is effectively ready.
 	// We don't want to use the /-/healthy handler here because it returns OK as
 	// soon as the web server is started (irrespective of the WAL replay).
+	readyProbeHandler := probeHandler("/-/ready", cpf, webConfigGenerator, webRoutePrefix)
 	startupProbe := &v1.Probe{
-		ProbeHandler:     probeHandler("/-/ready"),
+		ProbeHandler:     readyProbeHandler,
 		TimeoutSeconds:   probeTimeoutSeconds,
 		PeriodSeconds:    15,
 		FailureThreshold: 60,
 	}
 
-	livenessProbe := &v1.Probe{
-		ProbeHandler:     probeHandler("/-/healthy"),
-		TimeoutSeconds:   probeTimeoutSeconds,
-		PeriodSeconds:    5,
-		FailureThreshold: 6,
-	}
-
 	readinessProbe := &v1.Probe{
-		ProbeHandler:     probeHandler("/-/ready"),
+		ProbeHandler:     readyProbeHandler,
 		TimeoutSeconds:   probeTimeoutSeconds,
 		PeriodSeconds:    5,
 		FailureThreshold: 3,
 	}
 
-	podAnnotations := map[string]string{}
-	podLabels := map[string]string{
-		"app.kubernetes.io/version": cg.version.String(),
+	livenessProbe := &v1.Probe{
+		ProbeHandler:     probeHandler("/-/healthy", cpf, webConfigGenerator, webRoutePrefix),
+		TimeoutSeconds:   probeTimeoutSeconds,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
 	}
+
+	podAnnotations, podLabels := buildPodMetadata(cpf, cg)
 	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
 	// We should try to avoid removing such immutable fields whenever possible since doing
 	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
@@ -688,185 +441,36 @@ func makeStatefulSetSpec(
 	podSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/managed-by": "prometheus-operator",
-		"app.kubernetes.io/instance":   p.Name,
-		"prometheus":                   p.Name,
+		"app.kubernetes.io/instance":   promName,
+		"prometheus":                   promName,
 		shardLabelName:                 fmt.Sprintf("%d", shard),
-		prometheusNameLabelName:        p.Name,
-	}
-	if p.Spec.PodMetadata != nil {
-		if p.Spec.PodMetadata.Labels != nil {
-			for k, v := range p.Spec.PodMetadata.Labels {
-				podLabels[k] = v
-			}
-		}
-		if p.Spec.PodMetadata.Annotations != nil {
-			for k, v := range p.Spec.PodMetadata.Annotations {
-				podAnnotations[k] = v
-			}
-		}
+		prometheusNameLabelName:        promName,
 	}
 
 	for k, v := range podSelectorLabels {
 		podLabels[k] = v
 	}
 
-	podAnnotations["kubectl.kubernetes.io/default-container"] = "prometheus"
-
 	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
 	finalLabels := c.Labels.Merge(podLabels)
 
 	var additionalContainers, operatorInitContainers []v1.Container
 
-	disableCompaction := p.Spec.DisableCompaction
 	prometheusURIScheme := "http"
-	if p.Spec.Web != nil && p.Spec.Web.TLSConfig != nil {
+	if cpf.Web != nil && cpf.Web.TLSConfig != nil {
 		prometheusURIScheme = "https"
 	}
-	if p.Spec.Thanos != nil {
-		thanosImage, err := operator.BuildImagePath(
-			operator.StringPtrValOrDefault(p.Spec.Thanos.Image, ""),
-			operator.StringPtrValOrDefault(p.Spec.Thanos.BaseImage, c.ThanosDefaultBaseImage),
-			operator.StringPtrValOrDefault(p.Spec.Thanos.Version, operator.DefaultThanosVersion),
-			operator.StringPtrValOrDefault(p.Spec.Thanos.Tag, ""),
-			operator.StringPtrValOrDefault(p.Spec.Thanos.SHA, ""),
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to build image path")
-		}
 
-		var grpcBindAddress, httpBindAddress string
-		if p.Spec.Thanos.ListenLocal || p.Spec.Thanos.GRPCListenLocal {
-			grpcBindAddress = "127.0.0.1"
-		}
-
-		if p.Spec.Thanos.ListenLocal || p.Spec.Thanos.HTTPListenLocal {
-			httpBindAddress = "127.0.0.1"
-		}
-
-		thanosArgs := []monitoringv1.Argument{
-			{Name: "prometheus.url", Value: fmt.Sprintf("%s://%s:9090%s", prometheusURIScheme, c.LocalHost, path.Clean(webRoutePrefix))},
-			{Name: "prometheus.http-client", Value: `{"tls_config": {"insecure_skip_verify":true}}`},
-			{Name: "grpc-address", Value: fmt.Sprintf("%s:10901", grpcBindAddress)},
-			{Name: "http-address", Value: fmt.Sprintf("%s:10902", httpBindAddress)},
-		}
-
-		if p.Spec.Thanos.GRPCServerTLSConfig != nil {
-			tls := p.Spec.Thanos.GRPCServerTLSConfig
-			if tls.CertFile != "" {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-cert", Value: tls.CertFile})
-			}
-			if tls.KeyFile != "" {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-key", Value: tls.KeyFile})
-			}
-			if tls.CAFile != "" {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-client-ca", Value: tls.CAFile})
-			}
-		}
-
-		boolFalse := false
-		boolTrue := true
-		container := v1.Container{
-			Name:                     "thanos-sidecar",
-			Image:                    thanosImage,
-			ImagePullPolicy:          p.Spec.ImagePullPolicy,
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			SecurityContext: &v1.SecurityContext{
-				AllowPrivilegeEscalation: &boolFalse,
-				ReadOnlyRootFilesystem:   &boolTrue,
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
-				},
-			},
-			Ports: []v1.ContainerPort{
-				{
-					Name:          "http",
-					ContainerPort: 10902,
-				},
-				{
-					Name:          "grpc",
-					ContainerPort: 10901,
-				},
-			},
-			Resources: p.Spec.Thanos.Resources,
-		}
-
-		for _, thanosSideCarVM := range p.Spec.Thanos.VolumeMounts {
-			container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
-				Name:      thanosSideCarVM.Name,
-				MountPath: thanosSideCarVM.MountPath,
-			})
-		}
-
-		if p.Spec.Thanos.ObjectStorageConfig != nil || p.Spec.Thanos.ObjectStorageConfigFile != nil {
-			if p.Spec.Thanos.ObjectStorageConfigFile != nil {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config-file", Value: *p.Spec.Thanos.ObjectStorageConfigFile})
-			} else {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config", Value: "$(OBJSTORE_CONFIG)"})
-				container.Env = append(container.Env, v1.EnvVar{
-					Name: "OBJSTORE_CONFIG",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: p.Spec.Thanos.ObjectStorageConfig,
-					},
-				})
-			}
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tsdb.path", Value: storageDir})
-			container.VolumeMounts = append(
-				container.VolumeMounts,
-				v1.VolumeMount{
-					Name:      volName,
-					MountPath: storageDir,
-					SubPath:   subPathForStorage(p.Spec.Storage),
-				},
-			)
-
-			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
-			// to avoid races during upload, if the uploads are configured.
-			disableCompaction = true
-		}
-
-		if p.Spec.Thanos.TracingConfig != nil || len(p.Spec.Thanos.TracingConfigFile) > 0 {
-			if len(p.Spec.Thanos.TracingConfigFile) > 0 {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config-file", Value: p.Spec.Thanos.TracingConfigFile})
-			} else {
-				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config", Value: "$(TRACING_CONFIG)"})
-				container.Env = append(container.Env, v1.EnvVar{
-					Name: "TRACING_CONFIG",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: p.Spec.Thanos.TracingConfig,
-					},
-				})
-			}
-		}
-
-		if p.Spec.Thanos.LogLevel != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.level", Value: p.Spec.Thanos.LogLevel})
-		} else if p.Spec.LogLevel != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.level", Value: p.Spec.LogLevel})
-		}
-		if p.Spec.Thanos.LogFormat != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.format", Value: p.Spec.Thanos.LogFormat})
-		} else if p.Spec.LogFormat != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.format", Value: p.Spec.LogFormat})
-		}
-
-		if p.Spec.Thanos.MinTime != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "min-time", Value: p.Spec.Thanos.MinTime})
-		}
-
-		if p.Spec.Thanos.ReadyTimeout != "" {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "prometheus.ready_timeout", Value: string(p.Spec.Thanos.ReadyTimeout)})
-		}
-
-		containerArgs, err := operator.BuildArgs(thanosArgs, p.Spec.Thanos.AdditionalArgs)
-		if err != nil {
-			return nil, err
-		}
-		container.Args = append([]string{"sidecar"}, containerArgs...)
-
-		additionalContainers = append(additionalContainers, container)
+	thanosContainer, err := createThanosContainer(&disableCompaction, p, thanos, c, prometheusURIScheme, webRoutePrefix)
+	if err != nil {
+		return nil, err
 	}
+	if thanosContainer != nil {
+		additionalContainers = append(additionalContainers, *thanosContainer)
+	}
+
 	if disableCompaction {
-		thanosBlockDuration := operator.StringValOrDefault(string(p.Spec.Thanos.BlockDuration), "2h")
+		thanosBlockDuration := operator.StringValOrDefault(string(thanos.BlockDuration), "2h")
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: thanosBlockDuration})
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: thanosBlockDuration})
 	}
@@ -895,8 +499,8 @@ func makeStatefulSetSpec(
 	}
 
 	var minReadySeconds int32
-	if p.Spec.MinReadySeconds != nil {
-		minReadySeconds = int32(*p.Spec.MinReadySeconds)
+	if cpf.MinReadySeconds != nil {
+		minReadySeconds = int32(*cpf.MinReadySeconds)
 	}
 
 	operatorInitContainers = append(operatorInitContainers,
@@ -904,23 +508,23 @@ func makeStatefulSetSpec(
 			"init-config-reloader",
 			operator.ReloaderConfig(c.ReloaderConfig),
 			operator.ReloaderRunOnce(),
-			operator.LogFormat(p.Spec.LogFormat),
-			operator.LogLevel(p.Spec.LogLevel),
+			operator.LogFormat(cpf.LogFormat),
+			operator.LogLevel(cpf.LogLevel),
 			operator.VolumeMounts(configReloaderVolumeMounts),
 			operator.ConfigFile(path.Join(confDir, configFilename)),
 			operator.ConfigEnvsubstFile(path.Join(confOutDir, configEnvsubstFilename)),
 			operator.WatchedDirectories(watchedDirectories),
 			operator.Shard(shard),
-			operator.ImagePullPolicy(p.Spec.ImagePullPolicy),
+			operator.ImagePullPolicy(cpf.ImagePullPolicy),
 		),
 	)
 
-	initContainers, err := k8sutil.MergePatchContainers(operatorInitContainers, p.Spec.InitContainers)
+	initContainers, err := k8sutil.MergePatchContainers(operatorInitContainers, cpf.InitContainers)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to merge init containers spec")
 	}
 
-	containerArgs, err := operator.BuildArgs(promArgs, p.Spec.AdditionalArgs)
+	containerArgs, err := operator.BuildArgs(promArgs, cpf.AdditionalArgs)
 
 	if err != nil {
 		return nil, err
@@ -932,14 +536,14 @@ func makeStatefulSetSpec(
 		{
 			Name:                     "prometheus",
 			Image:                    pImagePath,
-			ImagePullPolicy:          p.Spec.ImagePullPolicy,
+			ImagePullPolicy:          cpf.ImagePullPolicy,
 			Ports:                    ports,
 			Args:                     containerArgs,
 			VolumeMounts:             promVolumeMounts,
 			StartupProbe:             startupProbe,
 			LivenessProbe:            livenessProbe,
 			ReadinessProbe:           readinessProbe,
-			Resources:                p.Spec.Resources,
+			Resources:                cpf.Resources,
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 			SecurityContext: &v1.SecurityContext{
 				ReadOnlyRootFilesystem:   &boolTrue,
@@ -957,19 +561,19 @@ func makeStatefulSetSpec(
 				Host:   c.LocalHost + ":9090",
 				Path:   path.Clean(webRoutePrefix + "/-/reload"),
 			}),
-			operator.ListenLocal(p.Spec.ListenLocal),
+			operator.ListenLocal(cpf.ListenLocal),
 			operator.LocalHost(c.LocalHost),
-			operator.LogFormat(p.Spec.LogFormat),
-			operator.LogLevel(p.Spec.LogLevel),
+			operator.LogFormat(cpf.LogFormat),
+			operator.LogLevel(cpf.LogLevel),
 			operator.ConfigFile(path.Join(confDir, configFilename)),
 			operator.ConfigEnvsubstFile(path.Join(confOutDir, configEnvsubstFilename)),
 			operator.WatchedDirectories(watchedDirectories), operator.VolumeMounts(configReloaderVolumeMounts),
 			operator.Shard(shard),
-			operator.ImagePullPolicy(p.Spec.ImagePullPolicy),
+			operator.ImagePullPolicy(cpf.ImagePullPolicy),
 		),
 	}, additionalContainers...)
 
-	containers, err := k8sutil.MergePatchContainers(operatorContainers, p.Spec.Containers)
+	containers, err := k8sutil.MergePatchContainers(operatorContainers, cpf.Containers)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to merge containers spec")
 	}
@@ -978,7 +582,7 @@ func makeStatefulSetSpec(
 	// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 	return &appsv1.StatefulSetSpec{
 		ServiceName:         governingServiceName,
-		Replicas:            p.Spec.Replicas,
+		Replicas:            cpf.Replicas,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
@@ -995,18 +599,18 @@ func makeStatefulSetSpec(
 			Spec: v1.PodSpec{
 				Containers:                    containers,
 				InitContainers:                initContainers,
-				SecurityContext:               p.Spec.SecurityContext,
-				ServiceAccountName:            p.Spec.ServiceAccountName,
+				SecurityContext:               cpf.SecurityContext,
+				ServiceAccountName:            cpf.ServiceAccountName,
 				AutomountServiceAccountToken:  &boolTrue,
-				NodeSelector:                  p.Spec.NodeSelector,
-				PriorityClassName:             p.Spec.PriorityClassName,
+				NodeSelector:                  cpf.NodeSelector,
+				PriorityClassName:             cpf.PriorityClassName,
 				TerminationGracePeriodSeconds: &terminationGracePeriod,
 				Volumes:                       volumes,
-				Tolerations:                   p.Spec.Tolerations,
-				Affinity:                      p.Spec.Affinity,
-				TopologySpreadConstraints:     p.Spec.TopologySpreadConstraints,
-				HostAliases:                   operator.MakeHostAliases(p.Spec.HostAliases),
-				HostNetwork:                   p.Spec.HostNetwork,
+				Tolerations:                   cpf.Tolerations,
+				Affinity:                      cpf.Affinity,
+				TopologySpreadConstraints:     cpf.TopologySpreadConstraints,
+				HostAliases:                   operator.MakeHostAliases(cpf.HostAliases),
+				HostNetwork:                   cpf.HostNetwork,
 			},
 		},
 	}, nil
@@ -1076,4 +680,499 @@ func queryLogFilePath(queryLogFile string) string {
 	}
 
 	return filepath.Join(defaultQueryLogDirectory, queryLogFile)
+}
+
+// buildCommonPrometheusArgs builds a slice of arguments that are common between Prometheus Server and Agent.
+func buildCommonPrometheusArgs(cpf monitoringv1.CommonPrometheusFields, cg *ConfigGenerator, webRoutePrefix string) []monitoringv1.Argument {
+	promArgs := []monitoringv1.Argument{
+		{Name: "web.console.templates", Value: "/etc/prometheus/consoles"},
+		{Name: "web.console.libraries", Value: "/etc/prometheus/console_libraries"},
+		{Name: "config.file", Value: path.Join(confOutDir, configEnvsubstFilename)},
+		{Name: "web.enable-lifecycle"},
+	}
+
+	if cpf.Web != nil {
+		if cpf.Web.PageTitle != nil {
+			promArgs = cg.WithMinimumVersion("2.6.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "web.page-title", Value: *cpf.Web.PageTitle})
+		}
+
+		if cpf.Web.MaxConnections != nil {
+			promArgs = append(promArgs, monitoringv1.Argument{Name: "web.max-connections", Value: fmt.Sprintf("%d", *cpf.Web.MaxConnections)})
+		}
+	}
+
+	if cpf.EnableRemoteWriteReceiver {
+		promArgs = cg.WithMinimumVersion("2.33.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "web.enable-remote-write-receiver"})
+	}
+
+	if len(cpf.EnableFeatures) > 0 {
+		promArgs = cg.WithMinimumVersion("2.25.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "enable-feature", Value: strings.Join(cpf.EnableFeatures[:], ",")})
+	}
+
+	if cpf.ExternalURL != "" {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.external-url", Value: cpf.ExternalURL})
+	}
+
+	promArgs = append(promArgs, monitoringv1.Argument{Name: "web.route-prefix", Value: webRoutePrefix})
+
+	if cpf.LogLevel != "" && cpf.LogLevel != "info" {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "log.level", Value: cpf.LogLevel})
+	}
+
+	if cpf.LogFormat != "" && cpf.LogFormat != "logfmt" {
+		promArgs = cg.WithMinimumVersion("2.6.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "log.format", Value: cpf.LogFormat})
+	}
+
+	if cpf.WALCompression != nil {
+		arg := monitoringv1.Argument{Name: "no-storage.tsdb.wal-compression"}
+		if *cpf.WALCompression {
+			arg.Name = "storage.tsdb.wal-compression"
+		}
+		promArgs = cg.WithMinimumVersion("2.11.0").AppendCommandlineArgument(promArgs, arg)
+	}
+
+	if cpf.ListenLocal {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.listen-address", Value: "127.0.0.1:9090"})
+	}
+
+	return promArgs
+}
+
+// appendServerArgs appends arguments that are only valid for the Prometheus server.
+func appendServerArgs(
+	promArgs []monitoringv1.Argument,
+	cg *ConfigGenerator,
+	retention monitoringv1.Duration,
+	retentionSize monitoringv1.ByteSize,
+	rules monitoringv1.Rules,
+	query *monitoringv1.QuerySpec,
+	allowOverlappingBlocks, enableAdminAPI bool) []monitoringv1.Argument {
+	var (
+		retentionTimeFlagName  = "storage.tsdb.retention.time"
+		retentionTimeFlagValue = string(retention)
+	)
+	if cg.WithMaximumVersion("2.7.0").IsCompatible() {
+		retentionTimeFlagName = "storage.tsdb.retention"
+		if retention == "" {
+			retentionTimeFlagValue = defaultRetention
+		}
+	} else if retention == "" && retentionSize == "" {
+		retentionTimeFlagValue = defaultRetention
+	}
+
+	if retentionTimeFlagValue != "" {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: retentionTimeFlagName, Value: retentionTimeFlagValue})
+	}
+	if retentionSize != "" {
+		retentionSizeFlag := monitoringv1.Argument{Name: "storage.tsdb.retention.size", Value: string(retentionSize)}
+		promArgs = cg.WithMinimumVersion("2.7.0").AppendCommandlineArgument(promArgs, retentionSizeFlag)
+	}
+
+	promArgs = append(promArgs,
+		monitoringv1.Argument{Name: "storage.tsdb.path", Value: storageDir},
+	)
+
+	if enableAdminAPI {
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.enable-admin-api"})
+	}
+
+	if rules.Alert.ForOutageTolerance != "" {
+		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.for-outage-tolerance", Value: rules.Alert.ForOutageTolerance})
+	}
+	if rules.Alert.ForGracePeriod != "" {
+		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.for-grace-period", Value: rules.Alert.ForGracePeriod})
+	}
+	if rules.Alert.ResendDelay != "" {
+		promArgs = cg.WithMinimumVersion("2.4.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "rules.alert.resend-delay", Value: rules.Alert.ResendDelay})
+	}
+
+	if query != nil {
+		if query.LookbackDelta != nil {
+			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.lookback-delta", Value: *query.LookbackDelta})
+		}
+
+		if query.MaxSamples != nil && *query.MaxSamples > 0 {
+			promArgs = cg.WithMinimumVersion("2.5.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "query.max-samples", Value: fmt.Sprintf("%d", *query.MaxSamples)})
+		}
+
+		if query.MaxConcurrency != nil && *query.MaxConcurrency > 1 {
+			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.max-concurrency", Value: fmt.Sprintf("%d", *query.MaxConcurrency)})
+		}
+
+		if query.Timeout != nil {
+			promArgs = append(promArgs, monitoringv1.Argument{Name: "query.timeout", Value: string(*query.Timeout)})
+		}
+	}
+
+	if allowOverlappingBlocks {
+		promArgs = cg.WithMinimumVersion("2.11.0").WithMaximumVersion("2.39.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "storage.tsdb.allow-overlapping-blocks"})
+	}
+	return promArgs
+}
+
+// buildCommonVolumes returns a set of volumes to be mounted on statefulset spec that are common between Prometheus Server and Agent
+func buildCommonVolumes(p monitoringv1.PrometheusInterface, tlsAssetSecrets []string) ([]v1.Volume, []v1.VolumeMount, error) {
+	cpf := p.GetCommonPrometheusFields()
+	promName := p.GetObjectMeta().GetName()
+
+	assetsVolume := v1.Volume{
+		Name: "tls-assets",
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{},
+			},
+		},
+	}
+	for _, assetShard := range tlsAssetSecrets {
+		assetsVolume.Projected.Sources = append(assetsVolume.Projected.Sources,
+			v1.VolumeProjection{
+				Secret: &v1.SecretProjection{
+					LocalObjectReference: v1.LocalObjectReference{Name: assetShard},
+				},
+			})
+	}
+
+	volumes := []v1.Volume{
+		{
+			Name: "config",
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: configSecretName(promName),
+				},
+			},
+		},
+		assetsVolume,
+		{
+			Name: "config-out",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					// tmpfs is used here to avoid writing sensitive data into disk.
+					Medium: v1.StorageMediumMemory,
+				},
+			},
+		},
+	}
+
+	volName := volumeName(promName)
+	if cpf.Storage != nil {
+		if cpf.Storage.VolumeClaimTemplate.Name != "" {
+			volName = cpf.Storage.VolumeClaimTemplate.Name
+		}
+	}
+
+	promVolumeMounts := []v1.VolumeMount{
+		{
+			Name:      "config-out",
+			ReadOnly:  true,
+			MountPath: confOutDir,
+		},
+		{
+			Name:      "tls-assets",
+			ReadOnly:  true,
+			MountPath: tlsAssetsDir,
+		},
+		{
+			Name:      volName,
+			MountPath: storageDir,
+			SubPath:   subPathForStorage(cpf.Storage),
+		},
+	}
+
+	promVolumeMounts = append(promVolumeMounts, cpf.VolumeMounts...)
+
+	// Mount related secrets
+	rn := k8sutil.NewResourceNamerWithPrefix("secret")
+	for _, s := range cpf.Secrets {
+		name, err := rn.DNS1123Label(s)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		volumes = append(volumes, v1.Volume{
+			Name: name,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: s,
+				},
+			},
+		})
+		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+			Name:      name,
+			ReadOnly:  true,
+			MountPath: secretsDir + s,
+		})
+	}
+
+	rn = k8sutil.NewResourceNamerWithPrefix("configmap")
+	for _, c := range cpf.ConfigMaps {
+		name, err := rn.DNS1123Label(c)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		volumes = append(volumes, v1.Volume{
+			Name: name,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: c,
+					},
+				},
+			},
+		})
+		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+			Name:      name,
+			ReadOnly:  true,
+			MountPath: configmapsDir + c,
+		})
+	}
+
+	return volumes, promVolumeMounts, nil
+}
+
+// appendServerVolumes returns a set of volumes to be mounted on the statefulset spec that are specific to Prometheus Server
+func appendServerVolumes(volumes []v1.Volume, volumeMounts []v1.VolumeMount, queryLogFile string, ruleConfigMapNames []string) ([]v1.Volume, []v1.VolumeMount) {
+	if volume, ok := queryLogFileVolume(queryLogFile); ok {
+		volumes = append(volumes, volume)
+	}
+
+	for _, name := range ruleConfigMapNames {
+		volumes = append(volumes, v1.Volume{
+			Name: name,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: name,
+					},
+				},
+			},
+		})
+	}
+
+	for _, name := range ruleConfigMapNames {
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      name,
+			MountPath: rulesDir + "/" + name,
+		})
+	}
+
+	if vmount, ok := queryLogFileVolumeMount(queryLogFile); ok {
+		volumeMounts = append(volumeMounts, vmount)
+	}
+
+	return volumes, volumeMounts
+}
+
+func probeHandler(probePath string, cpf monitoringv1.CommonPrometheusFields, webConfigGenerator *ConfigGenerator, webRoutePrefix string) v1.ProbeHandler {
+	probePath = path.Clean(webRoutePrefix + probePath)
+	handler := v1.ProbeHandler{}
+	if cpf.ListenLocal {
+		probeURL := url.URL{
+			Scheme: "http",
+			Host:   "localhost:9090",
+			Path:   probePath,
+		}
+		handler.Exec = &v1.ExecAction{
+			Command: []string{
+				"sh",
+				"-c",
+				fmt.Sprintf(
+					`if [ -x "$(command -v curl)" ]; then exec %s; elif [ -x "$(command -v wget)" ]; then exec %s; else exit 1; fi`,
+					operator.CurlProber(probeURL.String()),
+					operator.WgetProber(probeURL.String()),
+				),
+			},
+		}
+		return handler
+	}
+
+	handler.HTTPGet = &v1.HTTPGetAction{
+		Path: probePath,
+		Port: intstr.FromString(cpf.PortName),
+	}
+	if cpf.Web != nil && cpf.Web.TLSConfig != nil && webConfigGenerator.IsCompatible() {
+		handler.HTTPGet.Scheme = v1.URISchemeHTTPS
+	}
+	return handler
+}
+
+func buildPodMetadata(cpf monitoringv1.CommonPrometheusFields, cg *ConfigGenerator) (map[string]string, map[string]string) {
+	podAnnotations := map[string]string{
+		"kubectl.kubernetes.io/default-container": "prometheus",
+	}
+	podLabels := map[string]string{
+		"app.kubernetes.io/version": cg.version.String(),
+	}
+
+	if cpf.PodMetadata != nil {
+		if cpf.PodMetadata.Labels != nil {
+			for k, v := range cpf.PodMetadata.Labels {
+				podLabels[k] = v
+			}
+		}
+		if cpf.PodMetadata.Annotations != nil {
+			for k, v := range cpf.PodMetadata.Annotations {
+				podAnnotations[k] = v
+			}
+		}
+	}
+
+	return podAnnotations, podLabels
+}
+
+func createThanosContainer(
+	disableCompaction *bool,
+	p monitoringv1.PrometheusInterface,
+	thanos *monitoringv1.ThanosSpec,
+	c *operator.Config,
+	prometheusURIScheme, webRoutePrefix string) (*v1.Container, error) {
+
+	var container *v1.Container
+	cpf := p.GetCommonPrometheusFields()
+
+	if thanos != nil {
+		thanosImage, err := operator.BuildImagePath(
+			operator.StringPtrValOrDefault(thanos.Image, ""),
+			operator.StringPtrValOrDefault(thanos.BaseImage, c.ThanosDefaultBaseImage),
+			operator.StringPtrValOrDefault(thanos.Version, operator.DefaultThanosVersion),
+			operator.StringPtrValOrDefault(thanos.Tag, ""),
+			operator.StringPtrValOrDefault(thanos.SHA, ""),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build image path")
+		}
+
+		var grpcBindAddress, httpBindAddress string
+		if thanos.ListenLocal || thanos.GRPCListenLocal {
+			grpcBindAddress = "127.0.0.1"
+		}
+
+		if thanos.ListenLocal || thanos.HTTPListenLocal {
+			httpBindAddress = "127.0.0.1"
+		}
+
+		thanosArgs := []monitoringv1.Argument{
+			{Name: "prometheus.url", Value: fmt.Sprintf("%s://%s:9090%s", prometheusURIScheme, c.LocalHost, path.Clean(webRoutePrefix))},
+			{Name: "prometheus.http-client", Value: `{"tls_config": {"insecure_skip_verify":true}}`},
+			{Name: "grpc-address", Value: fmt.Sprintf("%s:10901", grpcBindAddress)},
+			{Name: "http-address", Value: fmt.Sprintf("%s:10902", httpBindAddress)},
+		}
+
+		if thanos.GRPCServerTLSConfig != nil {
+			tls := thanos.GRPCServerTLSConfig
+			if tls.CertFile != "" {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-cert", Value: tls.CertFile})
+			}
+			if tls.KeyFile != "" {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-key", Value: tls.KeyFile})
+			}
+			if tls.CAFile != "" {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-client-ca", Value: tls.CAFile})
+			}
+		}
+
+		boolFalse := false
+		boolTrue := true
+		container = &v1.Container{
+			Name:                     "thanos-sidecar",
+			Image:                    thanosImage,
+			ImagePullPolicy:          cpf.ImagePullPolicy,
+			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &v1.SecurityContext{
+				AllowPrivilegeEscalation: &boolFalse,
+				ReadOnlyRootFilesystem:   &boolTrue,
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
+			},
+			Ports: []v1.ContainerPort{
+				{
+					Name:          "http",
+					ContainerPort: 10902,
+				},
+				{
+					Name:          "grpc",
+					ContainerPort: 10901,
+				},
+			},
+			Resources: thanos.Resources,
+		}
+
+		for _, thanosSideCarVM := range thanos.VolumeMounts {
+			container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+				Name:      thanosSideCarVM.Name,
+				MountPath: thanosSideCarVM.MountPath,
+			})
+		}
+
+		if thanos.ObjectStorageConfig != nil || thanos.ObjectStorageConfigFile != nil {
+			if thanos.ObjectStorageConfigFile != nil {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config-file", Value: *thanos.ObjectStorageConfigFile})
+			} else {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config", Value: "$(OBJSTORE_CONFIG)"})
+				container.Env = append(container.Env, v1.EnvVar{
+					Name: "OBJSTORE_CONFIG",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: thanos.ObjectStorageConfig,
+					},
+				})
+			}
+
+			volName := volumeName(p.GetObjectMeta().GetName())
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tsdb.path", Value: storageDir})
+			container.VolumeMounts = append(
+				container.VolumeMounts,
+				v1.VolumeMount{
+					Name:      volName,
+					MountPath: storageDir,
+					SubPath:   subPathForStorage(cpf.Storage),
+				},
+			)
+
+			// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/ we have to turn off compaction of Prometheus
+			// to avoid races during upload, if the uploads are configured.
+			*disableCompaction = true
+		}
+
+		if thanos.TracingConfig != nil || len(thanos.TracingConfigFile) > 0 {
+			if len(thanos.TracingConfigFile) > 0 {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config-file", Value: thanos.TracingConfigFile})
+			} else {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config", Value: "$(TRACING_CONFIG)"})
+				container.Env = append(container.Env, v1.EnvVar{
+					Name: "TRACING_CONFIG",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: thanos.TracingConfig,
+					},
+				})
+			}
+		}
+
+		if thanos.LogLevel != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.level", Value: thanos.LogLevel})
+		} else if cpf.LogLevel != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.level", Value: cpf.LogLevel})
+		}
+		if thanos.LogFormat != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.format", Value: thanos.LogFormat})
+		} else if cpf.LogFormat != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "log.format", Value: cpf.LogFormat})
+		}
+
+		if thanos.MinTime != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "min-time", Value: thanos.MinTime})
+		}
+
+		if thanos.ReadyTimeout != "" {
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "prometheus.ready_timeout", Value: string(thanos.ReadyTimeout)})
+		}
+
+		containerArgs, err := operator.BuildArgs(thanosArgs, thanos.AdditionalArgs)
+		if err != nil {
+			return nil, err
+		}
+		container.Args = append([]string{"sidecar"}, containerArgs...)
+	}
+
+	return container, nil
 }

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -57,7 +57,26 @@ func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulS
 		return nil, err
 	}
 
-	return makeStatefulSet(logger, "test", p, defaultTestConfig, cg, nil, "", 0, nil)
+	return makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		defaultTestConfig,
+		cg,
+		nil,
+		"",
+		0,
+		nil)
 }
 
 func TestStatefulSetLabelingAndAnnotations(t *testing.T) {
@@ -310,6 +329,12 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 									SubPath:   "",
 								},
 								{
+									Name:      "secret-test-secret1",
+									ReadOnly:  true,
+									MountPath: "/etc/prometheus/secrets/test-secret1",
+									SubPath:   "",
+								},
+								{
 									Name:      "rules-configmap-one",
 									ReadOnly:  false,
 									MountPath: "/etc/prometheus/rules/rules-configmap-one",
@@ -320,12 +345,6 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 									ReadOnly:  true,
 									MountPath: "/etc/prometheus/web_config/web-config.yaml",
 									SubPath:   "web-config.yaml",
-								},
-								{
-									Name:      "secret-test-secret1",
-									ReadOnly:  true,
-									MountPath: "/etc/prometheus/secrets/test-secret1",
-									SubPath:   "",
 								},
 							},
 						},
@@ -364,6 +383,14 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 							},
 						},
 						{
+							Name: "secret-test-secret1",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "test-secret1",
+								},
+							},
+						},
+						{
 							Name: "rules-configmap-one",
 							VolumeSource: v1.VolumeSource{
 								ConfigMap: &v1.ConfigMapVolumeSource{
@@ -378,14 +405,6 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "prometheus-volume-init-test-web-config",
-								},
-							},
-						},
-						{
-							Name: "secret-test-secret1",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
-									SecretName: "test-secret1",
 								},
 							},
 						},
@@ -418,7 +437,26 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 	cg, err := NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(logger, "volume-init-test", p, defaultTestConfig, cg, []string{"rules-configmap-one"}, "", 0, []string{tlsAssetsSecretName("volume-init-test") + "-0"})
+	sset, err := makeStatefulSet(
+		logger,
+		"volume-init-test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		defaultTestConfig,
+		cg,
+		[]string{"rules-configmap-one"},
+		"",
+		0,
+		[]string{tlsAssetsSecretName("volume-init-test") + "-0"})
 	require.NoError(t, err)
 
 	if !reflect.DeepEqual(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes) {
@@ -842,7 +880,26 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 	cg, err := NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(logger, "test", p, operatorConfig, cg, nil, "", 0, nil)
+	sset, err := makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		operatorConfig,
+		cg,
+		nil,
+		"",
+		0,
+		nil)
 	require.NoError(t, err)
 
 	image := sset.Spec.Template.Spec.Containers[0].Image
@@ -878,7 +935,26 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	cg, err := NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(logger, "test", p, thanosBaseImageConfig, cg, nil, "", 0, nil)
+	sset, err := makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		thanosBaseImageConfig,
+		cg,
+		nil,
+		"",
+		0,
+		nil)
 	require.NoError(t, err)
 
 	image := sset.Spec.Template.Spec.Containers[2].Image
@@ -1417,7 +1493,26 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 	cg, err := NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 1, nil)
+	sset, err := makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		testConfig,
+		cg,
+		nil,
+		"",
+		1,
+		nil)
 	require.NoError(t, err)
 
 	if *sset.Spec.Replicas != int32(2) {
@@ -1454,7 +1549,26 @@ func TestSidecarResources(t *testing.T) {
 		cg, err := NewConfigGenerator(logger, &p, false)
 		require.NoError(t, err)
 
-		sset, err := makeStatefulSet(logger, "test", p, testConfig, cg, nil, "", 0, nil)
+		sset, err := makeStatefulSet(
+			logger,
+			"test",
+			&p,
+			p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+			p.Spec.Retention,
+			p.Spec.RetentionSize,
+			p.Spec.Rules,
+			p.Spec.Query,
+			p.Spec.AllowOverlappingBlocks,
+			p.Spec.EnableAdminAPI,
+			p.Spec.QueryLogFile,
+			p.Spec.Thanos,
+			p.Spec.DisableCompaction,
+			testConfig,
+			cg,
+			nil,
+			"",
+			0,
+			nil)
 		require.NoError(t, err)
 		return sset
 	})
@@ -1840,7 +1954,26 @@ func TestConfigReloader(t *testing.T) {
 	cg, err := NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(logger, "test", p, defaultTestConfig, cg, nil, "", int32(expectedShardNum), nil)
+	sset, err := makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
+		p.Spec.Retention,
+		p.Spec.RetentionSize,
+		p.Spec.Rules,
+		p.Spec.Query,
+		p.Spec.AllowOverlappingBlocks,
+		p.Spec.EnableAdminAPI,
+		p.Spec.QueryLogFile,
+		p.Spec.Thanos,
+		p.Spec.DisableCompaction,
+		defaultTestConfig,
+		cg,
+		nil,
+		"",
+		int32(expectedShardNum),
+		nil)
 	require.NoError(t, err)
 
 	expectedArgsConfigReloader := []string{
@@ -2145,11 +2278,11 @@ func TestPrometheusAdditionalArgsNoError(t *testing.T) {
 	expectedPrometheusArgs := []string{
 		"--web.console.templates=/etc/prometheus/consoles",
 		"--web.console.libraries=/etc/prometheus/console_libraries",
-		"--storage.tsdb.retention.time=24h",
 		"--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
-		"--storage.tsdb.path=/prometheus",
 		"--web.enable-lifecycle",
 		"--web.route-prefix=/",
+		"--storage.tsdb.retention.time=24h",
+		"--storage.tsdb.path=/prometheus",
 		"--web.config.file=/etc/prometheus/web_config/web-config.yaml",
 		"--scrape.discovery-reload-interval=30s",
 		"--storage.tsdb.no-lockfile",

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1108,6 +1108,7 @@ func TestThanosObjectStorage(t *testing.T) {
 				ObjectStorageConfig: &v1.SecretKeySelector{
 					Key: testKey,
 				},
+				BlockDuration: "2h",
 			},
 		},
 	})
@@ -1194,6 +1195,7 @@ func TestThanosObjectStorageFile(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
 				ObjectStorageConfigFile: &testPath,
+				BlockDuration:           "2h",
 			},
 		},
 	})


### PR DESCRIPTION
## Description

This PR was built on top of https://github.com/prometheus-operator/prometheus-operator/pull/5310, so I could re-use the `PrometheusInterface` interface.

It follows the same strategy, arguments that are not present in `CommonPrometheusFields` are being passed as extra arguments to the functions `makeStatefulSet` and `makeStatefulSetSpec`.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
