### PR TITLE
replace UpdateStatus() for ApplyStatus Prometheus

### DIFF
--- a/pkg/operator/applyconfiguration.go
+++ b/pkg/operator/applyconfiguration.go
@@ -1,0 +1,66 @@
+// Copyright 2019 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	monitoringv1ac "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
+	monitoringv1alpha1ac "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1"
+)
+
+func ApplyConfigurationFromPrometheusAgent(p *monitoringv1alpha1.PrometheusAgent) *monitoringv1alpha1ac.PrometheusAgentApplyConfiguration {
+	psac := fillStatusAC(&p.Status)
+	return monitoringv1alpha1ac.PrometheusAgent(p.Name, p.Namespace).WithStatus(psac)
+}
+
+func ApplyConfigurationFromPrometheus(p *monitoringv1.Prometheus) *monitoringv1ac.PrometheusApplyConfiguration {
+	psac := fillStatusAC(&p.Status)
+	return monitoringv1ac.Prometheus(p.Name, p.Namespace).WithStatus(psac)
+}
+
+func fillStatusAC(status *monitoringv1.PrometheusStatus) *monitoringv1ac.PrometheusStatusApplyConfiguration {
+	psac := monitoringv1ac.PrometheusStatus().
+		WithPaused(status.Paused).
+		WithReplicas(status.Replicas).
+		WithAvailableReplicas(status.AvailableReplicas).
+		WithUpdatedReplicas(status.UpdatedReplicas).
+		WithUnavailableReplicas(status.UnavailableReplicas)
+
+	for _, condition := range status.Conditions {
+		psac.WithConditions(
+			monitoringv1ac.Condition().
+				WithType(condition.Type).
+				WithStatus(condition.Status).
+				WithLastTransitionTime(condition.LastTransitionTime).
+				WithReason(condition.Reason).
+				WithMessage(condition.Message).
+				WithObservedGeneration(condition.ObservedGeneration),
+		)
+	}
+
+	for _, shardStatus := range status.ShardStatuses {
+		psac.WithShardStatuses(
+			monitoringv1ac.ShardStatus().
+				WithShardID(shardStatus.ShardID).
+				WithReplicas(shardStatus.Replicas).
+				WithUpdatedReplicas(shardStatus.UpdatedReplicas).
+				WithAvailableReplicas(shardStatus.AvailableReplicas).
+				WithUnavailableReplicas(shardStatus.UnavailableReplicas),
+		)
+	}
+
+	return psac
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -32,6 +32,8 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
+const PrometheusOperatorFieldManager = "PrometheusOperator"
+
 var (
 	syncsDesc = prometheus.NewDesc(
 		"prometheus_operator_syncs",

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -807,8 +807,8 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	}
 	p.Status = *pStatus
 
-	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).ApplyStatus(ctx, operator.ApplyConfigurationFromPrometheusAgent(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
-		return errors.Wrap(err, "failed to update prometheus agent status subresource")
+	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).ApplyStatus(ctx, prompkg.ApplyConfigurationFromPrometheusAgent(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
+		return errors.Wrap(err, "failed to Apply prometheus agent status subresource")
 	}
 
 	return nil

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -51,8 +51,7 @@ import (
 )
 
 const (
-	resyncPeriod                   = 5 * time.Minute
-	prometheusOperatorFieldManager = "PrometheusOperator"
+	resyncPeriod = 5 * time.Minute
 )
 
 // Operator manages life cycle of Prometheus agent deployments and
@@ -810,8 +809,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	}
 	p.Status = *pStatus
 
-	pac := ApplyConfigurationFromPrometheus(p)
-	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).ApplyStatus(ctx, pac, metav1.ApplyOptions{FieldManager: prometheusOperatorFieldManager, Force: true}); err != nil {
+	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).ApplyStatus(ctx, applyConfigurationFromPrometheus(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
 		return errors.Wrap(err, "failed to update prometheus agent status subresource")
 	}
 
@@ -1254,7 +1252,7 @@ func ListOptions(name string) metav1.ListOptions {
 	}
 }
 
-func ApplyConfigurationFromPrometheus(p *monitoringv1alpha1.PrometheusAgent) *monitoringv1alpha1ac.PrometheusAgentApplyConfiguration {
+func applyConfigurationFromPrometheus(p *monitoringv1alpha1.PrometheusAgent) *monitoringv1alpha1ac.PrometheusAgentApplyConfiguration {
 	psac := monitoringv1ac.PrometheusStatus().
 		WithPaused(p.Status.Paused).
 		WithPaused(p.Status.Paused).

--- a/pkg/prometheus/applyconfiguration.go
+++ b/pkg/prometheus/applyconfiguration.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package operator
+package prometheus
 
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -22,16 +22,16 @@ import (
 )
 
 func ApplyConfigurationFromPrometheusAgent(p *monitoringv1alpha1.PrometheusAgent) *monitoringv1alpha1ac.PrometheusAgentApplyConfiguration {
-	psac := fillStatusAC(&p.Status)
+	psac := prometheusStatusApplyConfigurationFromPrometheusStatus(&p.Status)
 	return monitoringv1alpha1ac.PrometheusAgent(p.Name, p.Namespace).WithStatus(psac)
 }
 
 func ApplyConfigurationFromPrometheus(p *monitoringv1.Prometheus) *monitoringv1ac.PrometheusApplyConfiguration {
-	psac := fillStatusAC(&p.Status)
+	psac := prometheusStatusApplyConfigurationFromPrometheusStatus(&p.Status)
 	return monitoringv1ac.Prometheus(p.Name, p.Namespace).WithStatus(psac)
 }
 
-func fillStatusAC(status *monitoringv1.PrometheusStatus) *monitoringv1ac.PrometheusStatusApplyConfiguration {
+func prometheusStatusApplyConfigurationFromPrometheusStatus(status *monitoringv1.PrometheusStatus) *monitoringv1ac.PrometheusStatusApplyConfiguration {
 	psac := monitoringv1ac.PrometheusStatus().
 		WithPaused(status.Paused).
 		WithReplicas(status.Replicas).

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1370,7 +1370,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 
 	p.Status = *pStatus
 
-	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).ApplyStatus(ctx, operator.ApplyConfigurationFromPrometheus(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
+	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).ApplyStatus(ctx, prompkg.ApplyConfigurationFromPrometheus(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
 		return errors.Wrap(err, "failed to apply prometheus status subresource")
 	}
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -51,8 +51,7 @@ import (
 )
 
 const (
-	resyncPeriod                   = 5 * time.Minute
-	prometheusOperatorFieldManager = "PrometheusOperator"
+	resyncPeriod = 5 * time.Minute
 )
 
 // Operator manages life cycle of Prometheus deployments and
@@ -1372,8 +1371,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 
 	p.Status = *pStatus
 
-	pac := ApplyConfigurationFromPrometheus(p)
-	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).ApplyStatus(ctx, pac, metav1.ApplyOptions{FieldManager: prometheusOperatorFieldManager, Force: true}); err != nil {
+	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).ApplyStatus(ctx, applyConfigurationFromPrometheus(p), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
 		return errors.Wrap(err, "failed to apply prometheus status subresource")
 	}
 
@@ -1667,7 +1665,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitor
 	return nil
 }
 
-func ApplyConfigurationFromPrometheus(p *monitoringv1.Prometheus) *monitoringv1ac.PrometheusApplyConfiguration {
+func applyConfigurationFromPrometheus(p *monitoringv1.Prometheus) *monitoringv1ac.PrometheusApplyConfiguration {
 	psac := monitoringv1ac.PrometheusStatus().
 		WithPaused(p.Status.Paused).
 		WithPaused(p.Status.Paused).


### PR DESCRIPTION
## Description

To set the status subresource, the operator make use of ApplyStatus() instead of UpdateStatus()  to avoid informer errors.


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

- replace UpdateStatus() for ApplyStatus() in order to avoid informer errors.
