### PR TITLE
Background: When using a federated Prometheus operator outside the cl…

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -61,6 +61,7 @@ const (
 const (
 	defaultReloaderCPU    = "100m"
 	defaultReloaderMemory = "50Mi"
+	defaultReloaderEnvVer = ""
 )
 
 var (
@@ -153,6 +154,7 @@ func init() {
 	// the Prometheus Operator version if no Prometheus config reloader image is
 	// specified.
 	flagset.StringVar(&cfg.ReloaderConfig.Image, "prometheus-config-reloader", operator.DefaultPrometheusConfigReloaderImage, "Prometheus config reloader image")
+	flagset.StringVar(&cfg.ReloaderConfig.ConfigEnvvar, "prometheus-config-reloader-ordinal-from-envvar", defaultReloaderEnvVer, "Prometheus config reloader envvar")
 	flagset.StringVar(&cfg.ReloaderConfig.CPURequest, "config-reloader-cpu-request", defaultReloaderCPU, "Config Reloader CPU request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-cpu` value for the CPU request")
 	flagset.StringVar(&cfg.ReloaderConfig.CPULimit, "config-reloader-cpu-limit", defaultReloaderCPU, "Config Reloader CPU limit. Value \"0\" disables it and causes no limit to be configured. Flag overrides `--config-reloader-cpu` for the CPU limit")
 	flagset.StringVar(&cfg.ReloaderConfig.MemoryRequest, "config-reloader-memory-request", defaultReloaderMemory, "Config Reloader Memory request. Value \"0\" disables it and causes no request to be configured. Flag overrides `--config-reloader-memory` for the memory request")

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -54,6 +54,7 @@ type ContainerConfig struct {
 	CPULimit      string
 	MemoryRequest string
 	MemoryLimit   string
+	ConfigEnvvar  string
 	Image         string
 	EnableProbes  bool
 }

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -164,7 +164,9 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 	if configReloader.runOnce {
 		args = append(args, fmt.Sprintf("--watch-interval=%d", 0))
 	}
-
+	if configReloader.config.ConfigEnvvar != "" {
+		args = append(args, fmt.Sprintf("--statefulset-ordinal-from-envvar=%d", configReloader.config.ConfigEnvvar))
+	}
 	if configReloader.listenLocal {
 		args = append(args, fmt.Sprintf("--listen-address=%s:%d", configReloader.localHost, configReloaderPort))
 	} else {


### PR DESCRIPTION
…uster and using multiple replicas within the cluster, Prometheus_ The replication label will cause the data volume to double, and when querying the query_ Two sets of data will appear for the range type.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
