### PR TITLE
Hide generated files from Github diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 **/zz_generated.*.go linguist-generated=true
+bundle.yaml linguist-generated=true
+example/prometheus-operator-crd-full/* linguist-generated=true
+example/prometheus-operator-crd/* linguist-generated=true
+example/jsonnet/prometheus-operator/* linguist-generated=true
+Documentation/api.md linguist-generated=true


### PR DESCRIPTION
## Description

We've recently enabled a Github app that labels PRs by their diff size. Any PR that touches generated files is almost always labeled as XXL, which is not always true if we ignore generated files.

This PR properly configured generated files to be ignored in the Github diff, so they get labeled correctly. See: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github





## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
