### PR TITLE
fix: Missing .spec.serviceName in the Thanos Ruler statefulset

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -440,6 +440,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	return &appsv1.StatefulSetSpec{
 		Replicas:            tr.Spec.Replicas,
 		MinReadySeconds:     minReadySeconds,
+		ServiceName: governingServiceName,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -440,7 +440,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	return &appsv1.StatefulSetSpec{
 		Replicas:            tr.Spec.Replicas,
 		MinReadySeconds:     minReadySeconds,
-		ServiceName:         governingServiceName,
+		ServiceName: governingServiceName,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -438,9 +438,9 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	// PodManagementPolicy is set to Parallel to mitigate issues in kubernetes: https://github.com/kubernetes/kubernetes/issues/60164
 	// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 	return &appsv1.StatefulSetSpec{
+		ServiceName:         governingServiceName,
 		Replicas:            tr.Spec.Replicas,
 		MinReadySeconds:     minReadySeconds,
-		ServiceName: governingServiceName,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -440,7 +440,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	return &appsv1.StatefulSetSpec{
 		Replicas:            tr.Spec.Replicas,
 		MinReadySeconds:     minReadySeconds,
-		ServiceName: governingServiceName,
+		ServiceName:         governingServiceName,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -928,7 +928,7 @@ func TestStatefulSetMinReadySeconds(t *testing.T) {
 func TestStatefulSetServiceName(t *testing.T) {
 	tr := monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{
-			QueryEndpoints:  emptyQueryEndpoints,
+			QueryEndpoints: emptyQueryEndpoints,
 		},
 	}
 

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	containerName = "thanos-ruler"
+	containerName        = "thanos-ruler"
+	governingServiceName = "thanos-ruler-operated"
 )
 
 var (
@@ -932,14 +933,14 @@ func TestStatefulSetServiceName(t *testing.T) {
 		},
 	}
 
-	// assert set correctly if not nil
-	expect := "thanos-ruler-operated"
-	statefulSet, err := makeStatefulSetSpec(&tr, defaultTestConfig, nil)
+	// assert set correctly
+	expect := governingServiceName
+	spec, err := makeStatefulSetSpec(&tr, defaultTestConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statefulSet.ServiceName != expect {
-		t.Fatalf("expected ServiceName to be %s but got %s", expect, statefulSet.ServiceName)
+	if spec.ServiceName != expect {
+		t.Fatalf("expected ServiceName to be %s but got %s", expect, spec.ServiceName)
 	}
 }
 

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -934,7 +934,7 @@ func TestStatefulSetServiceName(t *testing.T) {
 
 	// assert set correctly if not nil
 	expect := "thanos-ruler-operated"
-	statefulSet, err = makeStatefulSetSpec(&tr, defaultTestConfig, nil)
+	statefulSet, err := makeStatefulSetSpec(&tr, defaultTestConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -928,6 +928,7 @@ func TestStatefulSetMinReadySeconds(t *testing.T) {
 func TestStatefulSetServiceName(t *testing.T) {
 	tr := monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{
+			ServiceName: nil,
 			QueryEndpoints:  emptyQueryEndpoints,
 		},
 	}

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -934,7 +934,7 @@ func TestStatefulSetServiceName(t *testing.T) {
 
 	// assert set correctly if not nil
 	expect := "thanos-ruler-operated-test"
-	tr.Spec.ServiceName = &expect
+	tr.Spec.ServiceName = expect
 	statefulSet, err = makeStatefulSetSpec(&tr, defaultTestConfig, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -928,14 +928,12 @@ func TestStatefulSetMinReadySeconds(t *testing.T) {
 func TestStatefulSetServiceName(t *testing.T) {
 	tr := monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{
-			ServiceName: nil,
 			QueryEndpoints:  emptyQueryEndpoints,
 		},
 	}
 
 	// assert set correctly if not nil
-	expect := "thanos-ruler-operated-test"
-	tr.Spec.ServiceName = expect
+	expect := "thanos-ruler-operated"
 	statefulSet, err = makeStatefulSetSpec(&tr, defaultTestConfig, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	containerName        = "thanos-ruler"
-	governingServiceName = "thanos-ruler-operated"
+	containerName = "thanos-ruler"
 )
 
 var (

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -925,6 +925,25 @@ func TestStatefulSetMinReadySeconds(t *testing.T) {
 	}
 }
 
+func TestStatefulSetServiceName(t *testing.T) {
+	tr := monitoringv1.ThanosRuler{
+		Spec: monitoringv1.ThanosRulerSpec{
+			QueryEndpoints:  emptyQueryEndpoints,
+		},
+	}
+
+	// assert set correctly if not nil
+	expect := "thanos-ruler-operated-test"
+	tr.Spec.ServiceName = &expect
+	statefulSet, err = makeStatefulSetSpec(&tr, defaultTestConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statefulSet.ServiceName != expect {
+		t.Fatalf("expected ServiceName to be %s but got %s", expect, statefulSet.ServiceName)
+	}
+}
+
 func TestStatefulSetPVC(t *testing.T) {
 	labels := map[string]string{
 		"testlabel": "testlabelvalue",


### PR DESCRIPTION
## Description
Fix missing .spec.serviceName in the Thanos Ruler statefulset
Fixes: #5631 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix: Missing .spec.serviceName in the Thanos Ruler statefulset
```
