### PR TITLE
Centralize informer creation in agent and server

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -63,7 +63,7 @@ Usage of ./operator:
     	Prometheus default base image (path without tag/version) (default "quay.io/prometheus/prometheus")
   -prometheus-instance-namespaces value
     	Namespaces where Prometheus and PrometheusAgent custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.
-  -prometheus-instance-selector string
+  -prometheus-instance-selector value
     	Label selector to filter Prometheus and PrometheusAgent Custom Resources to watch.
   -secret-field-selector string
     	Field selector to filter Secrets to watch

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -33,6 +33,7 @@ import (
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
 	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
 	alertmanagercontroller "github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -261,7 +261,7 @@ func Main() int {
 
 	k8sutil.MustRegisterClientGoMetrics(r)
 
-	cm, err := prompkg.InitCommonConfig(cfg)
+	cm, err := prompkg.InitCommonConfig(ctx, cfg, log.With(logger, "component", "prometheusoperator"))
 	if err != nil {
 		fmt.Fprint(os.Stderr, "instantiating common config failed: ", err)
 		cancel()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -174,7 +174,7 @@ func init() {
 	flagset.StringVar(&cfg.ClusterDomain, "cluster-domain", "", "The domain of the cluster. This is used to generate service FQDNs. If this is not specified, DNS search domain expansion is used instead.")
 	flagset.StringVar(&cfg.LogLevel, "log-level", "info", fmt.Sprintf("Log level to use. Possible values: %s", strings.Join(logging.AvailableLogLevels, ", ")))
 	flagset.StringVar(&cfg.LogFormat, "log-format", "logfmt", fmt.Sprintf("Log format to use. Possible values: %s", strings.Join(logging.AvailableLogFormats, ", ")))
-	flagset.StringVar(&cfg.PromSelector, "prometheus-instance-selector", "", "Label selector to filter Prometheus and PrometheusAgent Custom Resources to watch.")
+	flagset.Var(cfg.PromSelector, "prometheus-instance-selector", "Label selector to filter Prometheus and PrometheusAgent Custom Resources to watch.")
 	flagset.StringVar(&cfg.AlertManagerSelector, "alertmanager-instance-selector", "", "Label selector to filter AlertManager Custom Resources to watch.")
 	flagset.StringVar(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	flagset.StringVar(&cfg.SecretListWatchSelector, "secret-field-selector", "", "Field selector to filter Secrets to watch")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -33,10 +33,6 @@ import (
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
 	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
 	alertmanagercontroller "github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
-	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
@@ -49,18 +45,13 @@ import (
 	rbacproxytls "github.com/brancz/kube-rbac-proxy/pkg/tls"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"golang.org/x/sync/errgroup"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/kubernetes"
 	klog "k8s.io/klog/v2"
 )
 
@@ -269,7 +260,7 @@ func Main() int {
 
 	k8sutil.MustRegisterClientGoMetrics(r)
 
-	cm, err := initCommonConfig(cfg)
+	cm, err := prompkg.InitCommonConfig(cfg)
 	if err != nil {
 		fmt.Fprint(os.Stderr, "instantiating common config failed: ", err)
 		cancel()
@@ -474,143 +465,6 @@ func Main() int {
 	}
 
 	return 0
-}
-
-func initCommonConfig(c operator.Config) (*prompkg.CommonConfig, error) {
-	var cm prompkg.CommonConfig
-	var err error
-	cm.ClusterConfig, err = k8sutil.NewClusterConfig(c.Host, c.TLSInsecure, &c.TLSConfig)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "instantiating cluster config failed")
-	}
-
-	cm.KClient, err = kubernetes.NewForConfig(cm.ClusterConfig)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "instantiating kubernetes client failed")
-	}
-
-	cm.MClient, err = monitoringclient.NewForConfig(cm.ClusterConfig)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "instantiating monitoring client failed")
-	}
-
-	secretListWatchSelector, err := fields.ParseSelector(c.SecretListWatchSelector)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "can not parse secrets selector value")
-	}
-
-	// init promInfs
-	cm.PromInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			prompkg.ResyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.PromSelector
-			},
-		),
-		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating prometheus-agent informers")
-	}
-
-	// init smonInfs
-	cm.SmonInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.AllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			prompkg.ResyncPeriod,
-			nil,
-		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating servicemonitor informers")
-	}
-
-	// init pmonInfs
-	cm.PmonInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.AllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			prompkg.ResyncPeriod,
-			nil,
-		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating podmonitor informers")
-	}
-
-	// init probeInfs
-	cm.ProbeInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.AllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			prompkg.ResyncPeriod,
-			nil,
-		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating probe informers")
-	}
-
-	// init cmapInfs
-	cm.CmapInfs, err = informers.NewInformersForResource(
-		informers.NewKubeInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.KClient,
-			prompkg.ResyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.LabelSelector = prompkg.LabelPrometheusName
-			},
-		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating configmap informers")
-	}
-
-	// init secrInfs
-	cm.SecrInfs, err = informers.NewInformersForResource(
-		informers.NewKubeInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.KClient,
-			prompkg.ResyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.FieldSelector = secretListWatchSelector.String()
-			},
-		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating secrets informers")
-	}
-
-	// init ssetInfs
-	cm.SsetInfs, err = informers.NewInformersForResource(
-		informers.NewKubeInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.KClient,
-			prompkg.ResyncPeriod,
-			nil,
-		),
-		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
-	)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "error creating statefulset informers")
-	}
-
-	return &cm, nil
 }
 
 func main() {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -116,7 +116,7 @@ type Namespaces struct {
 	PrometheusAllowList, AlertmanagerAllowList, AlertmanagerConfigAllowList, ThanosRulerAllowList map[string]struct{}
 }
 
-type PromLabelSelector string
+type PromLabelSelector []rune
 
 // Set implements the flagset.Value interface.
 func (l PromLabelSelector) Set(value string) error {
@@ -124,11 +124,14 @@ func (l PromLabelSelector) Set(value string) error {
 	if err != nil {
 		return errors.New("can not parse prometheus selector value")
 	}
-	l = PromLabelSelector(value)
+
+	for pos, char := range value {
+		l[pos] = char
+	}
 	return nil
 }
 
-// Set implements the flagset.Value interface.
+// String implements the flagset.Value interface.
 func (l PromLabelSelector) String() string {
 	return string(l)
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/server"
@@ -41,7 +43,7 @@ type Config struct {
 	LocalHost                    string
 	LogLevel                     string
 	LogFormat                    string
-	PromSelector                 string
+	PromSelector                 PromLabelSelector
 	AlertManagerSelector         string
 	ThanosRulerSelector          string
 	SecretListWatchSelector      string
@@ -112,4 +114,21 @@ type Namespaces struct {
 	AllowList, DenyList map[string]struct{}
 	// Allow list for prometheus/alertmanager custom resources.
 	PrometheusAllowList, AlertmanagerAllowList, AlertmanagerConfigAllowList, ThanosRulerAllowList map[string]struct{}
+}
+
+type PromLabelSelector string
+
+// Set implements the flagset.Value interface.
+func (l PromLabelSelector) Set(value string) error {
+	_, err := labels.Parse(value)
+	if err != nil {
+		return errors.New("can not parse prometheus selector value")
+	}
+	l = PromLabelSelector(value)
+	return nil
+}
+
+// Set implements the flagset.Value interface.
+func (l PromLabelSelector) String() string {
+	return string(l)
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -126,7 +126,7 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		kclient:         cm.KClient,
 		mclient:         cm.MClient,
 		logger:          logger,
-		promInfs:        cm.PromInfs,
+		promInfs:        cm.PromAgInfs,
 		smonInfs:        cm.SmonInfs,
 		pmonInfs:        cm.PmonInfs,
 		probeInfs:       cm.ProbeInfs,

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -81,12 +81,6 @@ type Operator struct {
 // New creates a new controller.
 func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometheus.Registerer, cm *prompkg.CommonConfig) (*Operator, error) {
 
-
-	secretListWatchSelector, err := fields.ParseSelector(conf.SecretListWatchSelector)
-	if err != nil {
-		return nil, errors.Wrap(err, "can not parse secrets selector value")
-	}
-
 	// Check prerequisites for ScrapeConfig
 	verbs := map[string][]string{
 		monitoringv1alpha1.ScrapeConfigName: {"get", "list", "watch"},

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -81,9 +81,6 @@ type Operator struct {
 // New creates a new controller.
 func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometheus.Registerer, cm *prompkg.CommonConfig) (*Operator, error) {
 
-	if _, err := labels.Parse(conf.PromSelector); err != nil {
-		return nil, errors.Wrap(err, "can not parse prometheus-agent selector value")
-	}
 
 	secretListWatchSelector, err := fields.ParseSelector(conf.SecretListWatchSelector)
 	if err != nil {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -81,55 +81,27 @@ type Operator struct {
 // New creates a new controller.
 func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometheus.Registerer, cm *prompkg.CommonConfig) (*Operator, error) {
 
-	// Check prerequisites for ScrapeConfig
-	verbs := map[string][]string{
-		monitoringv1alpha1.ScrapeConfigName: {"get", "list", "watch"},
-	}
-	var scrapeConfigSupported bool
-	cc, err := k8sutil.NewCRDChecker(conf.Host, conf.TLSInsecure, &conf.TLSConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new CRDChecker object")
-	}
-
-	var namespaces = make([]string, 0, len(conf.Namespaces.AllowList))
-	for k := range conf.Namespaces.AllowList {
-		namespaces = append(namespaces, k)
-	}
-
-	err = cc.CheckPrerequisites(ctx,
-		namespaces,
-		verbs,
-		monitoringv1alpha1.SchemeGroupVersion.String(),
-		monitoringv1alpha1.ScrapeConfigName)
-	switch {
-	case errors.Is(err, k8sutil.ErrPrerequiresitesFailed):
-		level.Warn(logger).Log("msg", "ScrapeConfig CRD disabled because prerequisites are not met", "err", err)
-	case err != nil:
-		return nil, errors.Wrap(err, "failed to check prerequisites for the ScrapeConfig CRD ")
-	default:
-		scrapeConfigSupported = true
-	}
-
 	// All the metrics exposed by the controller get the controller="prometheus-agent" label.
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "prometheus-agent"}, r)
 
 	c := &Operator{
-		kclient:         cm.KClient,
-		mclient:         cm.MClient,
-		logger:          logger,
-		promInfs:        cm.PromAgInfs,
-		smonInfs:        cm.SmonInfs,
-		pmonInfs:        cm.PmonInfs,
-		probeInfs:       cm.ProbeInfs,
-		cmapInfs:        cm.CmapInfs,
-		secrInfs:        cm.SecrInfs,
-		ssetInfs:        cm.SsetInfs,
-		config:          conf,
-		metrics:         operator.NewMetrics(r),
-		reconciliations: &operator.ReconciliationTracker{},
-		scrapeConfigSupported: scrapeConfigSupported,
+		kclient:               cm.KClient,
+		mclient:               cm.MClient,
+		logger:                logger,
+		smonInfs:              cm.SmonInfs,
+		pmonInfs:              cm.PmonInfs,
+		probeInfs:             cm.ProbeInfs,
+		cmapInfs:              cm.CmapInfs,
+		secrInfs:              cm.SecrInfs,
+		ssetInfs:              cm.SsetInfs,
+		sconInfs:              cm.SconInfs,
+		config:                conf,
+		metrics:               operator.NewMetrics(r),
+		reconciliations:       &operator.ReconciliationTracker{},
+		scrapeConfigSupported: cm.ScrapeConfigSupported,
 	}
 
+	var err error
 	// init promAgInfs
 	c.promInfs, err = informers.NewInformersForResource(
 		informers.NewMonitoringInformerFactories(

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -33,6 +33,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -159,7 +160,7 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "can not parse secrets selector value")
 	}
-	if _, err := labels.Parse(conf.PromSelector); err != nil {
+	if _, err := labels.Parse(c.PromSelector); err != nil {
 		return nil, errors.Wrap(err, "can not parse prometheus selector value")
 	}
 	// init promInfs

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
@@ -49,14 +48,12 @@ type CommonConfig struct {
 	KClient       *kubernetes.Clientset
 	MClient       *monitoringclient.Clientset
 
-	PromInfs   *informers.ForResource
-	PromAgInfs *informers.ForResource
-	SmonInfs   *informers.ForResource
-	PmonInfs   *informers.ForResource
-	ProbeInfs  *informers.ForResource
-	CmapInfs   *informers.ForResource
-	SecrInfs   *informers.ForResource
-	SsetInfs   *informers.ForResource
+	SmonInfs  *informers.ForResource
+	PmonInfs  *informers.ForResource
+	ProbeInfs *informers.ForResource
+	CmapInfs  *informers.ForResource
+	SecrInfs  *informers.ForResource
+	SsetInfs  *informers.ForResource
 }
 
 func StatefulSetKeyToPrometheusKey(key string) (bool, string) {
@@ -158,39 +155,6 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 	secretListWatchSelector, err := fields.ParseSelector(c.SecretListWatchSelector)
 	if err != nil {
 		return nil, errors.Wrap(err, "can not parse secrets selector value")
-	}
-	// init promInfs
-	cm.PromInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			ResyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.PromSelector.String()
-			},
-		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusName),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating prometheus informers")
-	}
-
-	// init promAgInfs
-	cm.PromAgInfs, err = informers.NewInformersForResource(
-		informers.NewMonitoringInformerFactories(
-			c.Namespaces.PrometheusAllowList,
-			c.Namespaces.DenyList,
-			cm.MClient,
-			ResyncPeriod,
-			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.PromSelector.String()
-			},
-		),
-		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating prometheus-agent informers")
 	}
 
 	// init smonInfs

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -33,7 +33,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -160,9 +159,6 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "can not parse secrets selector value")
 	}
-	if _, err := labels.Parse(c.PromSelector); err != nil {
-		return nil, errors.Wrap(err, "can not parse prometheus selector value")
-	}
 	// init promInfs
 	cm.PromInfs, err = informers.NewInformersForResource(
 		informers.NewMonitoringInformerFactories(
@@ -171,7 +167,7 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 			cm.MClient,
 			ResyncPeriod,
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.PromSelector
+				options.LabelSelector = c.PromSelector.String()
 			},
 		),
 		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusName),
@@ -188,7 +184,7 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 			cm.MClient,
 			ResyncPeriod,
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = c.PromSelector
+				options.LabelSelector = c.PromSelector.String()
 			},
 		),
 		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName),

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -19,16 +19,39 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	ResyncPeriod = 5 * time.Minute
 )
 
 var prometheusKeyInShardStatefulSet = regexp.MustCompile("^(.+)/prometheus-(.+)-shard-[1-9][0-9]*$")
 var prometheusKeyInStatefulSet = regexp.MustCompile("^(.+)/prometheus-(.+)$")
+
+type CommonConfig struct {
+	ClusterConfig *rest.Config
+	KClient       *kubernetes.Clientset
+	MClient       *monitoringclient.Clientset
+
+	PromInfs  *informers.ForResource
+	SmonInfs  *informers.ForResource
+	PmonInfs  *informers.ForResource
+	ProbeInfs *informers.ForResource
+	CmapInfs  *informers.ForResource
+	SecrInfs  *informers.ForResource
+	SsetInfs  *informers.ForResource
+}
 
 func StatefulSetKeyToPrometheusKey(key string) (bool, string) {
 	r := prometheusKeyInStatefulSet

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -159,7 +159,9 @@ func InitCommonConfig(c operator.Config) (*CommonConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "can not parse secrets selector value")
 	}
-
+	if _, err := labels.Parse(conf.PromSelector); err != nil {
+		return nil, errors.Wrap(err, "can not parse prometheus selector value")
+	}
 	// init promInfs
 	cm.PromInfs, err = informers.NewInformersForResource(
 		informers.NewMonitoringInformerFactories(

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -96,10 +96,6 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		return nil, errors.Wrap(err, "instantiating metadata client failed")
 	}
 
-	if _, err := labels.Parse(conf.PromSelector); err != nil {
-		return nil, errors.Wrap(err, "can not parse prometheus selector value")
-	}
-
 	kubeletObjectName := ""
 	kubeletObjectNamespace := ""
 	kubeletSyncEnabled := false


### PR DESCRIPTION
## Description

as requested https://github.com/prometheus-operator/prometheus-operator/issues/5454
This PR created the main common informers and passed them to the server and agent.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/5454