### PR TITLE
alertmanager: add etc/alertmanager/config

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -569,7 +569,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 		})
 	}
 
-	watchedDirectories := []string{}
+	watchedDirectories := []string{alertmanagerConfigDir}
 	configReloaderVolumeMounts := []v1.VolumeMount{
 		{
 			Name:      alertmanagerConfigVolumeName,

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -389,6 +389,7 @@ func TestListenTLS(t *testing.T) {
 		"--reload-url=https://localhost:9093/-/reload",
 		"--config-file=/etc/alertmanager/config/alertmanager.yaml.gz",
 		"--config-envsubst-file=/etc/alertmanager/config_out/alertmanager.env.yaml",
+		"--watched-dir=/etc/alertmanager/config",
 	}
 
 	for _, c := range sset.Spec.Template.Spec.Containers {
@@ -1141,6 +1142,7 @@ func TestConfigReloader(t *testing.T) {
 		"--reload-url=http://localhost:9093/-/reload",
 		"--config-file=/etc/alertmanager/config/alertmanager.yaml.gz",
 		"--config-envsubst-file=/etc/alertmanager/config_out/alertmanager.env.yaml",
+		"--watched-dir=/etc/alertmanager/config",
 	}
 
 	for _, c := range baseSet.Spec.Template.Spec.Containers {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -237,6 +237,7 @@ func testAllNSAlertmanager(t *testing.T) {
 		"AMRollbackManualChanges":                 testAMRollbackManualChanges,
 		"AMMinReadySeconds":                       testAlertManagerMinReadySeconds,
 		"AMWeb":                                   testAMWeb,
+		"AMTemplateReloadConfig":                  testAMTmplateReloadConfig,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
## Description

 add etc/alertmanager/config to watched-dir when init pods to support config reload when template files are modified.
#5708 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


```
