### PR TITLE
chore: use helm/kind-action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -63,13 +63,14 @@ jobs:
       run: |
         export SHELL=/bin/bash
         make build image
-    - name: Start KinD
-      uses: engineerd/setup-kind@v0.5.0
+    - name: Start kind cluster
+      uses: helm/kind-action@v1.7.0
       with:
         version: ${{ env.kind-version }}
-        image: ${{ env.kind-image }}
+        node_image: ${{ env.kind-image }}
         wait: 300s
-        config: /test/e2e/kind-conf.yaml
+        config: ./test/e2e/kind-conf.yaml
+        cluster_name: e2e
     - name: Wait for cluster to finish bootstraping
       run: |
         kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
@@ -77,9 +78,9 @@ jobs:
         kubectl get pods -A
     - name: Load images
       run: |
-        kind load docker-image quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)
-        kind load docker-image quay.io/prometheus-operator/prometheus-config-reloader:$(git rev-parse --short HEAD)
-        kind load docker-image quay.io/prometheus-operator/admission-webhook:$(git rev-parse --short HEAD)
+        kind load docker-image -n e2e quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)
+        kind load docker-image -n e2e quay.io/prometheus-operator/prometheus-config-reloader:$(git rev-parse --short HEAD)
+        kind load docker-image -n e2e quay.io/prometheus-operator/admission-webhook:$(git rev-parse --short HEAD)
         kubectl apply -f scripts/kind-rbac.yaml
     - name: Run tests
       run: >


### PR DESCRIPTION
helm/kind-action seems to be more maintained than engineerd/setup-kind.

## Description

helm/kind-action seems to be more maintained than engineerd/setup-kind.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
