### PR TITLE
feature: make agent mode usable

### DIFF
--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -1409,26 +1409,40 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 		version                    string
 		specRetention              monitoringv1.Duration
 		specRetentionSize          monitoringv1.ByteSize
+		specEnableFeatures         []string
 		expectedRetentionArg       string
 		expectedRetentionSizeArg   string
 		shouldContainRetention     bool
 		shouldContainRetentionSize bool
 	}{
-		{"v2.5.0", "", "", "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=", true, false},
-		{"v2.5.0", "1d", "", "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=", true, false},
-		{"v2.5.0", "", "512MB", "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=512MB", true, false},
-		{"v2.5.0", "1d", "512MB", "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=512MB", true, false},
-		{"v2.7.0", "", "", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
-		{"v2.7.0", "1d", "", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
-		{"v2.7.0", "", "512MB", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
-		{"v2.7.0", "1d", "512MB", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		{"v2.5.0", "", "", []string{}, "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.5.0", "1d", "", []string{}, "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.5.0", "", "512MB", []string{}, "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=512MB", true, false},
+		{"v2.5.0", "1d", "512MB", []string{}, "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=512MB", true, false},
+		{"v2.7.0", "", "", []string{}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "1d", "", []string{}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "", "512MB", []string{}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
+		{"v2.7.0", "1d", "512MB", []string{}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		{"v2.7.0", "", "", []string{"agent"}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "1d", "", []string{"agent"}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "", "512MB", []string{"agent"}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
+		{"v2.7.0", "1d", "512MB", []string{"agent"}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		{"v2.32.0", "", "", []string{}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.32.0", "1d", "", []string{}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.32.0", "", "512MB", []string{}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
+		{"v2.32.0", "1d", "512MB", []string{}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		{"v2.32.0", "", "", []string{"agent"}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", false, false},
+		{"v2.32.0", "1d", "", []string{"agent"}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", false, false},
+		{"v2.32.0", "", "512MB", []string{"agent"}, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, false},
+		{"v2.32.0", "1d", "512MB", []string{"agent"}, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", false, false},
 	}
 
 	for i, test := range tests {
 		sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{
 				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					Version: test.version,
+					Version:        test.version,
+					EnableFeatures: test.specEnableFeatures,
 				},
 				Retention:     test.specRetention,
 				RetentionSize: test.specRetentionSize,


### PR DESCRIPTION
Using agent mode is imcompatible with tsdb flags wich get added by default
So if agent mode is use skip adding tsd path and retention and skip creating volumes related stuff

Statefulset might then become unuseful then but it works 

I have ben using a custom image on one of my kube lab succesfuly

#3989

## Description

Agent mode is available in prometheus but if we add it in operator, we get an error because of the presence of tsd flags
This pr intend to skip adding those fags if agent feature is on
Target #3989 

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
skip adding tsdb flags ans using pvc when agent mode is on
```
