### PR TITLE
Makefile: generate kustomization.yaml files

### DIFF
--- a/example/prometheus-operator-crd-full/kustomization.yaml
+++ b/example/prometheus-operator-crd-full/kustomization.yaml
@@ -1,0 +1,14 @@
+# Code generated using 'make generate-crds'. DO NOT EDIT
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring.coreos.com_alertmanagers.yaml
+- monitoring.coreos.com_servicemonitors.yaml
+- monitoring.coreos.com_podmonitors.yaml
+- monitoring.coreos.com_thanosrulers.yaml
+- monitoring.coreos.com_alertmanagerconfigs.yaml
+- monitoring.coreos.com_probes.yaml
+- monitoring.coreos.com_prometheuses.yaml
+- monitoring.coreos.com_scrapeconfigs.yaml
+- monitoring.coreos.com_prometheusrules.yaml
+- monitoring.coreos.com_prometheusagents.yaml

--- a/example/prometheus-operator-crd/kustomization.yaml
+++ b/example/prometheus-operator-crd/kustomization.yaml
@@ -1,0 +1,14 @@
+# Code generated using 'make generate-crds'. DO NOT EDIT
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring.coreos.com_alertmanagers.yaml
+- monitoring.coreos.com_servicemonitors.yaml
+- monitoring.coreos.com_podmonitors.yaml
+- monitoring.coreos.com_thanosrulers.yaml
+- monitoring.coreos.com_alertmanagerconfigs.yaml
+- monitoring.coreos.com_probes.yaml
+- monitoring.coreos.com_prometheuses.yaml
+- monitoring.coreos.com_scrapeconfigs.yaml
+- monitoring.coreos.com_prometheusrules.yaml
+- monitoring.coreos.com_prometheusagents.yaml


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

A step of a GitOps deployment pipeline could be installing the CRDs for Prometheus. 
By introducing these files, the CRDs can be easily referenced in an existing `kustomization.yaml` like below:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - github.com/prometheus-operator/prometheus-operator/example/prometheus-operator-crd/kustomization.yaml?ref=75d6002c04b7cd49a65025d55cd024f7d34a285f
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Makefile now generates kustomization.yaml files such that a user can reference the installation of these CRDs directly from a kustomization
```
