### PR TITLE
PrometheusRule CRD: declare spec.rules optional

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -30226,7 +30226,6 @@ spec:
                       type: array
                   required:
                   - name
-                  - rules
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
@@ -105,7 +105,6 @@ spec:
                       type: array
                   required:
                   - name
-                  - rules
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -105,7 +105,6 @@ spec:
                       type: array
                   required:
                   - name
-                  - rules
                   type: object
                 type: array
                 x-kubernetes-list-map-keys:

--- a/jsonnet/prometheus-operator/prometheusrules-crd.json
+++ b/jsonnet/prometheus-operator/prometheusrules-crd.json
@@ -118,8 +118,7 @@
                         }
                       },
                       "required": [
-                        "name",
-                        "rules"
+                        "name"
                       ],
                       "type": "object"
                     },

--- a/pkg/apis/monitoring/v1/prometheusrule_types.go
+++ b/pkg/apis/monitoring/v1/prometheusrule_types.go
@@ -64,7 +64,7 @@ type RuleGroup struct {
 	// Interval determines how often rules in the group are evaluated.
 	Interval Duration `json:"interval,omitempty"`
 	// List of alerting and recording rules.
-	Rules []Rule `json:"rules"`
+	Rules []Rule `json:"rules,omitempty"`
 	// PartialResponseStrategy is only used by ThanosRuler and will
 	// be ignored by Prometheus instances.
 	// More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -84,7 +84,7 @@ func TestPrometheusRuleCRDValidation(t *testing.T) {
 			promRuleSpec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{
 					{
-						Name:  "empty",
+						Name: "empty",
 					},
 				},
 			},

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -80,6 +80,16 @@ func TestPrometheusRuleCRDValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "empty-rule",
+			promRuleSpec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{
+					{
+						Name:  "empty",
+					},
+				},
+			},
+		},
+		{
 			name: "valid-partial-rsp-1",
 			promRuleSpec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{


### PR DESCRIPTION
PrometheusRule CRD: declare spec.rules optional

## Description

Fixing #5480 

Marking this as BUGFIX, since declare a property from required to optional is an non breaking change which is fixing an issue.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
PrometheusRule CRD: declare spec.rules optional
```
