### PR TITLE
Support VolumeMounts in ThanosRuler

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -3122,6 +3122,21 @@ be appended to other volumes that are generated as a result of StorageSpec objec
 </tr>
 <tr>
 <td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<p>VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
+VolumeMounts specified will be appended to other VolumeMounts in the ruler container,
+that are generated as a result of StorageSpec objects.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>objectStorageConfig</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core">
@@ -11769,6 +11784,21 @@ StorageSpec
 <td>
 <p>Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will
 be appended to other volumes that are generated as a result of StorageSpec objects.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumeMounts</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#volumemount-v1-core">
+[]Kubernetes core/v1.VolumeMount
+</a>
+</em>
+</td>
+<td>
+<p>VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
+VolumeMounts specified will be appended to other VolumeMounts in the ruler container,
+that are generated as a result of StorageSpec objects.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -36223,6 +36223,48 @@ spec:
               version:
                 description: Version of Thanos to be deployed.
                 type: string
+              volumeMounts:
+                description: VolumeMounts allows configuration of additional VolumeMounts
+                  on the output StatefulSet definition. VolumeMounts specified will
+                  be appended to other VolumeMounts in the ruler container, that are
+                  generated as a result of StorageSpec objects.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5123,6 +5123,48 @@ spec:
               version:
                 description: Version of Thanos to be deployed.
                 type: string
+              volumeMounts:
+                description: VolumeMounts allows configuration of additional VolumeMounts
+                  on the output StatefulSet definition. VolumeMounts specified will
+                  be appended to other VolumeMounts in the ruler container, that are
+                  generated as a result of StorageSpec objects.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5123,6 +5123,48 @@ spec:
               version:
                 description: Version of Thanos to be deployed.
                 type: string
+              volumeMounts:
+                description: VolumeMounts allows configuration of additional VolumeMounts
+                  on the output StatefulSet definition. VolumeMounts specified will
+                  be appended to other VolumeMounts in the ruler container, that are
+                  generated as a result of StorageSpec objects.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
               volumes:
                 description: Volumes allows configuration of additional volumes on
                   the output StatefulSet definition. Volumes specified will be appended

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4568,6 +4568,44 @@
                     "description": "Version of Thanos to be deployed.",
                     "type": "string"
                   },
+                  "volumeMounts": {
+                    "description": "VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition. VolumeMounts specified will be appended to other VolumeMounts in the ruler container, that are generated as a result of StorageSpec objects.",
+                    "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "This must match the Name of a Volume.",
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                          "type": "boolean"
+                        },
+                        "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "volumes": {
                     "description": "Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects.",
                     "items": {

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -109,6 +109,10 @@ type ThanosRulerSpec struct {
 	// Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will
 	// be appended to other volumes that are generated as a result of StorageSpec objects.
 	Volumes []v1.Volume `json:"volumes,omitempty"`
+	// VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
+	// VolumeMounts specified will be appended to other VolumeMounts in the ruler container,
+	// that are generated as a result of StorageSpec objects.
+	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 	// ObjectStorageConfig configures object storage in Thanos.
 	// Alternative to ObjectStorageConfigFile, and lower order priority.
 	ObjectStorageConfig *v1.SecretKeySelector `json:"objectStorageConfig,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2473,6 +2473,13 @@ func (in *ThanosRulerSpec) DeepCopyInto(out *ThanosRulerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]corev1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.ObjectStorageConfig != nil {
 		in, out := &in.ObjectStorageConfig, &out.ObjectStorageConfig
 		*out = new(corev1.SecretKeySelector)

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
@@ -42,6 +42,7 @@ type ThanosRulerSpecApplyConfiguration struct {
 	ServiceAccountName                 *string                                         `json:"serviceAccountName,omitempty"`
 	Storage                            *StorageSpecApplyConfiguration                  `json:"storage,omitempty"`
 	Volumes                            []corev1.Volume                                 `json:"volumes,omitempty"`
+	VolumeMounts                       []corev1.VolumeMount                            `json:"volumeMounts,omitempty"`
 	ObjectStorageConfig                *corev1.SecretKeySelector                       `json:"objectStorageConfig,omitempty"`
 	ObjectStorageConfigFile            *string                                         `json:"objectStorageConfigFile,omitempty"`
 	ListenLocal                        *bool                                           `json:"listenLocal,omitempty"`
@@ -228,6 +229,16 @@ func (b *ThanosRulerSpecApplyConfiguration) WithStorage(value *StorageSpecApplyC
 func (b *ThanosRulerSpecApplyConfiguration) WithVolumes(values ...corev1.Volume) *ThanosRulerSpecApplyConfiguration {
 	for i := range values {
 		b.Volumes = append(b.Volumes, values[i])
+	}
+	return b
+}
+
+// WithVolumeMounts adds the given value to the VolumeMounts field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the VolumeMounts field.
+func (b *ThanosRulerSpecApplyConfiguration) WithVolumeMounts(values ...corev1.VolumeMount) *ThanosRulerSpecApplyConfiguration {
+	for i := range values {
+		b.VolumeMounts = append(b.VolumeMounts, values[i])
 	}
 	return b
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -393,6 +393,13 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		})
 	}
 
+	for _, thanosRulerVM := range tr.Spec.VolumeMounts {
+		trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
+			Name:      thanosRulerVM.Name,
+			MountPath: thanosRulerVM.MountPath,
+		})
+	}
+
 	boolFalse := false
 	boolTrue := true
 	operatorContainers := append([]v1.Container{

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -144,6 +144,12 @@ func TestStatefulSetVolumes(t *testing.T) {
 									MountPath: "/etc/thanos/rules/rules-configmap-one",
 									SubPath:   "",
 								},
+								{
+									Name:      "additional-volume",
+									ReadOnly:  false,
+									MountPath: "/thanos/additional-volume",
+									SubPath:   "",
+								},
 							},
 						},
 					},
@@ -166,6 +172,14 @@ func TestStatefulSetVolumes(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: "additional-volume",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									Medium: "",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -175,7 +189,27 @@ func TestStatefulSetVolumes(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
-		Spec: monitoringv1.ThanosRulerSpec{QueryEndpoints: emptyQueryEndpoints},
+		Spec: monitoringv1.ThanosRulerSpec{
+			QueryEndpoints: emptyQueryEndpoints,
+			Volumes: []v1.Volume{
+				{
+					Name: "additional-volume",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium: "",
+						},
+					},
+				},
+			},
+			VolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "additional-volume",
+					ReadOnly:  false,
+					MountPath: "/thanos/additional-volume",
+					SubPath:   "",
+				},
+			},
+		},
 	}, defaultTestConfig, []string{"rules-configmap-one"}, "")
 	require.NoError(t, err)
 	if !reflect.DeepEqual(expected.Spec.Template.Spec.Volumes, sset.Spec.Template.Spec.Volumes) {


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Supports creating a VolumeMount in ThanosRuler objects
Closes #5538 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add VolumeMounts to ThanosRuler CRD to allow Volumes to be mounted within Ruler
```
