### PR TITLE
feature: prometheus validation webhooks

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -434,12 +434,32 @@ func run() int {
 		}
 	}
 
-	validationTriggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
+	promRuleMutationTiggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_rule_mutation_triggered_total",
+		Help: "Number of times a prometheusRule object triggered mutation",
+	})
+
+	promRuleMutationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_rule_mutation_errors_total",
+		Help: "Number of errors that occurred while mutating a prometheusRules object",
+	})
+
+	promValidationTriggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_prometheus_validation_triggered_total",
+		Help: "Number of times a prometheus object triggered validation",
+	})
+
+	promValidationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_prometheus_validation_errors_total",
+		Help: "Number of errors that occurred while validating a prometheus object",
+	})
+
+	promRuleValidationTriggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_triggered_total",
 		Help: "DEPRECATED, removed in v0.57.0: Number of times a prometheusRule object triggered validation",
 	})
 
-	validationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
+	promRuleValidationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_errors_total",
 		Help: "DEPRECATED, removed in v0.57.0: Number of errors that occurred while validating a prometheusRules object",
 	})
@@ -457,16 +477,24 @@ func run() int {
 	r.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		validationTriggeredCounter,
-		validationErrorsCounter,
+		promRuleMutationTiggeredCounter,
+		promRuleMutationErrorsCounter,
+		promValidationTriggeredCounter,
+		promValidationErrorsCounter,
+		promRuleValidationTriggeredCounter,
+		promRuleValidationErrorsCounter,
 		alertManagerConfigValidationTriggered,
 		alertManagerConfigValidationError,
 		version.NewCollector("prometheus_operator"),
 	)
 
 	admit.RegisterMetrics(
-		validationTriggeredCounter,
-		validationErrorsCounter,
+		promRuleMutationTiggeredCounter,
+		promRuleMutationErrorsCounter,
+		promValidationTriggeredCounter,
+		promValidationErrorsCounter,
+		promRuleValidationTriggeredCounter,
+		promRuleValidationErrorsCounter,
 		alertManagerConfigValidationTriggered,
 		alertManagerConfigValidationError,
 	)

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -324,12 +324,27 @@ func TestAlertmanagerConfigConversion(t *testing.T) {
 }
 
 func api() *Admission {
-	validationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
+	promRuleMutationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_rule_mutation_triggered_total",
+		Help: "Number of times a prometheusRule object triggered mutation",
+	})
+	promRuleMutationErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_rule_mutation_errors_total",
+		Help: "Number of errors that occurred while mutating a prometheusRules object",
+	})
+	promValidationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_prometheus_validation_triggered_total",
+		Help: "Number of times a prometheus object triggered validation",
+	})
+	promValidationErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_operator_prometheus_validation_errors_total",
+		Help: "Number of errors that occurred while validating a prometheus object",
+	})
+	promRuleValidationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_triggered_total",
 		Help: "Number of times a prometheusRule object triggered validation",
 	})
-
-	validationErrors := prometheus.NewCounter(prometheus.CounterOpts{
+	promRuleValidationErrors := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_rule_validation_errors_total",
 		Help: "Number of errors that occurred while validating a prometheusRules object",
 	})
@@ -337,14 +352,22 @@ func api() *Admission {
 		Name: "prometheus_operator_alertmanager_config_validation_triggered_total",
 		Help: "Number of times an alertmanagerconfig object triggered validation",
 	})
-
 	alertManagerConfigValidationError := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_operator_alertmanager_config_validation_errors_total",
 		Help: "Number of errors that occurred while validating a alertmanagerconfig object",
 	})
 
 	a := New(level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)), level.AllowNone()))
-	a.RegisterMetrics(validationTriggered, validationErrors, alertManagerConfigValidationTriggered, alertManagerConfigValidationError)
+	a.RegisterMetrics(
+		promRuleMutationTriggered,
+		promRuleMutationErrors,
+		promValidationTriggered,
+		promValidationErrors,
+		promRuleValidationTriggered,
+		promRuleValidationErrors,
+		alertManagerConfigValidationTriggered,
+		alertManagerConfigValidationError,
+	)
 
 	return a
 }

--- a/pkg/apis/monitoring/v1/prometheusrule_types.go
+++ b/pkg/apis/monitoring/v1/prometheusrule_types.go
@@ -24,6 +24,7 @@ const (
 	PrometheusRuleKind    = "PrometheusRule"
 	PrometheusRuleName    = "prometheusrules"
 	PrometheusRuleKindKey = "prometheusrule"
+	PrometheusKind        = "Prometheus"
 )
 
 // +genclient


### PR DESCRIPTION
## Description

prometheus validation webhooks that (currently) only check for deprecated field and warn if that's the case.

Fixes: #5681

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
prometheus validation webhooks that (currently) only check for deprecated field and warn if that's the case.
```
