### PR TITLE
support sharding for probe

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -957,6 +957,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		// Add configured relabelings.
 		xc := labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.StaticConfig.RelabelConfigs)
 		relabelings = append(relabelings, generateRelabelConfig(xc)...)
+		relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
 		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	case m.Spec.Targets.Ingress != nil:

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -909,6 +909,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 			},
 		}...)
 	}
+	relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
 	labeler := namespacelabeler.New(cpf.EnforcedNamespaceLabel, cpf.ExcludedFromEnforcement, false)
 
 	// As stated in the CRD documentation, if both StaticConfig and Ingress are
@@ -957,7 +958,6 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		// Add configured relabelings.
 		xc := labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.StaticConfig.RelabelConfigs)
 		relabelings = append(relabelings, generateRelabelConfig(xc)...)
-		relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
 		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	case m.Spec.Targets.Ingress != nil:
@@ -1054,10 +1054,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 
 		// Add configured relabelings.
 		relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.Ingress.RelabelConfigs))...)
-		relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
-
 		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
-
 	}
 
 	if m.Spec.TLSConfig != nil {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -909,7 +909,6 @@ func (cg *ConfigGenerator) generateProbeConfig(
 			},
 		}...)
 	}
-	relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
 	labeler := namespacelabeler.New(cpf.EnforcedNamespaceLabel, cpf.ExcludedFromEnforcement, false)
 
 	// As stated in the CRD documentation, if both StaticConfig and Ingress are
@@ -958,7 +957,6 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		// Add configured relabelings.
 		xc := labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.StaticConfig.RelabelConfigs)
 		relabelings = append(relabelings, generateRelabelConfig(xc)...)
-		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	case m.Spec.Targets.Ingress != nil:
 		// Generate kubernetes_sd_config section for the ingress resources.
@@ -1054,6 +1052,10 @@ func (cg *ConfigGenerator) generateProbeConfig(
 
 		// Add configured relabelings.
 		relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.Ingress.RelabelConfigs))...)
+	}
+
+	if m.Spec.Targets.StaticConfig != nil || m.Spec.Targets.Ingress != nil {
+		relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
 		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 	}
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1054,10 +1054,8 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.Ingress.RelabelConfigs))...)
 	}
 
-	if m.Spec.Targets.StaticConfig != nil || m.Spec.Targets.Ingress != nil {
-		relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
-		cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
-	}
+	relabelings = generateAddressShardingRelabelingRulesForProbes(relabelings, shards)
+	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	if m.Spec.TLSConfig != nil {
 		cfg = addSafeTLStoYaml(cfg, m.Namespace, m.Spec.TLSConfig.SafeTLSConfig)

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -504,15 +504,6 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
-  - source_labels:
     - __address__
     target_label: __param_target
   - source_labels:
@@ -522,6 +513,15 @@ scrape_configs:
     replacement: blackbox.exporter.io
   - target_label: namespace
     replacement: default
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop
@@ -610,6 +610,14 @@ scrape_configs:
   - target_label: job
     replacement: blackbox
   - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
+  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -618,14 +626,6 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-  - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -706,6 +706,14 @@ scrape_configs:
   - target_label: job
     replacement: blackbox
   - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
+  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -714,14 +722,6 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-  - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -809,15 +809,6 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -853,6 +844,15 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 
@@ -941,15 +941,6 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 2
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -985,6 +976,15 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 	require.Equal(t, expected, string(cfg))
@@ -1072,15 +1072,6 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -1118,6 +1109,15 @@ scrape_configs:
     action: replace
   - target_label: namespace
     replacement: default
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs:
   - target_label: namespace
     replacement: default
@@ -6589,6 +6589,14 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
+  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -6597,14 +6605,6 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-  - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -6636,6 +6636,14 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
+  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -6644,14 +6652,6 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
-  - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -8707,15 +8707,6 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
-  - source_labels:
     - __address__
     target_label: __param_target
   - source_labels:
@@ -8726,6 +8717,15 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `,
 		},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -504,6 +504,15 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
+  - source_labels:
     - __address__
     target_label: __param_target
   - source_labels:
@@ -513,15 +522,6 @@ scrape_configs:
     replacement: blackbox.exporter.io
   - target_label: namespace
     replacement: default
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop
@@ -610,14 +610,6 @@ scrape_configs:
   - target_label: job
     replacement: blackbox
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -626,6 +618,14 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -706,14 +706,6 @@ scrape_configs:
   - target_label: job
     replacement: blackbox
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -722,6 +714,14 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -809,6 +809,15 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -844,15 +853,6 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   metric_relabel_configs: []
 `
 
@@ -941,6 +941,15 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -976,15 +985,6 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 2
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   metric_relabel_configs: []
 `
 	require.Equal(t, expected, string(cfg))
@@ -1072,6 +1072,15 @@ scrape_configs:
   - source_labels:
     - job
     target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   - action: keep
     source_labels:
     - __meta_kubernetes_ingress_label_prometheus_io_probe
@@ -1109,15 +1118,6 @@ scrape_configs:
     action: replace
   - target_label: namespace
     replacement: default
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   metric_relabel_configs:
   - target_label: namespace
     replacement: default
@@ -6589,14 +6589,6 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -6605,6 +6597,14 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -6636,14 +6636,6 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
-    - __address__
-    target_label: __param_target
-  - source_labels:
-    - __param_target
-    target_label: instance
-  - target_label: __address__
-    replacement: blackbox.exporter.io
-  - source_labels:
     - __param_target
     target_label: __tmp_hash
     modulus: 1
@@ -6652,6 +6644,14 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
   metric_relabel_configs: []
 `
 
@@ -8707,6 +8707,15 @@ scrape_configs:
     - job
     target_label: __tmp_prometheus_job_name
   - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
+  - source_labels:
     - __address__
     target_label: __param_target
   - source_labels:
@@ -8717,15 +8726,6 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
-  - source_labels:
-    - __param_target
-    target_label: __tmp_hash
-    modulus: 1
-    action: hashmod
-  - source_labels:
-    - __tmp_hash
-    regex: $(SHARD)
-    action: keep
   metric_relabel_configs: []
 `,
 		},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -8636,6 +8636,19 @@ scrape_configs:
 - job_name: probe/default/probe1
   honor_timestamps: true
   metrics_path: ""
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `,
 		},
@@ -8661,6 +8674,19 @@ scrape_configs:
   metrics_path: /probe
   scheme: http
   proxy_url: socks://myproxy:9095
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `,
 		},
@@ -8747,6 +8773,19 @@ scrape_configs:
   params:
     module:
     - http_2xx
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `,
 		},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -513,6 +513,15 @@ scrape_configs:
     replacement: blackbox.exporter.io
   - target_label: namespace
     replacement: default
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop
@@ -608,6 +617,15 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 
@@ -695,6 +713,15 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 
@@ -6569,6 +6596,15 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 
@@ -6607,6 +6643,15 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: blackbox.exporter.io
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `
 
@@ -8672,6 +8717,15 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
+  - source_labels:
+    - __param_target
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
   metric_relabel_configs: []
 `,
 		},


### PR DESCRIPTION
## Description

fix https://github.com/prometheus-operator/prometheus-operator/issues/5176. 
By adding a sharding relabeling rule, prometheus operator will shard targets in the probe across the prometheus cluster.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
support sharding for probe.
```
