### PR TITLE
statefulset: remove redundant nil check around Labels and Annotations

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -360,15 +360,11 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 		"alertmanager":                 a.Name,
 	}
 	if a.Spec.PodMetadata != nil {
-		if a.Spec.PodMetadata.Labels != nil {
-			for k, v := range a.Spec.PodMetadata.Labels {
-				podLabels[k] = v
-			}
+		for k, v := range a.Spec.PodMetadata.Labels {
+			podLabels[k] = v
 		}
-		if a.Spec.PodMetadata.Annotations != nil {
-			for k, v := range a.Spec.PodMetadata.Annotations {
-				podAnnotations[k] = v
-			}
+		for k, v := range a.Spec.PodMetadata.Annotations {
+			podAnnotations[k] = v
 		}
 	}
 	for k, v := range podSelectorLabels {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -418,15 +418,11 @@ func BuildPodMetadata(cpf monitoringv1.CommonPrometheusFields, cg *ConfigGenerat
 	}
 
 	if cpf.PodMetadata != nil {
-		if cpf.PodMetadata.Labels != nil {
-			for k, v := range cpf.PodMetadata.Labels {
-				podLabels[k] = v
-			}
+		for k, v := range cpf.PodMetadata.Labels {
+			podLabels[k] = v
 		}
-		if cpf.PodMetadata.Annotations != nil {
-			for k, v := range cpf.PodMetadata.Annotations {
-				podAnnotations[k] = v
-			}
+		for k, v := range cpf.PodMetadata.Annotations {
+			podAnnotations[k] = v
 		}
 	}
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -343,15 +343,11 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	podAnnotations := map[string]string{}
 	podLabels := map[string]string{}
 	if tr.Spec.PodMetadata != nil {
-		if tr.Spec.PodMetadata.Labels != nil {
-			for k, v := range tr.Spec.PodMetadata.Labels {
-				podLabels[k] = v
-			}
+		for k, v := range tr.Spec.PodMetadata.Labels {
+			podLabels[k] = v
 		}
-		if tr.Spec.PodMetadata.Annotations != nil {
-			for k, v := range tr.Spec.PodMetadata.Annotations {
-				podAnnotations[k] = v
-			}
+		for k, v := range tr.Spec.PodMetadata.Annotations {
+			podAnnotations[k] = v
 		}
 	}
 	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.


### PR DESCRIPTION
## Description

From the Go docs:

> "If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/Cw_wnqYzemu

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
statefulset: remove redundant nil check around Labels and Annotations
```
