### PR TITLE
fix(docs): use external images to fix display on github

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -51,7 +51,7 @@ A common problem related to `ServiceMonitor` identification by Prometheus is rel
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![flow diagram](/img/custom-metrics-elements.png)
+![flow diagram](https://raw.githubusercontent.com/prometheus-operator/assets/main/img/custom-metrics-elements.png)
 
 Note: The `ServiceMonitor` references a `Service` (not a `Deployment`, or a `Pod`), by labels *and* by the port name in the `Service`. This *port name* is optional in Kubernetes, but must be specified for the `ServiceMonitor` to work. It is not the same as the port name on the `Pod` or container, although it can be.
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture](/img/architecture.png)
+![Prometheus Operator Architecture](https://raw.githubusercontent.com/prometheus-operator/assets/main/img/architecture.png)
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 


### PR DESCRIPTION
## Description

This is a way to fix the broken images while browsing documentation on GitHub directly whithout breaking them on https://prometheus-operator.dev.

In order to work, the org owner will need to create an `assets` repository and move the `img` folder and it's content to it. 

New repo: `https://github.com/prometheus-operator/assets`

This will fix:
- https://github.com/prometheus-operator/prometheus-operator/issues/5411
- https://github.com/prometheus-operator/prometheus-operator/pull/5326

Tradeoff: image will not be available from a local copy without internet access, but this should be pretty acceptable these days !

Let me know if you want to adapt repository name for the assets, or anything else!


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix: use external images to fix display on GitHub documentation
```
