### PR TITLE
api: define default value for `spec.portName`

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -610,7 +610,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1936,7 +1936,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2449,8 +2449,6 @@ ThanosSpec
 server in a Thanos environment.</p>
 <p>This section is experimental, it may change significantly without
 deprecation notice in any release.</p>
-<p>This is experimental and may change significantly without backward
-compatibility in any release.</p>
 </td>
 </tr>
 <tr>
@@ -3319,7 +3317,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4540,7 +4538,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5705,7 +5703,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -8981,7 +8979,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>
@@ -9494,8 +9492,6 @@ ThanosSpec
 server in a Thanos environment.</p>
 <p>This section is experimental, it may change significantly without
 deprecation notice in any release.</p>
-<p>This is experimental and may change significantly without backward
-compatibility in any release.</p>
 </td>
 </tr>
 <tr>
@@ -11888,7 +11884,7 @@ string
 </td>
 <td>
 <p>Port name used for the pods and governing service.
-This defaults to web</p>
+Defaults to <code>web</code>.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -8579,8 +8579,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods
@@ -17404,8 +17405,9 @@ spec:
                   type: string
                 type: array
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods
@@ -19603,8 +19605,7 @@ spec:
                 description: "Thanos configuration allows configuring various aspects
                   of a Prometheus server in a Thanos environment. \n This section
                   is experimental, it may change significantly without deprecation
-                  notice in any release. \n This is experimental and may change significantly
-                  without backward compatibility in any release."
+                  notice in any release."
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments
@@ -26762,8 +26763,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -4098,8 +4098,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4438,8 +4438,9 @@ spec:
                   type: string
                 type: array
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods
@@ -6637,8 +6638,7 @@ spec:
                 description: "Thanos configuration allows configuring various aspects
                   of a Prometheus server in a Thanos environment. \n This section
                   is experimental, it may change significantly without deprecation
-                  notice in any release. \n This is experimental and may change significantly
-                  without backward compatibility in any release."
+                  notice in any release."
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -3803,8 +3803,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4098,8 +4098,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4438,8 +4438,9 @@ spec:
                   type: string
                 type: array
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods
@@ -6637,8 +6638,7 @@ spec:
                 description: "Thanos configuration allows configuring various aspects
                   of a Prometheus server in a Thanos environment. \n This section
                   is experimental, it may change significantly without deprecation
-                  notice in any release. \n This is experimental and may change significantly
-                  without backward compatibility in any release."
+                  notice in any release."
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -3803,8 +3803,9 @@ spec:
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to web
+                default: web
+                description: Port name used for the pods and governing service. Defaults
+                  to `web`.
                 type: string
               priorityClassName:
                 description: Priority class assigned to the Pods

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3750,7 +3750,8 @@
                     "type": "object"
                   },
                   "portName": {
-                    "description": "Port name used for the pods and governing service. This defaults to web",
+                    "default": "web",
+                    "description": "Port name used for the pods and governing service. Defaults to `web`.",
                     "type": "string"
                   },
                   "priorityClassName": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4065,7 +4065,8 @@
                     "type": "array"
                   },
                   "portName": {
-                    "description": "Port name used for the pods and governing service. This defaults to web",
+                    "default": "web",
+                    "description": "Port name used for the pods and governing service. Defaults to `web`.",
                     "type": "string"
                   },
                   "priorityClassName": {
@@ -6147,7 +6148,7 @@
                     "type": "string"
                   },
                   "thanos": {
-                    "description": "Thanos configuration allows configuring various aspects of a Prometheus server in a Thanos environment. \n This section is experimental, it may change significantly without deprecation notice in any release. \n This is experimental and may change significantly without backward compatibility in any release.",
+                    "description": "Thanos configuration allows configuring various aspects of a Prometheus server in a Thanos environment. \n This section is experimental, it may change significantly without deprecation notice in any release.",
                     "properties": {
                       "additionalArgs": {
                         "description": "AdditionalArgs allows setting additional arguments for the Thanos container. The arguments are passed as-is to the Thanos container which may cause issues if they are invalid or not supported the given Thanos version. In case of an argument conflict (e.g. an argument which is already set by the operator itself) or when providing an invalid argument the reconciliation will fail and an error will be logged.",

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3470,7 +3470,8 @@
                     "type": "object"
                   },
                   "portName": {
-                    "description": "Port name used for the pods and governing service. This defaults to web",
+                    "default": "web",
+                    "description": "Port name used for the pods and governing service. Defaults to `web`.",
                     "type": "string"
                   },
                   "priorityClassName": {

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -205,7 +205,8 @@ type AlertmanagerSpec struct {
 	// Timeout for cluster peering.
 	ClusterPeerTimeout GoDuration `json:"clusterPeerTimeout,omitempty"`
 	// Port name used for the pods and governing service.
-	// This defaults to web
+	// Defaults to `web`.
+	// +kubebuilder:default:="web"
 	PortName string `json:"portName,omitempty"`
 	// ForceEnableClusterMode ensures Alertmanager does not deactivate the cluster mode when running with a single replica.
 	// Use case is e.g. spanning an Alertmanager cluster across Kubernetes clusters with a single replica in each.

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -15,11 +15,12 @@
 package v1
 
 import (
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 )
 
 const (
@@ -244,7 +245,8 @@ type CommonPrometheusFields struct {
 	// Priority class assigned to the Pods
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// Port name used for the pods and governing service.
-	// This defaults to web
+	// Defaults to `web`.
+	// +kubebuilder:default:="web"
 	PortName string `json:"portName,omitempty"`
 	// ArbitraryFSAccessThroughSMs configures whether configuration
 	// based on a service monitor can access arbitrary files on the file system
@@ -471,9 +473,6 @@ type PrometheusSpec struct {
 	//
 	// This section is experimental, it may change significantly without
 	// deprecation notice in any release.
-	//
-	// This is experimental and may change significantly without backward
-	// compatibility in any release.
 	Thanos *ThanosSpec `json:"thanos,omitempty"`
 	// QueryLogFile specifies the file to which PromQL queries are logged.
 	// If the filename has an empty path, e.g. 'query.log', prometheus-operator will mount the file into an

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -156,7 +156,8 @@ type ThanosRulerSpec struct {
 	//+kubebuilder:validation:Enum="";logfmt;json
 	LogFormat string `json:"logFormat,omitempty"`
 	// Port name used for the pods and governing service.
-	// This defaults to web
+	// Defaults to `web`.
+	// +kubebuilder:default:="web"
 	PortName string `json:"portName,omitempty"`
 	// Interval between consecutive evaluations.
 	// +kubebuilder:default:="15s"


### PR DESCRIPTION
## Description

Add default value to the OpenAPI spec definition.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Define default value for `spec.portName`.
```
