### PR TITLE
Test PrometheusAgent creation and deletion

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -1370,3 +1370,13 @@ func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo interface{}) {
 		)
 	}
 }
+
+func ListOptions(name string) metav1.ListOptions {
+	return metav1.ListOptions{
+		LabelSelector: fields.SelectorFromSet(fields.Set(map[string]string{
+			"app.kubernetes.io/name":       "prometheus-agent",
+			"app.kubernetes.io/managed-by": "prometheus-operator",
+			"app.kubernetes.io/instance":   name,
+		})).String(),
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -289,6 +289,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromStrategicMergePatch":                   testPromStrategicMergePatch,
 		"RelabelConfigCRDValidation":                testRelabelConfigCRDValidation,
 		"PromReconcileStatusWhenInvalidRuleCreated": testPromReconcileStatusWhenInvalidRuleCreated,
+		"CreatePrometheusAgent":                     testCreatePrometheusAgent,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+)
+
+func testCreatePrometheusAgent(t *testing.T) {
+	t.Parallel()
+
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+	name := "test"
+
+	prometheusAgentCRD := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
+
+	if _, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentCRD); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := framework.DeletePrometheusAgentAndWaitUntilGone(context.Background(), ns, name); err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -90,7 +90,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 			return resourceStatus{
 				expectedReplicas: expected,
 				generation:       current.Generation,
-				replicas:         current.Status.AvailableReplicas,
+				replicas:         current.Status.UpdatedReplicas,
 				conditions:       current.Status.Conditions,
 			}, nil
 		},

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -1,0 +1,129 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus/agent"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (f *Framework) MakeBasicPrometheusAgent(ns, name, group string, replicas int32) *monitoringv1alpha1.PrometheusAgent {
+	return &monitoringv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: map[string]string{},
+		},
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Replicas: &replicas,
+				Version:  operator.DefaultPrometheusVersion,
+				ServiceMonitorSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"group": group,
+					},
+				},
+				PodMonitorSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"group": group,
+					},
+				},
+				ServiceAccountName: "prometheus",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("400Mi"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func (f *Framework) CreatePrometheusAgentAndWaitUntilReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) (*monitoringv1alpha1.PrometheusAgent, error) {
+	result, err := f.MonClientV1alpha1.PrometheusAgents(ns).Create(ctx, p, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating %v prometheus-agent instances failed (%v): %v", p.Spec.Replicas, p.Name, err)
+	}
+
+	if err := f.WaitForPrometheusAgentReady(ctx, result, 5*time.Minute); err != nil {
+		return nil, fmt.Errorf("waiting for %v prometheus-agent instances timed out (%v): %v", p.Spec.Replicas, p.Name, err)
+	}
+
+	return result, nil
+}
+
+func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, timeout time.Duration) error {
+	expected := *p.Spec.Replicas
+	if p.Spec.Shards != nil && *p.Spec.Shards > 0 {
+		expected = expected * *p.Spec.Shards
+	}
+
+	if err := f.WaitForResourceAvailable(
+		ctx,
+		func(context.Context) (resourceStatus, error) {
+			current, err := f.MonClientV1alpha1.PrometheusAgents(p.Namespace).Get(ctx, p.Name, metav1.GetOptions{})
+			if err != nil {
+				return resourceStatus{}, err
+			}
+			return resourceStatus{
+				expectedReplicas: expected,
+				generation:       current.Generation,
+				replicas:         current.Status.AvailableReplicas,
+				conditions:       current.Status.Conditions,
+			}, nil
+		},
+		timeout,
+	); err != nil {
+		return errors.Wrapf(err, "prometheus-agent %v/%v failed to become available", p.Namespace, p.Name)
+	}
+
+	return nil
+}
+
+func (f *Framework) DeletePrometheusAgentAndWaitUntilGone(ctx context.Context, ns, name string) error {
+	_, err := f.MonClientV1alpha1.PrometheusAgents(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("requesting PrometheusAgent custom resource %v failed", name))
+	}
+
+	if err := f.MonClientV1alpha1.PrometheusAgents(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("deleting PrometheusAgent custom resource %v failed", name))
+	}
+
+	if err := f.WaitForPodsReady(
+		ctx,
+		ns,
+		f.DefaultTimeout,
+		0,
+		prometheusagent.ListOptions(name),
+	); err != nil {
+		return errors.Wrap(
+			err,
+			fmt.Sprintf("waiting for PrometheusAgent custom resource (%s) to vanish timed out", name),
+		)
+	}
+
+	return nil
+}

--- a/test/framework/status.go
+++ b/test/framework/status.go
@@ -48,6 +48,10 @@ func (f *Framework) WaitForResourceAvailable(ctx context.Context, getResourceSta
 
 		var reconciled, available *monitoringv1.Condition
 		for _, cond := range status.conditions {
+			// We need to create a new address for 'cond' inside the loop, otherwise we change the value of
+			// 'available' and 'reconciled' will have their pointer changed on every loop iteration.
+			// https://medium.com/swlh/use-pointer-of-for-range-loop-variable-in-go-3d3481f7ffc9
+			cond := cond
 			if cond.Type == monitoringv1.Available {
 				available = &cond
 			}


### PR DESCRIPTION
## Description

Adds a simple e2e test that creates and deletes a PrometheusAgent resource.

Opening it as a draft because, even though tests pass and the code looks correct, I've noticed that the test doesn't behave as expected. The PrometheusAgent resource isn't reconciled for some reason and the test pass anyway



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
