### PR TITLE
config-reloader: add the reload-timeout argument

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -60,7 +60,7 @@ func main() {
 	watchInterval := app.Flag("watch-interval", "how often the reloader re-reads the configuration file and directories; when set to 0, the program runs only once and exits").Default(defaultWatchInterval.String()).Duration()
 	delayInterval := app.Flag("delay-interval", "how long the reloader waits before reloading after it has detected a change").Default(defaultDelayInterval.String()).Duration()
 	retryInterval := app.Flag("retry-interval", "how long the reloader waits before retrying in case the endpoint returned an error").Default(defaultRetryInterval.String()).Duration()
-	reloadTimeout := app.Flag("reload-timeout", "how long the reloader waits for a response from reload URL").Default(defaultReloadTimeout.String()).Duration()
+	reloadTimeout := app.Flag("reload-timeout", "how long the reloader waits for a response from the reload URL").Default(defaultReloadTimeout.String()).Duration()
 
 	watchedDir := app.Flag("watched-dir", "directory to watch non-recursively").Strings()
 

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -70,7 +70,9 @@ func TestCreateHTTPClient(t *testing.T) {
 			Timeout:   30 * time.Second,
 		}
 
-		client := createHTTPClient()
+		timeoutDuration := 30 * time.Second
+
+		client := createHTTPClient(&timeoutDuration)
 
 		if diff := deep.Equal(client, expectedClient); diff != nil {
 			t.Errorf("found differences %v", diff)


### PR DESCRIPTION
This new argument enables you to increase (or decrease) the duration for config-reloader to wait after Prometheus' reload.

Fixes #5346

## Description

Allow the time waited for Prometheus' configuration reload to be customized. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add a new parameter `--reload-timeout` to prometheus-config-reloader to customize the wait time of prometheus' configuration reload.
```
