### PR TITLE
chore: use constants for env variables

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus-operator/prometheus-operator/pkg/versionutil"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -47,8 +48,7 @@ const (
 	defaultRetryInterval = 5 * time.Second  // 5 seconds was the value previously hardcoded in github.com/thanos-io/thanos/pkg/reloader.
 	defaultReloadTimeout = 30 * time.Second // 30 seconds was the default value
 
-	statefulsetOrdinalEnvvar            = "STATEFULSET_ORDINAL_NUMBER"
-	statefulsetOrdinalFromEnvvarDefault = "POD_NAME"
+	statefulsetOrdinalEnvvar = "STATEFULSET_ORDINAL_NUMBER"
 )
 
 func main() {
@@ -69,7 +69,7 @@ func main() {
 	createStatefulsetOrdinalFrom := app.Flag(
 		"statefulset-ordinal-from-envvar",
 		fmt.Sprintf("parse this environment variable to create %s, containing the statefulset ordinal number", statefulsetOrdinalEnvvar)).
-		Default(statefulsetOrdinalFromEnvvarDefault).String()
+		Default(operator.PodNameEnvVar).String()
 
 	listenAddress := app.Flag(
 		"listen-address",

--- a/cmd/prometheus-config-reloader/main_test.go
+++ b/cmd/prometheus-config-reloader/main_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
 var cases = []struct {
@@ -40,8 +42,8 @@ var cases = []struct {
 func TestCreateOrdinalEnvVar(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.in, func(t *testing.T) {
-			os.Setenv(statefulsetOrdinalFromEnvvarDefault, tt.in)
-			s := createOrdinalEnvvar(statefulsetOrdinalFromEnvvarDefault)
+			os.Setenv(operator.PodNameEnvVar, tt.in)
+			s := createOrdinalEnvvar(operator.PodNameEnvVar)
 			if os.Getenv(statefulsetOrdinalEnvvar) != tt.out {
 				t.Errorf("got %v, want %s", s, tt.out)
 			}

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -25,7 +25,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const configReloaderPort = 8080
+const (
+	configReloaderPort = 8080
+
+	// ShardEnvVar is the name of the environment variable injected into the
+	// config-reloader container that contains the shard number.
+	ShardEnvVar = "SHARD"
+
+	// PodNameEnvVar is the name of the environment variable injected in the
+	// config-reloader container that contains the pod name.
+	PodNameEnvVar = "POD_NAME"
+)
 
 // ConfigReloader contains the options to configure
 // a config-reloader container
@@ -152,7 +162,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		args    = make([]string, 0)
 		envVars = []v1.EnvVar{
 			{
-				Name: "POD_NAME",
+				Name: PodNameEnvVar,
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"},
 				},
@@ -225,7 +235,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 
 	if configReloader.shard != nil {
 		envVars = append(envVars, v1.EnvVar{
-			Name:  "SHARD",
+			Name:  ShardEnvVar,
 			Value: strconv.Itoa(int(*configReloader.shard)),
 		})
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -41,6 +41,8 @@ const (
 	kubernetesSDRoleEndpointSlice = "endpointslice"
 	kubernetesSDRolePod           = "pod"
 	kubernetesSDRoleIngress       = "ingress"
+
+	defaultReplicaExternalLabelName = "prometheus_replica"
 )
 
 var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
@@ -397,7 +399,7 @@ func (cg *ConfigGenerator) buildExternalLabels() yaml.MapSlice {
 
 	// Do not add the external label if the resulting value is empty.
 	if replicaExternalLabelName != "" {
-		m[replicaExternalLabelName] = "$(POD_NAME)"
+		m[replicaExternalLabelName] = fmt.Sprintf("$(%s)", operator.PodNameEnvVar)
 	}
 
 	for n, v := range cpf.ExternalLabels {
@@ -1372,7 +1374,7 @@ func generateAddressShardingRelabelingRulesWithSourceLabel(relabelings []yaml.Ma
 		{Key: "action", Value: "hashmod"},
 	}, yaml.MapSlice{
 		{Key: "source_labels", Value: []string{"__tmp_hash"}},
-		{Key: "regex", Value: "$(SHARD)"},
+		{Key: "regex", Value: fmt.Sprintf("$(%s)", operator.ShardEnvVar)},
 		{Key: "action", Value: "keep"},
 	})
 }

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -32,12 +32,11 @@ import (
 )
 
 const (
-	defaultReplicaExternalLabelName = "prometheus_replica"
-	StorageDir                      = "/prometheus"
-	ConfDir                         = "/etc/prometheus/config"
-	ConfOutDir                      = "/etc/prometheus/config_out"
-	WebConfigDir                    = "/etc/prometheus/web_config"
-	tlsAssetsDir                    = "/etc/prometheus/certs"
+	StorageDir   = "/prometheus"
+	ConfDir      = "/etc/prometheus/config"
+	ConfOutDir   = "/etc/prometheus/config_out"
+	WebConfigDir = "/etc/prometheus/web_config"
+	tlsAssetsDir = "/etc/prometheus/certs"
 	//TODO: RulesDir should be moved to the server package, since it is not used by the agent.
 	// It is here at the moment because promcfg uses it, and moving as is will cause import cycle error.
 	RulesDir                 = "/etc/prometheus/rules"


### PR DESCRIPTION
## Description

The SHARD and POD_NAME variables were defined in different places.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
