### PR TITLE
Makefile: generate kustomization.yaml in the CRD folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,10 +224,22 @@ generate: k8s-gen generate-crds bundle.yaml example/mixin/alerts.yaml example/th
 .PHONY: generate-crds
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET) $(TYPES_V1BETA1_TARGET)
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./v1/. paths=./v1alpha1/. output:crd:dir=$(PWD)/example/prometheus-operator-crd/
-	find example/prometheus-operator-crd/ -name '*.yaml' -print0 | xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
+	echo "# Code generated using 'make generate-crds'. DO NOT EDIT." > $(PWD)/example/prometheus-operator-crd/kustomization.yaml
+	echo -e "apiVersion: 'kustomize.config.k8s.io/v1beta1'\nkind: 'Kustomization'\nresources:" >> $(PWD)/example/prometheus-operator-crd/kustomization.yaml
+	find example/prometheus-operator-crd/ -name '*.yaml' ! -name 'kustomization.yaml' -print0 | sort -z | \
+		xargs -0 -I{} sh -c 'echo "- '\''./$$(basename $$1)'\''" >> "$(PWD)/example/prometheus-operator-crd/kustomization.yaml"' -- {}
+	$(GOJSONTOYAML_BINARY) -yamltojson < $(PWD)/example/prometheus-operator-crd/kustomization.yaml | jq > /dev/null
+	find example/prometheus-operator-crd/ -name '*.yaml' ! -name 'kustomization.yaml' -print0 | \
+		xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./... output:crd:dir=$(PWD)/example/prometheus-operator-crd-full
+	echo "# Code generated using 'make generate-crds'. DO NOT EDIT." > $(PWD)/example/prometheus-operator-crd-full/kustomization.yaml
+	echo -e "apiVersion: 'kustomize.config.k8s.io/v1beta1'\nkind: 'Kustomization'\nresources:" >> $(PWD)/example/prometheus-operator-crd-full/kustomization.yaml
+	find example/prometheus-operator-crd/ -name '*.yaml' ! -name 'kustomization.yaml' -print0 | sort -z | \
+		xargs -0 -I{} sh -c 'echo "- '\''./$$(basename $$1)'\''" >> "$(PWD)/example/prometheus-operator-crd-full/kustomization.yaml"' -- {}
+	$(GOJSONTOYAML_BINARY) -yamltojson < $(PWD)/example/prometheus-operator-crd-full/kustomization.yaml | jq > /dev/null
 	echo "// Code generated using 'make generate-crds'. DO NOT EDIT." > $(PWD)/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
-	echo "{spec+: {versions+: $$($(GOJSONTOYAML_BINARY) -yamltojson < example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml | jq '.spec.versions | map(select(.name == "v1beta1"))')}}" | $(JSONNETFMT_BINARY) - >> $(PWD)/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+	echo "{spec+: {versions+: $$($(GOJSONTOYAML_BINARY) -yamltojson < example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml | \
+		jq '.spec.versions | map(select(.name == "v1beta1"))')}}" | $(JSONNETFMT_BINARY) - >> $(PWD)/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
 
 .PHONY: generate-remote-write-certs
 generate-remote-write-certs:

--- a/example/prometheus-operator-crd-full/kustomization.yaml
+++ b/example/prometheus-operator-crd-full/kustomization.yaml
@@ -1,0 +1,14 @@
+# Code generated using 'make generate-crds'. DO NOT EDIT.
+apiVersion: 'kustomize.config.k8s.io/v1beta1'
+kind: 'Kustomization'
+resources:
+- './monitoring.coreos.com_alertmanagers.yaml'
+- './monitoring.coreos.com_servicemonitors.yaml'
+- './monitoring.coreos.com_podmonitors.yaml'
+- './monitoring.coreos.com_thanosrulers.yaml'
+- './monitoring.coreos.com_alertmanagerconfigs.yaml'
+- './monitoring.coreos.com_probes.yaml'
+- './monitoring.coreos.com_prometheuses.yaml'
+- './monitoring.coreos.com_scrapeconfigs.yaml'
+- './monitoring.coreos.com_prometheusrules.yaml'
+- './monitoring.coreos.com_prometheusagents.yaml'

--- a/example/prometheus-operator-crd/kustomization.yaml
+++ b/example/prometheus-operator-crd/kustomization.yaml
@@ -1,0 +1,14 @@
+# Code generated using 'make generate-crds'. DO NOT EDIT.
+apiVersion: 'kustomize.config.k8s.io/v1beta1'
+kind: 'Kustomization'
+resources:
+- './monitoring.coreos.com_alertmanagers.yaml'
+- './monitoring.coreos.com_servicemonitors.yaml'
+- './monitoring.coreos.com_podmonitors.yaml'
+- './monitoring.coreos.com_thanosrulers.yaml'
+- './monitoring.coreos.com_alertmanagerconfigs.yaml'
+- './monitoring.coreos.com_probes.yaml'
+- './monitoring.coreos.com_prometheuses.yaml'
+- './monitoring.coreos.com_scrapeconfigs.yaml'
+- './monitoring.coreos.com_prometheusrules.yaml'
+- './monitoring.coreos.com_prometheusagents.yaml'

--- a/scripts/generate-bundle.sh
+++ b/scripts/generate-bundle.sh
@@ -12,7 +12,7 @@ function concat() {
 
 function generate_bundle() {
     # shellcheck disable=SC2046
-    concat $(find "$@" -maxdepth 1 -name '*.yaml' | sort | grep -v service-monitor)
+    concat $(find "$@" -maxdepth 1 -name '*.yaml' ! -name 'kustomization.yaml' | sort | grep -v service-monitor)
 }
 
 generate_bundle example/rbac/prometheus-operator example/prometheus-operator-crd > bundle.yaml


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

A user can now reference this repository directly from their own kustomization.yaml, such that they can easily install the CRDs on their cluster.

Example:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- github.com/prometheus-operator/prometheus-operator/example/prometheus-operator-crd-full?ref=c18f161c90f163fc7b88c1cd3ee0243bed654434
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- [ENHANCEMENT] A user can now reference this repository directly from their own kustomization.yaml, such that they can easily install the CRDs on their cluster #5761
```
