### PR TITLE
chore: Also format docs on make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ Documentation/api.md: $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET) $(TYPES_V1BETA
 ##############
 
 .PHONY: format
-format: go-fmt jsonnet-fmt check-license shellcheck
+format: go-fmt jsonnet-fmt check-license shellcheck docs
 
 .PHONY: go-fmt
 go-fmt:


### PR DESCRIPTION
## Description

Sometimes, it's hard to identify the source of a formatting issue. `make check-docs` will complain about something that `make --always-make format generate` doesn't fix. `make docs` wasn't included in `make format`.

References:
- https://kubernetes.slack.com/archives/C01B03QCSMN/p1681670965886149

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

n/a
