### PR TITLE
chore: remove RulerStatus() function

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -17,7 +17,6 @@ package thanos
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -470,10 +469,6 @@ func (o *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
 	return tr.(*monitoringv1.ThanosRuler)
 }
 
-func statefulSetNameFromThanosName(name string) string {
-	return "thanos-ruler-" + name
-}
-
 func statefulSetKeyToThanosKey(key string) string {
 	keyParts := strings.Split(key, "/")
 	return keyParts[0] + "/" + strings.TrimPrefix(keyParts[1], "thanos-ruler-")
@@ -735,62 +730,6 @@ func ListOptions(name string) metav1.ListOptions {
 			thanosRulerLabel:         name,
 		})).String(),
 	}
-}
-
-// RulerStatus evaluates the current status of a ThanosRuler deployment with
-// respect to its specified resource object. It returns the status and a list of
-// pods that are not updated.
-// TODO(simonpasquier): remove after 0.66.0 is released.
-func RulerStatus(ctx context.Context, kclient kubernetes.Interface, tr *monitoringv1.ThanosRuler) (*monitoringv1.ThanosRulerStatus, []v1.Pod, error) {
-	res := &monitoringv1.ThanosRulerStatus{Paused: tr.Spec.Paused}
-
-	pods, err := kclient.CoreV1().Pods(tr.Namespace).List(ctx, ListOptions(tr.Name))
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "retrieving pods of failed")
-	}
-	sset, err := kclient.AppsV1().StatefulSets(tr.Namespace).Get(ctx, statefulSetNameFromThanosName(tr.Name), metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "retrieving stateful set failed")
-	}
-
-	res.Replicas = int32(len(pods.Items))
-
-	var oldPods []v1.Pod
-	for _, pod := range pods.Items {
-		ready, err := k8sutil.PodRunningAndReady(pod)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "cannot determine pod ready state")
-		}
-		if ready {
-			res.AvailableReplicas++
-			// TODO(fabxc): detect other fields of the pod template
-			// that are mutable.
-			if needsUpdate(&pod, sset.Spec.Template) {
-				oldPods = append(oldPods, pod)
-			} else {
-				res.UpdatedReplicas++
-			}
-			continue
-		}
-		res.UnavailableReplicas++
-	}
-
-	return res, oldPods, nil
-}
-
-func needsUpdate(pod *v1.Pod, tmpl v1.PodTemplateSpec) bool {
-	c1 := pod.Spec.Containers[0]
-	c2 := tmpl.Spec.Containers[0]
-
-	if c1.Image != c2.Image {
-		return true
-	}
-
-	if !reflect.DeepEqual(c1.Args, c2.Args) {
-		return true
-	}
-
-	return false
 }
 
 func (o *Operator) enqueueForThanosRulerNamespace(nsName string) {

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,25 +107,6 @@ func (f *Framework) PatchThanosRuler(ctx context.Context, name, ns string, spec 
 }
 
 func (f *Framework) WaitForThanosRulerReady(ctx context.Context, ns string, tr *monitoringv1.ThanosRuler, timeout time.Duration) error {
-	if f.operatorVersion.LT(semver.MustParse("0.65.0")) {
-		var pollErr error
-
-		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
-			st, _, pollErr := thanos.RulerStatus(context.Background(), f.KubeClient, tr)
-
-			if pollErr != nil {
-				return false, nil
-			}
-
-			if st.UpdatedReplicas == *tr.Spec.Replicas {
-				return true, nil
-			}
-
-			return false, nil
-		})
-		return errors.Wrapf(pollErr, "waiting for ThanosRuler %v/%v: %v", tr.Namespace, tr.Name, err)
-	}
-
 	expected := *tr.Spec.Replicas
 
 	if err := f.WaitForResourceAvailable(


### PR DESCRIPTION
## Description

This was a TODO to be resolved after v0.66.0 gets released.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
