### PR TITLE
refactor: Remove operator override on alertmanagerConfig top level co…

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -19370,8 +19370,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Boolean indicating whether an alert should continue matching subsequent
-sibling nodes. It will always be overridden to true for the first-level
-route by the Prometheus operator.</p>
+sibling nodes.</p>
 </td>
 </tr>
 <tr>
@@ -23068,8 +23067,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Boolean indicating whether an alert should continue matching subsequent
-sibling nodes. It will always be overridden to true for the first-level
-route by the Prometheus operator.</p>
+sibling nodes.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4796,8 +4796,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4819,8 +4819,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated
@@ -9533,8 +9532,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4796,8 +4796,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -5010,7 +5010,7 @@
                         "type": "array"
                       },
                       "continue": {
-                        "description": "Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.",
+                        "description": "Boolean indicating whether an alert should continue matching subsequent sibling nodes.",
                         "type": "boolean"
                       },
                       "groupBy": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -4857,7 +4857,7 @@
                     type: 'array',
                   },
                   continue: {
-                    description: 'Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.',
+                    description: 'Boolean indicating whether an alert should continue matching subsequent sibling nodes.',
                     type: 'boolean',
                   },
                   groupBy: {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -118,7 +118,6 @@ func (ne *noopEnforcer) processInhibitRule(_ types.NamespacedName, ir *inhibitRu
 }
 
 func (ne *noopEnforcer) processRoute(_ types.NamespacedName, r *route) *route {
-	r.Continue = true
 	return r
 }
 
@@ -175,8 +174,6 @@ func (ne *namespaceEnforcer) processRoute(crKey types.NamespacedName, r *route) 
 	} else {
 		r.Match["namespace"] = crKey.Namespace
 	}
-	// Alerts should still be evaluated by the following routes.
-	r.Continue = true
 
 	return r
 }

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -115,8 +115,7 @@ type Route struct {
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// Boolean indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be overridden to true for the first-level
-	// route by the Prometheus operator.
+	// sibling nodes.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -114,8 +114,7 @@ type Route struct {
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// Boolean indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be overridden to true for the first-level
-	// route by the Prometheus operator.
+	// sibling nodes.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.


### PR DESCRIPTION
…ntinue

Allow users to decide if they want the alert to still be evaluated by the following routes or not. Having the override blocks the possible usage where you have a catch-all route generating duplicate alerts since the route added by an `alertmanagerConfig` already filters to its namespace.

Fixes #5019

## Description

As of now the `prometheus-operator` enforces `continue: true` on the routes generated by `alertmanagerConfig` and by doing so the users don't have any kind of control if the alerts should be evaluated by following roles or not, they will always be evaluated the following. The `prometheus-operator` should allow the users to decide if they want to continue or not, it shouldn't strip this power from the users.

## Your Proposal Title

* **Owners:**
  * @iblackman

* **Related Tickets:**
  * https://github.com/prometheus-operator/prometheus-operator/issues/5019


> TL;DR: This change removes the override done by the `prometheus-operator` on the `continue` value on top-level routes generated by `alertmanagerConfig` empowering the users to decide if they want to continue or not the evaluation of the alerts for the following routes.

## Why

Currently, once you define an `alertmanagerConfig` for example:
```yaml
apiVersion: monitoring.coreos.com/v1alpha1
kind: AlertmanagerConfig
metadata:
  name: example
  namespace: example
spec:
  route:
    continue: false
    groupBy:
    - alertname
    - container
    - pod
    - statefulset
    - replicaset
    - daemonset
    - deployment
    - namespace
    - targetName
    - persistentvolumeclaim
    groupInterval: 10m
    groupWait: 1m
    receiver: pagerduty-example
    repeatInterval: 30m
```

It will result in the following `Alertmanager` configuration:
```yaml
global:
  ...
route:
  ...
  routes:
  - receiver: example/example/pagerduty-example
    group_by:
    - alertname
    - container
    - pod
    - statefulset
    - replicaset
    - daemonset
    - deployment
    - namespace
    - targetName
    - persistentvolumeclaim
    matchers:
    - namespace="example"
    continue: true
    group_wait: 1m
    group_interval: 10m
    repeat_interval: 30m
inhibit_rules:
...
```

You can notice that even though the value for `continue` in the `alertmanagerConfig/example` was set to `false`, its value in the route generated in `Alertmanager` configuration was set to `true`. Overriding what was passed by the user.

### Pitfalls of the current solution

With the current behavior, it is not possible to set `continue: false` in the `alertmanagerConfig` top-level route. Because the operator always overrides that value to `true`.

## Goals

Goals and use cases for the solution as proposed in [How](#how):

* Allow easy collaboration and decision making on design ideas.
* Have a consistent design style that is readable and understandable.
* Have a design style that is concise and covers all the essential information.

## How

Stop with the override done by the operator on the top-level route of an `alertmanagerConfig` respecting the value passed for the attribute `continue`. By removing `r.Continue = true` from `processRoute`.

* How will you test and verify?
  * Tested in a local environment and it worked as expected, taking the value `continue: false` into consideration.
* How will you migrate users, without downtime? How do we solve incompatibilities?
  * I have not found any incompatibilities.
* What open questions are left? 
    * It is possible that people are currently setting the value to `false` but since the operator is overriding it they are not aware of it, and once this change is merged their value will be taken into consideration and it may change the route evaluation for them. 

## Alternatives

If the proposed change isn't acceptable we could create a global level variable to control this behavior of the operator to allow users if they desire to stop the override done by the `prometheus-operator`, where the default value could be to override but at least it would allow people to change it.

## Action Plan

By merging this PR it will already remove the override.

