### PR TITLE
fix: Wrap downstream error when checking that a CRD is installed

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -156,7 +156,7 @@ func (cc CRDChecker) CheckPrerequisites(ctx context.Context, nsAllowList []strin
 func (cc CRDChecker) validateCRDInstallation(sgv, resource string) error {
 	crdInstalled, err := IsAPIGroupVersionResourceSupported(cc.kclient.Discovery(), sgv, resource)
 	if err != nil {
-		return fmt.Errorf("failed to check if the API supports %s resource (apiGroup:  %q)", resource, sgv)
+		return fmt.Errorf("failed to check if the API supports %s resource (apiGroup: %q): %w", resource, sgv, err)
 	}
 	if !crdInstalled {
 		return fmt.Errorf("%w: %s resource (apiGroup: %q) not installed", ErrPrerequiresitesFailed, resource, sgv)


### PR DESCRIPTION
## Description
We didn't report the error from `IsAPIGroupVersionResourceSupported`. Now wrapping it for easier debugging.

References:
- https://github.com/prometheus-operator/prometheus-operator/pull/5335#issuecomment-1526575149

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Report downstream errors when CRD validation fails
```
