### PR TITLE
chore: Deduplicate CRD constants

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -348,11 +348,11 @@ func run() int {
 		kclient,
 		namespaces(cfg.Namespaces.AllowList).asSlice(),
 		monitoringv1alpha1.SchemeGroupVersion,
-		monitoringv1alpha1.ScrapeConfigName,
+		monitoring.ScrapeConfigName,
 		k8sutil.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
-			Resource: monitoringv1alpha1.ScrapeConfigName,
+			Resource: monitoring.ScrapeConfigName,
 			Verbs:    []string{"get", "list", "watch"},
 		},
 	)
@@ -375,17 +375,17 @@ func run() int {
 		kclient,
 		namespaces(cfg.Namespaces.PrometheusAllowList).asSlice(),
 		monitoringv1alpha1.SchemeGroupVersion,
-		monitoringv1alpha1.PrometheusAgentName,
+		monitoring.PrometheusAgentName,
 		k8sutil.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
-			Resource: monitoringv1alpha1.PrometheusAgentName,
+			Resource: monitoring.PrometheusAgentName,
 			Verbs:    []string{"get", "list", "watch"},
 		},
 		k8sutil.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
-			Resource: fmt.Sprintf("%s/status", monitoringv1alpha1.PrometheusAgentName),
+			Resource: fmt.Sprintf("%s/status", monitoring.PrometheusAgentName),
 			Verbs:    []string{"update"},
 		},
 	)

--- a/cmd/po-lint/main.go
+++ b/cmd/po-lint/main.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/versionutil"
@@ -57,7 +58,7 @@ func main() {
 		}
 
 		switch meta.Kind {
-		case v1.AlertmanagersKind:
+		case monitoring.AlertmanagersKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -71,7 +72,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("alertmanager is invalid: %v", err)
 			}
-		case v1.PrometheusesKind:
+		case monitoring.PrometheusesKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -85,7 +86,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("prometheus is invalid: %v", err)
 			}
-		case v1.PrometheusRuleKind:
+		case monitoring.PrometheusRuleKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -103,7 +104,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("prometheus rule validation failed: %v", err)
 			}
-		case v1.ServiceMonitorsKind:
+		case monitoring.ServiceMonitorsKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -117,7 +118,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("serviceMonitor is invalid: %v", err)
 			}
-		case v1.PodMonitorsKind:
+		case monitoring.PodMonitorsKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -131,7 +132,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("podMonitor is invalid: %v", err)
 			}
-		case v1.ProbesKind:
+		case monitoring.ProbesKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -144,7 +145,7 @@ func main() {
 			if err := decoder.Decode(&probe); err != nil {
 				log.Fatalf("probe is invalid: %v", err)
 			}
-		case v1.ThanosRulerKind:
+		case monitoring.ThanosRulerKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)
@@ -158,7 +159,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("thanosRuler is invalid: %v", err)
 			}
-		case v1alpha1.AlertmanagerConfigKind:
+		case monitoring.AlertmanagerConfigKind:
 			j, err := yaml.YAMLToJSON(content)
 			if err != nil {
 				log.Fatalf("unable to convert YAML to JSON: %v", err)

--- a/cmd/po-rule-migration/main.go
+++ b/cmd/po-rule-migration/main.go
@@ -111,7 +111,7 @@ func CMToRule(cm *v1.ConfigMap) ([]monitoringv1.PrometheusRule, error) {
 
 		rule := monitoringv1.PrometheusRule{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       monitoringv1.PrometheusRuleKind,
+				Kind:       monitoring.PrometheusRuleKind,
 				APIVersion: monitoring.GroupName + "/" + monitoringv1.Version,
 			},
 

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -31,6 +31,7 @@ import (
 
 	validationv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation/v1alpha1"
 	validationv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation/v1beta1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
@@ -45,11 +46,11 @@ const (
 	errUnmarshalConfig           = "Cannot unmarhsal config from spec"
 
 	group                  = "monitoring.coreos.com"
-	prometheusRuleResource = monitoringv1.PrometheusRuleName
+	prometheusRuleResource = monitoring.PrometheusRuleName
 	prometheusRuleVersion  = monitoringv1.Version
 
-	alertManagerConfigResource = monitoringv1beta1.AlertmanagerConfigName
-	alertManagerConfigKind     = monitoringv1beta1.AlertmanagerConfigKind
+	alertManagerConfigResource = monitoring.AlertmanagerConfigName
+	alertManagerConfigKind     = monitoring.AlertmanagerConfigKind
 
 	prometheusRuleValidatePath     = "/admission-prometheusrules/validate"
 	prometheusRuleMutatePath       = "/admission-prometheusrules/mutate"

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
 	validationv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -160,7 +161,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		o.logger,
 		o,
 		o.metrics,
-		monitoringv1.AlertmanagersKind,
+		monitoring.AlertmanagersKind,
 		r,
 	)
 
@@ -190,7 +191,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 				options.LabelSelector = c.config.AlertManagerSelector
 			},
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.AlertmanagerName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.AlertmanagerName),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating alertmanager informers: %w", err)
@@ -210,7 +211,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.AlertmanagerConfigName),
+		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoring.AlertmanagerConfigName),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating alertmanagerconfig informers: %w", err)
@@ -356,7 +357,7 @@ func (c *Operator) handleAlertmanagerConfigAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "AlertmanagerConfig added")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.AlertmanagerConfigKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.AlertmanagerConfigKind, operator.AddEvent).Inc()
 
 		c.enqueueForNamespace(o.GetNamespace())
 	}
@@ -370,7 +371,7 @@ func (c *Operator) handleAlertmanagerConfigUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "AlertmanagerConfig updated")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.AlertmanagerConfigKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.AlertmanagerConfigKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForNamespace(o.GetNamespace())
 	}
@@ -380,7 +381,7 @@ func (c *Operator) handleAlertmanagerConfigDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "AlertmanagerConfig delete")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.AlertmanagerConfigKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.AlertmanagerConfigKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForNamespace(o.GetNamespace())
 	}
@@ -1114,8 +1115,8 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 	level.Debug(c.logger).Log("msg", "selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(amcKeys, ","), "namespace", am.Namespace, "prometheus", am.Name)
 
 	if amKey, ok := c.accessor.MetaNamespaceKey(am); ok {
-		c.metrics.SetSelectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, len(res))
-		c.metrics.SetRejectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, rejected)
+		c.metrics.SetSelectedResources(amKey, monitoring.AlertmanagerConfigKind, len(res))
+		c.metrics.SetRejectedResources(amKey, monitoring.AlertmanagerConfigKind, rejected)
 	}
 
 	return res, nil

--- a/pkg/apis/monitoring/resource.go
+++ b/pkg/apis/monitoring/resource.go
@@ -19,26 +19,45 @@ import (
 )
 
 const (
-	PrometheusesKind = "Prometheus"
-	PrometheusName   = "prometheuses"
+	PrometheusesKind  = "Prometheus"
+	PrometheusName    = "prometheuses"
+	PrometheusKindKey = "prometheus"
 
-	AlertmanagersKind = "Alertmanager"
-	AlertmanagerName  = "alertmanagers"
+	AlertmanagersKind   = "Alertmanager"
+	AlertmanagerName    = "alertmanagers"
+	AlertManagerKindKey = "alertmanager"
 
-	ServiceMonitorsKind = "ServiceMonitor"
-	ServiceMonitorName  = "servicemonitors"
+	AlertmanagerConfigKind    = "AlertmanagerConfig"
+	AlertmanagerConfigName    = "alertmanagerconfigs"
+	AlertmanagerConfigKindKey = "alertmanagerconfig"
 
-	PodMonitorsKind = "PodMonitor"
-	PodMonitorName  = "podmonitors"
+	ServiceMonitorsKind   = "ServiceMonitor"
+	ServiceMonitorName    = "servicemonitors"
+	ServiceMonitorKindKey = "servicemonitor"
 
-	PrometheusRuleKind = "PrometheusRule"
-	PrometheusRuleName = "prometheusrules"
+	PodMonitorsKind   = "PodMonitor"
+	PodMonitorName    = "podmonitors"
+	PodMonitorKindKey = "podmonitor"
 
-	ProbesKind = "Probe"
-	ProbeName  = "probes"
+	PrometheusAgentsKind   = "PrometheusAgent"
+	PrometheusAgentName    = "prometheusagents"
+	PrometheusAgentKindKey = "prometheusagent"
 
-	ScrapeConfigsKind = "ScrapeConfig"
-	ScrapeConfigName  = "scrapeconfigs"
+	PrometheusRuleKind    = "PrometheusRule"
+	PrometheusRuleName    = "prometheusrules"
+	PrometheusRuleKindKey = "prometheusrule"
+
+	ProbesKind   = "Probe"
+	ProbeName    = "probes"
+	ProbeKindKey = "probe"
+
+	ScrapeConfigsKind   = "ScrapeConfig"
+	ScrapeConfigName    = "scrapeconfigs"
+	ScrapeConfigKindKey = "scrapeconfig"
+
+	ThanosRulerKind    = "ThanosRuler"
+	ThanosRulerName    = "thanosrulers"
+	ThanosRulerKindKey = "thanosrulers"
 )
 
 var resourceToKindMap = map[string]string{

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	AlertmanagersKind   = "Alertmanager"
-	AlertmanagerName    = "alertmanagers"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagersKind = "Alertmanager"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagerName = "alertmanagers"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	AlertManagerKindKey = "alertmanager"
 )
 

--- a/pkg/apis/monitoring/v1/podmonitor_types.go
+++ b/pkg/apis/monitoring/v1/podmonitor_types.go
@@ -22,8 +22,14 @@ import (
 )
 
 const (
-	PodMonitorsKind   = "PodMonitor"
-	PodMonitorName    = "podmonitors"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PodMonitorsKind = "PodMonitor"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PodMonitorName = "podmonitors"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	PodMonitorKindKey = "podmonitor"
 )
 

--- a/pkg/apis/monitoring/v1/probe_types.go
+++ b/pkg/apis/monitoring/v1/probe_types.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	ProbesKind   = "Probe"
-	ProbeName    = "probes"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ProbesKind = "Probe"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ProbeName = "probes"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	ProbeKindKey = "probe"
 )
 

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -26,8 +26,14 @@ import (
 )
 
 const (
-	PrometheusesKind  = "Prometheus"
-	PrometheusName    = "prometheuses"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusesKind = "Prometheus"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusName = "prometheuses"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	PrometheusKindKey = "prometheus"
 )
 

--- a/pkg/apis/monitoring/v1/prometheusrule_types.go
+++ b/pkg/apis/monitoring/v1/prometheusrule_types.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	PrometheusRuleKind    = "PrometheusRule"
-	PrometheusRuleName    = "prometheusrules"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusRuleKind = "PrometheusRule"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusRuleName = "prometheusrules"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	PrometheusRuleKindKey = "prometheusrule"
 )
 

--- a/pkg/apis/monitoring/v1/servicemonitor_types.go
+++ b/pkg/apis/monitoring/v1/servicemonitor_types.go
@@ -20,8 +20,14 @@ import (
 )
 
 const (
-	ServiceMonitorsKind   = "ServiceMonitor"
-	ServiceMonitorName    = "servicemonitors"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ServiceMonitorsKind = "ServiceMonitor"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ServiceMonitorName = "servicemonitors"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	ServiceMonitorKindKey = "servicemonitor"
 )
 

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	ThanosRulerKind    = "ThanosRuler"
-	ThanosRulerName    = "thanosrulers"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ThanosRulerKind = "ThanosRuler"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ThanosRulerName = "thanosrulers"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	ThanosRulerKindKey = "thanosrulers"
 )
 

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -29,10 +29,14 @@ import (
 )
 
 const (
-	Version = "v1alpha1"
-
-	AlertmanagerConfigKind    = "AlertmanagerConfig"
-	AlertmanagerConfigName    = "alertmanagerconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagerConfigKind = "AlertmanagerConfig"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagerConfigName = "alertmanagerconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	AlertmanagerConfigKindKey = "alertmanagerconfig"
 )
 

--- a/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+++ b/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
@@ -21,8 +21,14 @@ import (
 )
 
 const (
-	PrometheusAgentsKind   = "PrometheusAgent"
-	PrometheusAgentName    = "prometheusagents"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusAgentsKind = "PrometheusAgent"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	PrometheusAgentName = "prometheusagents"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	PrometheusAgentKindKey = "prometheusagent"
 )
 

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -22,8 +22,14 @@ import (
 )
 
 const (
-	ScrapeConfigsKind   = "ScrapeConfig"
-	ScrapeConfigName    = "scrapeconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ScrapeConfigsKind = "ScrapeConfig"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	ScrapeConfigName = "scrapeconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	ScrapeConfigKindKey = "scrapeconfig"
 )
 

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+const (
+	Version = "v1alpha1"
+)

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -29,10 +29,14 @@ import (
 )
 
 const (
-	Version = "v1beta1"
-
-	AlertmanagerConfigKind    = "AlertmanagerConfig"
-	AlertmanagerConfigName    = "alertmanagerconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagerConfigKind = "AlertmanagerConfig"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
+	AlertmanagerConfigName = "alertmanagerconfigs"
+	// Deprecated: Use github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+	// TODO: Remove in v0.75
 	AlertmanagerConfigKindKey = "alertmanagerconfig"
 )
 

--- a/pkg/apis/monitoring/v1beta1/types.go
+++ b/pkg/apis/monitoring/v1beta1/types.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+const (
+	Version = "v1beta1"
+)

--- a/pkg/namespacelabeler/labeler_test.go
+++ b/pkg/namespacelabeler/labeler_test.go
@@ -149,7 +149,7 @@ func TestEnforceNamespaceLabelOnPrometheusRules(t *testing.T) {
 				{
 					Namespace: "foo",
 					Group:     "monitoring.coreos.com",
-					Resource:  monitoringv1.PrometheusRuleName,
+					Resource:  monitoring.PrometheusRuleName,
 				},
 			},
 
@@ -220,7 +220,7 @@ func TestEnforceNamespaceLabelOnPrometheusRules(t *testing.T) {
 				{
 					Namespace: "bar",
 					Group:     monitoring.GroupName,
-					Resource:  monitoringv1.PrometheusRuleName,
+					Resource:  monitoring.PrometheusRuleName,
 				},
 			},
 
@@ -251,7 +251,7 @@ func TestEnforceNamespaceLabelOnPrometheusRules(t *testing.T) {
 						monitoringv1.ObjectReference{
 							Namespace: rule.RuleNamespace,
 							Group:     monitoring.GroupName,
-							Resource:  monitoringv1.PrometheusRuleName,
+							Resource:  monitoring.PrometheusRuleName,
 							Name:      rule.RuleName,
 						})
 				}
@@ -319,7 +319,7 @@ func TestEnforceNamespaceLabelOnPrometheusMonitors(t *testing.T) {
 				{
 					Namespace: "bar",
 					Group:     monitoring.GroupName,
-					Resource:  monitoringv1.ServiceMonitorName,
+					Resource:  monitoring.ServiceMonitorName,
 					Name:      "exclude-me",
 				},
 			},
@@ -343,7 +343,7 @@ func TestEnforceNamespaceLabelOnPrometheusMonitors(t *testing.T) {
 				{
 					Namespace: "bar",
 					Group:     monitoring.GroupName,
-					Resource:  monitoringv1.ServiceMonitorName,
+					Resource:  monitoring.ServiceMonitorName,
 				},
 			},
 			Expected: expandServiceMonitor(&promServiceMonitorFlat{
@@ -383,7 +383,7 @@ func expandPromRule(r *promRuleFlat) monitoringv1.PrometheusRule {
 			Labels:    r.Labels,
 		},
 		TypeMeta: metav1.TypeMeta{
-			Kind:       monitoringv1.PrometheusRuleKind,
+			Kind:       monitoring.PrometheusRuleKind,
 			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
@@ -410,7 +410,7 @@ func expandServiceMonitor(r *promServiceMonitorFlat) monitoringv1.ServiceMonitor
 			Labels:    r.Labels,
 		},
 		TypeMeta: metav1.TypeMeta{
-			Kind:       monitoringv1.ServiceMonitorsKind,
+			Kind:       monitoring.ServiceMonitorsKind,
 			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -135,7 +136,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		c.logger,
 		c,
 		c.metrics,
-		monitoringv1alpha1.PrometheusAgentsKind,
+		monitoring.PrometheusAgentsKind,
 		r,
 	)
 
@@ -149,7 +150,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 				options.LabelSelector = c.config.PromSelector
 			},
 		),
-		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName),
+		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoring.PrometheusAgentName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating prometheus-agent informers: %w", err)
@@ -170,7 +171,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.ServiceMonitorName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating servicemonitor informers: %w", err)
@@ -184,7 +185,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.PodMonitorName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating podmonitor informers: %w", err)
@@ -198,7 +199,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.ProbeName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating probe informers: %w", err)
@@ -213,7 +214,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 				resyncPeriod,
 				nil,
 			),
-			monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.ScrapeConfigName),
+			monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoring.ScrapeConfigName),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error creating scrapeconfig informers: %w", err)
@@ -879,7 +880,7 @@ func (c *Operator) handleSmonAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor added")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.AddEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -894,7 +895,7 @@ func (c *Operator) handleSmonUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor updated")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -905,7 +906,7 @@ func (c *Operator) handleSmonDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor delete")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -916,7 +917,7 @@ func (c *Operator) handlePmonAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor added")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -930,7 +931,7 @@ func (c *Operator) handlePmonUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor updated")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -941,7 +942,7 @@ func (c *Operator) handlePmonDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor delete")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -951,7 +952,7 @@ func (c *Operator) handlePmonDelete(obj interface{}) {
 func (c *Operator) handleBmonAdd(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "Probe added")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -964,7 +965,7 @@ func (c *Operator) handleBmonUpdate(old, cur interface{}) {
 
 	if o, ok := c.accessor.ObjectMetadata(cur); ok {
 		level.Debug(c.logger).Log("msg", "Probe updated")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.UpdateEvent)
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.UpdateEvent)
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -973,7 +974,7 @@ func (c *Operator) handleBmonUpdate(old, cur interface{}) {
 func (c *Operator) handleBmonDelete(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "Probe delete")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.DeleteEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -982,7 +983,7 @@ func (c *Operator) handleBmonDelete(obj interface{}) {
 func (c *Operator) handleScrapeConfigAdd(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig added")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -995,7 +996,7 @@ func (c *Operator) handleScrapeConfigUpdate(old, cur interface{}) {
 
 	if o, ok := c.accessor.ObjectMetadata(cur); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig updated")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.UpdateEvent)
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.UpdateEvent)
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -1004,7 +1005,7 @@ func (c *Operator) handleScrapeConfigUpdate(old, cur interface{}) {
 func (c *Operator) handleScrapeConfigDelete(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig deleted")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.DeleteEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -1536,7 +1536,7 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 		{
 			Namespace: "pod-monitor-ns",
 			Group:     monitoring.GroupName,
-			Resource:  monitoringv1.PodMonitorName,
+			Resource:  monitoring.PodMonitorName,
 			Name:      "testpodmonitor1",
 		},
 	}
@@ -1563,7 +1563,7 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: monitoring.GroupName + "/" + monitoringv1.Version,
-					Kind:       monitoringv1.PodMonitorsKind,
+					Kind:       monitoring.PodMonitorsKind,
 				},
 				Spec: monitoringv1.PodMonitorSpec{
 					PodTargetLabels: []string{"example", "env"},
@@ -1681,7 +1681,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 		{
 			Namespace: "service-monitor-ns",
 			Group:     monitoring.GroupName,
-			Resource:  monitoringv1.ServiceMonitorName,
+			Resource:  monitoring.ServiceMonitorName,
 			Name:      "", // exclude all servicemonitors in this namespace
 		},
 	}
@@ -1707,7 +1707,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: monitoring.GroupName + "/" + monitoringv1.Version,
-					Kind:       monitoringv1.ServiceMonitorsKind,
+					Kind:       monitoring.ServiceMonitorsKind,
 				},
 				Spec: monitoringv1.ServiceMonitorSpec{
 					Selector: metav1.LabelSelector{

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -188,8 +189,8 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 	level.Debug(rs.l).Log("msg", "selected ServiceMonitors", "servicemonitors", strings.Join(smKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
-		rs.metrics.SetSelectedResources(pKey, monitoringv1.ServiceMonitorsKind, len(res))
-		rs.metrics.SetRejectedResources(pKey, monitoringv1.ServiceMonitorsKind, rejected)
+		rs.metrics.SetSelectedResources(pKey, monitoring.ServiceMonitorsKind, len(res))
+		rs.metrics.SetRejectedResources(pKey, monitoring.ServiceMonitorsKind, rejected)
 	}
 
 	return res, nil
@@ -437,8 +438,8 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 	level.Debug(rs.l).Log("msg", "selected PodMonitors", "podmonitors", strings.Join(pmKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
-		rs.metrics.SetSelectedResources(pKey, monitoringv1.PodMonitorsKind, len(res))
-		rs.metrics.SetRejectedResources(pKey, monitoringv1.PodMonitorsKind, rejected)
+		rs.metrics.SetSelectedResources(pKey, monitoring.PodMonitorsKind, len(res))
+		rs.metrics.SetRejectedResources(pKey, monitoring.PodMonitorsKind, rejected)
 	}
 
 	return res, nil
@@ -583,8 +584,8 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 	level.Debug(rs.l).Log("msg", "selected Probes", "probes", strings.Join(probeKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
-		rs.metrics.SetSelectedResources(pKey, monitoringv1.ProbesKind, len(res))
-		rs.metrics.SetRejectedResources(pKey, monitoringv1.ProbesKind, rejected)
+		rs.metrics.SetSelectedResources(pKey, monitoring.ProbesKind, len(res))
+		rs.metrics.SetRejectedResources(pKey, monitoring.ProbesKind, rejected)
 	}
 
 	return res, nil
@@ -750,8 +751,8 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 	level.Debug(rs.l).Log("msg", "selected ScrapeConfigs", "scrapeConfig", strings.Join(scrapeConfigKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if sKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
-		rs.metrics.SetSelectedResources(sKey, monitoringv1alpha1.ScrapeConfigsKind, len(res))
-		rs.metrics.SetRejectedResources(sKey, monitoringv1alpha1.ScrapeConfigsKind, rejected)
+		rs.metrics.SetSelectedResources(sKey, monitoring.ScrapeConfigsKind, len(res))
+		rs.metrics.SetRejectedResources(sKey, monitoring.ScrapeConfigsKind, rejected)
 	}
 
 	return res, nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
@@ -176,7 +177,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		c.logger,
 		c,
 		c.metrics,
-		monitoringv1.PrometheusesKind,
+		monitoring.PrometheusesKind,
 		r,
 	)
 
@@ -190,7 +191,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 				options.LabelSelector = c.config.PromSelector
 			},
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.PrometheusName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating prometheus informers: %w", err)
@@ -210,7 +211,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.ServiceMonitorName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating servicemonitor informers: %w", err)
@@ -224,7 +225,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.PodMonitorName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating podmonitor informers: %w", err)
@@ -238,7 +239,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.ProbeName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating probe informers: %w", err)
@@ -253,7 +254,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 				resyncPeriod,
 				nil,
 			),
-			monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.ScrapeConfigName),
+			monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoring.ScrapeConfigName),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error creating scrapeconfigs informers: %w", err)
@@ -267,7 +268,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusRuleName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.PrometheusRuleName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating prometheusrule informers: %w", err)
@@ -702,7 +703,7 @@ func (c *Operator) handleSmonAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor added")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.AddEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -717,7 +718,7 @@ func (c *Operator) handleSmonUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor updated")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -728,7 +729,7 @@ func (c *Operator) handleSmonDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "ServiceMonitor delete")
-		c.metrics.TriggerByCounter(monitoringv1.ServiceMonitorsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ServiceMonitorsKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -739,7 +740,7 @@ func (c *Operator) handlePmonAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor added")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -753,7 +754,7 @@ func (c *Operator) handlePmonUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor updated")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -764,7 +765,7 @@ func (c *Operator) handlePmonDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PodMonitor delete")
-		c.metrics.TriggerByCounter(monitoringv1.PodMonitorsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PodMonitorsKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -774,7 +775,7 @@ func (c *Operator) handlePmonDelete(obj interface{}) {
 func (c *Operator) handleBmonAdd(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "Probe added")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -787,7 +788,7 @@ func (c *Operator) handleBmonUpdate(old, cur interface{}) {
 
 	if o, ok := c.accessor.ObjectMetadata(cur); ok {
 		level.Debug(c.logger).Log("msg", "Probe updated")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.UpdateEvent)
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.UpdateEvent)
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -796,7 +797,7 @@ func (c *Operator) handleBmonUpdate(old, cur interface{}) {
 func (c *Operator) handleBmonDelete(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "Probe delete")
-		c.metrics.TriggerByCounter(monitoringv1.ProbesKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ProbesKind, operator.DeleteEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -805,7 +806,7 @@ func (c *Operator) handleBmonDelete(obj interface{}) {
 func (c *Operator) handleScrapeConfigAdd(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig added")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.AddEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -818,7 +819,7 @@ func (c *Operator) handleScrapeConfigUpdate(old, cur interface{}) {
 
 	if o, ok := c.accessor.ObjectMetadata(cur); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig updated")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.UpdateEvent)
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.UpdateEvent)
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -827,7 +828,7 @@ func (c *Operator) handleScrapeConfigUpdate(old, cur interface{}) {
 func (c *Operator) handleScrapeConfigDelete(obj interface{}) {
 	if o, ok := c.accessor.ObjectMetadata(obj); ok {
 		level.Debug(c.logger).Log("msg", "ScrapeConfig deleted")
-		c.metrics.TriggerByCounter(monitoringv1alpha1.ScrapeConfigsKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.ScrapeConfigsKind, operator.DeleteEvent).Inc()
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
 }
@@ -837,7 +838,7 @@ func (c *Operator) handleRuleAdd(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PrometheusRule added")
-		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.AddEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.AddEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -852,7 +853,7 @@ func (c *Operator) handleRuleUpdate(old, cur interface{}) {
 	o, ok := c.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PrometheusRule updated")
-		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.UpdateEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.UpdateEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}
@@ -863,7 +864,7 @@ func (c *Operator) handleRuleDelete(obj interface{}) {
 	o, ok := c.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(c.logger).Log("msg", "PrometheusRule deleted")
-		c.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.DeleteEvent).Inc()
+		c.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.DeleteEvent).Inc()
 
 		c.enqueueForMonitorNamespace(o.GetNamespace())
 	}

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -55,7 +55,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 			monitoringv1.ObjectReference{
 				Namespace: rule.RuleNamespace,
 				Group:     monitoring.GroupName,
-				Resource:  monitoringv1.PrometheusRuleName,
+				Resource:  monitoring.PrometheusRuleName,
 				Name:      rule.RuleName,
 			})
 	}
@@ -79,8 +79,8 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 	}
 
 	if pKey, ok := c.accessor.MetaNamespaceKey(p); ok {
-		c.metrics.SetSelectedResources(pKey, monitoringv1.PrometheusRuleKind, len(newRules))
-		c.metrics.SetRejectedResources(pKey, monitoringv1.PrometheusRuleKind, rejected)
+		c.metrics.SetSelectedResources(pKey, monitoring.PrometheusRuleKind, len(newRules))
+		c.metrics.SetRejectedResources(pKey, monitoring.PrometheusRuleKind, rejected)
 	}
 
 	currentConfigMapList, err := cClient.List(ctx, prometheusRulesConfigMapSelector(p.Name))

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1ac "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
@@ -141,7 +142,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		o.logger,
 		o,
 		o.metrics,
-		monitoringv1.ThanosRulerKind,
+		monitoring.ThanosRulerKind,
 		r,
 	)
 
@@ -171,7 +172,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 				options.LabelSelector = o.config.ThanosRulerSelector
 			},
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ThanosRulerName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.ThanosRulerName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating thanosruler informers: %w", err)
@@ -191,7 +192,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			resyncPeriod,
 			nil,
 		),
-		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusRuleName),
+		monitoringv1.SchemeGroupVersion.WithResource(monitoring.PrometheusRuleName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating prometheusrule informers: %w", err)
@@ -404,7 +405,7 @@ func (o *Operator) handleRuleAdd(obj interface{}) {
 	meta, ok := o.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule added")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.AddEvent).Inc()
+		o.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.AddEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
@@ -419,7 +420,7 @@ func (o *Operator) handleRuleUpdate(old, cur interface{}) {
 	meta, ok := o.accessor.ObjectMetadata(cur)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule updated")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.UpdateEvent).Inc()
+		o.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.UpdateEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}
@@ -430,7 +431,7 @@ func (o *Operator) handleRuleDelete(obj interface{}) {
 	meta, ok := o.accessor.ObjectMetadata(obj)
 	if ok {
 		level.Debug(o.logger).Log("msg", "PrometheusRule deleted")
-		o.metrics.TriggerByCounter(monitoringv1.PrometheusRuleKind, operator.DeleteEvent).Inc()
+		o.metrics.TriggerByCounter(monitoring.PrometheusRuleKind, operator.DeleteEvent).Inc()
 
 		o.enqueueForRulesNamespace(meta.GetNamespace())
 	}

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -56,7 +56,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 			monitoringv1.ObjectReference{
 				Namespace: rule.RuleNamespace,
 				Group:     monitoring.GroupName,
-				Resource:  monitoringv1.PrometheusRuleName,
+				Resource:  monitoring.PrometheusRuleName,
 				Name:      rule.RuleName,
 			})
 	}
@@ -80,8 +80,8 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 	}
 
 	if tKey, ok := o.accessor.MetaNamespaceKey(t); ok {
-		o.metrics.SetSelectedResources(tKey, monitoringv1.PrometheusRuleKind, len(newRules))
-		o.metrics.SetRejectedResources(tKey, monitoringv1.PrometheusRuleKind, rejected)
+		o.metrics.SetSelectedResources(tKey, monitoring.PrometheusRuleKind, len(newRules))
+		o.metrics.SetRejectedResources(tKey, monitoring.PrometheusRuleKind, rejected)
 	}
 
 	currentConfigMapList, err := cClient.List(ctx, prometheusRulesConfigMapSelector(t.Name))

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prometheus "github.com/prometheus-operator/prometheus-operator/pkg/prometheus/server"
@@ -4300,7 +4301,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 				{
 					Namespace: ns,
 					Group:     "monitoring.coreos.com",
-					Resource:  monitoringv1.ServiceMonitorName,
+					Resource:  monitoring.ServiceMonitorName,
 				},
 			}
 			_, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -260,7 +260,7 @@ func (f *Framework) PatchAlertmanager(ctx context.Context, name, ns string, spec
 	b, err := json.Marshal(
 		&monitoringv1.Alertmanager{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       monitoringv1.AlertmanagersKind,
+				Kind:       monitoring.AlertmanagersKind,
 				APIVersion: schema.GroupVersion{Group: monitoring.GroupName, Version: monitoringv1.Version}.String(),
 			},
 			Spec: spec,

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -42,8 +42,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	v1monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	v1alpha1monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1alpha1"
 	v1beta1monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1beta1"
@@ -284,56 +282,56 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 		}
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.AlertmanagerName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.AlertmanagerName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.Alertmanagers(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Alertmanager CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PodMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.PodMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.PodMonitors(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PodMonitor CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ProbeName, func(opts metav1.ListOptions) (object runtime.Object, err error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.ProbeName, func(opts metav1.ListOptions) (object runtime.Object, err error) {
 		return f.MonClientV1.Probes(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Probe CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PrometheusName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.PrometheusName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.Prometheuses(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Prometheus CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PrometheusRuleName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.PrometheusRuleName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.PrometheusRules(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PrometheusRule CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ServiceMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.ServiceMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.ServiceMonitors(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize ServiceMonitor CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ThanosRulerName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.ThanosRulerName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1.ThanosRulers(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize ThanosRuler CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.AlertmanagerConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.AlertmanagerConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1alpha1.AlertmanagerConfigs(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
@@ -347,7 +345,7 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 		return nil, fmt.Errorf("wait for AlertmanagerConfig v1beta1 CRD: %w", err)
 	}
 
-	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.PrometheusAgentName, func(opts metav1.ListOptions) (runtime.Object, error) {
+	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.PrometheusAgentName, func(opts metav1.ListOptions) (runtime.Object, error) {
 		return f.MonClientV1alpha1.PrometheusAgents(v1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
@@ -355,7 +353,7 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 	}
 
 	if opts.EnableScrapeConfigs {
-		err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.ScrapeConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
+		err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoring.ScrapeConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
 			return f.MonClientV1alpha1.ScrapeConfigs(v1.NamespaceAll).List(ctx, opts)
 		})
 		if err != nil {
@@ -521,7 +519,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 
 	group := monitoring.GroupName
 
-	alertmanagerCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.AlertmanagerName))
+	alertmanagerCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.AlertmanagerName))
 	if err != nil {
 		return fmt.Errorf("failed to make alertmanager CRD: %w", err)
 	}
@@ -530,7 +528,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete alertmanager CRD: %w", err)
 	}
 
-	podMonitorCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.PodMonitorName))
+	podMonitorCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.PodMonitorName))
 	if err != nil {
 		return fmt.Errorf("failed to make podMonitor CRD: %w", err)
 	}
@@ -539,7 +537,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete podMonitor CRD: %w", err)
 	}
 
-	probeCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.ProbeName))
+	probeCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.ProbeName))
 	if err != nil {
 		return fmt.Errorf("failed to make probe CRD: %w", err)
 	}
@@ -548,7 +546,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete probe CRD: %w", err)
 	}
 
-	prometheusCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.PrometheusName))
+	prometheusCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.PrometheusName))
 	if err != nil {
 		return fmt.Errorf("failed to make prometheus CRD: %w", err)
 	}
@@ -557,7 +555,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete prometheus CRD: %w", err)
 	}
 
-	prometheusRuleCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.PrometheusRuleName))
+	prometheusRuleCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.PrometheusRuleName))
 	if err != nil {
 		return fmt.Errorf("failed to make prometheusRule CRD: %w", err)
 	}
@@ -566,7 +564,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete prometheusRule CRD: %w", err)
 	}
 
-	serviceMonitorCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.ServiceMonitorName))
+	serviceMonitorCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.ServiceMonitorName))
 	if err != nil {
 		return fmt.Errorf("failed to make serviceMonitor CRD: %w", err)
 	}
@@ -575,7 +573,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete serviceMonitor CRD: %w", err)
 	}
 
-	thanosRulerCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1.ThanosRulerName))
+	thanosRulerCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.ThanosRulerName))
 	if err != nil {
 		return fmt.Errorf("failed to make thanosRuler CRD: %w", err)
 	}
@@ -584,7 +582,7 @@ func (f *Framework) DeletePrometheusOperatorClusterResource(ctx context.Context)
 		return fmt.Errorf("failed to delete thanosRuler CRD: %w", err)
 	}
 
-	alertmanagerConfigCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoringv1alpha1.AlertmanagerConfigName))
+	alertmanagerConfigCRD, err := f.MakeCRD(fmt.Sprintf("%s/prometheus-operator-crd/%s_%s.yaml", f.exampleDir, group, monitoring.AlertmanagerConfigName))
 	if err != nil {
 		return fmt.Errorf("failed to make alertmanagerConfig CRD: %w", err)
 	}

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -335,7 +335,7 @@ func (f *Framework) PatchPrometheus(ctx context.Context, name, ns string, spec m
 	b, err := json.Marshal(
 		&monitoringv1.Prometheus{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       monitoringv1.PrometheusesKind,
+				Kind:       monitoring.PrometheusesKind,
 				APIVersion: schema.GroupVersion{Group: monitoring.GroupName, Version: monitoringv1.Version}.String(),
 			},
 			Spec: spec,

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -134,7 +134,7 @@ func (f *Framework) PatchPrometheusAgent(ctx context.Context, name, ns string, s
 	b, err := json.Marshal(
 		&monitoringv1alpha1.PrometheusAgent{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       monitoringv1alpha1.PrometheusAgentsKind,
+				Kind:       monitoring.PrometheusAgentsKind,
 				APIVersion: schema.GroupVersion{Group: monitoring.GroupName, Version: monitoringv1alpha1.Version}.String(),
 			},
 			Spec: spec,

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -78,7 +78,7 @@ func (f *Framework) PatchThanosRuler(ctx context.Context, name, ns string, spec 
 	b, err := json.Marshal(
 		&monitoringv1.ThanosRuler{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       monitoringv1.ThanosRulerKind,
+				Kind:       monitoring.ThanosRulerKind,
 				APIVersion: schema.GroupVersion{Group: monitoring.GroupName, Version: monitoringv1.Version}.String(),
 			},
 			Spec: spec,


### PR DESCRIPTION
## Description

This is a follow up from #5577 in which we duplicated consts to add ScrapeConfigs to ObjectReference.

cc @mcbenjemaa 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Deprecates CRD constants and moves them to `api/monitoring`. This only impacts developers reusing our CRDs in their projects. The constants will be removed in v0.75.
```
