### PR TITLE
Add spec.muteTimeIntervals[].timeIntervals[].location

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -17701,6 +17701,18 @@ HTTPConfig
 <p>Years is a list of YearRange</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>location</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Location is the time zone for the time interval</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1alpha1.TimeRange">TimeRange
@@ -21022,6 +21034,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>Years is a list of YearRange</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>location</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Location is the time zone for the time interval</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is the time zone for the time interval
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is the time zone for the time interval
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:
@@ -8834,6 +8837,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is the time zone for the time interval
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -157,6 +157,9 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location is the time zone for the time interval
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -169,6 +169,10 @@
                                 },
                                 "type": "array"
                               },
+                              "location": {
+                                "description": "Location is the time zone for the time interval",
+                                "type": "string"
+                              },
                               "months": {
                                 "description": "Months is a list of MonthRange",
                                 "items": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -4570,6 +4570,10 @@
                             },
                             type: 'array',
                           },
+                          location: {
+                            description: 'Location is the time zone for the time interval',
+                            type: 'string',
+                          },
                           months: {
                             description: 'Months is a list of MonthRange',
                             items: {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1281,6 +1281,12 @@ func convertMuteTimeInterval(in *monitoringv1alpha1.MuteTimeInterval, crKey type
 			})
 		}
 
+		loc, err := time.LoadLocation(timeInterval.Location)
+		if err != nil {
+			return nil, err
+		}
+		ti.Location = &timeinterval.Location{Location: loc}
+
 		muteTimeInterval.Name = makeNamespacedString(in.Name, crKey)
 		muteTimeInterval.TimeIntervals = append(muteTimeInterval.TimeIntervals, ti)
 	}

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -955,6 +955,9 @@ type TimeInterval struct {
 	// Years is a list of YearRange
 	// +optional
 	Years []YearRange `json:"years,omitempty"`
+	// Location is the time zone for the time interval
+	// +optional
+	Location string `json:"location,omitempty"`
 }
 
 // Time defines a time in 24hr format

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -957,6 +957,9 @@ type TimePeriod struct {
 	// Years is a list of YearRange
 	// +optional
 	Years []YearRange `json:"years,omitempty"`
+	// Location is the time zone for the time interval
+	// +optional
+	Location string `json:"location,omitempty"`
 }
 
 // Time defines a time in 24hr format

--- a/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -99,6 +99,7 @@ func convertTimeIntervalsFrom(in []v1alpha1.TimeInterval) []TimePeriod {
 			doms = make([]DayOfMonthRange, 0, len(ti.DaysOfMonth))
 			mrs  = make([]MonthRange, 0, len(ti.Months))
 			yrs  = make([]YearRange, 0, len(ti.Years))
+			loc  string
 		)
 
 		for _, tr := range ti.Times {
@@ -121,6 +122,8 @@ func convertTimeIntervalsFrom(in []v1alpha1.TimeInterval) []TimePeriod {
 			yrs = append(yrs, YearRange(yr))
 		}
 
+		loc = ti.Location
+
 		out = append(
 			out,
 			TimePeriod{
@@ -129,6 +132,7 @@ func convertTimeIntervalsFrom(in []v1alpha1.TimeInterval) []TimePeriod {
 				DaysOfMonth: doms,
 				Months:      mrs,
 				Years:       yrs,
+				Location:    loc,
 			},
 		)
 	}

--- a/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -92,6 +92,7 @@ func convertTimeIntervalsTo(in []TimePeriod) []v1alpha1.TimeInterval {
 			doms = make([]v1alpha1.DayOfMonthRange, 0, len(ti.DaysOfMonth))
 			mrs  = make([]v1alpha1.MonthRange, 0, len(ti.Months))
 			yrs  = make([]v1alpha1.YearRange, 0, len(ti.Years))
+			loc  string
 		)
 
 		for _, tr := range ti.Times {
@@ -114,6 +115,8 @@ func convertTimeIntervalsTo(in []TimePeriod) []v1alpha1.TimeInterval {
 			yrs = append(yrs, v1alpha1.YearRange(yr))
 		}
 
+		loc = ti.Location
+
 		out = append(
 			out,
 			v1alpha1.TimeInterval{
@@ -122,6 +125,7 @@ func convertTimeIntervalsTo(in []TimePeriod) []v1alpha1.TimeInterval {
 				DaysOfMonth: doms,
 				Months:      mrs,
 				Years:       yrs,
+				Location:    loc,
 			},
 		)
 	}

--- a/pkg/apis/monitoring/v1beta1/validation.go
+++ b/pkg/apis/monitoring/v1beta1/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (hc *HTTPConfig) Validate() error {
@@ -96,6 +97,11 @@ func (ti TimeInterval) Validate() error {
 				return fmt.Errorf("year range at %d is invalid: %w", i, err)
 			}
 		}
+		_, err := time.LoadLocation(ti.Location)
+		if err != nil {
+			return fmt.Errorf("location is invalid: %w", err)
+		}
+
 	}
 	return nil
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/timeinterval.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/timeinterval.go
@@ -28,6 +28,7 @@ type TimeIntervalApplyConfiguration struct {
 	DaysOfMonth []DayOfMonthRangeApplyConfiguration `json:"daysOfMonth,omitempty"`
 	Months      []monitoringv1alpha1.MonthRange     `json:"months,omitempty"`
 	Years       []monitoringv1alpha1.YearRange      `json:"years,omitempty"`
+	Location    *string                             `json:"location,omitempty"`
 }
 
 // TimeIntervalApplyConfiguration constructs an declarative configuration of the TimeInterval type for use with
@@ -89,5 +90,13 @@ func (b *TimeIntervalApplyConfiguration) WithYears(values ...monitoringv1alpha1.
 	for i := range values {
 		b.Years = append(b.Years, values[i])
 	}
+	return b
+}
+
+// WithLocation sets the Location field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Location field is set to the value of the last call.
+func (b *TimeIntervalApplyConfiguration) WithLocation(value string) *TimeIntervalApplyConfiguration {
+	b.Location = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1beta1/timeperiod.go
+++ b/pkg/client/applyconfiguration/monitoring/v1beta1/timeperiod.go
@@ -28,6 +28,7 @@ type TimePeriodApplyConfiguration struct {
 	DaysOfMonth []DayOfMonthRangeApplyConfiguration `json:"daysOfMonth,omitempty"`
 	Months      []monitoringv1beta1.MonthRange      `json:"months,omitempty"`
 	Years       []monitoringv1beta1.YearRange       `json:"years,omitempty"`
+	Location    *string                             `json:"location,omitempty"`
 }
 
 // TimePeriodApplyConfiguration constructs an declarative configuration of the TimePeriod type for use with
@@ -89,5 +90,13 @@ func (b *TimePeriodApplyConfiguration) WithYears(values ...monitoringv1beta1.Yea
 	for i := range values {
 		b.Years = append(b.Years, values[i])
 	}
+	return b
+}
+
+// WithLocation sets the Location field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Location field is set to the value of the last call.
+func (b *TimePeriodApplyConfiguration) WithLocation(value string) *TimePeriodApplyConfiguration {
+	b.Location = &value
 	return b
 }


### PR DESCRIPTION
## Description

Add the missing field location in timeInterval struct

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add spec.muteTimeIntervals[].timeIntervals[].location to AlertmanagerConfig
```

Closes https://github.com/prometheus-operator/prometheus-operator/issues/5512