### PR TITLE
Upgrade k8s utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	k8s.io/client-go v0.28.0
 	k8s.io/component-base v0.28.0
 	k8s.io/klog/v2 v2.100.1
-	k8s.io/utils v0.0.0-20230711102312-30195339c3c7
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.15.1
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -892,6 +892,8 @@ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5Ohx
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
 k8s.io/utils v0.0.0-20230711102312-30195339c3c7 h1:ZgnF1KZsYxWIifwSNZFZgNtWE89WI5yiP5WwlfDoIyc=
 k8s.io/utils v0.0.0-20230711102312-30195339c3c7/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringingv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -69,27 +69,27 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 			name: "valid global config",
 			globalConfig: &monitoringingv1.AlertmanagerGlobalConfig{
 				SMTPConfig: &monitoringingv1.GlobalSMTPConfig{
-					From: pointer.String("from"),
+					From: ptr.To("from"),
 					SmartHost: &monitoringingv1.HostPort{
 						Host: "smtp.example.org",
 						Port: "587",
 					},
-					Hello:        pointer.String("smtp.example.org"),
-					AuthUsername: pointer.String("dev@smtp.example.org"),
+					Hello:        ptr.To("smtp.example.org"),
+					AuthUsername: ptr.To("dev@smtp.example.org"),
 					AuthPassword: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "smtp-auth",
 						},
 						Key: "password",
 					},
-					AuthIdentity: pointer.String("dev@smtp.example.org"),
+					AuthIdentity: ptr.To("dev@smtp.example.org"),
 					AuthSecret: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "smtp-auth",
 						},
 						Key: "secret",
 					},
-					RequireTLS: pointer.Bool(true),
+					RequireTLS: ptr.To(true),
 				},
 				ResolveTimeout: "30s",
 				HTTPConfig: &monitoringingv1.HTTPConfig{
@@ -114,7 +114,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 							"some": "value",
 						},
 					},
-					FollowRedirects: pointer.Bool(true),
+					FollowRedirects: ptr.To(true),
 				},
 			},
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
@@ -143,7 +143,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 			},
 			want: &alertmanagerConfig{
 				Global: &globalConfig{
-					ResolveTimeout: func(d model.Duration) *model.Duration { return &d }(model.Duration(30 * time.Second)),
+					ResolveTimeout: ptr.To(model.Duration(30 * time.Second)),
 					SMTPFrom:       "from",
 					SMTPSmarthost: config.HostPort{
 						Host: "smtp.example.org",
@@ -154,7 +154,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 					SMTPAuthPassword: "password",
 					SMTPAuthIdentity: "dev@smtp.example.org",
 					SMTPAuthSecret:   "secret",
-					SMTPRequireTLS:   pointer.Bool(true),
+					SMTPRequireTLS:   ptr.To(true),
 					HTTPConfig: &httpClientConfig{
 						OAuth2: &oauth2{
 							ClientID:     "clientID",
@@ -165,7 +165,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 								"some": "value",
 							},
 						},
-						FollowRedirects: pointer.Bool(true),
+						FollowRedirects: ptr.To(true),
 					},
 				},
 				Receivers: []*receiver{
@@ -635,7 +635,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 			name: "globalConfig has null resolve timeout",
 			globalConfig: &monitoringingv1.AlertmanagerGlobalConfig{
 				HTTPConfig: &monitoringingv1.HTTPConfig{
-					FollowRedirects: pointer.Bool(true),
+					FollowRedirects: ptr.To(true),
 				},
 			},
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
@@ -660,7 +660,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 			want: &alertmanagerConfig{
 				Global: &globalConfig{
 					HTTPConfig: &httpClientConfig{
-						FollowRedirects: pointer.Bool(true),
+						FollowRedirects: ptr.To(true),
 					},
 				},
 				Receivers: []*receiver{
@@ -785,7 +785,7 @@ func TestGenerateConfig(t *testing.T) {
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{
 				Global: &globalConfig{
-					ResolveTimeout: func(d model.Duration) *model.Duration { return &d }(model.Duration(time.Minute)),
+					ResolveTimeout: ptr.To(model.Duration(time.Minute)),
 				},
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
@@ -798,7 +798,7 @@ func TestGenerateConfig(t *testing.T) {
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{
 				Global: &globalConfig{
-					SMTPRequireTLS: func(b bool) *bool { return &b }(false),
+					SMTPRequireTLS: ptr.To(false),
 				},
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
@@ -811,7 +811,7 @@ func TestGenerateConfig(t *testing.T) {
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{
 				Global: &globalConfig{
-					SMTPRequireTLS: func(b bool) *bool { return &b }(true),
+					SMTPRequireTLS: ptr.To(true),
 				},
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
@@ -1261,9 +1261,7 @@ func TestGenerateConfig(t *testing.T) {
 						Receivers: []monitoringv1alpha1.Receiver{{
 							Name: "test",
 							WebhookConfigs: []monitoringv1alpha1.WebhookConfig{{
-								URL: func(s string) *string {
-									return &s
-								}("http://test.url"),
+								URL: ptr.To("http://test.url"),
 								HTTPConfig: &monitoringv1alpha1.HTTPConfig{
 									OAuth2: &monitoringingv1.OAuth2{
 										ClientID: monitoringingv1.SecretOrConfigMap{
@@ -1286,7 +1284,7 @@ func TestGenerateConfig(t *testing.T) {
 											"some": "value",
 										},
 									},
-									FollowRedirects: pointer.Bool(true),
+									FollowRedirects: ptr.To(true),
 								},
 							}},
 						}},
@@ -2371,7 +2369,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MinVersion: "TLS12",
 					MaxVersion: "TLS12",
@@ -2386,7 +2384,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MinVersion: "TLS12",
 					MaxVersion: "TLS12",
@@ -2456,7 +2454,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MinVersion: "TLS13",
 					MaxVersion: "TLS12",
@@ -2475,7 +2473,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MinVersion: "TLS14",
 				},
@@ -2493,7 +2491,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MaxVersion: "TLS14",
 				},
@@ -2511,7 +2509,7 @@ func TestHTTPClientConfig(t *testing.T) {
 					TokenURL:         "d",
 					ProxyURL:         "http://example.com/",
 				},
-				EnableHTTP2: pointer.Bool(false),
+				EnableHTTP2: ptr.To(false),
 				TLSConfig: &tlsConfig{
 					MinVersion: "TLS12",
 					MaxVersion: "TLS12",

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -188,7 +188,7 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				t.Fatal("expected two Alertmanager CRDs to produce the same hash but got different hash")
 			}
 
-			a2Hash, err = createSSetInputHash(tc.a, Config{}, nil, appsv1.StatefulSetSpec{Replicas: func(i int32) *int32 { return &i }(2)})
+			a2Hash, err = createSSetInputHash(tc.a, Config{}, nil, appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -482,7 +482,7 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 							{
-								URL: pointer.String("http://test.local"),
+								URL: ptr.To("http://test.local"),
 							},
 						},
 					}},

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -17,7 +17,7 @@ package v1beta1
 import (
 	"testing"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 )
@@ -382,7 +382,7 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 							},
 							WebhookConfigs: []monitoringv1beta1.WebhookConfig{
 								{
-									URL: pointer.String("https://www.test.com"),
+									URL: ptr.To("https://www.test.com"),
 									URLSecret: &monitoringv1beta1.SecretKeySelector{
 										Name: "creds",
 										Key:  "url",

--- a/pkg/operator/statefulset_reporter.go
+++ b/pkg/operator/statefulset_reporter.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -182,7 +183,7 @@ func NewStatefulSetReporter(ctx context.Context, kclient kubernetes.Interface, s
 			continue
 		}
 
-		stsReporter.Pods = append(stsReporter.Pods, (func(p Pod) *Pod { return &p })(Pod(p)))
+		stsReporter.Pods = append(stsReporter.Pods, ptr.To(Pod(p)))
 	}
 
 	return stsReporter, nil

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -889,7 +889,7 @@ func (c *Operator) loadConfigFromSecret(sks *v1.SecretKeySelector, s *v1.SecretL
 		}
 	}
 
-	if !pointer.BoolDeref(sks.Optional, true) {
+	if !ptr.Deref(sks.Optional, true) {
 		return nil, fmt.Errorf("secret %v could not be found", sks.Name)
 	}
 

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -934,7 +934,7 @@ scrape_configs:
 
 func TestProbeIngressSDConfigGenerationWithShards(t *testing.T) {
 	p := defaultPrometheus()
-	p.Spec.Shards = pointer.Int32(2)
+	p.Spec.Shards = ptr.To(int32(2))
 
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.GenerateServerConfiguration(
@@ -1599,7 +1599,7 @@ func TestAlertmanagerTimeoutConfig(t *testing.T) {
 				Namespace:  "default",
 				Port:       intstr.FromString("web"),
 				APIVersion: "v2",
-				Timeout:    (*monitoringv1.Duration)(pointer.String("60s")),
+				Timeout:    (*monitoringv1.Duration)(ptr.To("60s")),
 			},
 		},
 	}
@@ -1905,7 +1905,7 @@ scrape_configs:
 		},
 		{
 			name:   "one prometheus shard",
-			result: getCfg(pointer.Int32(1)),
+			result: getCfg(ptr.To(int32(1))),
 			expected: `global:
   evaluation_interval: 30s
   scrape_interval: 30s
@@ -1932,7 +1932,7 @@ scrape_configs:
 		},
 		{
 			name:   "sharded prometheus",
-			result: getCfg(pointer.Int32(3)),
+			result: getCfg(ptr.To(int32(3))),
 			expected: `global:
   evaluation_interval: 30s
   scrape_interval: 30s
@@ -4489,7 +4489,7 @@ func generateTestConfig(t *testing.T, version string) ([]byte, error) {
 					"label2": "value2",
 				},
 				Version:  version,
-				Replicas: func(i int32) *int32 { return &i }(1),
+				Replicas: ptr.To(int32(1)),
 				ServiceMonitorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
@@ -5504,7 +5504,7 @@ remote_read:
 			version: "v2.25.0",
 			remoteRead: monitoringv1.RemoteReadSpec{
 				URL:             "http://example.com",
-				FollowRedirects: pointer.Bool(true),
+				FollowRedirects: ptr.To(true),
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -5522,7 +5522,7 @@ remote_read:
 			version: "v2.26.0",
 			remoteRead: monitoringv1.RemoteReadSpec{
 				URL:             "http://example.com",
-				FollowRedirects: pointer.Bool(false),
+				FollowRedirects: ptr.To(false),
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -5541,7 +5541,7 @@ remote_read:
 			version: "v2.26.0",
 			remoteRead: monitoringv1.RemoteReadSpec{
 				URL:                  "http://example.com",
-				FilterExternalLabels: pointer.Bool(true),
+				FilterExternalLabels: ptr.To(true),
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -5576,7 +5576,7 @@ remote_read:
 			version: "v2.34.0",
 			remoteRead: monitoringv1.RemoteReadSpec{
 				URL:                  "http://example.com",
-				FilterExternalLabels: pointer.Bool(false),
+				FilterExternalLabels: ptr.To(false),
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -5595,7 +5595,7 @@ remote_read:
 			version: "v2.34.0",
 			remoteRead: monitoringv1.RemoteReadSpec{
 				URL:                  "http://example.com",
-				FilterExternalLabels: pointer.Bool(true),
+				FilterExternalLabels: ptr.To(true),
 			},
 			expected: `global:
   evaluation_interval: 30s
@@ -6396,7 +6396,7 @@ scrape_configs:
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelLimit >= 0 {
-				p.Spec.EnforcedLabelLimit = pointer.Uint64(uint64(tc.enforcedLabelLimit))
+				p.Spec.EnforcedLabelLimit = ptr.To(uint64(tc.enforcedLabelLimit))
 			}
 
 			serviceMonitor := monitoringv1.ServiceMonitor{
@@ -6615,7 +6615,7 @@ scrape_configs:
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelNameLengthLimit >= 0 {
-				p.Spec.EnforcedLabelNameLengthLimit = pointer.Uint64(uint64(tc.enforcedLabelNameLengthLimit))
+				p.Spec.EnforcedLabelNameLengthLimit = ptr.To(uint64(tc.enforcedLabelNameLengthLimit))
 			}
 
 			podMonitor := monitoringv1.PodMonitor{
@@ -6822,7 +6822,7 @@ scrape_configs:
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelValueLengthLimit >= 0 {
-				p.Spec.EnforcedLabelValueLengthLimit = pointer.Uint64(uint64(tc.enforcedLabelValueLengthLimit))
+				p.Spec.EnforcedLabelValueLengthLimit = ptr.To(uint64(tc.enforcedLabelValueLengthLimit))
 			}
 
 			probe := monitoringv1.Probe{
@@ -8400,7 +8400,7 @@ func TestStorageSettingMaxExemplars(t *testing.T) {
 		{
 			Scenario: "Exemplars maxSize is set to 5000000",
 			Exemplars: &monitoringv1.Exemplars{
-				MaxSize: pointer.Int64(5000000),
+				MaxSize: ptr.To(int64(5000000)),
 			},
 			ExpectedConfig: `global:
   evaluation_interval: 30s
@@ -8418,7 +8418,7 @@ storage:
 			Scenario: "max_exemplars is not set if version is less than v2.29.0",
 			Version:  "v2.28.0",
 			Exemplars: &monitoringv1.Exemplars{
-				MaxSize: pointer.Int64(5000000),
+				MaxSize: ptr.To(int64(5000000)),
 			},
 			ExpectedConfig: `global:
   evaluation_interval: 30s
@@ -9053,7 +9053,7 @@ scrape_configs:
 		{
 			name: "metrics_path",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				MetricsPath: pointer.String("/metrics"),
+				MetricsPath: ptr.To("/metrics"),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9121,7 +9121,7 @@ scrape_configs:
 		{
 			name: "honor_timestamp",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorTimestamps: pointer.Bool(true),
+				HonorTimestamps: ptr.To(true),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9137,7 +9137,7 @@ scrape_configs:
 		{
 			name: "honor_labels",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorLabels: pointer.Bool(true),
+				HonorLabels: ptr.To(true),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9310,7 +9310,7 @@ scrape_configs:
 		{
 			name: "scheme",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				Scheme: pointer.String("HTTPS"),
+				Scheme: ptr.To("HTTPS"),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9326,11 +9326,11 @@ scrape_configs:
 		{
 			name: "limits",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				SampleLimit:           pointer.Uint64(10000),
-				TargetLimit:           pointer.Uint64(1000),
-				LabelLimit:            pointer.Uint64(50),
-				LabelNameLengthLimit:  pointer.Uint64(40),
-				LabelValueLengthLimit: pointer.Uint64(30),
+				SampleLimit:           ptr.To(uint64(10000)),
+				TargetLimit:           ptr.To(uint64(1000)),
+				LabelLimit:            ptr.To(uint64(50)),
+				LabelNameLengthLimit:  ptr.To(uint64(40)),
+				LabelValueLengthLimit: ptr.To(uint64(30)),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9350,7 +9350,7 @@ scrape_configs:
 		{
 			name: "params",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				MetricsPath: pointer.String("/federate"),
+				MetricsPath: ptr.To("/federate"),
 				Params:      map[string][]string{"match[]": {"{job=\"prometheus\"}", "{__name__=~\"job:.*\"}"}},
 			},
 			expectedCfg: `global:
@@ -9371,7 +9371,7 @@ scrape_configs:
 		{
 			name: "scrape_interval",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				ScrapeInterval: (*monitoringv1.Duration)(pointer.String("15s")),
+				ScrapeInterval: (*monitoringv1.Duration)(ptr.To("15s")),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9387,7 +9387,7 @@ scrape_configs:
 		{
 			name: "scrape_timeout",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				ScrapeTimeout: (*monitoringv1.Duration)(pointer.String("10s")),
+				ScrapeTimeout: (*monitoringv1.Duration)(ptr.To("10s")),
 			},
 			expectedCfg: `global:
   evaluation_interval: 30s
@@ -9484,22 +9484,22 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 				ConsulSDConfigs: []monitoringv1alpha1.ConsulSDConfig{
 					{
 						Server:       "localhost",
-						Datacenter:   pointer.String("we1"),
-						Namespace:    pointer.String("observability"),
-						Partition:    pointer.String("1"),
-						Scheme:       pointer.String("https"),
+						Datacenter:   ptr.To("we1"),
+						Namespace:    ptr.To("observability"),
+						Partition:    ptr.To("1"),
+						Scheme:       ptr.To("https"),
 						Services:     []string{"prometheus", "alertmanager"},
 						Tags:         []string{"tag1"},
-						TagSeparator: pointer.String(";"),
+						TagSeparator: ptr.To(";"),
 						NodeMeta: map[string]string{
 							"service": "service_name",
 							"name":    "node_name",
 						},
-						AllowStale:           pointer.Bool(false),
-						RefreshInterval:      (*monitoringv1.Duration)(pointer.String("30s")),
-						ProxyUrl:             pointer.String("http://no-proxy.com"),
-						NoProxy:              pointer.String("0.0.0.0"),
-						ProxyFromEnvironment: pointer.Bool(true),
+						AllowStale:           ptr.To(false),
+						RefreshInterval:      (*monitoringv1.Duration)(ptr.To("30s")),
+						ProxyUrl:             ptr.To("http://no-proxy.com"),
+						NoProxy:              ptr.To("0.0.0.0"),
+						ProxyFromEnvironment: ptr.To(true),
 						ProxyConnectHeader: map[string]v1.SecretKeySelector{
 							"header": {
 								LocalObjectReference: v1.LocalObjectReference{
@@ -9508,8 +9508,8 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 								Key: "proxy-header",
 							},
 						},
-						FollowRedirects: pointer.Bool(true),
-						EnableHttp2:     pointer.Bool(true),
+						FollowRedirects: ptr.To(true),
+						EnableHttp2:     ptr.To(true),
 						TokenRef: &v1.SecretKeySelector{
 							LocalObjectReference: v1.LocalObjectReference{
 								Name: "foo",
@@ -9811,15 +9811,15 @@ tracing:
 		},
 		{
 			tracingConfig: &monitoringv1.PrometheusTracingConfig{
-				ClientType:       pointer.String("grpc"),
+				ClientType:       ptr.To("grpc"),
 				Endpoint:         "https://otel-collector.default.svc.local:3333",
 				SamplingFraction: &samplingTwo,
 				Headers: map[string]string{
 					"custom": "header",
 				},
-				Compression: pointer.String("gzip"),
-				Timeout:     (*monitoringv1.Duration)(pointer.String("10s")),
-				Insecure:    pointer.Bool(false),
+				Compression: ptr.To("gzip"),
+				Timeout:     (*monitoringv1.Duration)(ptr.To("10s")),
+				Insecure:    ptr.To(false),
 			},
 			name:        "Expect valid config",
 			expectedErr: false,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1474,7 +1474,7 @@ func (c *Operator) loadConfigFromSecret(sks *v1.SecretKeySelector, s *v1.SecretL
 		}
 	}
 
-	if !pointer.BoolDeref(sks.Optional, true) {
+	if !ptr.Deref(sks.Optional, true) {
 		return nil, fmt.Errorf("secret %v could not be found", sks.Name)
 	}
 

--- a/pkg/prometheus/server/operator_test.go
+++ b/pkg/prometheus/server/operator_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
@@ -229,7 +230,7 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				t.Fatal("expected two Prometheus CRDs to produce the same hash but got different hash")
 			}
 
-			p2Hash, err = createSSetInputHash(tc.a, c, []string{}, nil, appsv1.StatefulSetSpec{Replicas: func(i int32) *int32 { return &i }(2)})
+			p2Hash, err = createSSetInputHash(tc.a, c, []string{}, nil, appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
@@ -2671,8 +2671,6 @@ func TestThanosAdditionalArgsDuplicate(t *testing.T) {
 }
 
 func TestPrometheusQuerySpec(t *testing.T) {
-	durationPtr := func(s string) *monitoringv1.Duration { d := monitoringv1.Duration(s); return &d }
-
 	for _, tc := range []struct {
 		name string
 
@@ -2690,10 +2688,10 @@ func TestPrometheusQuerySpec(t *testing.T) {
 		},
 		{
 			name:           "all values provided",
-			lookbackDelta:  pointer.String("2m"),
-			maxConcurrency: pointer.Int32(10),
-			maxSamples:     pointer.Int32(10000),
-			timeout:        durationPtr("1m"),
+			lookbackDelta:  ptr.To("2m"),
+			maxConcurrency: ptr.To(int32(10)),
+			maxSamples:     ptr.To(int32(10000)),
+			timeout:        ptr.To(monitoringv1.Duration("1m")),
 
 			expected: []string{
 				"--query.lookback-delta=2m",
@@ -2704,10 +2702,10 @@ func TestPrometheusQuerySpec(t *testing.T) {
 		},
 		{
 			name:           "zero values are skipped",
-			lookbackDelta:  pointer.String("2m"),
-			maxConcurrency: pointer.Int32(0),
-			maxSamples:     pointer.Int32(0),
-			timeout:        durationPtr("1m"),
+			lookbackDelta:  ptr.To("2m"),
+			maxConcurrency: ptr.To(int32(0)),
+			maxSamples:     ptr.To(int32(0)),
+			timeout:        ptr.To(monitoringv1.Duration("1m")),
 
 			expected: []string{
 				"--query.lookback-delta=2m",
@@ -2716,10 +2714,10 @@ func TestPrometheusQuerySpec(t *testing.T) {
 		},
 		{
 			name:           "max samples skipped if version < 2.5",
-			lookbackDelta:  pointer.String("2m"),
-			maxConcurrency: pointer.Int32(10),
-			maxSamples:     pointer.Int32(10000),
-			timeout:        durationPtr("1m"),
+			lookbackDelta:  ptr.To("2m"),
+			maxConcurrency: ptr.To(int32(10)),
+			maxSamples:     ptr.To(int32(10000)),
+			timeout:        ptr.To(monitoringv1.Duration("1m")),
 			version:        "v2.4.0",
 
 			expected: []string{
@@ -2730,10 +2728,10 @@ func TestPrometheusQuerySpec(t *testing.T) {
 		},
 		{
 			name:           "max samples not skipped if version > 2.5",
-			lookbackDelta:  pointer.String("2m"),
-			maxConcurrency: pointer.Int32(10),
-			maxSamples:     pointer.Int32(10000),
-			timeout:        durationPtr("1m"),
+			lookbackDelta:  ptr.To("2m"),
+			maxConcurrency: ptr.To(int32(10)),
+			maxSamples:     ptr.To(int32(10000)),
+			timeout:        ptr.To(monitoringv1.Duration("1m")),
 			version:        "v2.5.0",
 
 			expected: []string{
@@ -2816,7 +2814,7 @@ func TestSecurityContextCapabilities(t *testing.T) {
 			name: "Thanos sidecar with object storage",
 			spec: monitoringv1.PrometheusSpec{
 				Thanos: &monitoringv1.ThanosSpec{
-					ObjectStorageConfigFile: func(s string) *string { return &s }("/etc/thanos.cfg"),
+					ObjectStorageConfigFile: ptr.To("/etc/thanos.cfg"),
 				},
 			},
 		},

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -26,7 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -82,20 +82,20 @@ func shardsNumber(
 ) int32 {
 	cpf := p.GetCommonPrometheusFields()
 
-	if pointer.Int32Deref(cpf.Shards, 1) <= 1 {
+	if ptr.Deref(cpf.Shards, 1) <= 1 {
 		return 1
 	}
 
 	return *cpf.Shards
 }
 
-// ReplicasNumberPtr returns a pointer to the normalized number of replicas.
+// ReplicasNumberPtr returns a ptr to the normalized number of replicas.
 func ReplicasNumberPtr(
 	p monitoringv1.PrometheusInterface,
 ) *int32 {
 	cpf := p.GetCommonPrometheusFields()
 
-	replicas := pointer.Int32Deref(cpf.Replicas, 1)
+	replicas := ptr.Deref(cpf.Replicas, 1)
 	if replicas < 0 {
 		replicas = 1
 	}
@@ -135,8 +135,8 @@ func MakeConfigurationSecret(p monitoringv1.PrometheusInterface, config operator
 			Labels:      config.Labels.Merge(ManagedByOperatorLabels),
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         typeMeta.APIVersion,
-				BlockOwnerDeletion: pointer.Bool(true),
-				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: ptr.To(true),
+				Controller:         ptr.To(true),
 				Kind:               typeMeta.Kind,
 				Name:               objMeta.GetName(),
 				UID:                objMeta.GetUID(),

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -1075,7 +1075,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					},
 					// HTML field with an empty string must appear as-is in the generated configuration.
 					// See https://github.com/prometheus-operator/prometheus-operator/issues/5421
-					HTML: pointer.String(""),
+					HTML: ptr.To(""),
 				}},
 				VictorOpsConfigs: []monitoringv1alpha1.VictorOpsConfig{{
 					APIKey: &v1.SecretKeySelector{
@@ -1690,27 +1690,27 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 		Name: alertmanagerConfig.Name,
 		Global: &monitoringv1.AlertmanagerGlobalConfig{
 			SMTPConfig: &monitoringv1.GlobalSMTPConfig{
-				From: pointer.String("from"),
+				From: ptr.To("from"),
 				SmartHost: &monitoringv1.HostPort{
 					Host: "smtp.example.org",
 					Port: "587",
 				},
-				Hello:        pointer.String("smtp.example.org"),
-				AuthUsername: pointer.String("dev@smtp.example.org"),
+				Hello:        ptr.To("smtp.example.org"),
+				AuthUsername: ptr.To("dev@smtp.example.org"),
 				AuthPassword: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{
 						Name: "smtp-auth",
 					},
 					Key: "password",
 				},
-				AuthIdentity: pointer.String("dev@smtp.example.org"),
+				AuthIdentity: ptr.To("dev@smtp.example.org"),
 				AuthSecret: &v1.SecretKeySelector{
 					LocalObjectReference: v1.LocalObjectReference{
 						Name: "smtp-auth",
 					},
 					Key: "secret",
 				},
-				RequireTLS: pointer.Bool(true),
+				RequireTLS: ptr.To(true),
 			},
 			ResolveTimeout: "30s",
 			HTTPConfig: &monitoringv1.HTTPConfig{
@@ -1735,7 +1735,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 						"some": "value",
 					},
 				},
-				FollowRedirects: pointer.Bool(true),
+				FollowRedirects: ptr.To(true),
 			},
 		},
 		Templates: []monitoringv1.SecretOrConfigMap{
@@ -2025,7 +2025,7 @@ func testAMRollbackManualChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sset.Spec.Replicas = pointer.Int32(0)
+	sset.Spec.Replicas = ptr.To(int32(0))
 	sset, err = ssetClient.Update(context.Background(), sset, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -4567,7 +4567,7 @@ func testPrometheusCRDValidation(t *testing.T) {
 					},
 				},
 				Query: &monitoringv1.QuerySpec{
-					MaxConcurrency: pointer.Int32(100),
+					MaxConcurrency: ptr.To(int32(100)),
 				},
 			},
 		},
@@ -4585,7 +4585,7 @@ func testPrometheusCRDValidation(t *testing.T) {
 					},
 				},
 				Query: &monitoringv1.QuerySpec{
-					MaxConcurrency: pointer.Int32(0),
+					MaxConcurrency: ptr.To(int32(0)),
 				},
 			},
 			expectedError: true,

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -24,7 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -270,7 +270,7 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 	createMTLSSecret(t, secretName, ns)
 
 	sc := framework.MakeBasicScrapeConfig(ns, "scrape-config")
-	sc.Spec.Scheme = pointer.String("HTTPS")
+	sc.Spec.Scheme = ptr.To("HTTPS")
 	sc.Spec.Authorization = &monitoringv1.SafeAuthorization{
 		Credentials: &v1.SecretKeySelector{
 			LocalObjectReference: v1.LocalObjectReference{

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
@@ -278,7 +278,7 @@ func (f *Framework) PatchAlertmanager(ctx context.Context, name, ns string, spec
 		types.ApplyPatchType,
 		b,
 		metav1.PatchOptions{
-			Force:        pointer.Bool(true),
+			Force:        ptr.To(true),
 			FieldManager: "e2e-test",
 		},
 	)
@@ -296,7 +296,7 @@ func (f *Framework) ScaleAlertmanagerAndWaitUntilReady(ctx context.Context, name
 		name,
 		ns,
 		monitoringv1.AlertmanagerSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To(replicas),
 		},
 	)
 }
@@ -471,7 +471,7 @@ func (f *Framework) WaitForAlertmanagerFiringAlert(ctx context.Context, ns, svcN
 		}
 
 		for _, alert := range alerts {
-			if alert.Labels["alertname"] == alertName && alert.Status.State != pointer.String("firing") {
+			if alert.Labels["alertname"] == alertName && alert.Status.State != ptr.To("firing") {
 				return true, nil
 			}
 		}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -712,7 +713,7 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 
 	// Deploy only 1 replica because the end-to-end environment (single node
 	// cluster) can't satisfy the anti-affinity rules.
-	deploy.Spec.Replicas = func(i int32) *int32 { return &i }(1)
+	deploy.Spec.Replicas = ptr.To(int32(1))
 	deploy.Spec.Template.Spec.Affinity = nil
 	deploy.Spec.Strategy = appsv1.DeploymentStrategy{}
 

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -325,7 +326,7 @@ func (f *Framework) ScalePrometheusAndWaitUntilReady(ctx context.Context, name, 
 		ns,
 		monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Replicas: func(i int32) *int32 { return &i }(replicas),
+				Replicas: ptr.To(int32(replicas)),
 			},
 		},
 	)
@@ -351,7 +352,7 @@ func (f *Framework) PatchPrometheus(ctx context.Context, name, ns string, spec m
 		types.ApplyPatchType,
 		b,
 		metav1.PatchOptions{
-			Force:        func(b bool) *bool { return &b }(true),
+			Force:        ptr.To(true),
 			FieldManager: "e2e-test",
 		},
 	)

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -94,7 +95,7 @@ func (f *Framework) PatchThanosRuler(ctx context.Context, name, ns string, spec 
 		types.ApplyPatchType,
 		b,
 		metav1.PatchOptions{
-			Force:        func(b bool) *bool { return &b }(true),
+			Force:        ptr.To(true),
 			FieldManager: "e2e-test",
 		},
 	)


### PR DESCRIPTION
## Description

Remove usage of the deprecated `k8s.io/utils/pointer` package.
Needs #5804 first.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
