### PR TITLE
chore: Move limits to *uint64 and add optional markers

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -893,6 +893,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -904,6 +905,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -916,6 +918,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -928,6 +931,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -1177,6 +1181,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.</p>
 </td>
 </tr>
@@ -1188,6 +1193,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -1199,6 +1205,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -1211,6 +1218,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -1223,6 +1231,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -2840,6 +2849,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.</p>
 </td>
 </tr>
@@ -2851,6 +2861,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -2862,6 +2873,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -2874,6 +2886,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -2886,6 +2899,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -7823,6 +7837,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -7834,6 +7849,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -7846,6 +7862,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -7858,6 +7875,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -8062,6 +8080,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.</p>
 </td>
 </tr>
@@ -8073,6 +8092,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -8084,6 +8104,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -8096,6 +8117,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -8108,6 +8130,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -11419,6 +11442,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.</p>
 </td>
 </tr>
@@ -11430,6 +11454,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>TargetLimit defines a limit on the number of scraped targets that will be accepted.</p>
 </td>
 </tr>
@@ -11441,6 +11466,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on number of labels that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -11453,6 +11479,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels name that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>
@@ -11465,6 +11492,7 @@ uint64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Per-scrape limit on length of labels value that will be accepted for a sample.
 Only valid in Prometheus versions 2.27.0 and newer.</p>
 </td>

--- a/pkg/apis/monitoring/v1/podmonitor_types.go
+++ b/pkg/apis/monitoring/v1/podmonitor_types.go
@@ -58,18 +58,22 @@ type PodMonitorSpec struct {
 	// Selector to select which namespaces the Endpoints objects are discovered from.
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
 	// SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	SampleLimit uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
 	// TargetLimit defines a limit on the number of scraped targets that will be accepted.
-	TargetLimit uint64 `json:"targetLimit,omitempty"`
+	// +optional
+	TargetLimit *uint64 `json:"targetLimit,omitempty"`
 	// Per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelLimit uint64 `json:"labelLimit,omitempty"`
+	// +optional
+	LabelLimit *uint64 `json:"labelLimit,omitempty"`
 	// Per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelNameLengthLimit uint64 `json:"labelNameLengthLimit,omitempty"`
+	// +optional
+	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
 	// Per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelValueLengthLimit uint64 `json:"labelValueLengthLimit,omitempty"`
+	// +optional
+	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
 	// Attaches node metadata to discovered targets.
 	// Requires Prometheus v2.35.0 and above.
 	AttachMetadata *AttachMetadata `json:"attachMetadata,omitempty"`

--- a/pkg/apis/monitoring/v1/probe_types.go
+++ b/pkg/apis/monitoring/v1/probe_types.go
@@ -79,18 +79,23 @@ type ProbeSpec struct {
 	// Authorization section for this endpoint
 	Authorization *SafeAuthorization `json:"authorization,omitempty"`
 	// SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	SampleLimit uint64 `json:"sampleLimit,omitempty"`
+	// +optional
+	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
 	// TargetLimit defines a limit on the number of scraped targets that will be accepted.
-	TargetLimit uint64 `json:"targetLimit,omitempty"`
+	// +optional
+	TargetLimit *uint64 `json:"targetLimit,omitempty"`
 	// Per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelLimit uint64 `json:"labelLimit,omitempty"`
+	// +optional
+	LabelLimit *uint64 `json:"labelLimit,omitempty"`
 	// Per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelNameLengthLimit uint64 `json:"labelNameLengthLimit,omitempty"`
+	// +optional
+	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
 	// Per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelValueLengthLimit uint64 `json:"labelValueLengthLimit,omitempty"`
+	// +optional
+	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
 }
 
 // ProbeTargets defines how to discover the probed targets.

--- a/pkg/apis/monitoring/v1/servicemonitor_types.go
+++ b/pkg/apis/monitoring/v1/servicemonitor_types.go
@@ -65,18 +65,23 @@ type ServiceMonitorSpec struct {
 	// Selector to select which namespaces the Kubernetes Endpoints objects are discovered from.
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
 	// SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	SampleLimit uint64 `json:"sampleLimit,omitempty"`
+	// +optional
+	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
 	// TargetLimit defines a limit on the number of scraped targets that will be accepted.
-	TargetLimit uint64 `json:"targetLimit,omitempty"`
+	// +optional
+	TargetLimit *uint64 `json:"targetLimit,omitempty"`
 	// Per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelLimit uint64 `json:"labelLimit,omitempty"`
+	// +optional
+	LabelLimit *uint64 `json:"labelLimit,omitempty"`
 	// Per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelNameLengthLimit uint64 `json:"labelNameLengthLimit,omitempty"`
+	// +optional
+	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
 	// Per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelValueLengthLimit uint64 `json:"labelValueLengthLimit,omitempty"`
+	// +optional
+	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
 	// Attaches node metadata to discovered targets.
 	// Requires Prometheus v2.37.0 and above.
 	AttachMetadata *AttachMetadata `json:"attachMetadata,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1327,6 +1327,31 @@ func (in *PodMonitorSpec) DeepCopyInto(out *PodMonitorSpec) {
 	}
 	in.Selector.DeepCopyInto(&out.Selector)
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
+	if in.SampleLimit != nil {
+		in, out := &in.SampleLimit, &out.SampleLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.TargetLimit != nil {
+		in, out := &in.TargetLimit, &out.TargetLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelLimit != nil {
+		in, out := &in.LabelLimit, &out.LabelLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelNameLengthLimit != nil {
+		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelValueLengthLimit != nil {
+		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
+		*out = new(uint64)
+		**out = **in
+	}
 	if in.AttachMetadata != nil {
 		in, out := &in.AttachMetadata, &out.AttachMetadata
 		*out = new(AttachMetadata)
@@ -1426,6 +1451,31 @@ func (in *ProbeSpec) DeepCopyInto(out *ProbeSpec) {
 		in, out := &in.Authorization, &out.Authorization
 		*out = new(SafeAuthorization)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SampleLimit != nil {
+		in, out := &in.SampleLimit, &out.SampleLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.TargetLimit != nil {
+		in, out := &in.TargetLimit, &out.TargetLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelLimit != nil {
+		in, out := &in.LabelLimit, &out.LabelLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelNameLengthLimit != nil {
+		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelValueLengthLimit != nil {
+		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
+		*out = new(uint64)
+		**out = **in
 	}
 }
 
@@ -2332,6 +2382,31 @@ func (in *ServiceMonitorSpec) DeepCopyInto(out *ServiceMonitorSpec) {
 	}
 	in.Selector.DeepCopyInto(&out.Selector)
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
+	if in.SampleLimit != nil {
+		in, out := &in.SampleLimit, &out.SampleLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.TargetLimit != nil {
+		in, out := &in.TargetLimit, &out.TargetLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelLimit != nil {
+		in, out := &in.LabelLimit, &out.LabelLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelNameLengthLimit != nil {
+		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
+		*out = new(uint64)
+		**out = **in
+	}
+	if in.LabelValueLengthLimit != nil {
+		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
+		*out = new(uint64)
+		**out = **in
+	}
 	if in.AttachMetadata != nil {
 		in, out := &in.AttachMetadata, &out.AttachMetadata
 		*out = new(AttachMetadata)

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -205,8 +205,8 @@ var (
 
 // AddLimitsToYAML appends the given limit key to the configuration if
 // supported by the Prometheus version.
-func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit uint64, enforcedLimit *uint64) yaml.MapSlice {
-	if limit == 0 && enforcedLimit == nil {
+func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit *uint64, enforcedLimit *uint64) yaml.MapSlice {
+	if limit == nil && enforcedLimit == nil {
 		return cfg
 	}
 
@@ -1346,14 +1346,14 @@ func generateRunningFilter() yaml.MapSlice {
 	}
 }
 
-func getLimit(user uint64, enforced *uint64) uint64 {
+func getLimit(user *uint64, enforced *uint64) uint64 {
 	if enforced != nil {
-		if user < *enforced && user != 0 || *enforced == 0 {
-			return user
+		if user != nil && *user < *enforced && *user != 0 || *enforced == 0 {
+			return *user
 		}
 		return *enforced
 	}
-	return user
+	return 0
 }
 
 func generateAddressShardingRelabelingRules(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5129,7 +5129,8 @@ scrape_configs:
 				},
 			}
 			if tc.limit >= 0 {
-				serviceMonitor.Spec.SampleLimit = uint64(tc.limit)
+				sampleLimit := uint64(tc.limit)
+				serviceMonitor.Spec.SampleLimit = &sampleLimit
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -5385,7 +5386,8 @@ scrape_configs:
 				},
 			}
 			if tc.limit >= 0 {
-				serviceMonitor.Spec.TargetLimit = uint64(tc.limit)
+				limit := uint64(tc.limit)
+				serviceMonitor.Spec.TargetLimit = &limit
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -6389,7 +6391,8 @@ scrape_configs:
 				},
 			}
 			if tc.labelLimit >= 0 {
-				serviceMonitor.Spec.LabelLimit = uint64(tc.labelLimit)
+				labelLimit := uint64(tc.labelLimit)
+				serviceMonitor.Spec.LabelLimit = &labelLimit
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -6606,7 +6609,8 @@ scrape_configs:
 				},
 			}
 			if tc.labelNameLengthLimit >= 0 {
-				podMonitor.Spec.LabelNameLengthLimit = uint64(tc.labelNameLengthLimit)
+				labelNameLengthLimit := uint64(tc.labelNameLengthLimit)
+				podMonitor.Spec.LabelNameLengthLimit = &labelNameLengthLimit
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -6805,7 +6809,8 @@ scrape_configs:
 				},
 			}
 			if tc.labelValueLengthLimit >= 0 {
-				probe.Spec.LabelValueLengthLimit = uint64(tc.labelValueLengthLimit)
+				labelValueLengthLimit := uint64(tc.labelValueLengthLimit)
+				probe.Spec.LabelValueLengthLimit = &labelValueLengthLimit
 			}
 
 			cg := mustNewConfigGenerator(t, p)


### PR DESCRIPTION
## Description

References:
* https://github.com/prometheus-operator/prometheus-operator/pull/5658#discussion_r1227145581
* https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

n/a
