### PR TITLE
Do not check the am version if no discord configs

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1323,6 +1323,9 @@ func checkDiscordConfigs(
 	store *assets.Store,
 	amVersion semver.Version,
 ) error {
+	if len(configs) == 0 {
+		return nil
+	}
 	if amVersion.LT(semver.MustParse("0.25.0")) {
 		return fmt.Errorf(`discordConfigs' is available in Alertmanager >= 0.25.0 only - current %s`, amVersion)
 	}


### PR DESCRIPTION
## Description

When you run a prometheus-operator from the main or release-0.67 branch, and declare an alertmanager CR which alertmanager version less than v0.25.0, then all your declared alertmanagerConfig CRs will be skipped due to unnecessary check for receiver configs of discord type. So fix it.

An alertmanager CR with alertmanager v0.24.0:
```
apiVersion: monitoring.coreos.com/v1
kind: Alertmanager
metadata:
  labels:
    app: alertmanager
  name: ecms
  namespace: default
spec:
  alertmanagerConfigMatcherStrategy:
    type: None
  alertmanagerConfigNamespaceSelector: {}
  alertmanagerConfigSelector:
    matchLabels:
      emla.io/used-by: ecms
  clusterPeerTimeout: 60s
  configSecret: alertmanager
  image: prom/alertmanager-linux-amd64:release-0.24-es
  logLevel: info
  replicas: 2
  retention: 120h
  routePrefix: /
  serviceAccountName: default
  version: v0.24.0
---
apiVersion: v1
data:
  alertmanager.yaml: cmVjZWl2ZXJzOgotIG5hbWU6ICJudWxsIgpyb3V0ZToKICByZWNlaXZlcjogIm51bGwiCnRlbXBsYXRlczoKLSAvZXRjL2FsZXJ0bWFuYWdlci9jb25maWcvKi50bXBsCg==
  emailAuthPassword: cGFzczIwMjMwODAyd29yZA==
kind: Secret
metadata:
  labels:
    app: alertmanager
  name: alertmanager
  namespace: default
type: Opaque
```

An alertmanagerConfig CR of non-discord type:
```
apiVersion: monitoring.coreos.com/v1beta1
kind: AlertmanagerConfig
metadata:
  labels:
    emla.io/used-by: ecms
  name: subscription-platform-default
  namespace: default
spec:
  receivers:
  - emailConfigs:
    - authPassword:
        key: emailAuthPassword
        name: alertmanager
      authUsername: noreply@easystack.cn
      from: noreply@easystack.cn
      hello: smtp.xxxxxx.com
      requireTLS: true
      sendResolved: false
      smarthost: smtp.xxxxxx.com:25
      to: qiliang.cheng@easystack.cn
    name: subscription-platform-default
  route:
    groupBy:
    - alertname
    - group_id
    groupInterval: 5m
    groupWait: 30s
    receiver: subscription-platform-default
    repeatInterval: 3h
```

Warning log:
```
......
level=warn ts=2023-08-02T13:44:15.64755Z caller=operator.go:1087 component=alertmanageroperator msg="skipping alertmanagerconfig" error="discordConfigs' is available in Alertmanager >= 0.25.0 only - current 0.24.0" alertmanagerconfig=default/subscription-platform-default namespace=default alertmanager=ecms
......
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix AlertmanagerConfig being skipped for non-discord type receivers.
```
