### PR TITLE
chore: fix e2e tests

### DIFF
--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -134,7 +134,7 @@ func testScrapeConfigLifecycle(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, true, true, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, false, true, true)
 	require.NoError(t, err)
 
 	p := framework.MakeBasicPrometheus(ns, "prom", "group", 1)
@@ -199,7 +199,7 @@ func testPromOperatorStartsWithoutScrapeConfigCRD(t *testing.T) {
 	err := framework.DeleteCRD(context.Background(), "scrapeconfigs.monitoring.coreos.com")
 	require.NoError(t, err)
 
-	_, err = framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, true, true, false)
+	_, err = framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, false, true, false)
 	require.NoError(t, err)
 
 	time.Sleep(10 * time.Second)
@@ -222,6 +222,6 @@ func testPromOperatorStartsWithoutScrapeConfigCRD(t *testing.T) {
 	}
 
 	// re-create Prometheus-Operator to reinstall the CRDs
-	_, err = framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, true, true, true)
+	_, err = framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, false, true, true)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

The new ScrapeConfig e2e tests (#5575) deployed the operator + admission webhook + webhook configurations without cleaning the wehhook configurations after the tests completed. The end result was that some of the following tests were failing because the admission service wasn't present anymore (e.g. the creation of PrometheusRules failed).

In practice, the admission webhook is not required for the ScrapeConfig tests, hence this change deploys only the operator.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
