### PR TITLE
chore: adding golden files support on webconfig tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ example/prometheus-operator-crd-full/* linguist-generated=true
 example/prometheus-operator-crd/* linguist-generated=true
 example/jsonnet/prometheus-operator/* linguist-generated=true
 Documentation/api.md linguist-generated=true
+**/testdata/*.golden linguist-generated=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - Make sure the tests pass, and add any new tests as appropriate.
+- If the tests are checking long strings such as yaml, json or any other complex content, ensure you're using golden files.
 - Submit a pull request to the original repository.
 
 Many files (documentation, manifests, ...) in this repository are auto-generated. For instance, `bundle.yaml` is generated from the *Jsonnet* files in `/jsonnet/prometheus-operator`. Before submitting a pull request, make sure that you've executed `make generate` and committed the generated changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - Make sure the tests pass, and add any new tests as appropriate.
-- If the tests are checking long strings such as yaml, json or any other complex content, ensure you're using golden files.
+- If the tests are checking long strings such as YAML, JSON or any other complex content, ensure you're using [golden files](https://pkg.go.dev/gotest.tools/v3/golden).
 - Submit a pull request to the original repository.
 
 Many files (documentation, manifests, ...) in this repository are auto-generated. For instance, `bundle.yaml` is generated from the *Jsonnet* files in `/jsonnet/prometheus-operator`. Before submitting a pull request, make sure that you've executed `make generate` and committed the generated changes.

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,10 @@ test-unit:
 test-long:
 	go test $(TEST_RUN_ARGS) $(pkgs) -count=1 -v
 
+.PHONY: test-unit-update-golden
+test-unit-update-golden:
+	./scripts/update-golden-files.sh
+
 test/instrumented-sample-app/certs/cert.pem test/instrumented-sample-app/certs/key.pem:
 	cd test/instrumented-sample-app && make generate-certs
 

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.5.0
 	k8s.io/kube-openapi v0.0.0-20230525220651-2546d827e515 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -902,6 +902,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/webconfig/testdata/HTTP_config_with_all_parameters.golden
+++ b/pkg/webconfig/testdata/HTTP_config_with_all_parameters.golden
@@ -1,0 +1,8 @@
+http_server_config:
+  http2: false
+  headers:
+    Content-Security-Policy: test
+    Strict-Transport-Security: test
+    X-Content-Type-Options: nosniff
+    X-Frame-Options: sameorigin
+    X-XSS-Protection: test

--- a/pkg/webconfig/testdata/TLS_config_with_all_parameters_from secrets.golden
+++ b/pkg/webconfig/testdata/TLS_config_with_all_parameters_from secrets.golden
@@ -1,0 +1,14 @@
+tls_server_config:
+  cert_file: /web_certs_path_prefix/secret/test-secret-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.keySecret
+  client_auth_type: RequireAnyClientCert
+  client_ca_file: /web_certs_path_prefix/secret/test-secret-ca/tls.ca
+  min_version: TLS11
+  max_version: TLS13
+  cipher_suites:
+  - cipher-1
+  - cipher-2
+  prefer_server_cipher_suites: false
+  curve_preferences:
+  - curve-1
+  - curve-2

--- a/pkg/webconfig/testdata/minimal_TLS_config_with_certificate_from_configmap.golden
+++ b/pkg/webconfig/testdata/minimal_TLS_config_with_certificate_from_configmap.golden
@@ -1,0 +1,3 @@
+tls_server_config:
+  cert_file: /web_certs_path_prefix/configmap/test-configmap-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key

--- a/pkg/webconfig/testdata/minimal_TLS_config_with_certificate_from_secret.golden
+++ b/pkg/webconfig/testdata/minimal_TLS_config_with_certificate_from_secret.golden
@@ -1,0 +1,3 @@
+tls_server_config:
+  cert_file: /web_certs_path_prefix/secret/test-secret-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key

--- a/pkg/webconfig/testdata/minimal_TLS_config_with_client_CA_from configmap.golden
+++ b/pkg/webconfig/testdata/minimal_TLS_config_with_client_CA_from configmap.golden
@@ -1,0 +1,4 @@
+tls_server_config:
+  cert_file: /web_certs_path_prefix/configmap/test-configmap-cert/tls.crt
+  key_file: /web_certs_path_prefix/secret/test-secret-key/tls.key
+  client_ca_file: /web_certs_path_prefix/configmap/test-configmap-ca/tls.client_ca

--- a/scripts/update-golden-files.sh
+++ b/scripts/update-golden-files.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script updates the golden files for unit tests that import the 'gotest.tools/v3/golden' dependency in a Go project.
+# It lists all packages in the project, checks for the dependency in test imports, and runs unit tests with '-update' to update golden files.
 
 dependency="gotest.tools/v3/golden"
 

--- a/scripts/update-golden-files.sh
+++ b/scripts/update-golden-files.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+dependency="gotest.tools/v3/golden"
+
+# List all packages in the project
+packages=$(go list ./...)
+
+# Loop through each package and check if it imports the specific dependency
+for pkg in $packages; do
+    # Use 'go list' with 'XTestImports' template to get the imports from test binaries
+    imports=$(go list -f '{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' "$pkg")
+    
+    # Check if the dependency is in the imports
+    if echo "$imports" | grep -q "$dependency"; then
+        # If the dependency is found, run the unit tests updating the golden files
+        go test "$pkg" -update -timeout 30s
+    fi
+done


### PR DESCRIPTION
## Description

I'm adding golden file supports on `webconfig` package, solves #5741

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
adding golden file supports on `webconfig` package
```
