### PR TITLE
Fix objec --> object typo

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2136,7 +2136,7 @@ bool
 <p>When true, <code>spec.namespaceSelector</code> from all PodMonitor, ServiceMonitor
 and Probe objects will be ignored. They will only discover targets
 within the namespace of the PodMonitor, ServiceMonitor and Probe
-objec.</p>
+object.</p>
 </td>
 </tr>
 <tr>
@@ -6300,7 +6300,7 @@ bool
 <p>When true, <code>spec.namespaceSelector</code> from all PodMonitor, ServiceMonitor
 and Probe objects will be ignored. They will only discover targets
 within the namespace of the PodMonitor, ServiceMonitor and Probe
-objec.</p>
+object.</p>
 </td>
 </tr>
 <tr>
@@ -10031,7 +10031,7 @@ bool
 <p>When true, <code>spec.namespaceSelector</code> from all PodMonitor, ServiceMonitor
 and Probe objects will be ignored. They will only discover targets
 within the namespace of the PodMonitor, ServiceMonitor and Probe
-objec.</p>
+object.</p>
 </td>
 </tr>
 <tr>
@@ -15323,7 +15323,7 @@ bool
 <p>When true, <code>spec.namespaceSelector</code> from all PodMonitor, ServiceMonitor
 and Probe objects will be ignored. They will only discover targets
 within the namespace of the PodMonitor, ServiceMonitor and Probe
-objec.</p>
+object.</p>
 </td>
 </tr>
 <tr>
@@ -18890,7 +18890,7 @@ bool
 <p>When true, <code>spec.namespaceSelector</code> from all PodMonitor, ServiceMonitor
 and Probe objects will be ignored. They will only discover targets
 within the namespace of the PodMonitor, ServiceMonitor and Probe
-objec.</p>
+object.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16786,7 +16786,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it
@@ -25559,7 +25559,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -2681,7 +2681,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3049,7 +3049,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -2681,7 +2681,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3049,7 +3049,7 @@ spec:
                 description: When true, `spec.namespaceSelector` from all PodMonitor,
                   ServiceMonitor and Probe objects will be ignored. They will only
                   discover targets within the namespace of the PodMonitor, ServiceMonitor
-                  and Probe objec.
+                  and Probe object.
                 type: boolean
               image:
                 description: "Container image name for Prometheus. If specified, it

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -2378,7 +2378,7 @@
                     "type": "boolean"
                   },
                   "ignoreNamespaceSelectors": {
-                    "description": "When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor and Probe objects will be ignored. They will only discover targets within the namespace of the PodMonitor, ServiceMonitor and Probe objec.",
+                    "description": "When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor and Probe objects will be ignored. They will only discover targets within the namespace of the PodMonitor, ServiceMonitor and Probe object.",
                     "type": "boolean"
                   },
                   "image": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2754,7 +2754,7 @@
                     "type": "boolean"
                   },
                   "ignoreNamespaceSelectors": {
-                    "description": "When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor and Probe objects will be ignored. They will only discover targets within the namespace of the PodMonitor, ServiceMonitor and Probe objec.",
+                    "description": "When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor and Probe objects will be ignored. They will only discover targets within the namespace of the PodMonitor, ServiceMonitor and Probe object.",
                     "type": "boolean"
                   },
                   "image": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -407,7 +407,7 @@ type CommonPrometheusFields struct {
 	// When true, `spec.namespaceSelector` from all PodMonitor, ServiceMonitor
 	// and Probe objects will be ignored. They will only discover targets
 	// within the namespace of the PodMonitor, ServiceMonitor and Probe
-	// objec.
+	// object.
 	IgnoreNamespaceSelectors bool `json:"ignoreNamespaceSelectors,omitempty"`
 
 	// When not empty, a label will be added to


### PR DESCRIPTION
## Description

This only fixes a typo in comments and documentation.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Fix `objec` --> `object` typo
```
