### PR TITLE
refactor: move common steps from server and agent to prompkg

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -15,7 +15,6 @@
 package prometheusagent
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -716,35 +715,12 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return err
 	}
 
-	for i, remote := range p.Spec.RemoteWrite {
-		if err := prompkg.ValidateRemoteWriteSpec(remote); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		key := fmt.Sprintf("remoteWrite/%d", i)
-		if err := store.AddBasicAuth(ctx, p.GetNamespace(), remote.BasicAuth, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddOAuth2(ctx, p.GetNamespace(), remote.OAuth2, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddTLSConfig(ctx, p.GetNamespace(), remote.TLSConfig); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddAuthorizationCredentials(ctx, p.GetNamespace(), remote.Authorization, fmt.Sprintf("remoteWrite/auth/%d", i)); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddSigV4(ctx, p.GetNamespace(), remote.Sigv4, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
+	if err := prompkg.AddRemoteWritesToStore(ctx, store, p.GetNamespace(), p.Spec.RemoteWrite); err != nil {
+		return err
 	}
 
-	if p.Spec.APIServerConfig != nil {
-		if err := store.AddBasicAuth(ctx, p.GetNamespace(), p.Spec.APIServerConfig.BasicAuth, "apiserver"); err != nil {
-			return errors.Wrap(err, "apiserver config")
-		}
-		if err := store.AddAuthorizationCredentials(ctx, p.GetNamespace(), p.Spec.APIServerConfig.Authorization, "apiserver/auth"); err != nil {
-			return errors.Wrapf(err, "apiserver config")
-		}
+	if err := prompkg.AddAPIServerConfigToStore(ctx, store, p.GetNamespace(), p.Spec.APIServerConfig); err != nil {
+		return err
 	}
 
 	additionalScrapeConfigs, err := c.loadConfigFromSecret(p.Spec.AdditionalScrapeConfigs, SecretsInPromNS)
@@ -765,20 +741,13 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return errors.Wrap(err, "generating config failed")
 	}
 
-	s := prompkg.MakeConfigSecret(p, c.config)
-	s.ObjectMeta.Annotations = map[string]string{
-		"generated": "true",
-	}
-
 	// Compress config to avoid 1mb secret limit for a while
-	var buf bytes.Buffer
-	if err = operator.GzipConfig(&buf, conf); err != nil {
-		return errors.Wrap(err, "couldn't gzip config")
+	s, err := prompkg.MakeCompressedSecretForPrometheus(p, c.config, conf)
+	if err != nil {
+		return errors.Wrap(err, "creating compressed secret failed")
 	}
-	s.Data[prompkg.ConfigFilename] = buf.Bytes()
 
 	level.Debug(c.logger).Log("msg", "updating Prometheus configuration secret")
-
 	return k8sutil.CreateOrUpdateSecret(ctx, sClient, s)
 }
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -15,7 +15,6 @@
 package prometheus
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -1534,51 +1533,18 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return err
 	}
 
-	for i, remote := range p.Spec.RemoteRead {
-		if err := store.AddBasicAuth(ctx, p.GetNamespace(), remote.BasicAuth, fmt.Sprintf("remoteRead/%d", i)); err != nil {
-			return errors.Wrapf(err, "remote read %d", i)
-		}
-		if err := store.AddOAuth2(ctx, p.GetNamespace(), remote.OAuth2, fmt.Sprintf("remoteRead/%d", i)); err != nil {
-			return errors.Wrapf(err, "remote read %d", i)
-		}
-		if err := store.AddTLSConfig(ctx, p.GetNamespace(), remote.TLSConfig); err != nil {
-			return errors.Wrapf(err, "remote read %d", i)
-		}
-		if err := store.AddAuthorizationCredentials(ctx, p.GetNamespace(), remote.Authorization, fmt.Sprintf("remoteRead/auth/%d", i)); err != nil {
-			return errors.Wrapf(err, "remote read %d", i)
-		}
+	if err := prompkg.AddRemoteReadsToStore(ctx, store, p.GetNamespace(), p.Spec.RemoteRead); err != nil {
+		return err
 	}
 
-	for i, remote := range p.Spec.RemoteWrite {
-		if err := prompkg.ValidateRemoteWriteSpec(remote); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		key := fmt.Sprintf("remoteWrite/%d", i)
-		if err := store.AddBasicAuth(ctx, p.GetNamespace(), remote.BasicAuth, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddOAuth2(ctx, p.GetNamespace(), remote.OAuth2, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddTLSConfig(ctx, p.GetNamespace(), remote.TLSConfig); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddAuthorizationCredentials(ctx, p.GetNamespace(), remote.Authorization, fmt.Sprintf("remoteWrite/auth/%d", i)); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
-		if err := store.AddSigV4(ctx, p.GetNamespace(), remote.Sigv4, key); err != nil {
-			return errors.Wrapf(err, "remote write %d", i)
-		}
+	if err := prompkg.AddRemoteWritesToStore(ctx, store, p.GetNamespace(), p.Spec.RemoteWrite); err != nil {
+		return err
 	}
 
-	if p.Spec.APIServerConfig != nil {
-		if err := store.AddBasicAuth(ctx, p.GetNamespace(), p.Spec.APIServerConfig.BasicAuth, "apiserver"); err != nil {
-			return errors.Wrap(err, "apiserver config")
-		}
-		if err := store.AddAuthorizationCredentials(ctx, p.GetNamespace(), p.Spec.APIServerConfig.Authorization, "apiserver/auth"); err != nil {
-			return errors.Wrapf(err, "apiserver config")
-		}
+	if err := prompkg.AddAPIServerConfigToStore(ctx, store, p.GetNamespace(), p.Spec.APIServerConfig); err != nil {
+		return err
 	}
+
 	if p.Spec.Alerting != nil {
 		for i, am := range p.Spec.Alerting.Alertmanagers {
 			if err := store.AddBasicAuth(ctx, p.GetNamespace(), am.BasicAuth, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
@@ -1626,20 +1592,13 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return errors.Wrap(err, "generating config failed")
 	}
 
-	s := prompkg.MakeConfigSecret(p, c.config)
-	s.ObjectMeta.Annotations = map[string]string{
-		"generated": "true",
-	}
-
 	// Compress config to avoid 1mb secret limit for a while
-	var buf bytes.Buffer
-	if err = operator.GzipConfig(&buf, conf); err != nil {
-		return errors.Wrap(err, "couldn't gzip config")
+	s, err := prompkg.MakeCompressedSecretForPrometheus(p, c.config, conf)
+	if err != nil {
+		return errors.Wrap(err, "creating compressed secret failed")
 	}
-	s.Data[prompkg.ConfigFilename] = buf.Bytes()
 
 	level.Debug(c.logger).Log("msg", "updating Prometheus configuration secret")
-
 	return k8sutil.CreateOrUpdateSecret(ctx, sClient, s)
 }
 

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -15,12 +15,14 @@
 package prometheus
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -125,6 +127,22 @@ func MakeConfigSecret(p monitoringv1.PrometheusInterface, config operator.Config
 			ConfigFilename: {},
 		},
 	}
+}
+
+func MakeCompressedSecretForPrometheus(p monitoringv1.PrometheusInterface, config operator.Config, data []byte) (*v1.Secret, error) {
+
+	s := MakeConfigSecret(p, config)
+	s.ObjectMeta.Annotations = config.Annotations.Merge(map[string]string{
+		"generated": "true",
+	})
+
+	var buf bytes.Buffer
+	if err := operator.GzipConfig(&buf, data); err != nil {
+		return nil, errors.Wrap(err, "failed to gzip config")
+	}
+	s.Data[ConfigFilename] = buf.Bytes()
+
+	return s, nil
 }
 
 func ConfigSecretName(p monitoringv1.PrometheusInterface) string {

--- a/pkg/prometheus/store.go
+++ b/pkg/prometheus/store.go
@@ -1,0 +1,90 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+)
+
+func AddRemoteWritesToStore(ctx context.Context, store *assets.Store, namespace string, remotes []monv1.RemoteWriteSpec) error {
+	if store == nil && len(remotes) > 0 {
+		return errors.New("remoteWrites cannot be added to a nil store")
+	}
+
+	for i, remote := range remotes {
+		if err := ValidateRemoteWriteSpec(remote); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+		key := fmt.Sprintf("remoteWrite/%d", i)
+		if err := store.AddBasicAuth(ctx, namespace, remote.BasicAuth, key); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+		if err := store.AddOAuth2(ctx, namespace, remote.OAuth2, key); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+		if err := store.AddTLSConfig(ctx, namespace, remote.TLSConfig); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+		if err := store.AddAuthorizationCredentials(ctx, namespace, remote.Authorization, fmt.Sprintf("remoteWrite/auth/%d", i)); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+		if err := store.AddSigV4(ctx, namespace, remote.Sigv4, key); err != nil {
+			return errors.Wrapf(err, "remote write %d", i)
+		}
+	}
+	return nil
+}
+
+func AddRemoteReadsToStore(ctx context.Context, store *assets.Store, namespace string, remotes []monv1.RemoteReadSpec) error {
+	if store == nil && len(remotes) > 0 {
+		return errors.New("remoteReads cannot be added to a nil store")
+	}
+
+	for i, remote := range remotes {
+		if err := store.AddBasicAuth(ctx, namespace, remote.BasicAuth, fmt.Sprintf("remoteRead/%d", i)); err != nil {
+			return errors.Wrapf(err, "remote read %d", i)
+		}
+		if err := store.AddOAuth2(ctx, namespace, remote.OAuth2, fmt.Sprintf("remoteRead/%d", i)); err != nil {
+			return errors.Wrapf(err, "remote read %d", i)
+		}
+		if err := store.AddTLSConfig(ctx, namespace, remote.TLSConfig); err != nil {
+			return errors.Wrapf(err, "remote read %d", i)
+		}
+		if err := store.AddAuthorizationCredentials(ctx, namespace, remote.Authorization, fmt.Sprintf("remoteRead/auth/%d", i)); err != nil {
+			return errors.Wrapf(err, "remote read %d", i)
+		}
+	}
+	return nil
+}
+
+func AddAPIServerConfigToStore(ctx context.Context, store *assets.Store, namespace string, config *monv1.APIServerConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if err := store.AddBasicAuth(ctx, namespace, config.BasicAuth, "apiserver"); err != nil {
+		return errors.Wrap(err, "apiserver config")
+	}
+	if err := store.AddAuthorizationCredentials(ctx, namespace, config.Authorization, "apiserver/auth"); err != nil {
+		return errors.Wrapf(err, "apiserver config")
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

This commit partially address https://github.com/prometheus-operator/prometheus-operator/issues/5455 by refactoring server and agent operator code that updates the prometheus config secrets. It moves the common functionalities to pkg/prometheus (prompkg).

The refactor adds the following functions

Store Related
  * AddRemoteWritesToStore
  * AddRemoteReadToStore
  * AddAPIServerConfigToStore

Operator Related
  * MakeCompressedSecretForPrometheus

GH: https://github.com/prometheus-operator/prometheus-operator/issues/5455


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.) refactor

