### PR TITLE
Quote enums for consistency in monitoring.coreos.com_alertmanagerconf…

### DIFF
--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -69,8 +69,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -102,8 +102,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -5205,8 +5205,8 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
-                          - =~
+                          - '='
+                          - '=~'
                           - '!~'
                           type: string
                         name:


### PR DESCRIPTION
## Description

Quotes are added to the equal signs in crd-alertmanagerconfigs.yaml. This will fix the appliance of the crd using the ansible module kubernetes.core.k8s (which uses PyYAML under the hood) which errors if these equal signs are not quoted.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added quotes to unquoted enums in the CRD of alertmanagerconfig
```
