### PR TITLE
Ensure securityContext.seccompProfile.type is set

### DIFF
--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -157,6 +157,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus-operator-admission-webhook
       volumes:
       - name: tls-certificates

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -37773,6 +37773,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus-operator
 ---
 apiVersion: v1

--- a/example/admission-webhook/deployment.yaml
+++ b/example/admission-webhook/deployment.yaml
@@ -63,6 +63,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus-operator-admission-webhook
       volumes:
       - name: tls-certificates

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -50,4 +50,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus-operator

--- a/jsonnet/prometheus-operator/admission-webhook.libsonnet
+++ b/jsonnet/prometheus-operator/admission-webhook.libsonnet
@@ -102,6 +102,7 @@ function(params) {
             securityContext: {
               runAsNonRoot: true,
               runAsUser: 65534,
+              seccompProfile: { type: 'RuntimeDefault' },
             },
             serviceAccountName: aw._config.name,
             automountServiceAccountToken: false,

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -178,6 +178,7 @@ function(params) {
             securityContext: {
               runAsNonRoot: true,
               runAsUser: 65534,
+              seccompProfile: { type: 'RuntimeDefault' },
             },
             serviceAccountName: po.config.name,
             automountServiceAccountToken: true,


### PR DESCRIPTION
## Description
This sets the default value for `securityContext.seccompProfile.type`.  When running with warnings for `PodSecurity "restricted:1.26.0` a message is emitted that this is unset.

Message
```
Warning: would violate PodSecurity "restricted:1.26.0": seccompProfile (pod or container "prometheus-operator" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/prometheus-operator created
```

As `RuntimeDefault` is already the used default this should have no user facing changes.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Set a default for `securityContext.seccompProfile.type` on `deployment.apps/prometheus-operator`
```
