### PR TITLE
apis: Add Thanos BlockSize control

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -12454,6 +12454,20 @@ string
 </tr>
 <tr>
 <td>
+<code>blockSize</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.Duration">
+Duration
+</a>
+</em>
+</td>
+<td>
+<p>BlockDuration controls the size of TSDB blocks produced by Prometheus. Default is 2h to match the upstream Prometheus defaults.
+WARNING: Changing the block duration can impact the performance and efficiency of the entire Prometheus/Thanos stack due to how it interacts with memory and Thanos compactors. It is recommended to keep this value set to a multiple of 120 times your longest scrape or rule interval. For example, 30s * 120 = 1h.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>readyTimeout</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.Duration">

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -19633,6 +19633,18 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  blockSize:
+                    default: 2h
+                    description: 'BlockDuration controls the size of TSDB blocks produced
+                      by Prometheus. Default is 2h to match the upstream Prometheus
+                      defaults. WARNING: Changing the block duration can impact the
+                      performance and efficiency of the entire Prometheus/Thanos stack
+                      due to how it interacts with memory and Thanos compactors. It
+                      is recommended to keep this value set to a multiple of 120 times
+                      your longest scrape or rule interval. For example, 30s * 120
+                      = 1h.'
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                    type: string
                   grpcListenLocal:
                     description: If true, the Thanos sidecar listens on the loopback
                       interface for the gRPC endpoints. It has no effect if `listenLocal`

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6667,6 +6667,18 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  blockSize:
+                    default: 2h
+                    description: 'BlockDuration controls the size of TSDB blocks produced
+                      by Prometheus. Default is 2h to match the upstream Prometheus
+                      defaults. WARNING: Changing the block duration can impact the
+                      performance and efficiency of the entire Prometheus/Thanos stack
+                      due to how it interacts with memory and Thanos compactors. It
+                      is recommended to keep this value set to a multiple of 120 times
+                      your longest scrape or rule interval. For example, 30s * 120
+                      = 1h.'
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                    type: string
                   grpcListenLocal:
                     description: If true, the Thanos sidecar listens on the loopback
                       interface for the gRPC endpoints. It has no effect if `listenLocal`

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6667,6 +6667,18 @@ spec:
                     description: 'Thanos base image if other than default. Deprecated:
                       use ''image'' instead'
                     type: string
+                  blockSize:
+                    default: 2h
+                    description: 'BlockDuration controls the size of TSDB blocks produced
+                      by Prometheus. Default is 2h to match the upstream Prometheus
+                      defaults. WARNING: Changing the block duration can impact the
+                      performance and efficiency of the entire Prometheus/Thanos stack
+                      due to how it interacts with memory and Thanos compactors. It
+                      is recommended to keep this value set to a multiple of 120 times
+                      your longest scrape or rule interval. For example, 30s * 120
+                      = 1h.'
+                    pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                    type: string
                   grpcListenLocal:
                     description: If true, the Thanos sidecar listens on the loopback
                       interface for the gRPC endpoints. It has no effect if `listenLocal`

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6175,6 +6175,12 @@
                         "description": "Thanos base image if other than default. Deprecated: use 'image' instead",
                         "type": "string"
                       },
+                      "blockSize": {
+                        "default": "2h",
+                        "description": "BlockDuration controls the size of TSDB blocks produced by Prometheus. Default is 2h to match the upstream Prometheus defaults. WARNING: Changing the block duration can impact the performance and efficiency of the entire Prometheus/Thanos stack due to how it interacts with memory and Thanos compactors. It is recommended to keep this value set to a multiple of 120 times your longest scrape or rule interval. For example, 30s * 120 = 1h.",
+                        "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                        "type": "string"
+                      },
                       "grpcListenLocal": {
                         "description": "If true, the Thanos sidecar listens on the loopback interface for the gRPC endpoints. It has no effect if `listenLocal` is true.",
                         "type": "boolean"

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -653,6 +653,10 @@ type ThanosSpec struct {
 	LogFormat string `json:"logFormat,omitempty"`
 	// MinTime for Thanos sidecar to be configured with. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.
 	MinTime string `json:"minTime,omitempty"`
+	// BlockDuration controls the size of TSDB blocks produced by Prometheus. Default is 2h to match the upstream Prometheus defaults.
+	// WARNING: Changing the block duration can impact the performance and efficiency of the entire Prometheus/Thanos stack due to how it interacts with memory and Thanos compactors. It is recommended to keep this value set to a multiple of 120 times your longest scrape or rule interval. For example, 30s * 120 = 1h.
+	// +kubebuilder:default:="2h"
+	BlockDuration Duration `json:"blockSize,omitempty"`
 	// ReadyTimeout is the maximum time Thanos sidecar will wait for Prometheus to start. Eg 10m
 	ReadyTimeout Duration `json:"readyTimeout,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosspec.go
@@ -41,6 +41,7 @@ type ThanosSpecApplyConfiguration struct {
 	LogLevel                *string                      `json:"logLevel,omitempty"`
 	LogFormat               *string                      `json:"logFormat,omitempty"`
 	MinTime                 *string                      `json:"minTime,omitempty"`
+	BlockDuration           *apismonitoringv1.Duration   `json:"blockSize,omitempty"`
 	ReadyTimeout            *apismonitoringv1.Duration   `json:"readyTimeout,omitempty"`
 	VolumeMounts            []v1.VolumeMount             `json:"volumeMounts,omitempty"`
 	AdditionalArgs          []ArgumentApplyConfiguration `json:"additionalArgs,omitempty"`
@@ -185,6 +186,14 @@ func (b *ThanosSpecApplyConfiguration) WithLogFormat(value string) *ThanosSpecAp
 // If called multiple times, the MinTime field is set to the value of the last call.
 func (b *ThanosSpecApplyConfiguration) WithMinTime(value string) *ThanosSpecApplyConfiguration {
 	b.MinTime = &value
+	return b
+}
+
+// WithBlockDuration sets the BlockDuration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the BlockDuration field is set to the value of the last call.
+func (b *ThanosSpecApplyConfiguration) WithBlockDuration(value apismonitoringv1.Duration) *ThanosSpecApplyConfiguration {
+	b.BlockDuration = &value
 	return b
 }
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -866,8 +866,9 @@ func makeStatefulSetSpec(
 		additionalContainers = append(additionalContainers, container)
 	}
 	if disableCompaction {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: "2h"})
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: "2h"})
+		thanosBlockDuration := operator.StringValOrDefault(string(p.Spec.Thanos.BlockDuration), "2h")
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: thanosBlockDuration})
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: thanosBlockDuration})
 	}
 
 	var watchedDirectories []string

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1195,6 +1195,32 @@ func TestThanosObjectStorageFile(t *testing.T) {
 	}
 }
 
+func TestThanosBlockDuration(t *testing.T) {
+	testKey := "thanos-config-secret-test"
+
+	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			Thanos: &monitoringv1.ThanosSpec{
+				BlockDuration: "1h",
+				ObjectStorageConfig: &v1.SecretKeySelector{
+					Key: testKey,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	found := false
+	for _, arg := range sset.Spec.Template.Spec.Containers[0].Args {
+		if arg == "--storage.tsdb.max-block-duration=1h" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Thanos BlockDuration arg change not found")
+	}
+}
+
 func TestThanosTracing(t *testing.T) {
 	testKey := "thanos-config-secret-test"
 


### PR DESCRIPTION
## Description


Add a BlockSize param to the ThanosSpec to allow configuration of the Prometheus min/max block duration when using the Thanos Sidecar.

Fixes: https://github.com/prometheus-operator/prometheus-operator/issues/4414

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
apis: Add Thanos BlockSize control
```