### PR TITLE
feat: adding golden files support on alertmanger tests

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -757,7 +757,7 @@ func TestGenerateConfig(t *testing.T) {
 		amVersion       *semver.Version
 		matcherStrategy monitoringingv1.AlertmanagerConfigMatcherStrategy
 		amConfigs       map[string]*monitoringv1alpha1.AlertmanagerConfig
-		expected        string
+		golden          string
 	}
 	version24, err := semver.ParseTolerant("v0.24.0")
 	if err != nil {
@@ -778,12 +778,7 @@ func TestGenerateConfig(t *testing.T) {
 				Receivers: []*receiver{{Name: "null"}},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: "null"
-receivers:
-- name: "null"
-templates: []
-`,
+			golden:    "skeleton_base_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global send_revolved, no CRs",
@@ -796,14 +791,7 @@ templates: []
 				Receivers: []*receiver{{Name: "null"}},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `global:
-  resolve_timeout: 1m
-route:
-  receiver: "null"
-receivers:
-- name: "null"
-templates: []
-`,
+			golden:    "skeleton_base_with_global_send_revolved_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to false, no CRs",
@@ -816,14 +804,7 @@ templates: []
 				Receivers: []*receiver{{Name: "null"}},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `global:
-  smtp_require_tls: false
-route:
-  receiver: "null"
-receivers:
-- name: "null"
-templates: []
-`,
+			golden:    "skeleton_base_with_global_smtp_require_tls_set_to_false,_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to true, no CRs",
@@ -836,14 +817,7 @@ templates: []
 				Receivers: []*receiver{{Name: "null"}},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `global:
-  smtp_require_tls: true
-route:
-  receiver: "null"
-receivers:
-- name: "null"
-templates: []
-`,
+			golden:    "skeleton_base_with_global_smtp_require_tls_set_to_true_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with inhibit rules, no CRs",
@@ -859,19 +833,7 @@ templates: []
 				Receivers: []*receiver{{Name: "null"}},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: "null"
-inhibit_rules:
-- target_matchers:
-  - test!=dropped
-  - expect=~this-value
-  source_matchers:
-  - test!=dropped
-  - expect=~this-value
-receivers:
-- name: "null"
-templates: []
-`,
+			golden:    "skeleton_base_with_inhibit_rules_no_CRs.golden",
 		},
 		{
 			name:    "base with sub route and matchers, no CRs",
@@ -890,17 +852,7 @@ templates: []
 				},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: custom
-    matchers:
-    - namespace=custom-test
-receivers:
-- name: "null"
-- name: custom
-templates: []
-`,
+			golden:    "base_with_sub_route_and_matchers_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with mute time intervals, no CRs",
@@ -953,20 +905,7 @@ templates: []
 				},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: "null"
-receivers:
-- name: "null"
-mute_time_intervals:
-- name: maintenance_windows
-  time_intervals:
-  - times:
-    - start_time: "17:00"
-      end_time: "24:00"
-    days_of_month: ["7", "18", "28"]
-    months: ["1"]
-templates: []
-`,
+			golden:    "skeleton_base_with_mute_time_intervals_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with sns receiver, no CRs",
@@ -996,24 +935,7 @@ templates: []
 				},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: sns-test
-receivers:
-- name: sns-test
-  sns_configs:
-  - api_url: https://sns.us-west-2.amazonaws.com
-    sigv4:
-      region: us-west-2
-      access_key: key
-      secret_key: secret
-      profile: dev
-      role_arn: arn:dev
-    topic_arn: arn:test
-    phone_number: "+12345"
-    target_arn: arn:target
-    subject: testing
-templates: []
-`,
+			golden:    "skeleton_base_with_sns_receiver_no_CRs.golden",
 		},
 		{
 			name:      "skeleton base with active_time_intervals, no CRs",
@@ -1046,20 +968,7 @@ templates: []
 				},
 			},
 			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: "null"
-    active_time_intervals:
-    - workdays
-receivers:
-- name: "null"
-time_intervals:
-- name: workdays
-  time_intervals:
-  - weekdays: ['monday:friday']
-templates: []
-`,
+			golden:    "skeleton_base_with_active_time_intervals_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -1083,20 +992,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    group_by:
-    - job
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-templates: []
-`,
+			golden: "skeleton_base_simple_CR.golden",
 		},
 		{
 			name:    "skeleton base, simple CR with namespaceMatcher disabled",
@@ -1123,18 +1019,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    group_by:
-    - job
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-templates: []
-`,
+			golden: "skeleton_base_simple_CR_with_namespaceMatcher_disabled.golden",
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only (deprecated matchers not converted)",
@@ -1174,21 +1059,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-inhibit_rules:
-- target_match:
-    alertname: TargetDown
-    namespace: mynamespace
-  source_match:
-    alertname: NodeNotReady
-    namespace: mynamespace
-  equal:
-  - node
-receivers:
-- name: "null"
-templates: []
-`,
+			golden: "skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_not_converted.golden",
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only (deprecated matchers are converted)",
@@ -1225,21 +1096,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-inhibit_rules:
-- target_matchers:
-  - alertname="TargetDown"
-  - namespace="mynamespace"
-  source_matchers:
-  - alertname=~"NodeNotReady"
-  - namespace="mynamespace"
-  equal:
-  - node
-receivers:
-- name: "null"
-templates: []
-`,
+			golden: "skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_are_converted.golden",
 		},
 		{
 			name:    "skeleton base, CR with inhibition rules only",
@@ -1277,21 +1134,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-inhibit_rules:
-- target_matchers:
-  - alertname!="TargetDown"
-  - namespace="mynamespace"
-  source_matchers:
-  - alertname=~"NodeNotReady"
-  - namespace="mynamespace"
-  equal:
-  - node
-receivers:
-- name: "null"
-templates: []
-`,
+			golden: "skeleton_base,_CR_with_inhibition_rules_only.golden",
 		},
 		{
 			name:    "base with subroute - deprecated matching pattern, simple CR",
@@ -1317,19 +1160,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-  - receiver: "null"
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-templates: []
-`,
+			golden: "base_with_subroute_deprecated_matching_pattern_simple_CR.golden",
 		},
 		{
 			name: "CR with Pagerduty Receiver",
@@ -1387,27 +1218,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test-pd
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test-pd
-  pagerduty_configs:
-  - routing_key: 1234abc
-    images:
-    - src: https://some-image.com
-      alt: some-image
-      href: https://some-image.com
-    links:
-    - href: https://some-link.com
-      text: some-link
-templates: []
-`,
+			golden: "CR_with_Pagerduty_Receiver.golden",
 		},
 		{
 			name: "CR with Webhook Receiver and custom http config (oauth2)",
@@ -1482,30 +1293,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  webhook_configs:
-  - url: http://test.url
-    http_config:
-      oauth2:
-        client_id: clientID
-        client_secret: clientSecret
-        scopes:
-        - any
-        token_url: https://test.com
-        endpoint_params:
-          some: value
-      follow_redirects: true
-templates: []
-`,
+			golden: "CR_with_Webhook_Receiver_and_custom_http_config_oauth2.golden",
 		},
 		{
 			name: "CR with Opsgenie Receiver",
@@ -1550,20 +1338,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  opsgenie_configs:
-  - api_key: 1234abc
-templates: []
-`,
+			golden: "CR_with_Opsgenie_Receiver.golden",
 		},
 		{
 			name: "CR with Opsgenie Team Responder",
@@ -1612,23 +1387,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  opsgenie_configs:
-  - api_key: 1234abc
-    responders:
-    - name: myname
-      type: team
-templates: []
-`,
+			golden: "CR_with_Opsgenie_Team_Responder.golden",
 		},
 		{
 			name: "CR with WeChat Receiver",
@@ -1674,21 +1433,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  wechat_configs:
-  - api_secret: wechatsecret
-    corp_id: wechatcorpid
-templates: []
-`,
+			golden: "CR_with_WeChat_Receiver.golden",
 		},
 
 		{
@@ -1737,24 +1482,8 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  telegram_configs:
-  - api_url: https://api.telegram.org
-    bot_token: bipbop
-    chat_id: 12345
-templates: []
-`,
+			golden: "CR_with_Telegram_Receiver.golden",
 		},
-
 		{
 
 			name:    "CR with Slack Receiver and global Slack URL",
@@ -1802,30 +1531,7 @@ templates: []
 					},
 				},
 			},
-			expected: `global:
-  slack_api_url: http://slack.example.com
-route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  slack_configs:
-  - fields:
-    - title: title
-      value: value
-    actions:
-    - type: type
-      text: text
-      name: my-action
-      confirm:
-        text: text
-templates: []
-`,
+			golden: "CR_with_Slack_Receiver_and_global_Slack_URL.golden",
 		},
 		{
 
@@ -1874,30 +1580,7 @@ templates: []
 					},
 				},
 			},
-			expected: `global:
-  slack_api_url_file: /etc/test
-route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  slack_configs:
-  - fields:
-    - title: title
-      value: value
-    actions:
-    - type: type
-      text: text
-      name: my-action
-      confirm:
-        text: text
-templates: []
-`,
+			golden: "CR_with_Slack_Receiver_and_global_Slack_URL_File.golden",
 		},
 		{
 
@@ -1956,25 +1639,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  sns_configs:
-  - api_url: https://sns.us-east-2.amazonaws.com
-    sigv4:
-      region: us-east-2
-      access_key: xyz
-      secret_key: "123"
-    topic_arn: test-topicARN
-templates: []
-`,
+			golden: "CR_with_SNS_Receiver_with_Access_and_Key.golden",
 		},
 		{
 
@@ -2022,24 +1687,7 @@ templates: []
 					},
 				},
 			},
-			expected: `route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  sns_configs:
-  - api_url: https://sns.us-east-2.amazonaws.com
-    sigv4:
-      region: us-east-2
-      role_arn: test-roleARN
-    topic_arn: test-topicARN
-templates: []
-`,
+			golden: "CR_with_SNS_Receiver_with_roleARN.golden",
 		},
 		{
 
@@ -2120,42 +1768,7 @@ templates: []
 					},
 				},
 			},
-			expected: `global:
-  slack_api_url_file: /etc/test
-route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-    mute_time_intervals:
-    - mynamespace/myamc/test
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  slack_configs:
-  - fields:
-    - title: title
-      value: value
-    actions:
-    - type: type
-      text: text
-      name: my-action
-      confirm:
-        text: text
-mute_time_intervals:
-- name: mynamespace/myamc/test
-  time_intervals:
-  - times:
-    - start_time: "08:00"
-      end_time: "17:00"
-    weekdays: [saturday, sunday]
-    days_of_month: ["1:10"]
-    months: ["1:3"]
-    years: ['2030:2050']
-templates: []
-`,
+			golden: "CR_with_Mute_Time_Intervals.golden",
 		},
 		{
 			name:    "CR with Active Time Intervals",
@@ -2236,42 +1849,7 @@ templates: []
 					},
 				},
 			},
-			expected: `global:
-  slack_api_url_file: /etc/test
-route:
-  receiver: "null"
-  routes:
-  - receiver: mynamespace/myamc/test
-    matchers:
-    - namespace="mynamespace"
-    continue: true
-    active_time_intervals:
-    - mynamespace/myamc/test
-receivers:
-- name: "null"
-- name: mynamespace/myamc/test
-  slack_configs:
-  - fields:
-    - title: title
-      value: value
-    actions:
-    - type: type
-      text: text
-      name: my-action
-      confirm:
-        text: text
-mute_time_intervals:
-- name: mynamespace/myamc/test
-  time_intervals:
-  - times:
-    - start_time: "08:00"
-      end_time: "17:00"
-    weekdays: [saturday, sunday]
-    days_of_month: ["1:10"]
-    months: ["1:3"]
-    years: ['2030:2050']
-templates: []
-`,
+			golden: "CR_with_Active_Time_Intervals.golden",
 		},
 	}
 
@@ -2301,9 +1879,7 @@ templates: []
 			}
 
 			// Verify the generated yaml is as expected
-			if diff := cmp.Diff(tc.expected, string(cfgBytes)); diff != "" {
-				t.Errorf("Unexpected result (-want +got):\n%s", diff)
-			}
+			golden.Assert(t, string(cfgBytes), tc.golden)
 
 			// Verify the generated config is something that Alertmanager will be happy with
 			_, err = alertmanagerConfigFromBytes(cfgBytes)
@@ -3627,25 +3203,12 @@ func TestSanitizeRoute(t *testing.T) {
 func TestLoadConfig(t *testing.T) {
 	testCase := []struct {
 		name     string
-		rawConf  []byte
 		expected *alertmanagerConfig
+		golden   string
 	}{
 		{
-			name: "mute_time_intervals field",
-			rawConf: []byte(`route:
-  receiver: "null"
-receivers:
-- name: "null"
-mute_time_intervals:
-- name: maintenance_windows
-  time_intervals:
-  - times:
-    - start_time: "17:00"
-      end_time: "24:00"
-    days_of_month: ["7", "18", "28"]
-    months: ["january"]
-templates: []
-`),
+			name:   "mute_time_intervals field",
+			golden: "mute_time_intervals_field.golden",
 			expected: &alertmanagerConfig{
 				Global: nil,
 				Route: &route{
@@ -3703,15 +3266,8 @@ templates: []
 			},
 		},
 		{
-			name: "Global opsgenie_api_key_file field",
-			rawConf: []byte(`route:
-  receiver: "null"
-receivers:
-- name: "null"
-global:
-  opsgenie_api_key_file: "xxx"
-templates: []
-`),
+			name:   "Global opsgenie_api_key_file field",
+			golden: "Global_opsgenie_api_key_file_field.golden",
 			expected: &alertmanagerConfig{
 				Global: &globalConfig{
 					OpsGenieAPIKeyFile: "xxx",
@@ -3728,17 +3284,8 @@ templates: []
 			},
 		},
 		{
-			name: "OpsGenie entity and actions fields",
-			rawConf: []byte(`route:
-  receiver: "opsgenie"
-receivers:
-- name: "opsgenie"
-  opsgenie_configs:
-  - entity: entity1
-    actions: action1,action2
-    api_key: xxx
-templates: []
-`),
+			name:   "OpsGenie entity and actions fields",
+			golden: "OpsGenie_entity_and_actions_fields.golden",
 			expected: &alertmanagerConfig{
 				Route: &route{
 					Receiver: "opsgenie",
@@ -3759,15 +3306,8 @@ templates: []
 			},
 		},
 		{
-			name: "Discord url field",
-			rawConf: []byte(`route:
-  receiver: "discord"
-receivers:
-- name: "discord"
-  discord_configs:
-  - webhook_url: http://example.com
-templates: []
-`),
+			name:   "Discord url field",
+			golden: "Discord_url_field.golden",
 			expected: &alertmanagerConfig{
 				Route: &route{
 					Receiver: "discord",
@@ -3789,7 +3329,7 @@ templates: []
 
 	for _, tc := range testCase {
 		t.Run(tc.name, func(t *testing.T) {
-			ac, err := alertmanagerConfigFromBytes(tc.rawConf)
+			ac, err := alertmanagerConfigFromBytes(golden.Get(t, tc.golden))
 			if err != nil {
 				t.Fatalf("expecing no error, got %v", err)
 			}

--- a/pkg/alertmanager/testdata/CR_with_Active_Time_Intervals.golden
+++ b/pkg/alertmanager/testdata/CR_with_Active_Time_Intervals.golden
@@ -1,0 +1,35 @@
+global:
+  slack_api_url_file: /etc/test
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+    active_time_intervals:
+    - mynamespace/myamc/test
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  slack_configs:
+  - fields:
+    - title: title
+      value: value
+    actions:
+    - type: type
+      text: text
+      name: my-action
+      confirm:
+        text: text
+mute_time_intervals:
+- name: mynamespace/myamc/test
+  time_intervals:
+  - times:
+    - start_time: "08:00"
+      end_time: "17:00"
+    weekdays: [saturday, sunday]
+    days_of_month: ["1:10"]
+    months: ["1:3"]
+    years: ['2030:2050']
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Mute_Time_Intervals.golden
+++ b/pkg/alertmanager/testdata/CR_with_Mute_Time_Intervals.golden
@@ -1,0 +1,35 @@
+global:
+  slack_api_url_file: /etc/test
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+    mute_time_intervals:
+    - mynamespace/myamc/test
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  slack_configs:
+  - fields:
+    - title: title
+      value: value
+    actions:
+    - type: type
+      text: text
+      name: my-action
+      confirm:
+        text: text
+mute_time_intervals:
+- name: mynamespace/myamc/test
+  time_intervals:
+  - times:
+    - start_time: "08:00"
+      end_time: "17:00"
+    weekdays: [saturday, sunday]
+    days_of_month: ["1:10"]
+    months: ["1:3"]
+    years: ['2030:2050']
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Opsgenie_Receiver.golden
+++ b/pkg/alertmanager/testdata/CR_with_Opsgenie_Receiver.golden
@@ -1,0 +1,13 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  opsgenie_configs:
+  - api_key: 1234abc
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Opsgenie_Team_Responder.golden
+++ b/pkg/alertmanager/testdata/CR_with_Opsgenie_Team_Responder.golden
@@ -1,0 +1,16 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  opsgenie_configs:
+  - api_key: 1234abc
+    responders:
+    - name: myname
+      type: team
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Pagerduty_Receiver.golden
+++ b/pkg/alertmanager/testdata/CR_with_Pagerduty_Receiver.golden
@@ -1,0 +1,20 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test-pd
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test-pd
+  pagerduty_configs:
+  - routing_key: 1234abc
+    images:
+    - src: https://some-image.com
+      alt: some-image
+      href: https://some-image.com
+    links:
+    - href: https://some-link.com
+      text: some-link
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_SNS_Receiver_with_Access_and_Key.golden
+++ b/pkg/alertmanager/testdata/CR_with_SNS_Receiver_with_Access_and_Key.golden
@@ -1,0 +1,18 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  sns_configs:
+  - api_url: https://sns.us-east-2.amazonaws.com
+    sigv4:
+      region: us-east-2
+      access_key: xyz
+      secret_key: "123"
+    topic_arn: test-topicARN
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_SNS_Receiver_with_roleARN.golden
+++ b/pkg/alertmanager/testdata/CR_with_SNS_Receiver_with_roleARN.golden
@@ -1,0 +1,17 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  sns_configs:
+  - api_url: https://sns.us-east-2.amazonaws.com
+    sigv4:
+      region: us-east-2
+      role_arn: test-roleARN
+    topic_arn: test-topicARN
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Slack_Receiver_and_global_Slack_URL.golden
+++ b/pkg/alertmanager/testdata/CR_with_Slack_Receiver_and_global_Slack_URL.golden
@@ -1,0 +1,23 @@
+global:
+  slack_api_url: http://slack.example.com
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  slack_configs:
+  - fields:
+    - title: title
+      value: value
+    actions:
+    - type: type
+      text: text
+      name: my-action
+      confirm:
+        text: text
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Slack_Receiver_and_global_Slack_URL_File.golden
+++ b/pkg/alertmanager/testdata/CR_with_Slack_Receiver_and_global_Slack_URL_File.golden
@@ -1,0 +1,23 @@
+global:
+  slack_api_url_file: /etc/test
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  slack_configs:
+  - fields:
+    - title: title
+      value: value
+    actions:
+    - type: type
+      text: text
+      name: my-action
+      confirm:
+        text: text
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Telegram_Receiver.golden
+++ b/pkg/alertmanager/testdata/CR_with_Telegram_Receiver.golden
@@ -1,0 +1,15 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  telegram_configs:
+  - api_url: https://api.telegram.org
+    bot_token: bipbop
+    chat_id: 12345
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_WeChat_Receiver.golden
+++ b/pkg/alertmanager/testdata/CR_with_WeChat_Receiver.golden
@@ -1,0 +1,14 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  wechat_configs:
+  - api_secret: wechatsecret
+    corp_id: wechatcorpid
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_Webhook_Receiver_and_custom_http_config_oauth2.golden
+++ b/pkg/alertmanager/testdata/CR_with_Webhook_Receiver_and_custom_http_config_oauth2.golden
@@ -1,0 +1,23 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  webhook_configs:
+  - url: http://test.url
+    http_config:
+      oauth2:
+        client_id: clientID
+        client_secret: clientSecret
+        scopes:
+        - any
+        token_url: https://test.com
+        endpoint_params:
+          some: value
+      follow_redirects: true
+templates: []

--- a/pkg/alertmanager/testdata/Discord_url_field.golden
+++ b/pkg/alertmanager/testdata/Discord_url_field.golden
@@ -1,0 +1,7 @@
+route:
+  receiver: "discord"
+receivers:
+- name: "discord"
+  discord_configs:
+  - webhook_url: http://example.com
+templates: []

--- a/pkg/alertmanager/testdata/Global_opsgenie_api_key_file_field.golden
+++ b/pkg/alertmanager/testdata/Global_opsgenie_api_key_file_field.golden
@@ -1,0 +1,7 @@
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+global:
+  opsgenie_api_key_file: "xxx"
+templates: []

--- a/pkg/alertmanager/testdata/OpsGenie_entity_and_actions_fields.golden
+++ b/pkg/alertmanager/testdata/OpsGenie_entity_and_actions_fields.golden
@@ -1,0 +1,9 @@
+route:
+  receiver: "opsgenie"
+receivers:
+- name: "opsgenie"
+  opsgenie_configs:
+  - entity: entity1
+    actions: action1,action2
+    api_key: xxx
+templates: []

--- a/pkg/alertmanager/testdata/base_with_sub_route_and_matchers_no_CRs.golden
+++ b/pkg/alertmanager/testdata/base_with_sub_route_and_matchers_no_CRs.golden
@@ -1,0 +1,10 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: custom
+    matchers:
+    - namespace=custom-test
+receivers:
+- name: "null"
+- name: custom
+templates: []

--- a/pkg/alertmanager/testdata/base_with_subroute_deprecated_matching_pattern_simple_CR.golden
+++ b/pkg/alertmanager/testdata/base_with_subroute_deprecated_matching_pattern_simple_CR.golden
@@ -1,0 +1,12 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+  - receiver: "null"
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+templates: []

--- a/pkg/alertmanager/testdata/mute_time_intervals_field.golden
+++ b/pkg/alertmanager/testdata/mute_time_intervals_field.golden
@@ -1,0 +1,13 @@
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+mute_time_intervals:
+- name: maintenance_windows
+  time_intervals:
+  - times:
+    - start_time: "17:00"
+      end_time: "24:00"
+    days_of_month: ["7", "18", "28"]
+    months: ["january"]
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base,_CR_with_inhibition_rules_only.golden
+++ b/pkg/alertmanager/testdata/skeleton_base,_CR_with_inhibition_rules_only.golden
@@ -1,0 +1,14 @@
+route:
+  receiver: "null"
+inhibit_rules:
+- target_matchers:
+  - alertname!="TargetDown"
+  - namespace="mynamespace"
+  source_matchers:
+  - alertname=~"NodeNotReady"
+  - namespace="mynamespace"
+  equal:
+  - node
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_are_converted.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_are_converted.golden
@@ -1,0 +1,14 @@
+route:
+  receiver: "null"
+inhibit_rules:
+- target_matchers:
+  - alertname="TargetDown"
+  - namespace="mynamespace"
+  source_matchers:
+  - alertname=~"NodeNotReady"
+  - namespace="mynamespace"
+  equal:
+  - node
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_not_converted.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_CR_with_inhibition_rules_only_deprecated_matchers_not_converted.golden
@@ -1,0 +1,14 @@
+route:
+  receiver: "null"
+inhibit_rules:
+- target_match:
+    alertname: TargetDown
+    namespace: mynamespace
+  source_match:
+    alertname: NodeNotReady
+    namespace: mynamespace
+  equal:
+  - node
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_no_CRs.golden
@@ -1,0 +1,5 @@
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_simple_CR.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_simple_CR.golden
@@ -1,0 +1,13 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    group_by:
+    - job
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_simple_CR_with_namespaceMatcher_disabled.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_simple_CR_with_namespaceMatcher_disabled.golden
@@ -1,0 +1,11 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    group_by:
+    - job
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_active_time_intervals_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_active_time_intervals_no_CRs.golden
@@ -1,0 +1,13 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: "null"
+    active_time_intervals:
+    - workdays
+receivers:
+- name: "null"
+time_intervals:
+- name: workdays
+  time_intervals:
+  - weekdays: ['monday:friday']
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_global_send_revolved_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_global_send_revolved_no_CRs.golden
@@ -1,0 +1,7 @@
+global:
+  resolve_timeout: 1m
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_global_smtp_require_tls_set_to_false,_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_global_smtp_require_tls_set_to_false,_no_CRs.golden
@@ -1,0 +1,7 @@
+global:
+  smtp_require_tls: false
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_global_smtp_require_tls_set_to_true_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_global_smtp_require_tls_set_to_true_no_CRs.golden
@@ -1,0 +1,7 @@
+global:
+  smtp_require_tls: true
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_inhibit_rules_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_inhibit_rules_no_CRs.golden
@@ -1,0 +1,12 @@
+route:
+  receiver: "null"
+inhibit_rules:
+- target_matchers:
+  - test!=dropped
+  - expect=~this-value
+  source_matchers:
+  - test!=dropped
+  - expect=~this-value
+receivers:
+- name: "null"
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_mute_time_intervals_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_mute_time_intervals_no_CRs.golden
@@ -1,0 +1,13 @@
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+mute_time_intervals:
+- name: maintenance_windows
+  time_intervals:
+  - times:
+    - start_time: "17:00"
+      end_time: "24:00"
+    days_of_month: ["7", "18", "28"]
+    months: ["1"]
+templates: []

--- a/pkg/alertmanager/testdata/skeleton_base_with_sns_receiver_no_CRs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_with_sns_receiver_no_CRs.golden
@@ -1,0 +1,17 @@
+route:
+  receiver: sns-test
+receivers:
+- name: sns-test
+  sns_configs:
+  - api_url: https://sns.us-west-2.amazonaws.com
+    sigv4:
+      region: us-west-2
+      access_key: key
+      secret_key: secret
+      profile: dev
+      role_arn: arn:dev
+    topic_arn: arn:test
+    phone_number: "+12345"
+    target_arn: arn:target
+    subject: testing
+templates: []


### PR DESCRIPTION
## Description

I'm adding golden file supports on `admission` package, solves #5739

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
adding golden file supports on `alertmanager` package
```
