### PR TITLE
Checkout branch ref on Dependabot workflows

### DIFF
--- a/.github/workflows/automerge-dependabot.yaml
+++ b/.github/workflows/automerge-dependabot.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Generate Documentation/compatibility.md
         if: contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
         run: |


### PR DESCRIPTION
## Description

Yet another PR trying to make #5849 pass 🥲.

The latest attempt failed to push because it was on a detached HEAD reference. This PR forces the checkout to be on the PR branch

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
