### PR TITLE
fix: reject monitors with invalid relabel configs

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -152,20 +152,14 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				break
 			}
 
-			for _, rl := range endpoint.RelabelConfigs {
-				if rl.Action != "" {
-					if err = validateRelabelConfig(rs.p, *rl); err != nil {
-						break
-					}
-				}
+			if err = validateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
+				err = fmt.Errorf("relabelConfigs: %w", err)
+				break
 			}
 
-			for _, rl := range endpoint.MetricRelabelConfigs {
-				if rl.Action != "" {
-					if err = validateRelabelConfig(rs.p, *rl); err != nil {
-						break
-					}
-				}
+			if err = validateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
+				err = fmt.Errorf("metricRelabelConfigs: %w", err)
+				break
 			}
 		}
 
@@ -225,21 +219,41 @@ func validateScrapeIntervalAndTimeout(p monitoringv1.PrometheusInterface, scrape
 	return CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval)
 }
 
+func validateRelabelConfigs(p monitoringv1.PrometheusInterface, rcs []*monitoringv1.RelabelConfig) error {
+	for i, rc := range rcs {
+		if rc == nil {
+			return fmt.Errorf("null relabel config")
+		}
+
+		if err := validateRelabelConfig(p, *rc); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
 func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.RelabelConfig) error {
 	relabelTarget := regexp.MustCompile(`^(?:(?:[a-zA-Z_]|\$(?:\{\w+\}|\w+))+\w*)+$`)
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
+
 	version, err := semver.ParseTolerant(promVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse Prometheus version")
 	}
+
 	minimumVersionCaseActions := version.GTE(semver.MustParse("2.36.0"))
 	minimumVersionEqualActions := version.GTE(semver.MustParse("2.41.0"))
+	if rc.Action == "" {
+		rc.Action = string(relabel.Replace)
+	}
+	action := strings.ToLower(rc.Action)
 
-	if (rc.Action == string(relabel.Lowercase) || rc.Action == string(relabel.Uppercase)) && !minimumVersionCaseActions {
+	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase)) && !minimumVersionCaseActions {
 		return errors.Errorf("%s relabel action is only supported from Prometheus version 2.36.0", rc.Action)
 	}
 
-	if (rc.Action == string(relabel.KeepEqual) || rc.Action == string(relabel.DropEqual)) && !minimumVersionEqualActions {
+	if (action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !minimumVersionEqualActions {
 		return errors.Errorf("%s relabel action is only supported from Prometheus version 2.41.0", rc.Action)
 	}
 
@@ -247,33 +261,33 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 		return errors.Wrapf(err, "invalid regex %s for relabel configuration", rc.Regex)
 	}
 
-	if rc.Modulus == 0 && rc.Action == string(relabel.HashMod) {
+	if rc.Modulus == 0 && action == string(relabel.HashMod) {
 		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
 	}
 
-	if (rc.Action == string(relabel.Replace) || rc.Action == string(relabel.HashMod) || rc.Action == string(relabel.Lowercase) || rc.Action == string(relabel.Uppercase) || rc.Action == string(relabel.KeepEqual) || rc.Action == string(relabel.DropEqual)) && rc.TargetLabel == "" {
+	if (action == string(relabel.Replace) || action == string(relabel.HashMod) || action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && rc.TargetLabel == "" {
 		return errors.Errorf("relabel configuration for %s action needs targetLabel value", rc.Action)
 	}
 
-	if (rc.Action == string(relabel.Replace) || rc.Action == string(relabel.Lowercase) || rc.Action == string(relabel.Uppercase) || rc.Action == string(relabel.KeepEqual) || rc.Action == string(relabel.DropEqual)) && !relabelTarget.MatchString(rc.TargetLabel) {
+	if (action == string(relabel.Replace) || action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !relabelTarget.MatchString(rc.TargetLabel) {
 		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
 
-	if (rc.Action == string(relabel.Lowercase) || rc.Action == string(relabel.Uppercase) || rc.Action == string(relabel.KeepEqual) || rc.Action == string(relabel.DropEqual)) && !(rc.Replacement == relabel.DefaultRelabelConfig.Replacement || rc.Replacement == "") {
+	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !(rc.Replacement == relabel.DefaultRelabelConfig.Replacement || rc.Replacement == "") {
 		return errors.Errorf("'replacement' can not be set for %s action", rc.Action)
 	}
 
-	if rc.Action == string(relabel.LabelMap) {
+	if action == string(relabel.LabelMap) {
 		if rc.Replacement != "" && !relabelTarget.MatchString(rc.Replacement) {
 			return errors.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
 		}
 	}
 
-	if rc.Action == string(relabel.HashMod) && !model.LabelName(rc.TargetLabel).IsValid() {
+	if action == string(relabel.HashMod) && !model.LabelName(rc.TargetLabel).IsValid() {
 		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
 
-	if rc.Action == string(relabel.KeepEqual) || rc.Action == string(relabel.DropEqual) {
+	if action == string(relabel.KeepEqual) || action == string(relabel.DropEqual) {
 		if !(rc.Regex == "" || rc.Regex == relabel.DefaultRelabelConfig.Regex.String()) ||
 			!(rc.Modulus == uint64(0) ||
 				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
@@ -285,7 +299,7 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 		}
 	}
 
-	if rc.Action == string(relabel.LabelDrop) || rc.Action == string(relabel.LabelKeep) {
+	if action == string(relabel.LabelDrop) || action == string(relabel.LabelKeep) {
 		if len(rc.SourceLabels) != 0 ||
 			!(rc.TargetLabel == "" ||
 				rc.TargetLabel == relabel.DefaultRelabelConfig.TargetLabel) ||
@@ -385,20 +399,14 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				break
 			}
 
-			for _, rl := range endpoint.RelabelConfigs {
-				if rl.Action != "" {
-					if err = validateRelabelConfig(rs.p, *rl); err != nil {
-						break
-					}
-				}
+			if err = validateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
+				err = fmt.Errorf("relabelConfigs: %w", err)
+				break
 			}
 
-			for _, rl := range endpoint.MetricRelabelConfigs {
-				if rl.Action != "" {
-					if err = validateRelabelConfig(rs.p, *rl); err != nil {
-						break
-					}
-				}
+			if err = validateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
+				err = fmt.Errorf("metricRelabelConfigs: %w", err)
+				break
 			}
 		}
 
@@ -488,7 +496,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 			level.Warn(rs.l).Log(
 				"msg", "skipping probe",
 				"error", err.Error(),
-				"probe", probe,
+				"probe", probeName,
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
@@ -532,19 +540,34 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 			continue
 		}
 
-		for _, rl := range probe.Spec.MetricRelabelConfigs {
-			if rl.Action != "" {
-				if err = validateRelabelConfig(rs.p, *rl); err != nil {
-					rejectFn(probe, err)
-					continue
-				}
-			}
-		}
-		if err = validateProberURL(probe.Spec.ProberSpec.URL); err != nil {
-			err := errors.Wrapf(err, "%s url specified in proberSpec is invalid, it should be of the format `hostname` or `hostname:port`", probe.Spec.ProberSpec.URL)
+		if err = validateRelabelConfigs(rs.p, probe.Spec.MetricRelabelConfigs); err != nil {
+			err = fmt.Errorf("metricRelabelConfigs: %w", err)
 			rejectFn(probe, err)
 			continue
 		}
+
+		if probe.Spec.Targets.StaticConfig != nil {
+			if err = validateRelabelConfigs(rs.p, probe.Spec.Targets.StaticConfig.RelabelConfigs); err != nil {
+				err = fmt.Errorf("targets.staticConfig.relabelConfigs: %w", err)
+				rejectFn(probe, err)
+				continue
+			}
+		}
+
+		if probe.Spec.Targets.Ingress != nil {
+			if err = validateRelabelConfigs(rs.p, probe.Spec.Targets.Ingress.RelabelConfigs); err != nil {
+				err = fmt.Errorf("targets.ingress.relabelConfigs: %w", err)
+				rejectFn(probe, err)
+				continue
+			}
+		}
+
+		if err = validateProberURL(probe.Spec.ProberSpec.URL); err != nil {
+			err := fmt.Errorf("%s url specified in proberSpec is invalid, it should be of the format `hostname` or `hostname:port`: %w", probe.Spec.ProberSpec.URL, err)
+			rejectFn(probe, err)
+			continue
+		}
+
 		res[probeName] = probe
 	}
 
@@ -639,6 +662,11 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+		}
+
+		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {
+			rejectFn(sc, fmt.Errorf("relabelConfigs: %w", err))
+			continue
 		}
 
 		scKey := fmt.Sprintf("scrapeconfig/%s/%s", sc.GetNamespace(), sc.GetName())

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -15,13 +15,27 @@
 package prometheus
 
 import (
-	"fmt"
+	"context"
+	"os"
 	"testing"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
+
+func newLogger() log.Logger {
+	return level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowWarn())
+}
 
 func TestValidateRelabelConfig(t *testing.T) {
 	defaultRegexp, err := relabel.DefaultRelabelConfig.Regex.MarshalYAML()
@@ -388,7 +402,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
+		t.Run(tc.scenario, func(t *testing.T) {
 			err := validateRelabelConfig(&tc.prometheus, tc.relabelConfig)
 			if err != nil && !tc.expectedErr {
 				t.Fatalf("expected no error, got: %v", err)
@@ -400,77 +414,193 @@ func TestValidateRelabelConfig(t *testing.T) {
 	}
 }
 
-func TestValidateProberUrl(t *testing.T) {
+func TestSelectProbes(t *testing.T) {
 	for _, tc := range []struct {
-		scenario    string
-		proberSpec  monitoringv1.ProberSpec
-		expectedErr bool
+		scenario   string
+		updateSpec func(*monitoringv1.ProbeSpec)
+		selected   bool
 	}{
 		{
 			scenario: "url starting with http",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "http://blackbox-exporter.example.com",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "http://blackbox-exporter.example.com"
 			},
-			expectedErr: true,
+			selected: false,
 		},
 		{
 			scenario: "url starting with https",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "https://blackbox-exporter.example.com",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "https://blackbox-exporter.example.com"
 			},
-			expectedErr: true,
+			selected: false,
 		},
 		{
 			scenario: "url starting with ftp",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "ftp://fileserver.com",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "ftp://fileserver.com"
 			},
-			expectedErr: true,
+			selected: false,
 		},
 		{
 			scenario: "ip address as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "192.168.178.3",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "192.168.178.3"
 			},
+			selected: true,
 		},
 		{
 			scenario: "ip address:port as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "192.168.178.3:9090",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "192.168.178.3:9090"
 			},
+			selected: true,
 		},
 		{
 			scenario: "dnsname as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "blackbox-exporter.example.com",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "blackbox-exporter.example.com"
 			},
+			selected: true,
 		},
 		{
 			scenario: "dnsname:port as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "blackbox-exporter.example.com:8080",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "blackbox-exporter.example.com:8080"
 			},
+			selected: true,
 		},
 		{
 			scenario: "hostname as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "localhost",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "localhost"
 			},
+			selected: true,
 		},
 		{
 			scenario: "hostname starting with a digit as prober url",
-			proberSpec: monitoringv1.ProberSpec{
-				URL: "12-exporter.example.com",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.URL = "12-exporter.example.com"
+			},
+			selected: true,
+		},
+		{
+			scenario: "valid metric relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.MetricRelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  "valid",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid metric relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.MetricRelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  " invalid label name",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
 			},
 		},
+		{
+			scenario: "valid static relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig.RelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  "valid",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid static relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig.RelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  " invalid label name",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid ingress relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig = nil
+				ps.Targets.Ingress = &monitoringv1.ProbeTargetIngress{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  "valid",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				}
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid ingress relabeling config",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.Ingress = &monitoringv1.ProbeTargetIngress{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  " invalid label name",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				}
+			},
+			selected: false,
+		},
 	} {
-		t.Run(fmt.Sprintf("case %s %s", tc.scenario, tc.proberSpec.URL), func(t *testing.T) {
-			err := validateProberURL(tc.proberSpec.URL)
-			if err != nil && !tc.expectedErr {
-				t.Fatalf("expected no error, got: %v", err)
+		t.Run(tc.scenario, func(t *testing.T) {
+			rs := NewResourceSelector(
+				newLogger(),
+				&monitoringv1.Prometheus{},
+				nil,
+				nil,
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+			)
+
+			probe := &monitoringv1.Probe{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.ProbeSpec{
+					ProberSpec: monitoringv1.ProberSpec{
+						URL: "example.com:80",
+					},
+					Targets: monitoringv1.ProbeTargets{
+						StaticConfig: &monitoringv1.ProbeTargetStaticConfig{},
+					},
+				},
 			}
-			if err == nil && tc.expectedErr {
-				t.Fatalf("expected an error, got nil")
+			tc.updateSpec(&probe.Spec)
+
+			probes, err := rs.SelectProbes(context.Background(), func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error {
+				appendFn(probe)
+				return nil
+			})
+
+			require.NoError(t, err)
+			if tc.selected {
+				require.Equal(t, 1, len(probes))
+			} else {
+				require.Equal(t, 0, len(probes))
 			}
 		})
 	}
@@ -548,7 +678,7 @@ func TestValidateScrapeIntervalAndTimeout(t *testing.T) {
 			expectedErr: true,
 		},
 	} {
-		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
+		t.Run(tc.scenario, func(t *testing.T) {
 			for _, endpoint := range tc.smSpec.Endpoints {
 				err := validateScrapeIntervalAndTimeout(&tc.prometheus, endpoint.Interval, endpoint.ScrapeTimeout)
 				t.Logf("err %v", err)
@@ -558,6 +688,270 @@ func TestValidateScrapeIntervalAndTimeout(t *testing.T) {
 				if err == nil && tc.expectedErr {
 					t.Fatalf("expected an error, got nil")
 				}
+			}
+		})
+	}
+}
+
+func TestSelectServiceMonitors(t *testing.T) {
+	for _, tc := range []struct {
+		scenario   string
+		updateSpec func(*monitoringv1.ServiceMonitorSpec)
+		selected   bool
+	}{
+		{
+			scenario: "valid metric relabeling config",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  "valid",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid metric relabeling config",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  " invalid label name",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid relabeling config",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  "valid",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid relabeling config",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  " invalid label name",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: false,
+		},
+	} {
+		t.Run(tc.scenario, func(t *testing.T) {
+			rs := NewResourceSelector(
+				newLogger(),
+				&monitoringv1.Prometheus{},
+				nil,
+				nil,
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+			)
+
+			sm := &monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.ServiceMonitorSpec{},
+			}
+			tc.updateSpec(&sm.Spec)
+
+			sms, err := rs.SelectServiceMonitors(context.Background(), func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error {
+				appendFn(sm)
+				return nil
+			})
+
+			require.NoError(t, err)
+			if tc.selected {
+				require.Equal(t, 1, len(sms))
+			} else {
+				require.Equal(t, 0, len(sms))
+			}
+		})
+	}
+}
+
+func TestSelectPodMonitors(t *testing.T) {
+	for _, tc := range []struct {
+		scenario   string
+		updateSpec func(*monitoringv1.PodMonitorSpec)
+		selected   bool
+	}{
+		{
+			scenario: "valid metric relabeling config",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  "valid",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid metric relabeling config",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  " invalid label name",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid relabeling config",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  "valid",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid relabeling config",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					RelabelConfigs: []*monitoringv1.RelabelConfig{
+						{
+							Action:       "Replace",
+							TargetLabel:  " invalid label name",
+							SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+						},
+					},
+				})
+			},
+			selected: false,
+		},
+	} {
+		t.Run(tc.scenario, func(t *testing.T) {
+			rs := NewResourceSelector(
+				newLogger(),
+				&monitoringv1.Prometheus{},
+				nil,
+				nil,
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+			)
+
+			pm := &monitoringv1.PodMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			}
+			tc.updateSpec(&pm.Spec)
+
+			sms, err := rs.SelectPodMonitors(context.Background(), func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error {
+				appendFn(pm)
+				return nil
+			})
+
+			require.NoError(t, err)
+			if tc.selected {
+				require.Equal(t, 1, len(sms))
+			} else {
+				require.Equal(t, 0, len(sms))
+			}
+		})
+	}
+}
+
+func TestSelectScrapeConfigs(t *testing.T) {
+	for _, tc := range []struct {
+		scenario   string
+		updateSpec func(*monitoringv1alpha1.ScrapeConfigSpec)
+		selected   bool
+	}{
+		{
+			scenario: "valid relabeling config",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.RelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  "valid",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
+			},
+			selected: true,
+		},
+		{
+			scenario: "invalid relabeling config",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.RelabelConfigs = []*monitoringv1.RelabelConfig{
+					{
+						Action:       "Replace",
+						TargetLabel:  " invalid label name",
+						SourceLabels: []monitoringv1.LabelName{"foo", "bar"},
+					},
+				}
+			},
+			selected: false,
+		},
+	} {
+		t.Run(tc.scenario, func(t *testing.T) {
+			rs := NewResourceSelector(
+				newLogger(),
+				&monitoringv1.Prometheus{},
+				nil,
+				nil,
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+			)
+
+			sc := &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			}
+			tc.updateSpec(&sc.Spec)
+
+			sms, err := rs.SelectScrapeConfigs(context.Background(), func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error {
+				appendFn(sc)
+				return nil
+			})
+
+			require.NoError(t, err)
+			if tc.selected {
+				require.Equal(t, 1, len(sms))
+			} else {
+				require.Equal(t, 0, len(sms))
 			}
 		})
 	}


### PR DESCRIPTION
## Description

I noticed that probes, service monitors, pod monitors and scrape configs with invalid relabel configs were not rejected by the operator. This PR fixes it.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
reject ServiceMonitor, PodMonitor, Probe and ScrapeConfig with invalid relabel configs.
```
