### PR TITLE
fix: links to images in docs

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -51,7 +51,7 @@ A common problem related to `ServiceMonitor` identification by Prometheus is rel
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![flow diagram](/img/custom-metrics-elements.png)
+![flow diagram](img/custom-metrics-elements.png)
 
 Note: The `ServiceMonitor` references a `Service` (not a `Deployment`, or a `Pod`), by labels *and* by the port name in the `Service`. This *port name* is optional in Kubernetes, but must be specified for the `ServiceMonitor` to work. It is not the same as the port name on the `Pod` or container, although it can be.
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture](/img/architecture.png)
+![Prometheus Operator Architecture](../img/architecture.png)
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 


### PR DESCRIPTION
## Description

Fixes links to images in Doc by using relative links instead of absolute. 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE`  - Doc (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
