### PR TITLE
fix: Alertmanager and Prometheus don't pick up new certificates after renewal

### DIFF
--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -382,6 +382,21 @@ func TestListenTLS(t *testing.T) {
 	if !reloadURLFound {
 		t.Fatalf("expected to find arg %s in config reloader", expectedConfigReloaderReloadURL)
 	}
+
+	expectedArgsConfigReloader := []string{
+		"--listen-address=:8080",
+		"--reload-url=https://localhost:9093/-/reload",
+		"--config-file=/etc/alertmanager/config/alertmanager.yaml.gz",
+		"--config-envsubst-file=/etc/alertmanager/config_out/alertmanager.env.yaml",
+	}
+
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if c.Name == "config-reloader" {
+			if !reflect.DeepEqual(c.Args, expectedArgsConfigReloader) {
+				t.Fatalf("expected container args are %s, but found %s", expectedArgsConfigReloader, c.Args)
+			}
+		}
+	}
 }
 
 // below Alertmanager v0.13.0 all flags are with single dash.

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -1,0 +1,162 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusagent
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+)
+
+var (
+	defaultTestConfig = &operator.Config{
+		LocalHost:                  "localhost",
+		ReloaderConfig:             operator.DefaultReloaderTestConfig.ReloaderConfig,
+		PrometheusDefaultBaseImage: operator.DefaultPrometheusBaseImage,
+		ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
+	}
+)
+
+func TestListenTLS(t *testing.T) {
+	sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Web: &monitoringv1.PrometheusWebSpec{
+					WebConfigFileFields: monitoringv1.WebConfigFileFields{
+						TLSConfig: &monitoringv1.WebTLSConfig{
+							KeySecret: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "some-secret",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								ConfigMap: &v1.ConfigMapKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "some-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
+		return v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   probePath,
+				Port:   intstr.FromString("web"),
+				Scheme: "HTTPS",
+			},
+		}
+	}
+
+	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
+	expectedStartupProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+	if !reflect.DeepEqual(actualStartupProbe, expectedStartupProbe) {
+		t.Fatalf("Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
+	}
+
+	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
+	expectedLivenessProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+	if !reflect.DeepEqual(actualLivenessProbe, expectedLivenessProbe) {
+		t.Fatalf("Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
+	}
+
+	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
+	expectedReadinessProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+	if !reflect.DeepEqual(actualReadinessProbe, expectedReadinessProbe) {
+		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)
+	}
+
+	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
+	reloadURLFound := false
+	for _, arg := range sset.Spec.Template.Spec.Containers[1].Args {
+		if arg == expectedConfigReloaderReloadURL {
+			reloadURLFound = true
+		}
+	}
+	if !reloadURLFound {
+		t.Fatalf("expected to find arg %s in config reloader", expectedConfigReloaderReloadURL)
+	}
+
+	expectedArgsConfigReloader := []string{
+		"--listen-address=:8080",
+		"--reload-url=https://localhost:9090/-/reload",
+		"--config-file=/etc/prometheus/config/prometheus.yaml.gz",
+		"--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml",
+	}
+
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if c.Name == "config-reloader" {
+			if !reflect.DeepEqual(c.Args, expectedArgsConfigReloader) {
+				t.Fatalf("expected container args are %s, but found %s", expectedArgsConfigReloader, c.Args)
+			}
+		}
+	}
+}
+
+func newLogger() log.Logger {
+	return level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowWarn())
+}
+
+func makeStatefulSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.StatefulSet, error) {
+	logger := newLogger()
+
+	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return makeStatefulSet(
+		logger,
+		"test",
+		&p,
+		defaultTestConfig,
+		cg,
+		"",
+		0,
+		nil)
+}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -669,6 +669,21 @@ func TestListenTLS(t *testing.T) {
 	}
 
 	fmt.Println(sset.Spec.Template.Spec.Containers[2].Args)
+
+	expectedArgsConfigReloader := []string{
+		"--listen-address=:8080",
+		"--reload-url=https://localhost:9090/-/reload",
+		"--config-file=/etc/prometheus/config/prometheus.yaml.gz",
+		"--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml",
+	}
+
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if c.Name == "config-reloader" {
+			if !reflect.DeepEqual(c.Args, expectedArgsConfigReloader) {
+				t.Fatalf("expected container args are %s, but found %s", expectedArgsConfigReloader, c.Args)
+			}
+		}
+	}
 }
 
 func TestTagAndShaAndVersion(t *testing.T) {

--- a/pkg/webconfig/config.go
+++ b/pkg/webconfig/config.go
@@ -16,6 +16,7 @@ package webconfig
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 
@@ -140,11 +141,11 @@ func (c Config) addTLSServerConfigToYaml(cfg yaml.MapSlice) yaml.MapSlice {
 
 	tlsServerConfig := yaml.MapSlice{}
 	if certPath := c.tlsCredentials.getCertMountPath(); certPath != "" {
-		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "cert_file", Value: certPath})
+		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "cert_file", Value: fmt.Sprintf("%s/%s", certPath, c.tlsCredentials.getCertFilename())})
 	}
 
 	if keyPath := c.tlsCredentials.getKeyMountPath(); keyPath != "" {
-		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "key_file", Value: keyPath})
+		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "key_file", Value: fmt.Sprintf("%s/%s", keyPath, c.tlsCredentials.getKeyFilename())})
 	}
 
 	if tls.ClientAuthType != "" {
@@ -155,7 +156,7 @@ func (c Config) addTLSServerConfigToYaml(cfg yaml.MapSlice) yaml.MapSlice {
 	}
 
 	if caPath := c.tlsCredentials.getCAMountPath(); caPath != "" {
-		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "client_ca_file", Value: caPath})
+		tlsServerConfig = append(tlsServerConfig, yaml.MapItem{Key: "client_ca_file", Value: fmt.Sprintf("%s/%s", caPath, c.tlsCredentials.getCAFilename())})
 	}
 
 	if tls.MinVersion != "" {

--- a/pkg/webconfig/config_test.go
+++ b/pkg/webconfig/config_test.go
@@ -61,8 +61,8 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 				},
 			},
 			expectedData: `tls_server_config:
-  cert_file: /web_certs_path_prefix/secret_test-secret_tls.crt
-  key_file: /web_certs_path_prefix/secret_test-secret_tls.key
+  cert_file: /web_certs_path_prefix/secret/test-secret-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key
 `,
 		},
 		{
@@ -86,8 +86,8 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 				},
 			},
 			expectedData: `tls_server_config:
-  cert_file: /web_certs_path_prefix/configmap_test-configmap_tls.crt
-  key_file: /web_certs_path_prefix/secret_test-secret_tls.key
+  cert_file: /web_certs_path_prefix/configmap/test-configmap-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key
 `,
 		},
 		{
@@ -119,9 +119,9 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 				},
 			},
 			expectedData: `tls_server_config:
-  cert_file: /web_certs_path_prefix/configmap_test-configmap_tls.crt
-  key_file: /web_certs_path_prefix/secret_test-secret_tls.key
-  client_ca_file: /web_certs_path_prefix/configmap_test-configmap_tls.client_ca
+  cert_file: /web_certs_path_prefix/configmap/test-configmap-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key
+  client_ca_file: /web_certs_path_prefix/configmap/test-configmap-ca/tls.client_ca
 `,
 		},
 		{
@@ -159,10 +159,10 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 				},
 			},
 			expectedData: `tls_server_config:
-  cert_file: /web_certs_path_prefix/secret_test-secret_tls.crt
-  key_file: /web_certs_path_prefix/secret_test-secret_tls.keySecret
+  cert_file: /web_certs_path_prefix/secret/test-secret-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.keySecret
   client_auth_type: RequireAnyClientCert
-  client_ca_file: /web_certs_path_prefix/secret_test-secret_tls.ca
+  client_ca_file: /web_certs_path_prefix/secret/test-secret-ca/tls.ca
   min_version: TLS11
   max_version: TLS13
   cipher_suites:
@@ -329,24 +329,24 @@ func TestGetMountParameters(t *testing.T) {
 				{
 					Name:             "web-config-tls-secret-key-some-secret-3556f148",
 					ReadOnly:         true,
-					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.key",
-					SubPath:          "tls.key",
+					MountPath:        "/etc/prometheus/web_config/secret/some-secret-key",
+					SubPath:          "",
 					MountPropagation: nil,
 					SubPathExpr:      "",
 				},
 				{
 					Name:             "web-config-tls-secret-cert-some-secret-3556f148",
 					ReadOnly:         true,
-					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.crt",
-					SubPath:          "tls.crt",
+					MountPath:        "/etc/prometheus/web_config/secret/some-secret-cert",
+					SubPath:          "",
 					MountPropagation: nil,
 					SubPathExpr:      "",
 				},
 				{
 					Name:             "web-config-tls-secret-client-ca-some-secret-3556f148",
 					ReadOnly:         true,
-					MountPath:        "/etc/prometheus/web_config/secret_some-secret_tls.client_ca",
-					SubPath:          "tls.client_ca",
+					MountPath:        "/etc/prometheus/web_config/secret/some-secret-ca",
+					SubPath:          "",
 					MountPropagation: nil,
 					SubPathExpr:      "",
 				},

--- a/pkg/webconfig/tls_credentials.go
+++ b/pkg/webconfig/tls_credentials.go
@@ -122,11 +122,18 @@ func (a tlsCredentials) mountParamsForSecret(
 		},
 	})
 
+	// We're mounting the volume in full as subPath mounts can't receive updates. This is important when renewing
+	// certificates. Prometheus and Alertmanager then load certificates on every request, there is no need to tell them
+	// to reload their configuration.
+	//
+	// References:
+	// * https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
+	// * https://github.com/prometheus-operator/prometheus-operator/issues/5527
+	// * https://github.com/prometheus-operator/prometheus-operator/pull/5535#discussion_r1194940482
 	mounts = append(mounts, corev1.VolumeMount{
 		Name:      volumeName,
 		ReadOnly:  true,
 		MountPath: mountPath,
-		SubPath:   secret.Key,
 	})
 
 	return volumes, mounts, nil
@@ -156,11 +163,18 @@ func (a tlsCredentials) mountParamsForConfigmap(
 		},
 	})
 
+	// We're mounting the volume in full as subPath mounts can't receive updates. This is important when renewing
+	// certificates. Prometheus and Alertmanager then load certificates on every request, there is no need to tell them
+	// to reload their configuration.
+	//
+	// References:
+	// * https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
+	// * https://github.com/prometheus-operator/prometheus-operator/issues/5527
+	// * https://github.com/prometheus-operator/prometheus-operator/pull/5535#discussion_r1194940482
 	mounts = append(mounts, corev1.VolumeMount{
 		Name:      volumeName,
 		ReadOnly:  true,
 		MountPath: mountPath,
-		SubPath:   configMap.Key,
 	})
 
 	return volumes, mounts, nil
@@ -169,13 +183,29 @@ func (a tlsCredentials) mountParamsForConfigmap(
 // getKeyMountPath is the mount path of the TLS key inside a prometheus container.
 func (a tlsCredentials) getKeyMountPath() string {
 	secret := monitoringv1.SecretOrConfigMap{Secret: &a.keySecret}
-	return a.tlsPathForSelector(secret)
+	return a.tlsPathForSelector(secret, "key")
+}
+
+// getKeyFilename returns the filename (key) of the key
+func (a tlsCredentials) getKeyFilename() string {
+	return a.keySecret.Key
 }
 
 // getCertMountPath is the mount path of the TLS certificate inside a prometheus container,
 func (a tlsCredentials) getCertMountPath() string {
 	if a.cert.ConfigMap != nil || a.cert.Secret != nil {
-		return a.tlsPathForSelector(a.cert)
+		return a.tlsPathForSelector(a.cert, "cert")
+	}
+
+	return ""
+}
+
+// getCertFilename returns the filename (key) of the certificate
+func (a tlsCredentials) getCertFilename() string {
+	if a.cert.Secret != nil {
+		return a.cert.Secret.Key
+	} else if a.cert.ConfigMap != nil {
+		return a.cert.ConfigMap.Key
 	}
 
 	return ""
@@ -184,18 +214,29 @@ func (a tlsCredentials) getCertMountPath() string {
 // getCAMountPath is the mount path of the client CA certificate inside a prometheus container.
 func (a tlsCredentials) getCAMountPath() string {
 	if a.clientCA.ConfigMap != nil || a.clientCA.Secret != nil {
-		return a.tlsPathForSelector(a.clientCA)
+		return a.tlsPathForSelector(a.clientCA, "ca")
 	}
 
 	return ""
 }
 
-func (a *tlsCredentials) tlsPathForSelector(sel monitoringv1.SecretOrConfigMap) string {
+// getCAFilename is the mount path of the client CA certificate inside a prometheus container.
+func (a tlsCredentials) getCAFilename() string {
+	if a.clientCA.Secret != nil {
+		return a.clientCA.Secret.Key
+	} else if a.clientCA.ConfigMap != nil {
+		return a.clientCA.ConfigMap.Key
+	}
+
+	return ""
+}
+
+func (a *tlsCredentials) tlsPathForSelector(sel monitoringv1.SecretOrConfigMap, mountType string) string {
 	var filename string
 	if sel.Secret != nil {
-		filename = fmt.Sprintf("secret_%s_%s", sel.Secret.Name, sel.Secret.Key)
+		filename = fmt.Sprintf("secret/%s-%s", sel.Secret.Name, mountType)
 	} else {
-		filename = fmt.Sprintf("configmap_%s_%s", sel.ConfigMap.Name, sel.ConfigMap.Key)
+		filename = fmt.Sprintf("configmap/%s-%s", sel.ConfigMap.Name, mountType)
 	}
 
 	return path.Join(a.mountPath, filename)

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2043,6 +2043,91 @@ func testAMWeb(t *testing.T) {
 			pollErr = fmt.Errorf("config reloader failed to reload once")
 			return false, nil
 		}
+		return true, nil
+	})
+
+	if err != nil {
+		t.Fatalf("poll function execution error: %v: %v", err, pollErr)
+	}
+
+	// Simulate a certificate renewal and check that the new certificate is in place
+	certBytesNew, keyBytesNew, err := certutil.GenerateSelfSignedCertKey(host, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = framework.CreateOrUpdateSecretWithCert(context.Background(), certBytesNew, keyBytesNew, ns, "web-tls"); err != nil {
+		t.Fatal(err)
+	}
+
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		amPods, err := kubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			pollErr = err
+			return false, nil
+		}
+
+		if len(amPods.Items) == 0 {
+			pollErr = fmt.Errorf("No alertmanager pods found in namespace %s", ns)
+			return false, nil
+		}
+
+		cfg := framework.RestConfig
+		podName := amPods.Items[0].Name
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		closer, err := testFramework.StartPortForward(ctx, cfg, "https", podName, ns, "9093")
+		if err != nil {
+			pollErr = fmt.Errorf("failed to start port forwarding: %v", err)
+			t.Log(pollErr)
+			return false, nil
+		}
+		defer closer()
+
+		// The alertmanager certificate is issued to <pod>.<namespace>.svc,
+		// but port-forwarding is done through localhost.
+		// This is why we use an http client which skips the TLS verification.
+		// In the test we will verify the TLS certificate manually to make sure
+		// the alertmanager instance is configured properly.
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		err = http2.ConfigureTransport(transport)
+		if err != nil {
+			pollErr = err
+			return false, nil
+		}
+
+		httpClient := http.Client{
+			Transport: transport,
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "https://localhost:9093", nil)
+		if err != nil {
+			pollErr = err
+			return false, nil
+		}
+
+		respNew, err := httpClient.Do(req)
+		if err != nil {
+			pollErr = err
+			return false, nil
+		}
+
+		receivedCertBytesNew, err := certutil.EncodeCertificates(respNew.TLS.PeerCertificates...)
+		if err != nil {
+			pollErr = err
+			return false, nil
+		}
+
+		if !bytes.Equal(receivedCertBytesNew, certBytesNew) {
+			pollErr = fmt.Errorf("certificate received from alertmanager instance does not match the one which is configured after certificate renewal")
+			return false, nil
+		}
 
 		return true, nil
 	})


### PR DESCRIPTION
## Description
The fix is to not use `subPath` when mounting web certificates. As per
[Kubernetes' documentation][1], mounts using subPath will not get updates. This
commit changes it to full mounts. Prometheus and Alertmanager use
[exporter-toolkit][2] which reloads the certs for every query.
    
This commit also extends Prometheus' and Alertmanager's stateful tests to check
prometheus-config-reloader arguments.
    
References:
* https://github.com/prometheus-operator/prometheus-operator/issues/5527
* https://github.com/prometheus-operator/prometheus-operator/pull/5535#discussion_r1194940482
    
[1]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
[2]: https://github.com/prometheus/exporter-toolkit

Fixes #5527 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Prometheus and Alertmanager will now use updated certificates (for instance, in the case of a certificate renewal).
```
