### PR TITLE
fix: reconcile on namespace changes

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -303,6 +303,15 @@ func run() int {
 		return 1
 	}
 
+	kubernetesVersion, err := kclient.Discovery().ServerVersion()
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to request Kubernetes server version", "err", err)
+		cancel()
+		return 1
+	}
+	cfg.KubernetesVersion = *kubernetesVersion
+	level.Info(logger).Log("msg", "connection established", "cluster-version", cfg.KubernetesVersion)
+
 	scrapeConfigSupported, err := checkPrerequisites(
 		ctx,
 		logger,

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -16,21 +16,27 @@ package listwatch
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/scheme"
+	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 )
 
-// NewUnprivilegedNamespaceListWatchFromClient mimics
+// NewNamespaceListWatchFromClient mimics
 // cache.NewListWatchFromClient. It allows for the creation of a
 // cache.ListWatch for namespaces from a client that does not have `List`
 // privileges. If the slice of namespaces contains only v1.NamespaceAll, then
@@ -44,56 +50,144 @@ import (
 //
 // If the allowed namespaces includes exactly one entry with the value v1.NamespaceAll (empty string),
 // the given denied namespaces are applied.
-func NewUnprivilegedNamespaceListWatchFromClient(
+func NewNamespaceListWatchFromClient(
 	ctx context.Context,
 	l log.Logger,
-	c cache.Getter,
+	k8sVersion version.Info,
+	corev1Client corev1.CoreV1Interface,
+	ssarClient authv1.SelfSubjectAccessReviewInterface,
 	allowedNamespaces, deniedNamespaces map[string]struct{},
-) cache.ListerWatcher {
+) (cache.ListerWatcher, bool, error) {
 	if l == nil {
 		l = log.NewNopLogger()
 	}
 
-	// If the only namespace given is `v1.NamespaceAll`, then this
-	// cache.ListWatch must be privileged. In this case, return a regular
-	// cache.ListWatch tweaked with denylist fieldselector
-	// filtering the given denied namespaces.
+	listWatchAllowed, reasons, err := k8sutil.IsAllowed(
+		ctx,
+		ssarClient,
+		nil, // namespaces is a cluster-scoped resource.
+		k8sutil.ResourceAttribute{
+			Resource: "namespaces",
+			Verbs:    []string{"list", "watch"},
+		},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// The "kubernetes.io/metadata.name" label is GA since Kubernetes 1.22.
+	var metadataNameLabelSupported bool
+	v, err := semver.ParseTolerant(k8sVersion.String())
+	if err != nil {
+		level.Warn(l).Log("msg", "failed to parse Kubernetes version", "version", k8sVersion.String(), "err", err)
+	} else {
+		metadataNameLabelSupported = v.GTE(semver.MustParse("1.22.0"))
+	}
+
 	if IsAllNamespaces(allowedNamespaces) {
+		if !listWatchAllowed {
+			err := fmt.Errorf("missing list/watch permissions on the 'namespaces' resource")
+			for _, r := range reasons {
+				err = fmt.Errorf("%w: %w", err, r)
+			}
+
+			return nil, false, err
+		}
+
+		// deniedNamespaces is only supported with allowedNamespaces = "all".
 		tweak := func(options *metav1.ListOptions) {
 			DenyTweak(options, "metadata.name", deniedNamespaces)
 		}
+		if metadataNameLabelSupported {
+			// Using a label selector is more efficient but requires Kubernetes 1.22 at least.
+			tweak = func(options *metav1.ListOptions) {
+				TweakByLabel(options, "kubernetes.io/metadata.name", ExcludeFilterType, deniedNamespaces)
+			}
+		}
 
-		return cache.NewFilteredListWatchFromClient(c, "namespaces", metav1.NamespaceAll, tweak)
+		level.Debug(l).Log("msg", "using privileged namespace lister/watcher")
+		return cache.NewFilteredListWatchFromClient(
+			corev1Client.RESTClient(),
+			"namespaces",
+			metav1.NamespaceAll,
+			tweak,
+		), true, nil
+	}
+
+	if listWatchAllowed && metadataNameLabelSupported {
+		level.Debug(l).Log("msg", "using privileged namespace lister/watcher")
+		return cache.NewFilteredListWatchFromClient(
+			corev1Client.RESTClient(),
+			"namespaces",
+			metav1.NamespaceAll,
+			func(options *metav1.ListOptions) {
+				TweakByLabel(options, "kubernetes.io/metadata.name", IncludeFilterType, allowedNamespaces)
+			},
+		), true, nil
+	}
+
+	// At this point, the operator has no list/watch permissions on the
+	// namespaces resource. Check if it has at least the get permission to
+	// emulate the list/watch operations.
+	attrs := make([]k8sutil.ResourceAttribute, 0, len(allowedNamespaces))
+	for n := range allowedNamespaces {
+		attrs = append(attrs, k8sutil.ResourceAttribute{
+			Verbs:    []string{"get"},
+			Resource: "namespaces",
+			Name:     n,
+		})
+	}
+
+	getAllowed, reasons, err := k8sutil.IsAllowed(
+		ctx,
+		ssarClient,
+		nil, // namespaces is a cluster-scoped resource.
+		attrs...,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Only log a warning to preserve backward compatibility.
+	if !getAllowed {
+		err := fmt.Errorf("missing permissions")
+		for _, r := range reasons {
+			err = fmt.Errorf("%w: %w", err, r)
+		}
+
+		level.Warn(l).Log("msg", "the operator lacks required permissions which may result in degraded functionalities", "err", err)
 	}
 
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		list := &v1.NamespaceList{}
 		for name := range allowedNamespaces {
-			result := &v1.Namespace{}
-			err := c.Get().
-				Resource("namespaces").
-				Name(name).
-				VersionedParams(&options, scheme.ParameterCodec).
-				Do(ctx).
-				Into(result)
-			if apierrors.IsNotFound(err) {
-				level.Info(l).Log("msg", "namespace not found", "namespace", name)
-				continue
-			}
+			result, err := corev1Client.Namespaces().Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, "unexpected error while listing namespaces")
+				if apierrors.IsNotFound(err) {
+					level.Info(l).Log("msg", "namespace not found", "namespace", name)
+					continue
+				}
+
+				return nil, fmt.Errorf("unexpected error while listing namespaces: %w", err)
 			}
+
 			list.Items = append(list.Items, *result)
 		}
 		return list, nil
 	}
+
+	// Since the client does not have Watch privileges, do not
+	// actually watch anything. Use a watch.FakeWatcher here to
+	// implement watch.Interface but not send any events.
 	watchFunc := func(_ metav1.ListOptions) (watch.Interface, error) {
-		// Since the client does not have Watch privileges, do not
-		// actually watch anything. Use a watch.FakeWatcher here to
-		// implement watch.Interface but not send any events.
+		// TODO(simonpasquier): implement a poll-based watcher that gets the
+		// list of namespaces perdiocially and send watch.Event() whenever it
+		// detects a change.
 		return watch.NewFake(), nil
 	}
-	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+
+	level.Debug(l).Log("msg", "using unprivileged namespace lister/watcher")
+	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}, false, nil
 }
 
 // IsAllNamespaces checks if the given map of namespaces
@@ -118,18 +212,56 @@ func IdenticalNamespaces(a, b map[string]struct{}) bool {
 	return true
 }
 
-// DenyTweak modifies the given list options
-// by adding a field selector not matching the given values.
+type FilterType string
+
+const (
+	IncludeFilterType = "Include"
+	ExcludeFilterType = "Exclude"
+)
+
+// TweakByLabel modifies the given list options by adding a label selector
+// matching/excluding the given values.
+func TweakByLabel(options *metav1.ListOptions, label string, filter FilterType, valueSet map[string]struct{}) {
+	if len(valueSet) == 0 {
+		return
+	}
+
+	var labels []string
+	for value := range valueSet {
+		labels = append(labels, value)
+	}
+	sort.Strings(labels)
+
+	var op string
+	switch filter {
+	case IncludeFilterType:
+		op = "in"
+	case ExcludeFilterType:
+		op = "notin"
+	default:
+		panic(fmt.Sprintf("unsupported filter: %q", filter))
+	}
+	selectors := []string{fmt.Sprintf("%s %s (%s)", label, op, strings.Join(labels, ","))}
+
+	if options.LabelSelector != "" {
+		selectors = append(selectors, options.LabelSelector)
+	}
+
+	options.LabelSelector = strings.Join(selectors, ",")
+}
+
+// DenyTweak modifies the given list options by adding a field selector *not*
+// matching the given values.
 func DenyTweak(options *metav1.ListOptions, field string, valueSet map[string]struct{}) {
 	if len(valueSet) == 0 {
 		return
 	}
 
 	var selectors []string
-
 	for value := range valueSet {
 		selectors = append(selectors, field+"!="+value)
 	}
+	sort.Strings(selectors)
 
 	if options.FieldSelector != "" {
 		selectors = append(selectors, options.FieldSelector)

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -16,6 +16,9 @@ package listwatch
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIdenticalNamespaces(t *testing.T) {
@@ -48,6 +51,145 @@ func TestIdenticalNamespaces(t *testing.T) {
 			if ret != tc.ret {
 				t.Fatalf("expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
 			}
+		})
+	}
+}
+
+func TestDenyTweak(t *testing.T) {
+	for _, tc := range []struct {
+		options  metav1.ListOptions
+		field    string
+		valueSet map[string]struct{}
+
+		exp string
+	}{
+		{
+			field:    "metadata.name",
+			valueSet: map[string]struct{}{},
+			exp:      "",
+		},
+		{
+			options: metav1.ListOptions{
+				FieldSelector: "metadata.namespace=foo",
+			},
+			field:    "metadata.name",
+			valueSet: map[string]struct{}{},
+			exp:      "metadata.namespace=foo",
+		},
+		{
+			field: "metadata.name",
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "metadata.name!=bar,metadata.name!=foo",
+		},
+		{
+			options: metav1.ListOptions{
+				FieldSelector: "metadata.namespace=foo",
+			},
+			field: "metadata.name",
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "metadata.name!=bar,metadata.name!=foo,metadata.namespace=foo",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			options := tc.options
+			DenyTweak(&options, tc.field, tc.valueSet)
+			require.Equal(t, tc.exp, options.FieldSelector)
+		})
+	}
+}
+
+func TestOnlyTweak(t *testing.T) {
+	for _, tc := range []struct {
+		options  metav1.ListOptions
+		label    string
+		filter   FilterType
+		valueSet map[string]struct{}
+
+		exp string
+	}{
+		{
+			label:    "kubernetes.io/metadata.name",
+			filter:   IncludeFilterType,
+			valueSet: map[string]struct{}{},
+			exp:      "",
+		},
+		{
+			options: metav1.ListOptions{
+				LabelSelector: "foo=bar",
+			},
+			label:    "kubernetes.io/metadata.name",
+			filter:   IncludeFilterType,
+			valueSet: map[string]struct{}{},
+			exp:      "foo=bar",
+		},
+		{
+			label:  "kubernetes.io/metadata.name",
+			filter: IncludeFilterType,
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "kubernetes.io/metadata.name in (bar,foo)",
+		},
+		{
+			options: metav1.ListOptions{
+				LabelSelector: "foo=bar",
+			},
+			label:  "kubernetes.io/metadata.name",
+			filter: IncludeFilterType,
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "kubernetes.io/metadata.name in (bar,foo),foo=bar",
+		},
+		{
+			label:    "kubernetes.io/metadata.name",
+			filter:   ExcludeFilterType,
+			valueSet: map[string]struct{}{},
+			exp:      "",
+		},
+		{
+			options: metav1.ListOptions{
+				LabelSelector: "foo=bar",
+			},
+			label:    "kubernetes.io/metadata.name",
+			filter:   ExcludeFilterType,
+			valueSet: map[string]struct{}{},
+			exp:      "foo=bar",
+		},
+		{
+			label:  "kubernetes.io/metadata.name",
+			filter: ExcludeFilterType,
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "kubernetes.io/metadata.name notin (bar,foo)",
+		},
+		{
+			options: metav1.ListOptions{
+				LabelSelector: "foo=bar",
+			},
+			label:  "kubernetes.io/metadata.name",
+			filter: ExcludeFilterType,
+			valueSet: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+			},
+			exp: "kubernetes.io/metadata.name notin (bar,foo),foo=bar",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			options := tc.options
+			TweakByLabel(&options, tc.label, tc.filter, tc.valueSet)
+			require.Equal(t, tc.exp, options.LabelSelector)
 		})
 	}
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/server"
@@ -30,10 +31,11 @@ import (
 // Config defines configuration parameters for the Operator.
 type Config struct {
 	// Kubernetes client configuration.
-	Host            string
-	TLSInsecure     bool
-	TLSConfig       rest.TLSClientConfig
-	ImpersonateUser string
+	Host              string
+	TLSInsecure       bool
+	TLSConfig         rest.TLSClientConfig
+	ImpersonateUser   string
+	KubernetesVersion version.Info
 
 	ClusterDomain                string
 	KubeletObject                string

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -301,7 +301,7 @@ func (rr *ResourceReconciler) onStatefulSetAdd(ss *appsv1.StatefulSet) {
 }
 
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
-	level.Debug(rr.logger).Log("msg", "update handler", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+	level.Debug(rr.logger).Log("msg", "update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
 	if rr.DeletionInProgress(cur) {
 		return

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -257,7 +257,20 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		return nil, errors.Wrap(err, "error creating statefulset informers")
 	}
 
-	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) cache.SharedIndexInformer {
+	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) (cache.SharedIndexInformer, error) {
+		lw, privileged, err := listwatch.NewNamespaceListWatchFromClient(
+			ctx,
+			o.logger,
+			o.config.KubernetesVersion,
+			o.kclient.CoreV1(),
+			o.kclient.AuthorizationV1().SelfSubjectAccessReviews(),
+			allowList,
+			o.config.Namespaces.DenyList,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		// nsResyncPeriod is used to control how often the namespace informer
 		// should resync. If the unprivileged ListerWatcher is used, then the
 		// informer must resync more often because it cannot watch for
@@ -266,23 +279,28 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		// If the only namespace is v1.NamespaceAll, then the client must be
 		// privileged and a regular cache.ListWatch will be used. In this case
 		// watching works and we do not need to resync so frequently.
-		if listwatch.IsAllNamespaces(allowList) {
+		if privileged {
 			nsResyncPeriod = resyncPeriod
 		}
-		nsInf := cache.NewSharedIndexInformer(
-			o.metrics.NewInstrumentedListerWatcher(
-				listwatch.NewUnprivilegedNamespaceListWatchFromClient(ctx, o.logger, o.kclient.CoreV1().RESTClient(), allowList, o.config.Namespaces.DenyList),
-			),
-			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
-		)
 
-		return nsInf
+		return cache.NewSharedIndexInformer(
+			o.metrics.NewInstrumentedListerWatcher(lw),
+			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
+		), nil
 	}
-	c.nsMonInf = newNamespaceInformer(c, c.config.Namespaces.AllowList)
+
+	c.nsMonInf, err = newNamespaceInformer(c, c.config.Namespaces.AllowList)
+	if err != nil {
+		return nil, err
+	}
+
 	if listwatch.IdenticalNamespaces(c.config.Namespaces.AllowList, c.config.Namespaces.PrometheusAllowList) {
 		c.nsPromInf = c.nsMonInf
 	} else {
-		c.nsPromInf = newNamespaceInformer(c, c.config.Namespaces.PrometheusAllowList)
+		c.nsPromInf, err = newNamespaceInformer(c, c.config.Namespaces.PrometheusAllowList)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	endpointSliceSupported, err := k8sutil.IsAPIGroupVersionResourceSupported(c.kclient.Discovery(), schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"}, "endpointslices")
@@ -307,27 +325,6 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 
 // Run the controller.
 func (c *Operator) Run(ctx context.Context) error {
-	errChan := make(chan error)
-	go func() {
-		v, err := c.kclient.Discovery().ServerVersion()
-		if err != nil {
-			errChan <- errors.Wrap(err, "communicating with server failed")
-			return
-		}
-		level.Info(c.logger).Log("msg", "connection established", "cluster-version", v)
-		errChan <- nil
-	}()
-
-	select {
-	case err := <-errChan:
-		if err != nil {
-			return err
-		}
-		level.Info(c.logger).Log("msg", "CRD API endpoints ready")
-	case <-ctx.Done():
-		return nil
-	}
-
 	go c.rr.Run(ctx)
 	defer c.rr.Stop()
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -318,7 +318,20 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		return nil, errors.Wrap(err, "error creating statefulset informers")
 	}
 
-	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) cache.SharedIndexInformer {
+	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) (cache.SharedIndexInformer, error) {
+		lw, privileged, err := listwatch.NewNamespaceListWatchFromClient(
+			ctx,
+			o.logger,
+			o.config.KubernetesVersion,
+			o.kclient.CoreV1(),
+			o.kclient.AuthorizationV1().SelfSubjectAccessReviews(),
+			allowList,
+			o.config.Namespaces.DenyList,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		// nsResyncPeriod is used to control how often the namespace informer
 		// should resync. If the unprivileged ListerWatcher is used, then the
 		// informer must resync more often because it cannot watch for
@@ -327,23 +340,28 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		// If the only namespace is v1.NamespaceAll, then the client must be
 		// privileged and a regular cache.ListWatch will be used. In this case
 		// watching works and we do not need to resync so frequently.
-		if listwatch.IsAllNamespaces(allowList) {
+		if privileged {
 			nsResyncPeriod = resyncPeriod
 		}
-		nsInf := cache.NewSharedIndexInformer(
-			o.metrics.NewInstrumentedListerWatcher(
-				listwatch.NewUnprivilegedNamespaceListWatchFromClient(ctx, o.logger, o.kclient.CoreV1().RESTClient(), allowList, o.config.Namespaces.DenyList),
-			),
-			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
-		)
 
-		return nsInf
+		return cache.NewSharedIndexInformer(
+			o.metrics.NewInstrumentedListerWatcher(lw),
+			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
+		), nil
 	}
-	c.nsMonInf = newNamespaceInformer(c, c.config.Namespaces.AllowList)
+
+	c.nsMonInf, err = newNamespaceInformer(c, c.config.Namespaces.AllowList)
+	if err != nil {
+		return nil, err
+	}
+
 	if listwatch.IdenticalNamespaces(c.config.Namespaces.AllowList, c.config.Namespaces.PrometheusAllowList) {
 		c.nsPromInf = c.nsMonInf
 	} else {
-		c.nsPromInf = newNamespaceInformer(c, c.config.Namespaces.PrometheusAllowList)
+		c.nsPromInf, err = newNamespaceInformer(c, c.config.Namespaces.PrometheusAllowList)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	endpointSliceSupported, err := k8sutil.IsAPIGroupVersionResourceSupported(c.kclient.Discovery(), schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"}, "endpointslices")
@@ -468,27 +486,6 @@ func (c *Operator) addHandlers() {
 
 // Run the controller.
 func (c *Operator) Run(ctx context.Context) error {
-	errChan := make(chan error)
-	go func() {
-		v, err := c.kclient.Discovery().ServerVersion()
-		if err != nil {
-			errChan <- errors.Wrap(err, "communicating with server failed")
-			return
-		}
-		level.Info(c.logger).Log("msg", "connection established", "cluster-version", v)
-		errChan <- nil
-	}()
-
-	select {
-	case err := <-errChan:
-		if err != nil {
-			return err
-		}
-		level.Info(c.logger).Log("msg", "CRD API endpoints ready")
-	case <-ctx.Done():
-		return nil
-	}
-
 	go c.rr.Run(ctx)
 	defer c.rr.Stop()
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -76,6 +77,7 @@ type Operator struct {
 
 // Config defines configuration parameters for the Operator.
 type Config struct {
+	KubernetesVersion      version.Info
 	ReloaderConfig         operator.ContainerConfig
 	ThanosDefaultBaseImage string
 	Namespaces             operator.Namespaces
@@ -120,6 +122,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		metrics:         operator.NewMetrics(r),
 		reconciliations: &operator.ReconciliationTracker{},
 		config: Config{
+			KubernetesVersion:      conf.KubernetesVersion,
 			ReloaderConfig:         conf.ReloaderConfig,
 			ThanosDefaultBaseImage: conf.ThanosDefaultBaseImage,
 			Namespaces:             conf.Namespaces,
@@ -206,7 +209,19 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		return nil, errors.Wrap(err, "error creating statefulset informers")
 	}
 
-	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) cache.SharedIndexInformer {
+	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) (cache.SharedIndexInformer, error) {
+		lw, privileged, err := listwatch.NewNamespaceListWatchFromClient(
+			ctx,
+			o.logger,
+			o.config.KubernetesVersion,
+			o.kclient.CoreV1(),
+			o.kclient.AuthorizationV1().SelfSubjectAccessReviews(),
+			allowList,
+			o.config.Namespaces.DenyList)
+		if err != nil {
+			return nil, err
+		}
+
 		// nsResyncPeriod is used to control how often the namespace informer
 		// should resync. If the unprivileged ListerWatcher is used, then the
 		// informer must resync more often because it cannot watch for
@@ -215,23 +230,30 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		// If the only namespace is v1.NamespaceAll, then the client must be
 		// privileged and a regular cache.ListWatch will be used. In this case
 		// watching works and we do not need to resync so frequently.
-		if listwatch.IsAllNamespaces(allowList) {
+		if privileged {
 			nsResyncPeriod = resyncPeriod
 		}
-		nsInf := cache.NewSharedIndexInformer(
-			o.metrics.NewInstrumentedListerWatcher(
-				listwatch.NewUnprivilegedNamespaceListWatchFromClient(ctx, o.logger, o.kclient.CoreV1().RESTClient(), allowList, o.config.Namespaces.DenyList),
-			),
-			&v1.Namespace{}, nsResyncPeriod, cache.Indexers{},
-		)
 
-		return nsInf
+		return cache.NewSharedIndexInformer(
+			o.metrics.NewInstrumentedListerWatcher(lw),
+			&v1.Namespace{},
+			nsResyncPeriod,
+			cache.Indexers{},
+		), nil
 	}
-	o.nsRuleInf = newNamespaceInformer(o, o.config.Namespaces.AllowList)
+
+	o.nsRuleInf, err = newNamespaceInformer(o, o.config.Namespaces.AllowList)
+	if err != nil {
+		return nil, err
+	}
+
 	if listwatch.IdenticalNamespaces(o.config.Namespaces.AllowList, o.config.Namespaces.ThanosRulerAllowList) {
 		o.nsThanosRulerInf = o.nsRuleInf
 	} else {
-		o.nsThanosRulerInf = newNamespaceInformer(o, o.config.Namespaces.ThanosRulerAllowList)
+		o.nsThanosRulerInf, err = newNamespaceInformer(o, o.config.Namespaces.ThanosRulerAllowList)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return o, nil
@@ -299,27 +321,6 @@ func (o *Operator) addHandlers() {
 
 // Run the controller.
 func (o *Operator) Run(ctx context.Context) error {
-	errChan := make(chan error)
-	go func() {
-		v, err := o.kclient.Discovery().ServerVersion()
-		if err != nil {
-			errChan <- errors.Wrap(err, "communicating with server failed")
-			return
-		}
-		level.Info(o.logger).Log("msg", "connection established", "cluster-version", v)
-		errChan <- nil
-	}()
-
-	select {
-	case err := <-errChan:
-		if err != nil {
-			return err
-		}
-		level.Info(o.logger).Log("msg", "CRD API endpoints ready")
-	case <-ctx.Done():
-		return nil
-	}
-
 	go o.rr.Run(ctx)
 	defer o.rr.Stop()
 

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -33,7 +33,17 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 	nonInstanceNs := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBACGlobal(context.Background(), t, testCtx, instanceNs)
 
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, nil, []string{instanceNs}, nil, false, true, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		operatorNs,
+		nil,
+		nil,
+		[]string{instanceNs},
+		nil,
+		false,
+		true, // clusterrole
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +102,17 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, nil, []string{deniedNs, instanceNs}, []string{instanceNs}, nil, false, true, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		operatorNs,
+		nil,
+		[]string{deniedNs, instanceNs},
+		[]string{instanceNs},
+		nil,
+		false,
+		true, // clusterrole
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +235,16 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		}
 	}
 
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, []string{allowedNs}, nil, []string{instanceNs}, nil, false, false, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		operatorNs,
+		[]string{allowedNs},
+		nil,
+		[]string{instanceNs},
+		nil,
+		false,
+		false, // not clusterrole
+		true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,11 +331,11 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 		// Remove the selecting label on the "allowed" namespace and check that
 		// the target is removed.
 		// See https://github.com/prometheus-operator/prometheus-operator/issues/3847
-		//if err := testFramework.RemoveLabelsFromNamespace(framework.KubeClient, allowedNs, "monitored"); err != nil {
+		//if err := framework.RemoveLabelsFromNamespace(context.Background(), allowedNs, "monitored"); err != nil {
 		//	t.Fatal(err)
 		//}
 
-		//if err := framework.WaitForActiveTargets(instanceNs, "prometheus-instance", 0); err != nil {
+		//if err := framework.WaitForActiveTargets(context.Background(), instanceNs, "prometheus-instance", 0); err != nil {
 		//	t.Fatal(err)
 		//}
 	}
@@ -369,7 +398,17 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 	}
 
 	// Configure the operator to watch also a non-existing namespace (e.g. "notfound").
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), operatorNs, []string{"notfound", allowedNs}, nil, []string{"notfound", instanceNs}, nil, false, true, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		operatorNs,
+		[]string{"notfound", allowedNs},
+		nil,
+		[]string{"notfound", instanceNs},
+		nil,
+		false,
+		true, // clusterrole
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -162,7 +162,17 @@ func testScrapeConfigLifecycle(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
-	_, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, []string{ns}, nil, []string{ns}, nil, false, true, true)
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		ns,
+		[]string{ns},
+		nil,
+		[]string{ns},
+		nil,
+		false,
+		true, // clusterrole
+		true,
+	)
 	require.NoError(t, err)
 
 	p := framework.MakeBasicPrometheus(ns, "prom", "group", 1)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -200,9 +200,17 @@ func (f *Framework) MakeEchoDeployment(group string) *appsv1.Deployment {
 // to control the installation for different version of Prometheus Operator. In addition
 // one can specify the namespaces to watch, which defaults to all namespaces.
 // Returns the CA, which can bs used to access the operator over TLS
-func (f *Framework) CreateOrUpdatePrometheusOperator(ctx context.Context, ns string, namespaceAllowlist,
-	namespaceDenylist, prometheusInstanceNamespaces, alertmanagerInstanceNamespaces []string,
-	createResourceAdmissionHooks, createClusterRoleBindings, createScrapeConfigCrd bool) ([]FinalizerFn, error) {
+func (f *Framework) CreateOrUpdatePrometheusOperator(
+	ctx context.Context,
+	ns string,
+	namespaceAllowlist,
+	namespaceDenylist,
+	prometheusInstanceNamespaces,
+	alertmanagerInstanceNamespaces []string,
+	createResourceAdmissionHooks,
+	createClusterRoleBindings,
+	createScrapeConfigCrd bool,
+) ([]FinalizerFn, error) {
 
 	var finalizers []FinalizerFn
 
@@ -363,7 +371,6 @@ func (f *Framework) CreateOrUpdatePrometheusOperator(ctx context.Context, ns str
 		webhookServerImage = "quay.io/prometheus-operator/admission-webhook:" + repoAndTag[1]
 	}
 
-	deploy.Spec.Template.Spec.Containers[0].Args = append(deploy.Spec.Template.Spec.Containers[0].Args, "--log-level=all")
 	deploy.Name = prometheusOperatorServiceDeploymentName
 
 	for _, ns := range namespaceAllowlist {


### PR DESCRIPTION
## Description
When the operator was configured to select only a limited number of
namespaces, it would not watch for namespace changes. It means that the
operator may not reconcile when a namespace label is added/removed
(affecting which objects should be selected or not).

This change enables the operator to use a privileged namespace
lister/watcher whenever the service account has the needed permissions.

**IMPORTANT:** it also requires Kubernetes >= 1.22 to be effective but the
operator will degrade to the less efficient implementation if this condition isn't met.

xref #3847 (one more PR required to fix it completely).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Reconcile monitoring resources on namespace updates.
```
