### PR TITLE
enhancement: Replace UpdateStatus() for ApplyStatus() to avoid informer errors

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1808,7 +1808,7 @@ func GetAppliedConfigFromCondition(c *monitoringv1.Condition) *monitoringv1ac.Co
 		WithObservedGeneration(c.ObservedGeneration)
 }
 
-func GetAppliedConfigStatusFromStatus(a *monitoringv1.Alertmanager, asac *monitoringv1ac.AlertmanagerStatusApplyConfiguration, values ...*monitoringv1ac.ConditionApplyConfiguration) {
+func GetAppliedConfigStatusFromStatus(a *monitoringv1.Alertmanager, asac *monitoringv1ac.AlertmanagerStatusApplyConfiguration, conditions ...monitoringv1.Condition) {
 	asac.WithPaused(a.Status.Paused)
 	asac.WithReplicas(a.Status.Replicas)
 	asac.WithAvailableReplicas(a.Status.AvailableReplicas)
@@ -1816,9 +1816,6 @@ func GetAppliedConfigStatusFromStatus(a *monitoringv1.Alertmanager, asac *monito
 	asac.WithUnavailableReplicas(a.Status.UnavailableReplicas)
 
 	for i := range values {
-		if values[i] == nil {
-			panic("nil value passed")
-		}
 		asac.WithConditions(values[i])
 	}
 }


### PR DESCRIPTION
## Description

To set the status subresource, the operator make use of ApplyStatus() instead of UpdateStatus()  to avoid informer errors.


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

- replace UpdateStatus() for ApplyStatus() in order to avoid informer errors.
