### PR TITLE
Document server-side apply for CRDs

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -11,6 +11,25 @@ draft: false
 description: Guide on troubleshooting the Prometheus Operator.
 ---
 
+### `CustomResourceDefinition "..." is invalid: metadata.annotations: Too long` issue
+
+When applying updated CRDs on a cluster, you may face the following error message:
+
+```bash
+$ kubectl apply -f $MANIFESTS
+The CustomResourceDefinition "prometheuses.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
+```
+
+The reason is that apply runs in the client by default and saves information into the object annotations but there's a hard limit on the size of annotations.
+
+The workaround is to use server-side apply which requires Kubernetes v1.22 at least.
+
+```bash
+kubectl apply --server-side --force-conflicts -f $MANIFESTS
+```
+
+If using ArgoCD, please refer to their [documentation](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/#server-side-apply).
+
 ### RBAC on Google Container Engine (GKE)
 
 When you try to create `ClusterRole` (`kube-state-metrics`, `prometheus` `prometheus-operator`, etc.) on GKE Kubernetes cluster running 1.6 version, you will probably run into permission errors:


### PR DESCRIPTION
## Description

This is only partially documented in the kube-prometheus README but it comes up often in the issues. Hopefully some people will find it helpful.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
