### PR TITLE
Fix collapsing user-guide weights

### DIFF
--- a/Documentation/user-guides/scrapeconfig.md
+++ b/Documentation/user-guides/scrapeconfig.md
@@ -1,5 +1,5 @@
 ---
-weight: 153
+weight: 154
 toc: true
 title: ScrapeConfig CRD
 menu:

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -1,5 +1,5 @@
 ---
-weight: 154
+weight: 155
 toc: true
 title: Admission webhook
 menu:


### PR DESCRIPTION
## Description

Noticed after opening https://github.com/prometheus-operator/website/pull/58. 

The Prometheus-Agent guide is already using 153


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
