### PR TITLE
docs: overriding behavior for common labels

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -106,7 +106,14 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.</p>
+<p>PodMetadata configures Labels and Annotations which are propagated to the Alertmanager pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;alertmanager&rdquo; label, set to the name of the Alertmanager instance.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Alertmanager instance.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;alertmanager&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Alertmanager version.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;alertmanager&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -1338,7 +1345,16 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;prometheus&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Prometheus version.
+* &ldquo;operator.prometheus.io/name&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;operator.prometheus.io/shard&rdquo; label, set to the shard number of the Prometheus object.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;prometheus&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -3238,7 +3254,13 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.</p>
+<p>PodMetadata contains Labels and Annotations gets propagated to the ThanosRuler pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;thanos-ruler&rdquo;.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the ThanosRuler instance.
+* &ldquo;thanos-ruler&rdquo; label, set to the name of the ThanosRuler instance.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;thanos-ruler&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -4443,7 +4465,14 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.</p>
+<p>PodMetadata configures Labels and Annotations which are propagated to the Alertmanager pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;alertmanager&rdquo; label, set to the name of the Alertmanager instance.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Alertmanager instance.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;alertmanager&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Alertmanager version.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;alertmanager&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -5545,7 +5574,16 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;prometheus&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Prometheus version.
+* &ldquo;operator.prometheus.io/name&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;operator.prometheus.io/shard&rdquo; label, set to the shard number of the Prometheus object.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;prometheus&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -9305,7 +9343,16 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;prometheus&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Prometheus version.
+* &ldquo;operator.prometheus.io/name&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;operator.prometheus.io/shard&rdquo; label, set to the shard number of the Prometheus object.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;prometheus&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -12985,7 +13032,13 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.</p>
+<p>PodMetadata contains Labels and Annotations gets propagated to the ThanosRuler pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;thanos-ruler&rdquo;.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the ThanosRuler instance.
+* &ldquo;thanos-ruler&rdquo; label, set to the name of the ThanosRuler instance.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;thanos-ruler&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -14613,7 +14666,16 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;prometheus&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Prometheus version.
+* &ldquo;operator.prometheus.io/name&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;operator.prometheus.io/shard&rdquo; label, set to the shard number of the Prometheus object.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;prometheus&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -18282,7 +18344,16 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
+out of which, the following are reserved and cannot be overridden:
+* &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
+* &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;prometheus&rdquo;.
+* &ldquo;app.kubernetes.io/version&rdquo; label, set to the Prometheus version.
+* &ldquo;operator.prometheus.io/name&rdquo; label, set to the name of the Prometheus object.
+* &ldquo;operator.prometheus.io/shard&rdquo; label, set to the shard number of the Prometheus object.
+* &ldquo;kubectl.kubernetes.io/default-container&rdquo; annotation, set to &ldquo;prometheus&rdquo;.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -106,8 +106,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures Labels and Annotations which are propagated to the Alertmanager pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;alertmanager&rdquo; label, set to the name of the Alertmanager instance.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Alertmanager instance.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -1345,8 +1345,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -3254,8 +3254,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata contains Labels and Annotations gets propagated to the ThanosRuler pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the ThanosRuler pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;thanos-ruler&rdquo;.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the ThanosRuler instance.
@@ -4465,8 +4465,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures Labels and Annotations which are propagated to the Alertmanager pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;alertmanager&rdquo; label, set to the name of the Alertmanager instance.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Alertmanager instance.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -5574,8 +5574,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -9343,8 +9343,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -13032,8 +13032,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata contains Labels and Annotations gets propagated to the ThanosRuler pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the ThanosRuler pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;app.kubernetes.io/name&rdquo; label, set to &ldquo;thanos-ruler&rdquo;.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the ThanosRuler instance.
@@ -14666,8 +14666,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.
@@ -18344,8 +18344,8 @@ EmbeddedObjectMetadata
 </em>
 </td>
 <td>
-<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods,
-out of which, the following are reserved and cannot be overridden:
+<p>PodMetadata configures labels and annotations which are propagated to the Prometheus pods.</p>
+<p>The following items are reserved and cannot be overridden:
 * &ldquo;prometheus&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/instance&rdquo; label, set to the name of the Prometheus object.
 * &ldquo;app.kubernetes.io/managed-by&rdquo; label, set to &ldquo;prometheus-operator&rdquo;.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9581,8 +9581,15 @@ spec:
                   objects are not goint to be performed, except for delete actions.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures Labels and Annotations which are
-                  propagated to the alertmanager pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Alertmanager pods. \n The following items
+                  are reserved and cannot be overridden: * \"alertmanager\" label,
+                  set to the name of the Alertmanager instance. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"alertmanager\". * \"app.kubernetes.io/version\"
+                  label, set to the Alertmanager version. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"alertmanager\"."
                 properties:
                   annotations:
                     additionalProperties:
@@ -18202,8 +18209,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:
@@ -27002,8 +27018,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:
@@ -38285,8 +38310,14 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata contains Labels and Annotations gets propagated
-                  to the thanos ruler pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the ThanosRuler pods. \n The following items are
+                  reserved and cannot be overridden: * \"app.kubernetes.io/name\"
+                  label, set to \"thanos-ruler\". * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/instance\"
+                  label, set to the name of the ThanosRuler instance. * \"thanos-ruler\"
+                  label, set to the name of the ThanosRuler instance. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"thanos-ruler\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -4299,8 +4299,15 @@ spec:
                   objects are not goint to be performed, except for delete actions.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures Labels and Annotations which are
-                  propagated to the alertmanager pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Alertmanager pods. \n The following items
+                  are reserved and cannot be overridden: * \"alertmanager\" label,
+                  set to the name of the Alertmanager instance. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"alertmanager\". * \"app.kubernetes.io/version\"
+                  label, set to the Alertmanager version. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"alertmanager\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4085,8 +4085,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4453,8 +4453,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -3870,8 +3870,14 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata contains Labels and Annotations gets propagated
-                  to the thanos ruler pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the ThanosRuler pods. \n The following items are
+                  reserved and cannot be overridden: * \"app.kubernetes.io/name\"
+                  label, set to \"thanos-ruler\". * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/instance\"
+                  label, set to the name of the ThanosRuler instance. * \"thanos-ruler\"
+                  label, set to the name of the ThanosRuler instance. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"thanos-ruler\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4299,8 +4299,15 @@ spec:
                   objects are not goint to be performed, except for delete actions.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures Labels and Annotations which are
-                  propagated to the alertmanager pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Alertmanager pods. \n The following items
+                  are reserved and cannot be overridden: * \"alertmanager\" label,
+                  set to the name of the Alertmanager instance. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"alertmanager\". * \"app.kubernetes.io/version\"
+                  label, set to the Alertmanager version. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"alertmanager\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4085,8 +4085,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4453,8 +4453,17 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures labels and annotations which are
-                  propagated to the Prometheus pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the Prometheus pods. \n The following items are
+                  reserved and cannot be overridden: * \"prometheus\" label, set to
+                  the name of the Prometheus object. * \"app.kubernetes.io/instance\"
+                  label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\"
+                  label, set to \"prometheus\". * \"app.kubernetes.io/version\" label,
+                  set to the Prometheus version. * \"operator.prometheus.io/name\"
+                  label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\"
+                  label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"prometheus\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -3870,8 +3870,14 @@ spec:
                   for deletion will be performed on the underlying objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata contains Labels and Annotations gets propagated
-                  to the thanos ruler pods.
+                description: "PodMetadata configures labels and annotations which
+                  are propagated to the ThanosRuler pods. \n The following items are
+                  reserved and cannot be overridden: * \"app.kubernetes.io/name\"
+                  label, set to \"thanos-ruler\". * \"app.kubernetes.io/managed-by\"
+                  label, set to \"prometheus-operator\". * \"app.kubernetes.io/instance\"
+                  label, set to the name of the ThanosRuler instance. * \"thanos-ruler\"
+                  label, set to the name of the ThanosRuler instance. * \"kubectl.kubernetes.io/default-container\"
+                  annotation, set to \"thanos-ruler\"."
                 properties:
                   annotations:
                     additionalProperties:

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3944,7 +3944,7 @@
                     "type": "boolean"
                   },
                   "podMetadata": {
-                    "description": "PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.",
+                    "description": "PodMetadata configures labels and annotations which are propagated to the Alertmanager pods. \n The following items are reserved and cannot be overridden: * \"alertmanager\" label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/instance\" label, set to the name of the Alertmanager instance. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"alertmanager\". * \"app.kubernetes.io/version\" label, set to the Alertmanager version. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"alertmanager\".",
                     "properties": {
                       "annotations": {
                         "additionalProperties": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3657,7 +3657,7 @@
                     "type": "boolean"
                   },
                   "podMetadata": {
-                    "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods.",
+                    "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods. \n The following items are reserved and cannot be overridden: * \"prometheus\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/instance\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"prometheus\". * \"app.kubernetes.io/version\" label, set to the Prometheus version. * \"operator.prometheus.io/name\" label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\" label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"prometheus\".",
                     "properties": {
                       "annotations": {
                         "additionalProperties": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4033,7 +4033,7 @@
                     "type": "boolean"
                   },
                   "podMetadata": {
-                    "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods.",
+                    "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods. \n The following items are reserved and cannot be overridden: * \"prometheus\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/instance\" label, set to the name of the Prometheus object. * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/name\" label, set to \"prometheus\". * \"app.kubernetes.io/version\" label, set to the Prometheus version. * \"operator.prometheus.io/name\" label, set to the name of the Prometheus object. * \"operator.prometheus.io/shard\" label, set to the shard number of the Prometheus object. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"prometheus\".",
                     "properties": {
                       "annotations": {
                         "additionalProperties": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3523,7 +3523,7 @@
                     "type": "boolean"
                   },
                   "podMetadata": {
-                    "description": "PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.",
+                    "description": "PodMetadata configures labels and annotations which are propagated to the ThanosRuler pods. \n The following items are reserved and cannot be overridden: * \"app.kubernetes.io/name\" label, set to \"thanos-ruler\". * \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\". * \"app.kubernetes.io/instance\" label, set to the name of the ThanosRuler instance. * \"thanos-ruler\" label, set to the name of the ThanosRuler instance. * \"kubectl.kubernetes.io/default-container\" annotation, set to \"thanos-ruler\".",
                     "properties": {
                       "annotations": {
                         "additionalProperties": {

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -60,7 +60,15 @@ func (l *Alertmanager) DeepCopyObject() runtime.Object {
 // https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +k8s:openapi-gen=true
 type AlertmanagerSpec struct {
-	// PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.
+	// PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.
+	//
+	// The following items are reserved and cannot be overridden:
+	// * "alertmanager" label, set to the name of the Alertmanager instance.
+	// * "app.kubernetes.io/instance" label, set to the name of the Alertmanager instance.
+	// * "app.kubernetes.io/managed-by" label, set to "prometheus-operator".
+	// * "app.kubernetes.io/name" label, set to "alertmanager".
+	// * "app.kubernetes.io/version" label, set to the Alertmanager version.
+	// * "kubectl.kubernetes.io/default-container" annotation, set to "alertmanager".
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Image if specified has precedence over baseImage, tag and sha
 	// combinations. Specifying the version is still necessary to ensure the
@@ -115,10 +123,10 @@ type AlertmanagerSpec struct {
 	// receiver (effectively dropping alert notifications).
 	ConfigSecret string `json:"configSecret,omitempty"`
 	// Log level for Alertmanager to be configured with.
-	//+kubebuilder:validation:Enum="";debug;info;warn;error
+	// +kubebuilder:validation:Enum="";debug;info;warn;error
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for Alertmanager to be configured with.
-	//+kubebuilder:validation:Enum="";logfmt;json
+	// +kubebuilder:validation:Enum="";logfmt;json
 	LogFormat string `json:"logFormat,omitempty"`
 	// Size is the expected size of the alertmanager cluster. The controller will
 	// eventually make the size of the running cluster equal to the expected

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -60,6 +60,16 @@ func (l *Prometheus) GetStatus() PrometheusStatus {
 // +k8s:deepcopy-gen=true
 type CommonPrometheusFields struct {
 	// PodMetadata configures labels and annotations which are propagated to the Prometheus pods.
+	//
+	// The following items are reserved and cannot be overridden:
+	// * "prometheus" label, set to the name of the Prometheus object.
+	// * "app.kubernetes.io/instance" label, set to the name of the Prometheus object.
+	// * "app.kubernetes.io/managed-by" label, set to "prometheus-operator".
+	// * "app.kubernetes.io/name" label, set to "prometheus".
+	// * "app.kubernetes.io/version" label, set to the Prometheus version.
+	// * "operator.prometheus.io/name" label, set to the name of the Prometheus object.
+	// * "operator.prometheus.io/shard" label, set to the shard number of the Prometheus object.
+	// * "kubectl.kubernetes.io/default-container" annotation, set to "prometheus".
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 
 	// ServiceMonitors to be selected for target discovery. An empty label
@@ -205,10 +215,10 @@ type CommonPrometheusFields struct {
 	PrometheusExternalLabelName *string `json:"prometheusExternalLabelName,omitempty"`
 
 	// Log level for Prometheus and the config-reloader sidecar.
-	//+kubebuilder:validation:Enum="";debug;info;warn;error
+	// +kubebuilder:validation:Enum="";debug;info;warn;error
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for Log level for Prometheus and the config-reloader sidecar.
-	//+kubebuilder:validation:Enum="";logfmt;json
+	// +kubebuilder:validation:Enum="";logfmt;json
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Interval between consecutive scrapes.
@@ -302,7 +312,7 @@ type CommonPrometheusFields struct {
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Defines the pod's topology spread constraints if specified.
-	//+optional
+	// +optional
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
 	// Defines the list of remote write configurations.
@@ -787,7 +797,7 @@ type PrometheusSpec struct {
 
 type PrometheusTracingConfig struct {
 	// Client used to export the traces. Supported values are `http` or `grpc`.
-	//+kubebuilder:validation:Enum=http;grpc
+	// +kubebuilder:validation:Enum=http;grpc
 	// +optional
 	ClientType *string `json:"clientType"`
 
@@ -809,7 +819,7 @@ type PrometheusTracingConfig struct {
 	Headers map[string]string `json:"headers"`
 
 	// Compression key for supported compression types. The only supported value is `gzip`.
-	//+kubebuilder:validation:Enum=gzip
+	// +kubebuilder:validation:Enum=gzip
 	// +optional
 	Compression *string `json:"compression"`
 
@@ -1023,10 +1033,10 @@ type ThanosSpec struct {
 	GRPCServerTLSConfig *TLSConfig `json:"grpcServerTlsConfig,omitempty"`
 
 	// Log level for the Thanos sidecar.
-	//+kubebuilder:validation:Enum="";debug;info;warn;error
+	// +kubebuilder:validation:Enum="";debug;info;warn;error
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for the Thanos sidecar.
-	//+kubebuilder:validation:Enum="";logfmt;json
+	// +kubebuilder:validation:Enum="";logfmt;json
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Defines the start of time range limit served by the Thanos sidecar's StoreAPI.

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -68,7 +68,14 @@ type ThanosRulerList struct {
 type ThanosRulerSpec struct {
 	// Version of Thanos to be deployed.
 	Version string `json:"version,omitempty"`
-	// PodMetadata contains Labels and Annotations gets propagated to the thanos ruler pods.
+	// PodMetadata configures labels and annotations which are propagated to the ThanosRuler pods.
+	//
+	// The following items are reserved and cannot be overridden:
+	// * "app.kubernetes.io/name" label, set to "thanos-ruler".
+	// * "app.kubernetes.io/managed-by" label, set to "prometheus-operator".
+	// * "app.kubernetes.io/instance" label, set to the name of the ThanosRuler instance.
+	// * "thanos-ruler" label, set to the name of the ThanosRuler instance.
+	// * "kubectl.kubernetes.io/default-container" annotation, set to "thanos-ruler".
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Thanos container image URL.
 	Image string `json:"image,omitempty"`
@@ -158,10 +165,10 @@ type ThanosRulerSpec struct {
 	// Deprecated: use excludedFromEnforcement instead.
 	PrometheusRulesExcludedFromEnforce []PrometheusRuleExcludeConfig `json:"prometheusRulesExcludedFromEnforce,omitempty"`
 	// Log level for ThanosRuler to be configured with.
-	//+kubebuilder:validation:Enum="";debug;info;warn;error
+	// +kubebuilder:validation:Enum="";debug;info;warn;error
 	LogLevel string `json:"logLevel,omitempty"`
 	// Log format for ThanosRuler to be configured with.
-	//+kubebuilder:validation:Enum="";logfmt;json
+	// +kubebuilder:validation:Enum="";logfmt;json
 	LogFormat string `json:"logFormat,omitempty"`
 	// Port name used for the pods and governing service.
 	// Defaults to `web`.


### PR DESCRIPTION

## Description

Document common (reserved) labels in:
* `alertmanager`
* `prometheus`
* `thanos-ruler`

Fixes #4549.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Document overriding behavior for common (reserved) labels.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Document overriding behavior in common (reserved) labels for `alertmanager`, `prometheus`, and `thanos-ruler.
```
