### PR TITLE
chore: add unit test with multiple AlertmanagerConfigs

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -995,6 +995,65 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "skeleton_base_simple_CR.golden",
 		},
 		{
+			name:    "multiple AlertmanagerConfig objects",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+					Routes: []*route{
+						{
+							Receiver:   "watchdog",
+							Matchers:   []string{"alertname=Watchdog"},
+							GroupByStr: []string{"alertname"},
+						},
+					},
+				},
+				Receivers: []*receiver{{Name: "null"}, {Name: "watchdog"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"ns1/amc1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc1",
+						Namespace: "ns1",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test1",
+							GroupBy:  []string{"job"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test1"}},
+					},
+				},
+				"ns1/amc2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc2",
+						Namespace: "ns1",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test2",
+							GroupBy:  []string{"instance"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test2"}},
+					},
+				},
+				"ns2/amc1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc1",
+						Namespace: "ns2",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test3",
+							GroupBy:  []string{"job", "instance"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test3"}},
+					},
+				},
+			},
+			golden: "skeleton_base_multiple_alertmanagerconfigs.golden",
+		},
+		{
 			name:    "skeleton base, simple CR with namespaceMatcher disabled",
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{

--- a/pkg/alertmanager/testdata/skeleton_base_multiple_alertmanagerconfigs.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_multiple_alertmanagerconfigs.golden
@@ -1,0 +1,34 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: ns1/amc1/test1
+    group_by:
+    - job
+    matchers:
+    - namespace="ns1"
+    continue: true
+  - receiver: ns1/amc2/test2
+    group_by:
+    - instance
+    matchers:
+    - namespace="ns1"
+    continue: true
+  - receiver: ns2/amc1/test3
+    group_by:
+    - job
+    - instance
+    matchers:
+    - namespace="ns2"
+    continue: true
+  - receiver: watchdog
+    group_by:
+    - alertname
+    matchers:
+    - alertname=Watchdog
+receivers:
+- name: "null"
+- name: watchdog
+- name: ns1/amc1/test1
+- name: ns1/amc2/test2
+- name: ns2/amc1/test3
+templates: []


### PR DESCRIPTION
## Description

While reviewing the code base, I realized that we don't have a test validating the generation of the Alertmanager configuration when multiple AlertmanagerConfig objects are reconciled.

Kudos to @nicolastakashi for the golden files implementation: it works like a breeze.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
