### PR TITLE
Run PrometheusVersionUpgrade tests separately

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -89,6 +89,7 @@ jobs:
         EXCLUDE_THANOSRULER_TESTS=${{ matrix.thanosruler }}
         EXCLUDE_OPERATOR_UPGRADE_TESTS=${{ matrix.operatorUpgrade }}
         FEATURE_GATED_TESTS=${{ matrix.featureGated }}
+        EXCLUDE_PROMETHEUS_UPGRADE_TESTS=exclude
         make test-e2e
 
   # Added to summarize the matrix and allow easy branch protection rules setup

--- a/.github/workflows/test-prom-version-upgrade.yaml
+++ b/.github/workflows/test-prom-version-upgrade.yaml
@@ -1,0 +1,50 @@
+name: e2e
+on:
+  schedule:
+    - cron:  '37 15 * * *' # Every day 15:37
+
+jobs:
+  e2e-tests:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Import environment variables from file
+      run: cat ".github/env" >> $GITHUB_ENV
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '${{ env.golang-version }}'
+    - name: Build images
+      run: |
+        export SHELL=/bin/bash
+        make build image
+    - name: Start KinD
+      uses: helm/kind-action@v1.7.0
+      with:
+        version: ${{ env.kind-version }}
+        node_image: ${{ env.kind-image }}
+        wait: 300s
+        config: ./test/e2e/kind-conf.yaml
+        cluster_name: e2e
+    - name: Wait for cluster to finish bootstraping
+      run: |
+        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
+        kubectl cluster-info
+        kubectl get pods -A
+    - name: Load images
+      run: |
+        kind load docker-image -n e2e quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)
+        kind load docker-image -n e2e quay.io/prometheus-operator/prometheus-config-reloader:$(git rev-parse --short HEAD)
+        kind load docker-image -n e2e quay.io/prometheus-operator/admission-webhook:$(git rev-parse --short HEAD)
+        kubectl apply -f scripts/kind-rbac.yaml
+    - name: Run tests
+      run: >
+        EXCLUDE_ALL_NS_TESTS=exclude
+        EXCLUDE_ALERTMANAGER_TESTS=exclude
+        EXCLUDE_PROMETHEUS_TESTS=exclude
+        EXCLUDE_PROMETHEUS_ALL_NS_TESTS=exclude
+        EXCLUDE_THANOSRULER_TESTS=exclude
+        EXCLUDE_OPERATOR_UPGRADE_TESTS=exclude
+        FEATURE_GATED_TESTS=exclude 
+        make test-e2e

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -67,6 +67,18 @@ func skipOperatorUpgradeTests(t *testing.T) {
 	}
 }
 
+func skipPromVersionUpgradeTests(t *testing.T) {
+	if os.Getenv("EXCLUDE_PROMETHEUS_UPGRADE_TESTS") != "" {
+		t.Skip("Skipping Prometheus Version upgrade tests")
+	}
+}
+
+func skipAllNSTests(t *testing.T) {
+	if os.Getenv("EXCLUDE_ALL_NS_TESTS") != "" {
+		t.Skip("Skipping AllNS upgrade tests")
+	}
+}
+
 // feature gated tests need to be explicitly included
 // not currently in use
 //
@@ -160,6 +172,8 @@ func TestMain(m *testing.M) {
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
 func TestAllNS(t *testing.T) {
+	skipAllNSTests(t)
+
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
 
@@ -253,7 +267,6 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromCreateDeleteCluster":                   testPromCreateDeleteCluster,
 		"PromScaleUpDownCluster":                    testPromScaleUpDownCluster,
 		"PromNoServiceMonitorSelector":              testPromNoServiceMonitorSelector,
-		"PromVersionMigration":                      testPromVersionMigration,
 		"PromResourceUpdate":                        testPromResourceUpdate,
 		"PromStorageLabelsAnnotations":              testPromStorageLabelsAnnotations,
 		"PromStorageUpdate":                         testPromStorageUpdate,
@@ -392,6 +405,18 @@ func TestOperatorUpgrade(t *testing.T) {
 const (
 	prometheusOperatorServiceName = "prometheus-operator"
 )
+
+// TestPrometheusVersionUpgrade tests that all Prometheus versions in the compatibility matrix can be upgraded
+func TestPrometheusVersionUpgrade(t *testing.T) {
+	skipPromVersionUpgradeTests(t)
+	testFuncs := map[string]func(t *testing.T){
+		"PromVersionMigration": testPromVersionMigration,
+	}
+
+	for name, f := range testFuncs {
+		t.Run(name, f)
+	}
+}
 
 func testServerTLS(ctx context.Context, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {


### PR DESCRIPTION
## Description

As our compatibility matrix grows, the tests assuring we can upgrade from one Prometheus version to the next are taking up to 1~2h to complete. We aim to accelerate our e2e tests that are required to pass on Pull Requests by moving this test to a separate CI, that runs once a day.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
