### PR TITLE
feat: runAsNonRoot true as default for config-reloader initcontainer

### DIFF
--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -237,6 +237,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		SecurityContext: &v1.SecurityContext{
 			AllowPrivilegeEscalation: &boolFalse,
 			ReadOnlyRootFilesystem:   &boolTrue,
+			RunAsNonRoot:             &boolTrue,
 			Capabilities: &v1.Capabilities{
 				Drop: []v1.Capability{"ALL"},
 			},


### PR DESCRIPTION
## Description
Besides the securityContext options `allowPrivilegeEscalation: false` and `readOnlyRootFilesystem: true` I also want to make sure that the config-reloader InitContainer runs with `runAsNonRoot: true`.

Unfortunately I haven't found a way to set this via the values of the prometheusOperator. I guess this happens fix at this point in the code (https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/operator/config_reloader.go#L237):

pkg/operator/config_reloader.go
```go
SecurityContext: &v1.SecurityContext{
	AllowPrivilegeEscalation: &boolFalse,
	ReadOnlyRootFilesystem:   &boolTrue,
	Capabilities: &v1.Capabilities{
		Drop: []v1.Capability{"ALL"},
	},
```
## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: set runAsNonRoot true as default for config-reloader initcontainer
```
