### PR TITLE
docs: Improve Thanos Ruler doc with examples

### DIFF
--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -85,7 +85,7 @@ responsible for compactions on a global, object storage level.
 
 ## Thanos Ruler
 
-The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one `queryEndpoints` which points to the location of Thanos Queriers. The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos rulers. The `alertmanagersConfig` allows you to provide the Alertmanager definition, so you can use Ruler to evaluate alerting rules defined on `PrometheusRule`. The `alertmanagersConfig` then will allow you to define your `--alertmanagers.config` argument via secret.
+The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one Query API server defined either by the `.spec.queryConfig` field or the `.spec.queryEndpoints` field.  It can also be configured to send alerts to Alertmanager with the `.spec.alertmanagersConfig`.
 
 ```yaml
 ...

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -85,7 +85,7 @@ responsible for compactions on a global, object storage level.
 
 ## Thanos Ruler
 
-The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one Query API server defined either by the `.spec.queryConfig` field or the `.spec.queryEndpoints` field.  It can also be configured to send alerts to Alertmanager with the `.spec.alertmanagersConfig`.
+The [Thanos Ruler](https://thanos.io/tip/components/rule.md/) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one Query API server defined either by the `.spec.queryConfig` field or the `.spec.queryEndpoints` field.  It can also be configured to send alerts to Alertmanager with the `.spec.alertmanagersConfig`.
 
 ```yaml
 ...
@@ -111,10 +111,16 @@ spec:
 More context for your Alertmanager configuration can be found in the [Thanos documentation](https://thanos.io/tip/components/rule.md/#alertmanager). An example:
 
 ```yaml
- alertmanagers:
-- static_configs:
-  - "dnssrv+_web._tcp.alertmanager-operated.monitoring.svc.cluster.local"
-  api_version: v2
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanosruler-alertmanager-config
+stringData:
+  alertmanager-configs.yaml: |-
+    alertmanagers:
+    - static_configs:
+      - "dnssrv+_web._tcp.alertmanager-operated.monitoring.svc.cluster.local"
+      api_version: v2
 ```
 
 Can be saved as `/tmp/alertmanager-configs.yaml`, and you can create in your namespace, for example `monitoring` as `thanosruler-alertmanager-config` imperatively with:

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -85,7 +85,7 @@ responsible for compactions on a global, object storage level.
 
 ## Thanos Ruler
 
-The [Thanos Ruler](https://thanos.io/tip/components/rule.md/) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one Query API server defined either by the `.spec.queryConfig` field or the `.spec.queryEndpoints` field.  It can also be configured to send alerts to Alertmanager with the `.spec.alertmanagersConfig`.
+The [Thanos Ruler](https://thanos.io/tip/components/rule.md/) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one Query API server defined either by the `.spec.queryConfig` field or the `.spec.queryEndpoints` field. It can also be configured to send alerts to Alertmanager with the `.spec.alertmanagersConfig`.
 
 ```yaml
 ...

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -85,8 +85,7 @@ responsible for compactions on a global, object storage level.
 
 ## Thanos Ruler
 
-The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component allows recording and alerting rules to be processed across
-multiple Prometheus instances. A `ThanosRuler` instance requires at least one `queryEndpoints` which points to the location of Thanos Queriers or Prometheus instances. The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos rulers. The `alertmanagersConfig` allows you to provide the Alertmanager definition, so you can use Ruler to evaluate alerting rules defined on `PrometheusRule`. The `alertmanagersConfig` then will allow you to define your `--alertmanagers.config` argument via secret.
+The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component evaluates Prometheus recording and alerting rules against chosen query API. A `ThanosRuler` instance requires at least one `queryEndpoints` which points to the location of Thanos Queriers. The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos rulers. The `alertmanagersConfig` allows you to provide the Alertmanager definition, so you can use Ruler to evaluate alerting rules defined on `PrometheusRule`. The `alertmanagersConfig` then will allow you to define your `--alertmanagers.config` argument via secret.
 
 ```yaml
 ...

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -113,7 +113,7 @@ More context for your Alertmanager configuration can be found in the [Thanos doc
 ```yaml
  alertmanagers:
 - static_configs: ["alertmanager-dns"]
-  api_version: v1
+  api_version: v2
 ```
 
 Can be saved as `/tmp/alertmanager-configs.yaml`, and you can create in your namespace, for example `monitoring` as `thanosruler-alertmanager-config` imperatively with:

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -112,7 +112,8 @@ More context for your Alertmanager configuration can be found in the [Thanos doc
 
 ```yaml
  alertmanagers:
-- static_configs: ["alertmanager-dns"]
+- static_configs:
+  - "dnssrv+_web._tcp.alertmanager-operated.monitoring.svc.cluster.local"
   api_version: v2
 ```
 

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -121,7 +121,9 @@ Can be saved as `/tmp/alertmanager-configs.yaml`, and you can create in your nam
 ```sh
 kubectl -n monitoring create secret generic thanosruler-alertmanager-config --from-file=alertmanager-configs.yaml=/tmp/alertmanager-configs.yaml
 ```
+
 The recording and alerting rules used by a `ThanosRuler` component, are configured using the same `PrometheusRule` objects which are used by Prometheus. In the given example, the rules contained in any `PrometheusRule` object which match the label `role=my-thanos-rules` will be loaded by the Thanos Ruler pods.
+
 ## Other Thanos Components
 
 Deploying the sidecar was the first step towards getting Thanos up and running, but there are more components to be deployed to get a complete Thanos setup.

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -87,6 +87,7 @@ responsible for compactions on a global, object storage level.
 
 The [Thanos Ruler](https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md) component allows recording and alerting rules to be processed across
 multiple Prometheus instances. A `ThanosRuler` instance requires at least one `queryEndpoints` which points to the location of Thanos Queriers or Prometheus instances. The `queryEndpoints` are used to configure the `--query` arguments(s) of the Thanos rulers. The `alertmanagersConfig` allows you to provide the Alertmanager definition, so you can use Ruler to evaluate alerting rules defined on `PrometheusRule`. The `alertmanagersConfig` then will allow you to define your `--alertmanagers.config` argument via secret.
+
 ```yaml
 ...
 apiVersion: monitoring.coreos.com/v1
@@ -115,9 +116,11 @@ More context for your Alertmanager configuration can be found in the [Thanos doc
 - static_configs: ["alertmanager-dns"]
   api_version: v1
 ```
+
 Can be saved as `/tmp/alertmanager-configs.yaml`, and you can create in your namespace, for example `monitoring` as `thanosruler-alertmanager-config` imperatively with:
+
 ```sh
-kubectl -n monitoring create secret generic thanosruler-alertmanager-config --from-file=/tmp/alertmanager-configs.yaml
+kubectl -n monitoring create secret generic thanosruler-alertmanager-config --from-file=alertmanager-configs.yaml=/tmp/alertmanager-configs.yaml
 ```
 The recording and alerting rules used by a `ThanosRuler` component, are configured using the same `PrometheusRule` objects which are used by Prometheus. In the given example, the rules contained in any `PrometheusRule` object which match the label `role=my-thanos-rules` will be loaded by the Thanos Ruler pods.
 ## Other Thanos Components


### PR DESCRIPTION
## Description
From issue [#5722](https://github.com/prometheus-operator/prometheus-operator/issues/5722), add example for the Alertmanager Configuration for Thanos Ruler.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
