### PR TITLE
improve run-external script to show usage info

### DIFF
--- a/scripts/run-external.sh
+++ b/scripts/run-external.sh
@@ -6,8 +6,9 @@ set -o pipefail
 # error on unset variables
 set -u
 
-if [[ -z "$1" ]]; then
-	echo "missing cluster name"
+if [[ -z "${1:-}" ]]; then
+	echo "ERROR: missing cluster name"
+	echo "usage: ❯ $0 <clustername>"
 	exit 1
 fi
 


### PR DESCRIPTION
## Description

Previously running `/scripts/run-external.sh` showed 
```
/scripts/run-external.sh : line 9: $1: unbound variable
```

which now shows 
```
ERROR: missing cluster name
usage: ❯ ./scripts/run-external.sh <clustername>
```



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

