### PR TITLE
Fix relabelings for ScrapeConfig

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2129,6 +2129,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 	}
 
 	cpf := cg.prom.GetCommonPrometheusFields()
+	relabelings := initRelabelings()
 	labeler := namespacelabeler.New(cpf.EnforcedNamespaceLabel, cpf.ExcludedFromEnforcement, false)
 
 	if sc.Spec.HonorTimestamps != nil {
@@ -2144,10 +2145,8 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 	}
 
 	if sc.Spec.RelabelConfigs != nil {
-		cfg = append(cfg, yaml.MapItem{
-			Key:   "relabel_configs",
-			Value: labeler.GetRelabelingConfigs(sc.TypeMeta, sc.ObjectMeta, sc.Spec.RelabelConfigs),
-		})
+		relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(sc.TypeMeta, sc.ObjectMeta, sc.Spec.RelabelConfigs))...)
+		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 	}
 
 	// StaticConfig


### PR DESCRIPTION
## Description

Fix relabelings issue in ScrapeConfig CRD, generate them correctly.
Fix #5610 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Fix relabelings issue in ScrapeConfig CRD.
```
