### PR TITLE
operator: include newline in error messages

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -262,7 +262,7 @@ func Main() int {
 
 	po, err := prometheuscontroller.New(ctx, cfg, log.With(logger, "component", "prometheusoperator"), r)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "instantiating prometheus controller failed: ", err)
+		fmt.Fprintln(os.Stderr, "instantiating prometheus controller failed: ", err)
 		cancel()
 		return 1
 	}
@@ -304,14 +304,14 @@ func Main() int {
 
 	ao, err := alertmanagercontroller.New(ctx, cfg, log.With(logger, "component", "alertmanageroperator"), r)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "instantiating alertmanager controller failed: ", err)
+		fmt.Fprintln(os.Stderr, "instantiating alertmanager controller failed: ", err)
 		cancel()
 		return 1
 	}
 
 	to, err := thanoscontroller.New(ctx, cfg, log.With(logger, "component", "thanosoperator"), r)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "instantiating thanos controller failed: ", err)
+		fmt.Fprintln(os.Stderr, "instantiating thanos controller failed: ", err)
 		cancel()
 		return 1
 	}
@@ -322,7 +322,7 @@ func Main() int {
 	admit.Register(mux)
 	l, err := net.Listen("tcp", cfg.ListenAddress)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "listening failed", cfg.ListenAddress, err)
+		fmt.Fprintln(os.Stderr, "listening failed", cfg.ListenAddress, err)
 		cancel()
 		return 1
 	}
@@ -335,7 +335,7 @@ func Main() int {
 		tlsConfig, err = server.NewTLSConfig(logger, cfg.ServerTLSConfig.CertFile, cfg.ServerTLSConfig.KeyFile,
 			cfg.ServerTLSConfig.ClientCAFile, cfg.ServerTLSConfig.MinVersion, cfg.ServerTLSConfig.CipherSuites)
 		if tlsConfig == nil || err != nil {
-			fmt.Fprint(os.Stderr, "invalid TLS config", err)
+			fmt.Fprintln(os.Stderr, "invalid TLS config", err)
 			cancel()
 			return 1
 		}
@@ -402,7 +402,7 @@ func Main() int {
 			cfg.ServerTLSConfig.ReloadInterval,
 		)
 		if err != nil {
-			fmt.Fprint(os.Stderr, "failed to initialize certificate reloader", err)
+			fmt.Fprintln(os.Stderr, "failed to initialize certificate reloader", err)
 			cancel()
 			return 1
 		}


### PR DESCRIPTION
common Kubernetes log configurations will not recognize the last log message of pod if it does not include a newline

## Description

I recently wasted some time debugging prometheus-operator constantly crashing while running with `hostNetwork: true`. I wasn't seeing any meaningful logs and the pod was exiting very quickly. It turned out that the port that the operator was attempting to acquire was already in use. I then wondered why this wasn't in the logs as it should be and found that my log viewing tool doesn't report the last text that a pod produces if it doesn't end in a newline.

Also I noted that every other output to stderr appends newlines so it would be good to be consistent as well.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Top level exit errors end with newline ensuring the logs don't get lost
```
