### PR TITLE
fix:  apply externalLabels after reserved labels in prometheus

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -110,21 +110,23 @@ func TestGlobalSettings(t *testing.T) {
 	)
 
 	for _, tc := range []struct {
-		Scenario              string
-		EvaluationInterval    monitoringv1.Duration
-		ScrapeInterval        monitoringv1.Duration
-		ScrapeTimeout         monitoringv1.Duration
-		ExternalLabels        map[string]string
-		QueryLogFile          string
-		Version               string
-		BodySizeLimit         *monitoringv1.ByteSize
-		SampleLimit           *uint64
-		TargetLimit           *uint64
-		LabelLimit            *uint64
-		LabelNameLengthLimit  *uint64
-		LabelValueLengthLimit *uint64
-		ExpectError           bool
-		Golden                string
+		Scenario                    string
+		EvaluationInterval          monitoringv1.Duration
+		ScrapeInterval              monitoringv1.Duration
+		ScrapeTimeout               monitoringv1.Duration
+		ExternalLabels              map[string]string
+		PrometheusExternalLabelName *string
+		ReplicaExternalLabelName    *string
+		QueryLogFile                string
+		Version                     string
+		BodySizeLimit               *monitoringv1.ByteSize
+		SampleLimit                 *uint64
+		TargetLimit                 *uint64
+		LabelLimit                  *uint64
+		LabelNameLengthLimit        *uint64
+		LabelValueLengthLimit       *uint64
+		ExpectError                 bool
+		Golden                      string
 	}{
 		{
 			Scenario:           "valid config",
@@ -159,6 +161,20 @@ func TestGlobalSettings(t *testing.T) {
 				"key2": "value2",
 			},
 			Golden: "external_label_specified.golden",
+		},
+		{
+			Scenario:           "external label specified along with reserved labels",
+			Version:            "v2.45.0",
+			ScrapeInterval:     "30s",
+			EvaluationInterval: "30s",
+			ExternalLabels: map[string]string{
+				"prometheus_replica": "1",
+				"prometheus":         "prometheus-k8s-1",
+				"some-other-key":     "some-value",
+			},
+			PrometheusExternalLabelName: ptr.To("prometheus"),
+			ReplicaExternalLabelName:    ptr.To("prometheus_replica"),
+			Golden:                      "external_label_specified_along_with_reserved_labels.golden",
 		},
 		{
 			Scenario:           "query log file",
@@ -197,17 +213,19 @@ func TestGlobalSettings(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: monitoringv1.PrometheusSpec{
 				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					ScrapeInterval:        tc.ScrapeInterval,
-					ScrapeTimeout:         tc.ScrapeTimeout,
-					ExternalLabels:        tc.ExternalLabels,
-					Version:               tc.Version,
-					TracingConfig:         nil,
-					BodySizeLimit:         tc.BodySizeLimit,
-					SampleLimit:           tc.SampleLimit,
-					TargetLimit:           tc.TargetLimit,
-					LabelLimit:            tc.LabelLimit,
-					LabelNameLengthLimit:  tc.LabelNameLengthLimit,
-					LabelValueLengthLimit: tc.LabelValueLengthLimit,
+					ScrapeInterval:              tc.ScrapeInterval,
+					ScrapeTimeout:               tc.ScrapeTimeout,
+					ExternalLabels:              tc.ExternalLabels,
+					PrometheusExternalLabelName: tc.PrometheusExternalLabelName,
+					ReplicaExternalLabelName:    tc.ReplicaExternalLabelName,
+					Version:                     tc.Version,
+					TracingConfig:               nil,
+					BodySizeLimit:               tc.BodySizeLimit,
+					SampleLimit:                 tc.SampleLimit,
+					TargetLimit:                 tc.TargetLimit,
+					LabelLimit:                  tc.LabelLimit,
+					LabelNameLengthLimit:        tc.LabelNameLengthLimit,
+					LabelValueLengthLimit:       tc.LabelValueLengthLimit,
 				},
 				EvaluationInterval: tc.EvaluationInterval,
 				QueryLogFile:       tc.QueryLogFile,

--- a/pkg/prometheus/testdata/external_label_specified_along_with_reserved_labels.golden
+++ b/pkg/prometheus/testdata/external_label_specified_along_with_reserved_labels.golden
@@ -1,0 +1,8 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: /
+    prometheus_replica: $(POD_NAME)
+    some-other-key: some-value
+scrape_configs: []


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

API document says following about externalLabels field:
```
// The labels to add to any time series or alerts when communicating with
// external systems (federation, remote storage, Alertmanager).
// Labels defined by `spec.replicaExternalLabelName` and
// `spec.prometheusExternalLabelName` take precedence over this list.
```

But in code externalLabels were applied after reserved labels.
This commit is to fix that.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix:  apply externalLabels after reserved labels in prometheus
```
