### PR TITLE
Highlight support channels for kube-prometheus-stack

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,6 +1,6 @@
 ---
 name: Support
-about: If you have questions about the Prometheus Operator
+about: If you have questions about the Prometheus Operator. If you have questions about helm installation, go to https://github.com/prometheus-community/helm-charts repository. If you have questions about kube-prometheus setup, go to https://github.com/prometheus-operator/kube-prometheus
 labels: kind/support
 ---
 


### PR DESCRIPTION
## Description

We still have more issues related to kube-prometheus-stack than anything else here 😅. It feels like mentioning the appropriate support channels for it is easily missed in the middle of the rest of the markdown.

This change highlights the correct channels to the [new issue page](https://github.com/prometheus-operator/prometheus-operator/issues/new/choose)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
