### PR TITLE
simplify running operator out of cluster

### DIFF
--- a/scripts/run-external.sh
+++ b/scripts/run-external.sh
@@ -1,20 +1,273 @@
 #!/usr/bin/env bash
-# exit immediately when a command fails
-set -e
-# only exit with zero if all commands of the pipeline exit successfully
-set -o pipefail
-# error on unset variables
-set -u
+# NOTE:
+#  -e exit immediately when a command fails
+#  -u error on unset variables
+#  -o pipefail  exit with zero only if all commands of the pipeline exit successfully
+set -eu -o pipefail
 
-if [[ -z "${1:-}" ]]; then
-	echo "ERROR: missing cluster name"
-	echo "usage: ❯ $0 <clustername>"
-	exit 1
-fi
+trap cleanup EXIT INT
 
-apiserver=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"$1\")].cluster.server}")
-cafile=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"$1\")].cluster.certificate-authority}")
-certfile=$(kubectl config view -o jsonpath="{.users[?(@.name == \"$1\")].user.client-certificate}")
-keyfile=$(kubectl config view -o jsonpath="{.users[?(@.name == \"$1\")].user.client-key}")
+# globals
+declare CLUSTER=""
+declare SHOW_USAGE=false
+declare SKIP_OPERATOR_RUN_CHECK=false
+declare USE_DEFAULT_CONTEXT=false
+declare API_SERVER=""
 
-./operator --apiserver="${apiserver}" --ca-file="${cafile}" --cert-file="${certfile}" --key-file="${keyfile}"
+# tmp operator files that needs to be cleaned up
+declare -r CA_FILE="tmp/CA_FILE"
+declare -r KEY_FILE="tmp/KEY_FILE"
+declare -r CERT_FILE="tmp/CERT_FILE"
+
+cleanup() {
+	rm -f "$CA_FILE" "$KEY_FILE" "$CERT_FILE"
+}
+
+run() {
+	echo " ❯ $* "
+	"$@"
+}
+
+header() {
+	local title="🔆🔆🔆  $*  🔆🔆🔆 "
+
+	local len=40
+	if [[ ${#title} -gt $len ]]; then
+		len=${#title}
+	fi
+
+	echo -e "\n\n  \033[1m${title}\033[0m"
+	echo -n "━━━━━"
+	printf '━%.0s' $(seq "$len")
+	echo "━━━━━"
+}
+
+info() {
+	echo " 🔔 $*"
+}
+
+ok() {
+	echo " ✅ $*"
+}
+
+warn() {
+	echo " ⚠️  $*"
+}
+
+err() {
+	echo " 🛑 ERROR: $*"
+}
+
+update_crds() {
+	header "Update Operator CRDs"
+
+	run kubectl apply --server-side --force-conflicts \
+		-f example/prometheus-operator-crd-full
+
+	info "Wait for CRDs to be registered"
+	run kubectl wait --for=condition=Established crds --all --timeout=120s
+}
+
+init_cluster_context() {
+	header "Set Cluster"
+	$USE_DEFAULT_CONTEXT && {
+		CLUSTER=$(kubectl config current-context)
+	}
+
+	info "Using cluster - '$CLUSTER'"
+	return 0
+}
+
+extract_certs() {
+	local cluster=".clusters[?(@.name == \"$CLUSTER\")].cluster"
+	local user=".users[?(@.name == \"$CLUSTER\")].user"
+
+	local ca key cert
+
+	API_SERVER=$(kubectl config view -o jsonpath="{$cluster.server}")
+	ca=$(kubectl config view --raw -o jsonpath="{$cluster.certificate-authority-data} | base64 -d")
+	key=$(kubectl config view --raw -o jsonpath="{$user.client-key-data}")
+	cert=$(kubectl config view --raw -o jsonpath="{$user.client-certificate-data}")
+
+	local fail=0
+	[[ -z "$API_SERVER" ]] && {
+		err "failed to get api server details; did you specify the right context?"
+		fail=1
+	}
+
+	[[ -z "$ca" ]] && {
+		err "CA is empty; did you specify the right context?"
+		fail=1
+	}
+
+	[[ -z "$cert" ]] && {
+		err "cert is empty; did you specify the right context?"
+		fail=1
+	}
+
+	[[ -z "$key" ]] && {
+		err "key is empty; did you specify the right context?"
+		fail=1
+	}
+
+	[[ "$fail" -ne 0 ]] && return 1
+
+	echo "$ca" >"$CA_FILE"
+	echo "$key" >"$KEY_FILE"
+	echo "$cert" >"$CERT_FILE"
+	return 0
+}
+
+run_operator() {
+	header "Run Operator"
+
+	# cleanup the files soon after the operator has had time to read it
+	(
+		sleep 5
+		cleanup
+	) &
+
+	info "Running operator against cluster: $CLUSTER - $API_SERVER"
+	echo "──────────────────────────────────────────────────────────────────"
+
+	run ./operator \
+		--apiserver="$API_SERVER" \
+		--ca-file="$CA_FILE" \
+		--cert-file="$CERT_FILE" \
+		--key-file="$KEY_FILE" 2>&1 | tee tmp/operator.log
+}
+
+validate_args() {
+	if [[ -z "$CLUSTER" ]] && ! $USE_DEFAULT_CONTEXT; then
+		err "missing cluster name or --use-default-context"
+		return 1
+	fi
+
+	# ensure both cluster and use-default-context isn't set
+	if [[ -n "$CLUSTER" ]] && $USE_DEFAULT_CONTEXT; then
+		err "Cannot provide both cluster name '$CLUSTER' and --use-default-context"
+		return 1
+	fi
+
+	return 0
+}
+
+ensure_operator_not_running() {
+	header "Ensure no other prometheus-operator is running"
+
+	$SKIP_OPERATOR_RUN_CHECK && {
+		info "skipping operator run check"
+		return 0
+	}
+
+	local po_label='app.kubernetes.io/name=prometheus-operator'
+
+	local po_pods
+	po_pods=$(kubectl get pods -A -l "$po_label" -o name | wc -l)
+
+	[[ "$po_pods" -gt 0 ]] && {
+		warn "Found $po_pods pods matching $po_label in cluster!"
+		echo "If it is safe to continue, rerun the script with --no-operator-run-check option"
+		return 1
+	}
+	ok "No pods with matching label $po_label running in cluster"
+
+	return 0
+}
+
+show_usage() {
+
+	local scr
+	scr="$(basename "$0")"
+
+	read -r -d '' help <<-EOF_HELP || true
+		Usage:
+		────────────────────────────────────────────
+		  ❯ $scr <cluster-name>
+		  ❯ $scr  -h|--help
+
+		Options:
+		⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻
+		  --help | -h                   show this help
+		  --no-operator-run-check | -f: skips the check that ensures no prometheus-operator
+		                                is running in the cluster.
+		  --use-default-context | -c:   Runs operator using current context
+																		NOTE: cannot use both -c and <cluster-name>
+
+		⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻
+		💡 Tips
+		⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻⎻
+		To get all cluster names in current context, run:
+		   ❯ kubectl config get-contexts -o name
+
+		To get current/default cluster names, run:
+		   ❯ kubectl config current-context
+
+	EOF_HELP
+
+	echo -e "$help"
+	return 0
+}
+
+parse_args() {
+	### while there are args parse them
+	while [[ -n "${1+xxx}" ]]; do
+		case $1 in
+		-h | --help)
+			SHOW_USAGE=true
+			# exit the loop
+			break
+			;;
+		--no-operator-run-check | -f)
+			shift
+			SKIP_OPERATOR_RUN_CHECK=true
+			shift
+			;;
+		--use-default-context | -c)
+			shift
+			USE_DEFAULT_CONTEXT=true
+			;;
+		*)
+			CLUSTER="$1"
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+build_operator() {
+	header "Building Operator"
+	run make operator
+}
+
+main() {
+	parse_args "$@" || {
+		show_usage
+		exit 1
+	}
+
+	$SHOW_USAGE && {
+		show_usage
+		exit 0
+	}
+
+	validate_args || {
+		show_usage
+		exit 1
+	}
+
+	# all files are relative to the the root of the project
+	cd "$(git rev-parse --show-toplevel)"
+	mkdir -p tmp
+
+	init_cluster_context
+	extract_certs
+
+	ensure_operator_not_running
+	build_operator
+	update_crds
+	run_operator
+}
+
+main "$@"

--- a/scripts/run-external.sh
+++ b/scripts/run-external.sh
@@ -85,9 +85,9 @@ extract_certs() {
 	local ca key cert
 
 	API_SERVER=$(kubectl config view -o jsonpath="{$cluster.server}")
-	ca=$(kubectl config view --raw -o jsonpath="{$cluster.certificate-authority-data} | base64 -d")
-	key=$(kubectl config view --raw -o jsonpath="{$user.client-key-data}")
-	cert=$(kubectl config view --raw -o jsonpath="{$user.client-certificate-data}")
+	ca=$(kubectl config view --raw -o jsonpath="{$cluster.certificate-authority-data}" | base64 -d)
+	key=$(kubectl config view --raw -o jsonpath="{$user.client-key-data}" | base64 -d)
+	cert=$(kubectl config view --raw -o jsonpath="{$user.client-certificate-data}" | base64 -d)
 
 	local fail=0
 	[[ -z "$API_SERVER" ]] && {


### PR DESCRIPTION
## Description

This patch simplifies running operator out of cluster by just running `./scripts/run-external.sh`

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


A sample run will look like the following 

```
❯ ./scripts/run-external.sh -c

  🔆🔆🔆  Set Cluster  🔆🔆🔆 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🔔 Using cluster - 'kind-po'


  🔆🔆🔆  Ensure no other prometheus-operator is running  🔆🔆🔆 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ✅ No pods with matching label app.kubernetes.io/name=prometheus-operator running in cluster


  🔆🔆🔆  Building Operator  🔆🔆🔆 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ make operator 
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -X github.com/prometheus/common/version.Revision=2117ec9b0 -X github.com/prometheus/common/version.BuildUser=sthaha -X github.com/prometheus/common/version.BuildDate=20230319-13:17:49 -X github.com/prometheus/common/version.Branch=simplify-running-op -X github.com/prometheus/common/version.Version=0.63.0" -o operator cmd/operator/main.go


  🔆🔆🔆  Update Operator CRDs  🔆🔆🔆 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ kubectl apply --server-side --force-conflicts -f example/prometheus-operator-crd-full 
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com serverside-applied
 🔔 Wait for CRDs to be registered
 ❯ kubectl wait --for=condition=Established crds --all --timeout=120s 
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com condition met
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com condition met


  🔆🔆🔆  Run Operator  🔆🔆🔆 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🔔 Running operator against cluster: kind-po - https://127.0.0.1:33169
──────────────────────────────────────────────────────────────────
 ❯ ./operator --apiserver=https://127.0.0.1:33169 --ca-file=tmp/CA_FILE --cert-file=tmp/CERT_FILE --key-file=tmp/KEY_FILE 
level=info ts=2023-03-19T03:17:54.392054466Z caller=main.go:220 msg="Starting Prometheus Operator" version="(version=0.63.0, branch=simplify-running-op, revision=2117ec9b0)"
level=info ts=2023-03-19T03:17:54.392097472Z caller=main.go:221 build_context="(go=go1.19, platform=linux/amd64, user=sthaha, date=20230319-13:17:49, tags=unknown)"
```

