### PR TITLE
Move prerequisite check

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -104,7 +104,7 @@ func checkPrerequisites(ctx context.Context, logger log.Logger, cc *k8sutil.CRDC
 	err := cc.CheckPrerequisites(ctx, allowedNamespaces, verbs, groupVersion, resourceName)
 	switch {
 	case errors.Is(err, k8sutil.ErrPrerequiresitesFailed):
-		level.Warn(logger).Log("msg", fmt.Sprintf("%s CRD not supported because prerequisites are not met", resourceName), "err", err)
+		level.Warn(logger).Log("msg", fmt.Sprintf("%s CRD not supported", resourceName), "reason", err)
 		return false, nil
 	case err != nil:
 		level.Error(logger).Log("msg", fmt.Sprintf("failed to check prerequisites for the %s CRD ", resourceName), "err", err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -104,7 +104,7 @@ func checkPrerequisites(ctx context.Context, logger log.Logger, cc *k8sutil.CRDC
 	err := cc.CheckPrerequisites(ctx, allowedNamespaces, verbs, groupVersion, resourceName)
 	switch {
 	case errors.Is(err, k8sutil.ErrPrerequiresitesFailed):
-		level.Warn(logger).Log("msg", fmt.Sprintf("%s CRD disabled because prerequisites are not met", resourceName), "err", err)
+		level.Warn(logger).Log("msg", fmt.Sprintf("%s CRD not supported because prerequisites are not met", resourceName), "err", err)
 		return false, nil
 	case err != nil:
 		level.Error(logger).Log("msg", fmt.Sprintf("failed to check prerequisites for the %s CRD ", resourceName), "err", err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -278,10 +278,6 @@ func Main() int {
 	k8sutil.MustRegisterClientGoMetrics(r)
 
 	allowedNamespaces := namespaces(cfg.Namespaces.AllowList).asSlice()
-	verbs := map[string][]string{
-		monitoringv1alpha1.PrometheusAgentName:                           {"get", "list", "watch"},
-		fmt.Sprintf("%s/status", monitoringv1alpha1.PrometheusAgentName): {"update"},
-	}
 
 	cc, err := k8sutil.NewCRDChecker(cfg.Host, cfg.TLSInsecure, &cfg.TLSConfig)
 	if err != nil {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -290,7 +290,18 @@ func Main() int {
 		return 1
 	}
 
-	scrapeConfigSupported, err := checkPrerequisites(ctx, logger, cc, allowedNamespaces, verbs, monitoringv1alpha1.SchemeGroupVersion.String(), monitoringv1alpha1.ScrapeConfigName)
+	scrapeConfigSupported, err := checkPrerequisites(
+		ctx,
+		logger,
+		cc,
+		allowedNamespaces,
+		map[string][]string{
+			monitoringv1alpha1.ScrapeConfigName: {"get", "list", "watch"},
+		},
+		monitoringv1alpha1.SchemeGroupVersion.String(),
+		monitoringv1alpha1.ScrapeConfigName,
+	)
+
 	if err != nil {
 		cancel()
 		return 1
@@ -303,7 +314,18 @@ func Main() int {
 		return 1
 	}
 
-	prometheusAgentSupported, err := checkPrerequisites(ctx, logger, cc, allowedNamespaces, verbs, monitoringv1alpha1.SchemeGroupVersion.String(), monitoringv1alpha1.PrometheusAgentName)
+	prometheusAgentSupported, err := checkPrerequisites(
+		ctx,
+		logger,
+		cc,
+		allowedNamespaces,
+		map[string][]string{
+			monitoringv1alpha1.PrometheusAgentName:                           {"get", "list", "watch"},
+			fmt.Sprintf("%s/status", monitoringv1alpha1.PrometheusAgentName): {"update"},
+		},
+		monitoringv1alpha1.SchemeGroupVersion.String(),
+		monitoringv1alpha1.PrometheusAgentName,
+	)
 	if err != nil {
 		cancel()
 		return 1

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -94,7 +94,7 @@ type Operator struct {
 }
 
 // New creates a new controller.
-func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometheus.Registerer) (*Operator, error) {
+func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometheus.Registerer, scrapeConfigSupported bool) (*Operator, error) {
 	cfg, err := k8sutil.NewClusterConfig(conf.Host, conf.TLSInsecure, &conf.TLSConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating cluster config failed")
@@ -136,35 +136,6 @@ func New(ctx context.Context, conf operator.Config, logger log.Logger, r prometh
 		kubeletObjectNamespace = parts[0]
 		kubeletObjectName = parts[1]
 		kubeletSyncEnabled = true
-	}
-
-	// Check prerequisites for ScrapeConfig
-	verbs := map[string][]string{
-		monitoringv1alpha1.ScrapeConfigName: {"get", "list", "watch"},
-	}
-	var scrapeConfigSupported bool
-	cc, err := k8sutil.NewCRDChecker(conf.Host, conf.TLSInsecure, &conf.TLSConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new CRDChecker object")
-	}
-
-	var namespaces = make([]string, 0, len(conf.Namespaces.AllowList))
-	for k := range conf.Namespaces.AllowList {
-		namespaces = append(namespaces, k)
-	}
-
-	err = cc.CheckPrerequisites(ctx,
-		namespaces,
-		verbs,
-		monitoringv1alpha1.SchemeGroupVersion.String(),
-		monitoringv1alpha1.ScrapeConfigName)
-	switch {
-	case errors.Is(err, k8sutil.ErrPrerequiresitesFailed):
-		level.Warn(logger).Log("msg", "ScrapeConfig CRD disabled because prerequisites are not met", "err", err)
-	case err != nil:
-		return nil, errors.Wrap(err, "failed to check prerequisites for the ScrapeConfig CRD ")
-	default:
-		scrapeConfigSupported = true
 	}
 
 	// All the metrics exposed by the controller get the controller="prometheus" label.


### PR DESCRIPTION
## Description

This PR moves the prerequisites check for `ScrapeConfig` CRD to `operator/main.go`.
Fixes: https://github.com/prometheus-operator/prometheus-operator/issues/5546


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
 Move the prerequisites check for `ScrapeConfig` CRD from `server/operator.go` to `operator/main.go`.
```
