### PR TITLE
Fix number of failed sync status

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -161,6 +161,8 @@ func (rt *ReconciliationTracker) Collect(ch chan<- prometheus.Metric) {
 	for _, st := range rt.statusByObject {
 		if st.Ok() {
 			ok++
+		} else {
+			failed++
 		}
 	}
 


### PR DESCRIPTION
## Description

This patch Fixes the number of  failed sync status is wrong.

It seems that the variable `failed`  is forgot to count.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix the wrong number of failed sync status 
```
