### PR TITLE
Change default resource requirements for config reloader

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -32,9 +32,9 @@ Usage of ./operator:
   -cluster-domain string
     	The domain of the cluster. This is used to generate service FQDNs. If this is not specified, DNS search domain expansion is used instead.
   -config-reloader-cpu-limit --config-reloader-cpu
-    	Config Reloader CPU limit. Value "0" disables it and causes no limit to be configured. Flag overrides --config-reloader-cpu for the CPU limit (default "100m")
+    	Config Reloader CPU limit. Value "0" disables it and causes no limit to be configured. Flag overrides --config-reloader-cpu for the CPU limit (default "10m")
   -config-reloader-cpu-request --config-reloader-cpu
-    	Config Reloader CPU request. Value "0" disables it and causes no request to be configured. Flag overrides --config-reloader-cpu value for the CPU request (default "100m")
+    	Config Reloader CPU request. Value "0" disables it and causes no request to be configured. Flag overrides --config-reloader-cpu value for the CPU request (default "10m")
   -config-reloader-memory-limit --config-reloader-memory
     	Config Reloader Memory limit. Value "0" disables it and causes no limit to be configured. Flag overrides --config-reloader-memory for the memory limit (default "50Mi")
   -config-reloader-memory-request --config-reloader-memory

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -60,7 +60,7 @@ const (
 )
 
 const (
-	defaultReloaderCPU    = "100m"
+	defaultReloaderCPU    = "10m"
 	defaultReloaderMemory = "50Mi"
 )
 


### PR DESCRIPTION
## Description

~~Related to what was discussed in #5446, this PR changes the default resource requirements, but only for PrometheusAgent pods.~~

~~The number I've chosen is random, we probably want to discuss the final number~~

After discussing on the #prometheus-operator-dev Slack channel and gathering numbers from different production environments, we have good confidence that decreasing the CPU request from 100m to 10m isn't going to harm users.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
[CHANGE] Default CPU requirements of config-reloader set to 10m
```
