### PR TITLE
Set Read/ReadHeaderTimeouts on http.Server

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -166,8 +166,10 @@ func newSrv(logger log.Logger, tlsConf *tls.Config) *srv {
 	return &srv{
 		logger: logger,
 		s: &http.Server{
-			Handler:   mux,
-			TLSConfig: tlsConf,
+			Handler:           mux,
+			TLSConfig:         tlsConf,
+			ReadHeaderTimeout: 30 * time.Second,
+			ReadTimeout:       30 * time.Second,
 			// use flags on standard logger to align with base logger and get consistent parsed fields form adapter:
 			// use shortfile flag to get proper 'caller' field (avoid being wrongly parsed/extracted from message)
 			// and no datetime related flag to keep 'ts' field from base logger (with controlled format)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -387,8 +387,10 @@ func Main() int {
 		})
 	}
 	srv := &http.Server{
-		Handler:   mux,
-		TLSConfig: tlsConfig,
+		Handler:           mux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       30 * time.Second,
 		// use flags on standard logger to align with base logger and get consistent parsed fields form adapter:
 		// use shortfile flag to get proper 'caller' field (avoid being wrongly parsed/extracted from message)
 		// and no datetime related flag to keep 'ts' field from base logger (with controlled format)

--- a/test/instrumented-sample-app/main.go
+++ b/test/instrumented-sample-app/main.go
@@ -127,9 +127,11 @@ func mTLSEndpoint() error {
 	address := ":8081"
 
 	server := &http.Server{
-		Addr:      address,
-		TLSConfig: tlsConfig,
-		Handler:   promhttp.Handler(),
+		Addr:              address,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		Handler:           promhttp.Handler(),
 	}
 
 	fmt.Printf("listening for metric requests on '%v' protected via mutual tls\n", address)


### PR DESCRIPTION


## Description
via gosec linter - G112: Potential slowloris attack

https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Set Read/ReadHeaderTimeouts on http.Server instances
```
