### PR TITLE
Add PrometheusAgent to Design docs

### DIFF
--- a/Documentation/design.md
+++ b/Documentation/design.md
@@ -22,6 +22,7 @@ The custom resources managed by the Prometheus Operator are:
 * [Probe](#probe)
 * [PrometheusRule](#prometheusrule)
 * [AlertmanagerConfig](#alertmanagerconfig)
+* [PrometheusAgent](#prometheusagent)
 
 ## Prometheus
 
@@ -145,3 +146,11 @@ spec:
     webhookConfigs:
     - url: 'http://example.com/'
 ```
+
+## PrometheusAgent
+
+The `PrometheusAgent` custom resource definition (CRD) declaratively defines a desired [Prometheus Agent](https://prometheus.io/blog/2021/11/16/agent/) setup to run in a Kubernetes cluster.
+
+Similar to the binaries of Prometheus Server and Prometheus Agent, the `Prometheus` and `PrometheusAgent` CRs are also similar. Inspired in the Agent binary, the Agent CR has several configuration options redacted when compared with regular Prometheus CR, e.g. alerting, PrometheusRules selectors, remote-read, storage and thanos sidecars.
+
+A more extensive read explaining why Agent support was done with a whole new CRD can be seen [here](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/designs/prometheus-agent.md).


### PR DESCRIPTION
## Description

Hopping that it lands on the website :)

https://prometheus-operator.dev/docs/operator/design/

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
