### PR TITLE
Test collecting metrics from operator when server and agent are deployed

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -297,6 +297,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"CreatePrometheusAgent":                     testCreatePrometheusAgent,
 		"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
 		"ScrapeConfigKubeNode":                      testScrapeConfigKubernetesNodeRole,
+		"PromCollectOperatorMetrics":                testMetricsFromOperatorWithAgentAndServer,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -17,6 +17,17 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 func testCreatePrometheusAgent(t *testing.T) {
@@ -68,4 +79,95 @@ func testAgentAndServerNameColision(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+// testMetricsFromOperatorWithAgentAndServer tests if scraping metrics from the Prometheus-Operator container
+// succeeds with Prometheus server and agent deployed.
+func testMetricsFromOperatorWithAgentAndServer(t *testing.T) {
+	t.Parallel()
+
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+	name := "test"
+
+	errorG, _ := errgroup.WithContext(context.Background())
+
+	createPromOperatorFunc := func() error {
+		_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, nil, nil, false, false, false)
+		return err
+	}
+	sm := framework.MakeBasicServiceMonitor(name)
+	createServiceMonitorFunc := func() error {
+		sm.Spec = monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": "prometheus-operator",
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					TargetPort: &intstr.IntOrString{IntVal: 8080},
+				},
+			},
+		}
+		_, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{})
+		return err
+	}
+	createPromAgentFunc := func() error {
+		prometheusAgentCRD := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
+		_, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentCRD)
+		return err
+	}
+	createPromFunc := func() error {
+		prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
+		prometheusCRD.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"group": name,
+			},
+		}
+		_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD)
+		return err
+	}
+	pSVC := framework.MakePrometheusService(name, name, v1.ServiceTypeClusterIP)
+	createPromSvcFunc := func() error {
+		_, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC)
+		return err
+	}
+
+	errorG.Go(createPromOperatorFunc)
+	errorG.Go(createServiceMonitorFunc)
+	errorG.Go(createPromAgentFunc)
+	errorG.Go(createPromFunc)
+	errorG.Go(createPromSvcFunc)
+
+	// Wait for the creation of all resources
+	err := errorG.Wait()
+	require.NoError(t, err)
+	defer func() {
+		err := framework.MonClientV1.ServiceMonitors(ns).Delete(context.Background(), sm.Name, metav1.DeleteOptions{})
+		t.Fatal(err)
+	}()
+
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+		res, err := framework.PrometheusQuery(ns, pSVC.Name, "http", "prometheus_operator_spec_replicas")
+		if err != nil {
+			return false, errors.Wrap(err, "failed to query Prometheus")
+		}
+
+		if len(res) == 0 {
+			return false, errors.Wrap(err, "query didn't return any metrics")
+		}
+
+		return true, nil
+	})
+	require.NoError(t, err)
+
+	err = framework.DeletePrometheusAgentAndWaitUntilGone(context.Background(), ns, name)
+	require.NoError(t, err)
+
+	err = framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, name)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Adding an e2e-test for the bug fixed in https://github.com/prometheus-operator/prometheus-operator/pull/5511

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
