### PR TITLE
tracing: add MinLength validation to the `endpoint` field

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -9943,7 +9943,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Client used to export the traces. Options are &ldquo;http&rdquo; or &ldquo;grpc&rdquo;.</p>
+<p>Client used to export the traces. Supported values are <code>http</code> or <code>grpc</code>.</p>
 </td>
 </tr>
 <tr>
@@ -10002,7 +10002,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Compression key for supported compression types. Supported compression: gzip</p>
+<p>Compression key for supported compression types. The only supported value is <code>gzip</code>.</p>
 </td>
 </tr>
 <tr>
@@ -10016,7 +10016,7 @@ Duration
 </td>
 <td>
 <em>(Optional)</em>
-<p>Maximum time the exporter will wait for each batch export. Default &lsquo;10s&rsquo;</p>
+<p>Maximum time the exporter will wait for each batch export.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -28596,21 +28596,22 @@ spec:
                   in a breaking way.
                 properties:
                   clientType:
-                    description: Client used to export the traces. Options are "http"
-                      or "grpc".
+                    description: Client used to export the traces. Supported values
+                      are `http` or `grpc`.
                     enum:
                     - http
                     - grpc
                     type: string
                   compression:
-                    description: 'Compression key for supported compression types.
-                      Supported compression: gzip'
+                    description: Compression key for supported compression types.
+                      The only supported value is `gzip`.
                     enum:
                     - gzip
                     type: string
                   endpoint:
                     description: Endpoint to send the traces to. Should be provided
                       in format <host>:<port>.
+                    minLength: 1
                     type: string
                   headers:
                     additionalProperties:
@@ -28631,7 +28632,7 @@ spec:
                     x-kubernetes-int-or-string: true
                   timeout:
                     description: Maximum time the exporter will wait for each batch
-                      export. Default '10s'
+                      export.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                   tlsConfig:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7423,21 +7423,22 @@ spec:
                   in a breaking way.
                 properties:
                   clientType:
-                    description: Client used to export the traces. Options are "http"
-                      or "grpc".
+                    description: Client used to export the traces. Supported values
+                      are `http` or `grpc`.
                     enum:
                     - http
                     - grpc
                     type: string
                   compression:
-                    description: 'Compression key for supported compression types.
-                      Supported compression: gzip'
+                    description: Compression key for supported compression types.
+                      The only supported value is `gzip`.
                     enum:
                     - gzip
                     type: string
                   endpoint:
                     description: Endpoint to send the traces to. Should be provided
                       in format <host>:<port>.
+                    minLength: 1
                     type: string
                   headers:
                     additionalProperties:
@@ -7458,7 +7459,7 @@ spec:
                     x-kubernetes-int-or-string: true
                   timeout:
                     description: Maximum time the exporter will wait for each batch
-                      export. Default '10s'
+                      export.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                   tlsConfig:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7423,21 +7423,22 @@ spec:
                   in a breaking way.
                 properties:
                   clientType:
-                    description: Client used to export the traces. Options are "http"
-                      or "grpc".
+                    description: Client used to export the traces. Supported values
+                      are `http` or `grpc`.
                     enum:
                     - http
                     - grpc
                     type: string
                   compression:
-                    description: 'Compression key for supported compression types.
-                      Supported compression: gzip'
+                    description: Compression key for supported compression types.
+                      The only supported value is `gzip`.
                     enum:
                     - gzip
                     type: string
                   endpoint:
                     description: Endpoint to send the traces to. Should be provided
                       in format <host>:<port>.
+                    minLength: 1
                     type: string
                   headers:
                     additionalProperties:
@@ -7458,7 +7459,7 @@ spec:
                     x-kubernetes-int-or-string: true
                   timeout:
                     description: Maximum time the exporter will wait for each batch
-                      export. Default '10s'
+                      export.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                   tlsConfig:

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6820,7 +6820,7 @@
                     "description": "TracingConfig configures tracing in Prometheus. This is an experimental feature, it may change in any upcoming release in a breaking way.",
                     "properties": {
                       "clientType": {
-                        "description": "Client used to export the traces. Options are \"http\" or \"grpc\".",
+                        "description": "Client used to export the traces. Supported values are `http` or `grpc`.",
                         "enum": [
                           "http",
                           "grpc"
@@ -6828,7 +6828,7 @@
                         "type": "string"
                       },
                       "compression": {
-                        "description": "Compression key for supported compression types. Supported compression: gzip",
+                        "description": "Compression key for supported compression types. The only supported value is `gzip`.",
                         "enum": [
                           "gzip"
                         ],
@@ -6836,6 +6836,7 @@
                       },
                       "endpoint": {
                         "description": "Endpoint to send the traces to. Should be provided in format <host>:<port>.",
+                        "minLength": 1,
                         "type": "string"
                       },
                       "headers": {
@@ -6863,7 +6864,7 @@
                         "x-kubernetes-int-or-string": true
                       },
                       "timeout": {
-                        "description": "Maximum time the exporter will wait for each batch export. Default '10s'",
+                        "description": "Maximum time the exporter will wait for each batch export.",
                         "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                         "type": "string"
                       },

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -533,13 +533,14 @@ type PrometheusSpec struct {
 }
 
 type PrometheusTracingConfig struct {
-	// Client used to export the traces. Options are "http" or "grpc".
+	// Client used to export the traces. Supported values are `http` or `grpc`.
 	//+kubebuilder:validation:Enum=http;grpc
 	// +optional
 	ClientType *string `json:"clientType"`
 
 	// Endpoint to send the traces to. Should be provided in format <host>:<port>.
-	//+required
+	// +kubebuilder:validation:MinLength:=1
+	// +required
 	Endpoint string `json:"endpoint"`
 
 	// Sets the probability a given trace will be sampled. Must be a float from 0 through 1.
@@ -554,12 +555,12 @@ type PrometheusTracingConfig struct {
 	// +optional
 	Headers map[string]string `json:"headers"`
 
-	// Compression key for supported compression types. Supported compression: gzip
+	// Compression key for supported compression types. The only supported value is `gzip`.
 	//+kubebuilder:validation:Enum=gzip
 	// +optional
 	Compression *string `json:"compression"`
 
-	// Maximum time the exporter will wait for each batch export. Default '10s'
+	// Maximum time the exporter will wait for each batch export.
 	// +optional
 	Timeout *Duration `json:"timeout"`
 


### PR DESCRIPTION
## Description

Prometheus rejects configuration with an empty value for the tracing endpoint. This is a follow-up from #5591. 

cc @ArthurSens @nicolastakashi 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
