### PR TITLE
reduce the number of reconciliations

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -708,7 +708,6 @@ func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNam
 		ThanosRulerLabels      map[string]string
 		ThanosRulerAnnotations map[string]string
 		ThanosRulerGeneration  int64
-		ThanosRulerSpec        monitoringv1.ThanosRulerSpec
 		Config                 Config
 		StatefulSetSpec        appsv1.StatefulSetSpec
 		RuleConfigMaps         []string `hash:"set"`
@@ -716,7 +715,6 @@ func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNam
 		ThanosRulerLabels:      tr.Labels,
 		ThanosRulerAnnotations: tr.Annotations,
 		ThanosRulerGeneration:  tr.Generation,
-		ThanosRulerSpec:        tr.Spec,
 		Config:                 c,
 		StatefulSetSpec:        ss,
 		RuleConfigMaps:         ruleConfigMapNames,

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -704,29 +704,29 @@ func (o *Operator) UpdateStatus(ctx context.Context, key string) error {
 }
 
 func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNames []string, ss appsv1.StatefulSetSpec) (string, error) {
-    hash, err := hashstructure.Hash(struct {
-        ThanosRulerLabels      map[string]string
-        ThanosRulerAnnotations map[string]string
-        ThanosRulerSpec        monitoringv1.ThanosRulerSpec
-        Config                 Config
-        StatefulSetSpec        appsv1.StatefulSetSpec
-        RuleConfigMaps         []string `hash:"set"`
-    }{
-        ThanosRulerLabels:      tr.Labels,
-        ThanosRulerAnnotations: tr.Annotations,
-        ThanosRulerSpec:        tr.Spec,
-        Config:                 c,
-        StatefulSetSpec:        ss,
-        RuleConfigMaps:         ruleConfigMapNames,
-    },
-        nil,
-    )
-    if err != nil {
-        return "", errors.Wrap(
-            err,
-            "failed to calculate combined hash",
-        )
-    }
+	hash, err := hashstructure.Hash(struct {
+		ThanosRulerLabels      map[string]string
+		ThanosRulerAnnotations map[string]string
+		ThanosRulerSpec        monitoringv1.ThanosRulerSpec
+		Config                 Config
+		StatefulSetSpec        appsv1.StatefulSetSpec
+		RuleConfigMaps         []string `hash:"set"`
+	}{
+		ThanosRulerLabels:      tr.Labels,
+		ThanosRulerAnnotations: tr.Annotations,
+		ThanosRulerSpec:        tr.Spec,
+		Config:                 c,
+		StatefulSetSpec:        ss,
+		RuleConfigMaps:         ruleConfigMapNames,
+	},
+		nil,
+	)
+	if err != nil {
+		return "", errors.Wrap(
+			err,
+			"failed to calculate combined hash",
+		)
+	}
 
 	return fmt.Sprintf("%d", hash), nil
 }

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -707,6 +707,7 @@ func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNam
 	hash, err := hashstructure.Hash(struct {
 		ThanosRulerLabels      map[string]string
 		ThanosRulerAnnotations map[string]string
+		ThanosRulerGeneration  int64
 		ThanosRulerSpec        monitoringv1.ThanosRulerSpec
 		Config                 Config
 		StatefulSetSpec        appsv1.StatefulSetSpec
@@ -714,6 +715,7 @@ func createSSetInputHash(tr monitoringv1.ThanosRuler, c Config, ruleConfigMapNam
 	}{
 		ThanosRulerLabels:      tr.Labels,
 		ThanosRulerAnnotations: tr.Annotations,
+		ThanosRulerGeneration:  tr.Generation,
 		ThanosRulerSpec:        tr.Spec,
 		Config:                 c,
 		StatefulSetSpec:        ss,


### PR DESCRIPTION
## Description

Reflecting the same changes as https://github.com/prometheus-operator/prometheus-operator/commit/bd658c582c697e256b0c17b329b9d46fdc452eb9#diff-c8f4eb63862907c2cd9e067b2cf70e03f4e134075bd28f507dade553850d4fa3L1627 in ThanosRuler CRD


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
reduce the number of reconciliations on ThanosRuler objects.
```
