### PR TITLE
fix: Add validation method for controller and crd's 

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -16,7 +16,6 @@ package k8sutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,11 +24,13 @@ import (
 	"strings"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/pkg/errors"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 	promversion "github.com/prometheus/common/version"
 	appsv1 "k8s.io/api/apps/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
 	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -51,10 +53,29 @@ var invalidDNS1123Characters = regexp.MustCompile("[^-a-z0-9]+")
 
 var scheme = runtime.NewScheme()
 
+var ErrPrerequiresitesFailed = errors.New("unmet prerequisites")
+
 func init() {
 	_ = monitoringv1.SchemeBuilder.AddToScheme(scheme)
 	_ = monitoringv1alpha1.SchemeBuilder.AddToScheme(scheme)
 	_ = monitoringv1beta1.SchemeBuilder.AddToScheme(scheme)
+}
+
+type CRDChecker struct {
+	kclient kubernetes.Interface
+}
+
+func NewCRDChecker(host string, tlsInsecure bool, tlsConfig *rest.TLSClientConfig) (*CRDChecker, error) {
+	cfg, err := NewClusterConfig(host, tlsInsecure, tlsConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "instantiating cluster config failed")
+	}
+
+	kclient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "instantiating kubernetes client failed")
+	}
+	return &CRDChecker{kclient: kclient}, nil
 }
 
 // PodRunningAndReady returns whether a pod is running and each container has
@@ -112,6 +133,71 @@ func NewClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientCo
 	cfg.UserAgent = fmt.Sprintf("PrometheusOperator/%s", promversion.Version)
 
 	return cfg, nil
+}
+
+// CheckPrerequisites checks if given resource's CRD is installed in the cluster and the operator
+// serviceaccount has the necessary RBAC verbs in the namespace list to reconcile it.
+func (cc CRDChecker) CheckPrerequisites(ctx context.Context, nsAllowList []string, verbs map[string][]string, sgv, resource string) error {
+	if err := cc.validateCRDInstallation(sgv, resource); err != nil {
+		return err
+	}
+
+	missingPermissions, err := cc.getMissingPermissions(ctx, nsAllowList, verbs)
+	if err != nil {
+		return err
+	}
+	if len(missingPermissions) > 0 {
+		return fmt.Errorf("%w: some permissions are missing: %v", ErrPrerequiresitesFailed, missingPermissions)
+	}
+
+	return nil
+}
+
+func (cc CRDChecker) validateCRDInstallation(sgv, resource string) error {
+	crdInstalled, err := IsAPIGroupVersionResourceSupported(cc.kclient.Discovery(), sgv, resource)
+	if err != nil {
+		return fmt.Errorf("failed to check if the API supports %s resource (apiGroup:  %q)", resource, sgv)
+	}
+	if !crdInstalled {
+		return fmt.Errorf("%w: %s resource (apiGroup: %q) not installed", ErrPrerequiresitesFailed, resource, sgv)
+	}
+	return nil
+}
+
+// getMissingPermissions returns the RBAC permissions that the controller would need to be
+// granted to fulfill its mission. An empty map means that everything is ok.
+func (cc CRDChecker) getMissingPermissions(ctx context.Context, nsAllowList []string, verbs map[string][]string) (map[string][]string, error) {
+	var ssar *authv1.SelfSubjectAccessReview
+	var ssarResponse *authv1.SelfSubjectAccessReview
+	var err error
+	missingPermissions := map[string][]string{}
+
+	for _, ns := range nsAllowList {
+		for resource, verbs := range verbs {
+			for _, verb := range verbs {
+				ssar = &authv1.SelfSubjectAccessReview{
+					Spec: authv1.SelfSubjectAccessReviewSpec{
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Verb:     verb,
+							Group:    monitoringv1alpha1.SchemeGroupVersion.Group,
+							Resource: resource,
+							// If ns is empty string, it will check cluster-wide
+							Namespace: ns,
+						},
+					},
+				}
+				ssarResponse, err = cc.kclient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, ssar, metav1.CreateOptions{})
+				if err != nil {
+					return nil, err
+				}
+				if !ssarResponse.Status.Allowed {
+					missingPermissions[resource] = append(missingPermissions[resource], verb)
+				}
+			}
+		}
+	}
+
+	return missingPermissions, nil
 }
 
 func IsResourceNotFoundError(err error) bool {


### PR DESCRIPTION
Move controller creation pre-requisites to validation method `CheckPrerequisites()` to avoid creating
controller object incase of validation failure. This is used for prometheus-agent controller as part of
this commit. These methods can be re-used for future CRD validation
and controllers

This change is result of alert fired during e2e test for prometheus-operator version upgrade in ocp https://github.com/openshift/prometheus-operator/pull/223. `PrometheusOperatorNotReady` was fired for `prometheus-agent` controller since CRD was not installed. Same alert will fire for upstream users who doesn't install prometheus-agent crd. This commit creates agent controller object only when validations are met.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add validation method for controller and crd's and don't create prometheusagent controller incase of validation failure
```
