### PR TITLE
chore: use generics for stringMapToMapSlice()

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -255,7 +255,9 @@ func (cg *ConfigGenerator) EndpointSliceSupported() bool {
 	return cg.version.GTE(semver.MustParse("2.21.0")) && cg.endpointSliceSupported
 }
 
-func stringMapToMapSlice(m map[string]string) yaml.MapSlice {
+// stringMapToMapSlice returns a yaml.MapSlice from a string map to ensure that
+// the output is deterministic.
+func stringMapToMapSlice[V any](m map[string]V) yaml.MapSlice {
 	res := yaml.MapSlice{}
 	ks := make([]string, 0, len(m))
 
@@ -269,27 +271,6 @@ func stringMapToMapSlice(m map[string]string) yaml.MapSlice {
 	}
 
 	return res
-}
-
-func sortStringMap(m map[string]string) map[string]string {
-	if len(m) <= 1 {
-		return m
-	}
-
-	keys := make([]string, 0, len(m))
-	result := make(map[string]string, len(m))
-
-	for key := range m {
-		keys = append(keys, key)
-	}
-
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		result[key] = m[key]
-	}
-
-	return result
 }
 
 func addSafeTLStoYaml(cfg yaml.MapSlice, namespace string, tls monitoringv1.SafeTLSConfig) yaml.MapSlice {
@@ -2446,7 +2427,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			if len(config.NodeMeta) > 0 {
 				configs[i] = append(configs[i], yaml.MapItem{
 					Key:   "node_meta",
-					Value: sortStringMap(config.NodeMeta),
+					Value: stringMapToMapSlice(config.NodeMeta),
 				})
 			}
 
@@ -2502,7 +2483,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 				configs[i] = append(configs[i], yaml.MapItem{
 					Key:   "proxy_connect_header",
-					Value: sortStringMap(proxyConnectHeader),
+					Value: stringMapToMapSlice(proxyConnectHeader),
 				})
 			}
 


### PR DESCRIPTION
## Description

Also use stringMapToMapSlice() in generateScrapeConfig().

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
