### PR TITLE
 replace UpdateStatus() for ApplyStatus ThanosRuler

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -55,8 +55,7 @@ import (
 )
 
 const (
-	resyncPeriod                   = 5 * time.Minute
-	prometheusOperatorFieldManager = "PrometheusOperator"
+	resyncPeriod = 5 * time.Minute
 )
 
 var (
@@ -806,9 +805,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	a.Status.Conditions = operator.UpdateConditions(a.Status.Conditions, availableCondition, reconciledCondition)
 	a.Status.Paused = a.Spec.Paused
 
-	aac := ApplyConfigurationFromAlertmanager(a)
-
-	if _, err = c.mclient.MonitoringV1().Alertmanagers(a.Namespace).ApplyStatus(ctx, aac, metav1.ApplyOptions{FieldManager: prometheusOperatorFieldManager, Force: true}); err != nil {
+	if _, err = c.mclient.MonitoringV1().Alertmanagers(a.Namespace).ApplyStatus(ctx, ApplyConfigurationFromAlertmanager(a), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
 		return errors.Wrap(err, "failed to apply status subresource")
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1794,7 +1794,6 @@ func tlsAssetsSecretName(name string) string {
 func ApplyConfigurationFromAlertmanager(a *monitoringv1.Alertmanager) *monitoringv1ac.AlertmanagerApplyConfiguration {
 	asac := monitoringv1ac.AlertmanagerStatus().
 		WithPaused(a.Status.Paused).
-		WithPaused(a.Status.Paused).
 		WithReplicas(a.Status.Replicas).
 		WithAvailableReplicas(a.Status.AvailableReplicas).
 		WithUpdatedReplicas(a.Status.UpdatedReplicas).

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -32,6 +32,8 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
+const PrometheusOperatorFieldManager = "PrometheusOperator"
+
 var (
 	syncsDesc = prometheus.NewDesc(
 		"prometheus_operator_syncs",

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -46,9 +46,8 @@ import (
 )
 
 const (
-	resyncPeriod                   = 5 * time.Minute
-	thanosRulerLabel               = "thanos-ruler"
-	prometheusOperatorFieldManager = "PrometheusOperator"
+	resyncPeriod     = 5 * time.Minute
+	thanosRulerLabel = "thanos-ruler"
 )
 
 // Operator manages life cycle of Thanos deployments and
@@ -693,9 +692,7 @@ func (o *Operator) UpdateStatus(ctx context.Context, key string) error {
 	tr.Status.Conditions = operator.UpdateConditions(tr.Status.Conditions, availableCondition, reconciledCondition)
 	tr.Status.Paused = tr.Spec.Paused
 
-	trac := ApplyConfigurationFromThanosRuler(tr)
-
-	if _, err = o.mclient.MonitoringV1().ThanosRulers(tr.Namespace).ApplyStatus(ctx, trac, metav1.ApplyOptions{FieldManager: prometheusOperatorFieldManager, Force: true}); err != nil {
+	if _, err = o.mclient.MonitoringV1().ThanosRulers(tr.Namespace).ApplyStatus(ctx, applyConfigurationFromThanosRuler(tr), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
 		return errors.Wrap(err, "failed to apply status subresource")
 	}
 
@@ -807,9 +804,8 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	}
 }
 
-func ApplyConfigurationFromThanosRuler(a *monitoringv1.ThanosRuler) *monitoringv1ac.ThanosRulerApplyConfiguration {
+func applyConfigurationFromThanosRuler(a *monitoringv1.ThanosRuler) *monitoringv1ac.ThanosRulerApplyConfiguration {
 	trac := monitoringv1ac.ThanosRulerStatus().
-		WithPaused(a.Status.Paused).
 		WithPaused(a.Status.Paused).
 		WithReplicas(a.Status.Replicas).
 		WithAvailableReplicas(a.Status.AvailableReplicas).


### PR DESCRIPTION
## Description

To set the status subresource, the operator make use of ApplyStatus() instead of UpdateStatus()  to avoid informer errors.


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

- replace UpdateStatus() for ApplyStatus() in order to avoid informer errors.
