### PR TITLE
updateResourceVersion

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -614,7 +614,7 @@ func (c *Operator) syncNodeEndpoints(ctx context.Context) error {
 		},
 	}
 
-	nodes, err := c.kclient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := c.kclient.CoreV1().Nodes().List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return errors.Wrap(err, "listing nodes failed")
 	}
@@ -1519,6 +1519,7 @@ func ListOptions(name string) metav1.ListOptions {
 			"app.kubernetes.io/name": "prometheus",
 			"prometheus":             name,
 		})).String(),
+		ResourceVersion: "0",
 	}
 }
 
@@ -1531,7 +1532,7 @@ func Status(ctx context.Context, kclient kubernetes.Interface, p *monitoringv1.P
 
 	var oldPods []v1.Pod
 	for _, ssetName := range prompkg.ExpectedStatefulSetShardNames(p) {
-		sset, err := kclient.AppsV1().StatefulSets(p.Namespace).Get(ctx, ssetName, metav1.GetOptions{})
+		sset, err := kclient.AppsV1().StatefulSets(p.Namespace).Get(ctx, ssetName, metav1.GetOptions{ResourceVersion: "0"})
 		if err != nil {
 			return monitoringv1.PrometheusStatus{}, nil, errors.Wrapf(err, "failed to retrieve statefulset %s/%s", p.Namespace, ssetName)
 		}
@@ -1620,7 +1621,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return errors.Wrap(err, "selecting Probes failed")
 	}
 	sClient := c.kclient.CoreV1().Secrets(p.Namespace)
-	SecretsInPromNS, err := sClient.List(ctx, metav1.ListOptions{})
+	SecretsInPromNS, err := sClient.List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Add 'resourceVersion' to ListOptions when get/list resource  througth client-go. 
Apiserver return data by using cache  instead of etcd server.
It's help improve response time and reduce stress of etcd server when node number is more than 1000  in k8s cluster.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```
Add 'resourceVersion=0' to ListOptions when get/list resource througth client-go.
```
