### PR TITLE
Add ScrapeConfigs to ObjectReference

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15680,6 +15680,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace
@@ -24051,6 +24052,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace
@@ -33814,6 +33816,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -2570,6 +2570,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -2923,6 +2923,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -2294,6 +2294,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -2570,6 +2570,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -2923,6 +2923,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -2294,6 +2294,7 @@ spec:
                       - servicemonitors
                       - podmonitors
                       - probes
+                      - scrapeconfigs
                       type: string
                   required:
                   - namespace

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -2305,7 +2305,8 @@
                             "prometheusrules",
                             "servicemonitors",
                             "podmonitors",
-                            "probes"
+                            "probes",
+                            "scrapeconfigs"
                           ],
                           "type": "string"
                         }

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2670,7 +2670,8 @@
                             "prometheusrules",
                             "servicemonitors",
                             "podmonitors",
-                            "probes"
+                            "probes",
+                            "scrapeconfigs"
                           ],
                           "type": "string"
                         }

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -2043,7 +2043,8 @@
                             "prometheusrules",
                             "servicemonitors",
                             "podmonitors",
-                            "probes"
+                            "probes",
+                            "scrapeconfigs"
                           ],
                           "type": "string"
                         }

--- a/pkg/apis/monitoring/resource.go
+++ b/pkg/apis/monitoring/resource.go
@@ -1,0 +1,60 @@
+// Copyright 2018 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"fmt"
+)
+
+const (
+	PrometheusesKind = "Prometheus"
+	PrometheusName   = "prometheuses"
+
+	AlertmanagersKind = "Alertmanager"
+	AlertmanagerName  = "alertmanagers"
+
+	ServiceMonitorsKind = "ServiceMonitor"
+	ServiceMonitorName  = "servicemonitors"
+
+	PodMonitorsKind = "PodMonitor"
+	PodMonitorName  = "podmonitors"
+
+	PrometheusRuleKind = "PrometheusRule"
+	PrometheusRuleName = "prometheusrules"
+
+	ProbesKind = "Probe"
+	ProbeName  = "probes"
+
+	ScrapeConfigsKind = "ScrapeConfig"
+	ScrapeConfigName  = "scrapeconfigs"
+)
+
+var resourceToKindMap = map[string]string{
+	PrometheusName:     PrometheusesKind,
+	AlertmanagerName:   AlertmanagersKind,
+	ServiceMonitorName: ServiceMonitorsKind,
+	PodMonitorName:     PodMonitorsKind,
+	PrometheusRuleName: PrometheusRuleKind,
+	ProbeName:          ProbesKind,
+	ScrapeConfigName:   ScrapeConfigsKind,
+}
+
+func ResourceToKind(s string) string {
+	kind, found := resourceToKindMap[s]
+	if !found {
+		panic(fmt.Sprintf("failed to map resource %q to a kind", s))
+	}
+	return kind
+}

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -17,25 +17,17 @@ package v1
 import (
 	"fmt"
 
-	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 )
 
 const (
 	Version = "v1"
 )
-
-var resourceToKind = map[string]string{
-	PrometheusName:     PrometheusesKind,
-	AlertmanagerName:   AlertmanagersKind,
-	ServiceMonitorName: ServiceMonitorsKind,
-	PodMonitorName:     PodMonitorsKind,
-	PrometheusRuleName: PrometheusRuleKind,
-	ProbeName:          ProbesKind,
-}
 
 // ByteSize is a valid memory size type based on powers-of-2, so 1KB is 1024B.
 // Supported units: B, KB, KiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB Ex: `512MB`.
@@ -83,7 +75,7 @@ type ObjectReference struct {
 	Group string `json:"group"`
 	// Resource of the referent.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=prometheusrules;servicemonitors;podmonitors;probes
+	// +kubebuilder:validation:Enum=prometheusrules;servicemonitors;podmonitors;probes;scrapeconfigs
 	Resource string `json:"resource"`
 	// Namespace of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
@@ -103,12 +95,8 @@ func (obj *ObjectReference) GroupResource() schema.GroupResource {
 }
 
 func (obj *ObjectReference) GroupKind() schema.GroupKind {
-	_, found := resourceToKind[obj.Resource]
-	if !found {
-		panic(fmt.Sprintf("failed to map resource %q to a kind", obj.Resource))
-	}
 	return schema.GroupKind{
-		Kind:  resourceToKind[obj.Resource],
+		Kind:  monitoring.ResourceToKind(obj.Resource),
 		Group: obj.getGroup(),
 	}
 }


### PR DESCRIPTION
## Description


- [X] Move `resourceToKind` away from the v1 package.
- [X] Add `scrapeconfigs` as part of the `ObjectReference.Resource` enum.

I have duplicated the consts in `monitoring/resource.go` otherwise it will cause a circular-dependency . 



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add ScrapeConfigs to ObjectReference
```

Closes https://github.com/prometheus-operator/prometheus-operator/issues/5544