### PR TITLE
fix: reject invalid ScrapeConfigs

### DIFF
--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -242,7 +242,7 @@ func (s *Store) AddSafeAuthorizationCredentials(ctx context.Context, namespace s
 
 	err := s.addToken(ctx, namespace, auth.Credentials, key)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get authorization token of type %s", auth.Type)
+		return errors.Wrapf(err, "failed to get authorization token of type %q", auth.Type)
 	}
 	return nil
 }
@@ -258,7 +258,7 @@ func (s *Store) AddAuthorizationCredentials(ctx context.Context, namespace strin
 
 	err := s.addToken(ctx, namespace, auth.Credentials, key)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get authorization token of type %s", auth.Type)
+		return errors.Wrapf(err, "failed to get authorization token of type %q", auth.Type)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

This is a follow-up of #5841. For the same reason that we didn't continue from the outer loop, invalid ScrapeConfig objects were not rejected.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
reject ScrapeConfig with invalid secret key references.
```
