### PR TITLE
fix: improve memory usage by using metadata informer

### DIFF
--- a/pkg/informers/kube.go
+++ b/pkg/informers/kube.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 )
 
 // NewKubeInformerFactories creates factories for kube resources
@@ -44,6 +46,26 @@ func NewKubeInformerFactories(
 		opts = append(opts, informers.WithNamespace(namespace))
 		ret[namespace] = informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResync, opts...)
 	}
+	return ret
+}
+
+// NewMetadataInformerFactory creates metadatainformer factory for kube resources
+// for the given allowed, and denied namespaces (these parameters being mutually exclusive).
+// mdClient, defaultResync, and tweakListOptions are  passed to the underlying informer factory.
+// factories
+func NewMetadataInformerFactory(
+	allowNamespaces, denyNamespaces map[string]struct{},
+	mdClient metadata.Interface,
+	defaultResync time.Duration,
+	tweakListOptions func(*metav1.ListOptions),
+) FactoriesForNamespaces {
+
+	tweaks, namespaces := newInformerOptions(allowNamespaces, denyNamespaces, tweakListOptions)
+
+	ret := metadataInformersForNamespace{}
+	for _, namespace := range namespaces {
+		ret[namespace] = metadatainformer.NewFilteredSharedInformerFactory(mdClient, defaultResync, namespace, tweaks)
+	}
 
 	return ret
 }
@@ -56,4 +78,14 @@ func (i kubeInformersForNamespaces) Namespaces() sets.Set[string] {
 
 func (i kubeInformersForNamespaces) ForResource(namespace string, resource schema.GroupVersionResource) (InformLister, error) {
 	return i[namespace].ForResource(resource)
+}
+
+type metadataInformersForNamespace map[string]metadatainformer.SharedInformerFactory
+
+func (i metadataInformersForNamespace) Namespaces() sets.Set[string] {
+	return sets.KeySet(i)
+}
+
+func (i metadataInformersForNamespace) ForResource(namespace string, resource schema.GroupVersionResource) (InformLister, error) {
+	return i[namespace].ForResource(resource), nil
 }

--- a/pkg/operator/accessor.go
+++ b/pkg/operator/accessor.go
@@ -46,7 +46,8 @@ func (a *Accessor) MetaNamespaceKey(obj interface{}) (string, bool) {
 	return k, true
 }
 
-// ObjectMetadata returns the object's metadata.
+// ObjectMetadata returns the object's metadata and bool indicating if the
+// conversion succeeded
 func (a *Accessor) ObjectMetadata(obj interface{}) (metav1.Object, bool) {
 	ts, ok := obj.(cache.DeletedFinalStateUnknown)
 	if ok {


### PR DESCRIPTION
This patch uses  metadatainformer package to watch secrets and configmaps so that all content need not be loaded into memory thus reducing the amount of memory consumed.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Prometheus Operator now consumes less memory that before when there are lots of secrets and config-maps 
present in the cluster.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Optimised to consume less memory when there are lots of secrets or configmaps in the cluster. 
```
