### PR TITLE
Fixing #5338 | Added labels in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,8 @@ COPY operator /bin/operator
 # On busybox 'nobody' has uid `65534'
 USER 65534
 
+LABEL org.opencontainers.image.source="https://github.com/prometheus-operator/prometheus-operator" \
+    org.opencontainers.image.documentation="https://prometheus-operator.dev/docs/prologue/introduction/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 ENTRYPOINT ["/bin/operator"]


### PR DESCRIPTION
## Description

* Fixing #5338
* Added OCI labels in the Dockerfile

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

* Added OCI labels in the Dockerfile

```release-note

```
