### PR TITLE
cmd/prometheus-config-reloader: add SIGTERM handler

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -22,8 +22,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
@@ -119,9 +121,12 @@ func main() {
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
-	var g run.Group
+	var (
+		g           run.Group
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
 	{
-		ctx, cancel := context.WithCancel(context.Background())
 		rel := reloader.New(
 			logger,
 			r,
@@ -145,20 +150,35 @@ func main() {
 			cancel()
 		})
 	}
-	f := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"up"}`))
-	}
+
 	if *listenAddress != "" && *watchInterval != 0 {
+		http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{Registry: r}))
+		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"up"}`))
+		})
+
+		srv := http.Server{Addr: *listenAddress}
+
 		g.Add(func() error {
 			level.Info(logger).Log("msg", "Starting web server for metrics", "listen", *listenAddress)
-			http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{Registry: r}))
-			http.HandleFunc("/healthz", f)
-			return http.ListenAndServe(*listenAddress, nil)
-		}, func(err error) {
-			level.Error(logger).Log("err", err)
+			return srv.ListenAndServe()
+		}, func(error) {
+			srv.Close()
 		})
 	}
+
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+	g.Add(func() error {
+		select {
+		case <-term:
+			level.Info(logger).Log("msg", "Received SIGTERM, exiting gracefully...")
+		case <-ctx.Done():
+		}
+
+		return nil
+	}, func(error) {})
 
 	if err := g.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Description

When a Prometheus pod is terminated, the container runtime sends a SIGTERM signal [1] to all pod's containers. Prior this change, prometheus-config-reloader would return a non-zero exit code in this case which can lead to the pod being reported as failed for a brief period of time and create additional work on the statefulset controller's side. To be a good citizen, prometheus-config-reloader should handle the signal and return gracefully.

[1] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
