### PR TITLE
jsonnet: add ScrapeConfig CRD to prometheus-operator.libsonnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ TYPES_V1_TARGET += pkg/apis/monitoring/v1/servicemonitor_types.go
 TYPES_V1_TARGET += pkg/apis/monitoring/v1/thanos_types.go
 
 TYPES_V1ALPHA1_TARGET := pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+TYPES_V1ALPHA1_TARGET += pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+TYPES_V1ALPHA1_TARGET += pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
 TYPES_V1BETA1_TARGET := pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
 
 TOOLS_BIN_DIR ?= $(shell pwd)/tmp/bin

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -40,6 +40,7 @@ function(params) {
   '0probeCustomResourceDefinition': import 'probes-crd.json',
   '0prometheusruleCustomResourceDefinition': import 'prometheusrules-crd.json',
   '0thanosrulerCustomResourceDefinition': import 'thanosrulers-crd.json',
+  '0scrapeconfigCustomResourceDefinition': import 'scrapeconfigs-crd.json',
 
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',


### PR DESCRIPTION
## Description

Useful for people that import prometheus-operator.libsonnet and want to use the new ScrapeConfig CRD.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
