### PR TITLE
Enable depguard linter against github.com/pkg/errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   enable:
   - revive
   - gci
+  - depguard
 
 issues:
   exclude-rules:
@@ -24,3 +25,16 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/prometheus-operator/prometheus-operator)
+  depguard:
+    rules:
+      forbid-pkg-errors:
+        deny:
+        - pkg: "github.com/pkg/errors"
+          dsc: Should be replaced with standard lib errors or fmt.Errorf
+
+severity:
+  default-severity: error
+  rules:
+    - linters:
+      - depguard
+      severity: info

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,13 +28,10 @@ linters-settings:
   depguard:
     rules:
       forbid-pkg-errors:
+        files:
+        - "**/admission/*.go"
+        - "**/alertmanager/*.go"
+        - "**/alertmanager/**/*.go"
         deny:
         - pkg: "github.com/pkg/errors"
           dsc: Should be replaced with standard lib errors or fmt.Errorf
-
-severity:
-  default-severity: error
-  rules:
-    - linters:
-      - depguard
-      severity: info

--- a/pkg/admission/jsonpatch.go
+++ b/pkg/admission/jsonpatch.go
@@ -17,14 +17,12 @@ package admission
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 func generatePatchesForNonStringLabelsAnnotations(content []byte) ([]string, error) {
 	groups := &RuleGroups{}
 	if err := json.Unmarshal(content, groups); err != nil {
-		return nil, errors.Wrap(err, "cannot unmarshal RuleGroups")
+		return nil, fmt.Errorf("cannot unmarshal RuleGroups: %w", err)
 	}
 
 	patches := new([]string)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -17,6 +17,7 @@ package alertmanager
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"regexp"
@@ -27,7 +28,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/mitchellh/hashstructure"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -112,17 +112,17 @@ type Config struct {
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer) (*Operator, error) {
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "instantiating kubernetes client failed")
+		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}
 
 	mdClient, err := metadata.NewForConfig(restConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "instantiating kubernetes client failed")
+		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}
 
 	mclient, err := monitoringclient.NewForConfig(restConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "instantiating monitoring client failed")
+		return nil, fmt.Errorf("instantiating monitoring client failed: %w", err)
 	}
 
 	// All the metrics exposed by the controller get the controller="alertmanager" label.
@@ -172,7 +172,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 	var err error
 
 	if _, err := labels.Parse(c.config.AlertManagerSelector); err != nil {
-		return errors.Wrap(err, "can not parse alertmanager selector value")
+		return fmt.Errorf("can not parse alertmanager selector value: %w", err)
 	}
 
 	c.metrics.MustRegister(c.reconciliations)
@@ -190,7 +190,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 		monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.AlertmanagerName),
 	)
 	if err != nil {
-		return errors.Wrap(err, "error creating alertmanager informers")
+		return fmt.Errorf("error creating alertmanager informers: %w", err)
 	}
 
 	var alertmanagerStores []cache.Store
@@ -210,12 +210,12 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 		monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.AlertmanagerConfigName),
 	)
 	if err != nil {
-		return errors.Wrap(err, "error creating alertmanagerconfig informers")
+		return fmt.Errorf("error creating alertmanagerconfig informers: %w", err)
 	}
 
 	secretListWatchSelector, err := fields.ParseSelector(c.config.SecretListWatchSelector)
 	if err != nil {
-		return errors.Wrap(err, "can not parse secrets selector value")
+		return fmt.Errorf("can not parse secrets selector value: %w", err)
 	}
 
 	c.secrInfs, err = informers.NewInformersForResource(
@@ -231,7 +231,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 		v1.SchemeGroupVersion.WithResource("secrets"),
 	)
 	if err != nil {
-		return errors.Wrap(err, "error creating secret informers")
+		return fmt.Errorf("error creating secret informers: %w", err)
 	}
 
 	c.ssetInfs, err = informers.NewInformersForResource(
@@ -245,7 +245,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
 	)
 	if err != nil {
-		return errors.Wrap(err, "error creating statefulset informers")
+		return fmt.Errorf("error creating statefulset informers: %w", err)
 	}
 
 	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) (cache.SharedIndexInformer, error) {
@@ -311,7 +311,7 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
 			if !operator.WaitForNamedCacheSync(ctx, "alertmanager", log.With(c.logger, "informer", infs.name), inf.Informer()) {
-				return errors.Errorf("failed to sync cache for %s informer", infs.name)
+				return fmt.Errorf("failed to sync cache for %s informer", infs.name)
 			}
 		}
 	}
@@ -324,7 +324,7 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 		{"AlertmanagerConfigNamespace", c.nsAlrtCfgInf},
 	} {
 		if !operator.WaitForNamedCacheSync(ctx, "alertmanager", log.With(c.logger, "informer", inf.name), inf.informer) {
-			return errors.Errorf("failed to sync cache for %s informer", inf.name)
+			return fmt.Errorf("failed to sync cache for %s informer", inf.name)
 		}
 	}
 
@@ -645,7 +645,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	am := aobj.(*monitoringv1.Alertmanager)
 	am = am.DeepCopy()
 	if err := k8sutil.AddTypeInformationToObject(am); err != nil {
-		return errors.Wrap(err, "failed to set Alertmanager type information")
+		return fmt.Errorf("failed to set Alertmanager type information: %w", err)
 	}
 
 	if am.Spec.Paused {
@@ -660,22 +660,22 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	assetStore := assets.NewStore(c.kclient.CoreV1(), c.kclient.CoreV1())
 
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {
-		return errors.Wrap(err, "provision alertmanager configuration")
+		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
 
 	tlsAssets, err := c.createOrUpdateTLSAssetSecrets(ctx, am, assetStore)
 	if err != nil {
-		return errors.Wrap(err, "creating tls asset secrets failed")
+		return fmt.Errorf("creating tls asset secrets failed: %w", err)
 	}
 
 	if err := c.createOrUpdateWebConfigSecret(ctx, am); err != nil {
-		return errors.Wrap(err, "synchronizing web config secret failed")
+		return fmt.Errorf("synchronizing web config secret failed: %w", err)
 	}
 
 	// Create governing service if it doesn't exist.
 	svcClient := c.kclient.CoreV1().Services(am.Namespace)
 	if err = k8sutil.CreateOrUpdateService(ctx, svcClient, makeStatefulSetService(am, c.config)); err != nil {
-		return errors.Wrap(err, "synchronizing governing service failed")
+		return fmt.Errorf("synchronizing governing service failed: %w", err)
 	}
 
 	existingStatefulSet, err := c.getStatefulSetFromAlertmanagerKey(key)
@@ -714,7 +714,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		level.Debug(logger).Log("msg", "no current statefulset found")
 		level.Debug(logger).Log("msg", "creating statefulset")
 		if _, err := ssetClient.Create(ctx, sset, metav1.CreateOptions{}); err != nil {
-			return errors.Wrap(err, "creating statefulset failed")
+			return fmt.Errorf("creating statefulset failed: %w", err)
 		}
 		return nil
 	}
@@ -734,13 +734,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		level.Info(logger).Log("msg", "recreating AlertManager StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
-			return errors.Wrap(err, "failed to delete StatefulSet to avoid forbidden action")
+			return fmt.Errorf("failed to delete StatefulSet to avoid forbidden action: %w", err)
 		}
 		return nil
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "updating StatefulSet failed")
+		return fmt.Errorf("updating StatefulSet failed: %w", err)
 	}
 
 	return nil
@@ -755,7 +755,7 @@ func (c *Operator) getAlertmanagerFromKey(key string) (*monitoringv1.Alertmanage
 			level.Info(c.logger).Log("msg", "Alertmanager not found", "key", key)
 			return nil, nil
 		}
-		return nil, errors.Wrap(err, "failed to retrieve Alertmanager from informer")
+		return nil, fmt.Errorf("failed to retrieve Alertmanager from informer: %w", err)
 	}
 
 	return obj.(*monitoringv1.Alertmanager).DeepCopy(), nil
@@ -773,7 +773,7 @@ func (c *Operator) getStatefulSetFromAlertmanagerKey(key string) (*appsv1.Statef
 			level.Info(c.logger).Log("msg", "StatefulSet not found", "key", ssetName)
 			return nil, nil
 		}
-		return nil, errors.Wrap(err, "failed to retrieve StatefulSet from informer")
+		return nil, fmt.Errorf("failed to retrieve StatefulSet from informer: %w", err)
 	}
 
 	return obj.(*appsv1.StatefulSet).DeepCopy(), nil
@@ -794,7 +794,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 
 	sset, err := c.getStatefulSetFromAlertmanagerKey(key)
 	if err != nil {
-		return errors.Wrap(err, "failed to get StatefulSet")
+		return fmt.Errorf("failed to get StatefulSet: %w", err)
 	}
 
 	if sset != nil && c.rr.DeletionInProgress(sset) {
@@ -803,7 +803,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 
 	stsReporter, err := operator.NewStatefulSetReporter(ctx, c.kclient, sset)
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve statefulset state")
+		return fmt.Errorf("failed to retrieve statefulset state: %w", err)
 	}
 
 	availableCondition := stsReporter.Update(a)
@@ -812,7 +812,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	a.Status.Paused = a.Spec.Paused
 
 	if _, err = c.mclient.MonitoringV1().Alertmanagers(a.Namespace).ApplyStatus(ctx, ApplyConfigurationFromAlertmanager(a), metav1.ApplyOptions{FieldManager: operator.PrometheusOperatorFieldManager, Force: true}); err != nil {
-		return errors.Wrap(err, "failed to apply status subresource")
+		return fmt.Errorf("failed to apply status subresource: %w", err)
 	}
 
 	return nil
@@ -849,7 +849,7 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *opera
 		nil,
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to calculate combined hash")
+		return "", fmt.Errorf("failed to calculate combined hash: %w", err)
 	}
 
 	return fmt.Sprintf("%d", hash), nil
@@ -912,12 +912,12 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 		amRawConfiguration, additionalData, err := c.loadConfigurationFromSecret(ctx, am)
 		if err != nil {
-			return errors.Wrap(err, "failed to retrieve configuration from secret")
+			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
 		err = c.createOrUpdateGeneratedConfigSecret(ctx, am, amRawConfiguration, additionalData)
 		if err != nil {
-			return errors.Wrap(err, "create or update generated config secret failed")
+			return fmt.Errorf("create or update generated config secret failed: %w", err)
 		}
 
 		return nil
@@ -926,12 +926,12 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 	amVersion := operator.StringValOrDefault(am.Spec.Version, operator.DefaultAlertmanagerVersion)
 	version, err := semver.ParseTolerant(amVersion)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse alertmanager version")
+		return fmt.Errorf("failed to parse alertmanager version: %w", err)
 	}
 
 	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, version, store)
 	if err != nil {
-		return errors.Wrap(err, "failed to select AlertmanagerConfig objects")
+		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
 	}
 
 	var (
@@ -944,12 +944,12 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 		globalAmConfig, err := c.mclient.MonitoringV1alpha1().AlertmanagerConfigs(am.Namespace).
 			Get(ctx, am.Spec.AlertmanagerConfiguration.Name, metav1.GetOptions{})
 		if err != nil {
-			return errors.Wrap(err, "failed to get global AlertmanagerConfig")
+			return fmt.Errorf("failed to get global AlertmanagerConfig: %w", err)
 		}
 
 		err = cfgBuilder.initializeFromAlertmanagerConfig(ctx, am.Spec.AlertmanagerConfiguration.Global, globalAmConfig)
 		if err != nil {
-			return errors.Wrap(err, "failed to initialize from global AlertmangerConfig")
+			return fmt.Errorf("failed to initialize from global AlertmangerConfig: %w", err)
 		}
 
 		// set templates
@@ -970,27 +970,27 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 		amRawConfiguration, additionalData, err = c.loadConfigurationFromSecret(ctx, am)
 		if err != nil {
-			return errors.Wrap(err, "failed to retrieve configuration from secret")
+			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
 		err = cfgBuilder.initializeFromRawConfiguration(amRawConfiguration)
 		if err != nil {
-			return errors.Wrap(err, "failed to initialize from secret")
+			return fmt.Errorf("failed to initialize from secret: %w", err)
 		}
 	}
 
 	if err := cfgBuilder.addAlertmanagerConfigs(ctx, amConfigs); err != nil {
-		return errors.Wrap(err, "failed to generate Alertmanager configuration")
+		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 
 	generatedConfig, err := cfgBuilder.marshalJSON()
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal configuration")
+		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}
 
 	err = c.createOrUpdateGeneratedConfigSecret(ctx, am, generatedConfig, additionalData)
 	if err != nil {
-		return errors.Wrap(err, "failed to create or update the generated configuration secret")
+		return fmt.Errorf("failed to create or update the generated configuration secret: %w", err)
 	}
 
 	return nil
@@ -1025,13 +1025,13 @@ func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *
 	// Compress config to avoid 1mb secret limit for a while
 	var buf bytes.Buffer
 	if err := operator.GzipConfig(&buf, conf); err != nil {
-		return errors.Wrap(err, "couldnt gzip config")
+		return fmt.Errorf("couldnt gzip config: %w", err)
 	}
 	generatedConfigSecret.Data[alertmanagerConfigFileCompressed] = buf.Bytes()
 
 	err := k8sutil.CreateOrUpdateSecret(ctx, sClient, generatedConfigSecret)
 	if err != nil {
-		return errors.Wrap(err, "failed to update generated config secret")
+		return fmt.Errorf("failed to update generated config secret: %w", err)
 	}
 
 	return nil
@@ -1055,7 +1055,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 			namespaces = append(namespaces, obj.(*v1.Namespace).Name)
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to list namespaces")
+			return nil, fmt.Errorf("failed to list namespaces: %w", err)
 		}
 
 		level.Debug(c.logger).Log("msg", "filtering namespaces to select AlertmanagerConfigs from", "namespaces", strings.Join(namespaces, ","), "namespace", am.Namespace, "alertmanager", am.Name)
@@ -1082,7 +1082,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 			}
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list alertmanager configs in namespace %s", ns)
+			return nil, fmt.Errorf("failed to list alertmanager configs in namespace %s: %w", ns, err)
 		}
 	}
 
@@ -1409,7 +1409,7 @@ func checkWebhookConfigs(
 				return err
 			}
 			if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
-				return errors.Wrapf(err, "webhook 'url' %s invalid", url)
+				return fmt.Errorf("webhook 'url' %s invalid: %w", url, err)
 			}
 		}
 
@@ -1537,7 +1537,7 @@ func checkPushoverConfigs(
 ) error {
 	checkSecret := func(secret *v1.SecretKeySelector, name string) error {
 		if secret == nil {
-			return errors.Errorf("mandatory field %s is empty", name)
+			return fmt.Errorf("mandatory field %s is empty", name)
 		}
 		s, err := store.GetSecretKey(ctx, namespace, *secret)
 		if err != nil {
@@ -1646,13 +1646,13 @@ func checkInhibitRules(amc *monitoringv1alpha1.AlertmanagerConfig, version semve
 
 		for j, tm := range rule.TargetMatch {
 			if err := tm.Validate(); err != nil {
-				return errors.Wrapf(err, "invalid targetMatchers[%d] in inhibitRule[%d] in config %s", j, i, amc.Name)
+				return fmt.Errorf("invalid targetMatchers[%d] in inhibitRule[%d] in config %s: %w", j, i, amc.Name, err)
 			}
 		}
 
 		for j, sm := range rule.SourceMatch {
 			if err := sm.Validate(); err != nil {
-				return errors.Wrapf(err, "invalid sourceMatchers[%d] in inhibitRule[%d] in config %s", j, i, amc.Name)
+				return fmt.Errorf("invalid sourceMatchers[%d] in inhibitRule[%d] in config %s: %w", j, i, amc.Name, err)
 			}
 		}
 	}
@@ -1700,7 +1700,7 @@ func (c *Operator) createOrUpdateTLSAssetSecrets(ctx context.Context, am *monito
 	sClient := c.kclient.CoreV1().Secrets(am.Namespace)
 
 	if err := sSecret.StoreSecrets(ctx, sClient); err != nil {
-		return nil, errors.Wrapf(err, "failed to create TLS assets secret for Alertmanager")
+		return nil, fmt.Errorf("failed to create TLS assets secret for Alertmanager: %w", err)
 	}
 
 	level.Debug(c.logger).Log("msg", "tls-asset secret: stored")
@@ -1743,7 +1743,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, a *monitor
 		fields,
 	)
 	if err != nil {
-		return errors.Wrap(err, "failed to initialize web config")
+		return fmt.Errorf("failed to initialize web config: %w", err)
 	}
 
 	secretClient := c.kclient.CoreV1().Secrets(a.Namespace)
@@ -1759,7 +1759,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, a *monitor
 	secretLabels := c.config.Labels.Merge(managedByOperatorLabels)
 
 	if err := webConfig.CreateOrUpdateWebConfigSecret(ctx, secretClient, secretAnnotations, secretLabels, ownerReference); err != nil {
-		return errors.Wrap(err, "failed to reconcile web config secret")
+		return fmt.Errorf("failed to reconcile web config secret: %w", err)
 	}
 
 	return nil

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -235,12 +234,12 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 		operator.StringValOrDefault(a.Spec.SHA, ""),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build image path")
+		return nil, fmt.Errorf("failed to build image path: %w", err)
 	}
 
 	version, err := semver.ParseTolerant(amVersion)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse alertmanager version")
+		return nil, fmt.Errorf("failed to parse alertmanager version: %w", err)
 	}
 
 	amArgs := []string{
@@ -448,7 +447,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 			})
 		}
 	default:
-		return nil, errors.Errorf("unsupported Alertmanager major version %s", version)
+		return nil, fmt.Errorf("unsupported Alertmanager major version %s", version)
 	}
 
 	assetsVolume := v1.Volume{
@@ -723,7 +722,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 
 	containers, err := k8sutil.MergePatchContainers(defaultContainers, a.Spec.Containers)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge containers spec")
+		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
 	}
 
 	var minReadySeconds int32
@@ -749,7 +748,7 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 
 	initContainers, err := k8sutil.MergePatchContainers(operatorInitContainers, a.Spec.InitContainers)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge init containers spec")
+		return nil, fmt.Errorf("failed to merge init containers spec: %w", err)
 	}
 
 	// PodManagementPolicy is set to Parallel to mitigate issues in kubernetes: https://github.com/kubernetes/kubernetes/issues/60164

--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -15,12 +15,11 @@
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -52,56 +51,56 @@ func validateReceivers(receivers []monitoringv1alpha1.Receiver) (map[string]stru
 
 	for _, receiver := range receivers {
 		if _, found := receiverNames[receiver.Name]; found {
-			return nil, errors.Errorf("%q receiver is not unique", receiver.Name)
+			return nil, fmt.Errorf("%q receiver is not unique: %w", receiver.Name, err)
 		}
 		receiverNames[receiver.Name] = struct{}{}
 
 		if err = validatePagerDutyConfigs(receiver.PagerDutyConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'pagerDutyConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'pagerDutyConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateOpsGenieConfigs(receiver.OpsGenieConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'opsGenieConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'opsGenieConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateSlackConfigs(receiver.SlackConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'slackConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'slackConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWebhookConfigs(receiver.WebhookConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'webhookConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'webhookConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWechatConfigs(receiver.WeChatConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'weChatConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'weChatConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateEmailConfig(receiver.EmailConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'emailConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'emailConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateVictorOpsConfigs(receiver.VictorOpsConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'victorOpsConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'victorOpsConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validatePushoverConfigs(receiver.PushoverConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'pushOverConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'pushOverConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateSnsConfigs(receiver.SNSConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'snsConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'snsConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateTelegramConfigs(receiver.TelegramConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'telegramConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'telegramConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWebexConfigs(receiver.WebexConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'webexConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'webexConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateDiscordConfigs(receiver.DiscordConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'discordConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'discordConfig' - receiver %s: %w", receiver.Name, err)
 		}
 	}
 
@@ -112,7 +111,7 @@ func validatePagerDutyConfigs(configs []monitoringv1alpha1.PagerDutyConfig) erro
 	for _, conf := range configs {
 		if conf.URL != "" {
 			if _, err := validation.ValidateURL(conf.URL); err != nil {
-				return errors.Wrap(err, "pagerduty validation failed for 'url'")
+				return fmt.Errorf("pagerduty validation failed for 'url': %w", err)
 			}
 		}
 		if conf.RoutingKey == nil && conf.ServiceKey == nil {
@@ -133,7 +132,7 @@ func validateOpsGenieConfigs(configs []monitoringv1alpha1.OpsGenieConfig) error 
 		}
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -173,7 +172,7 @@ func validateWebhookConfigs(configs []monitoringv1alpha1.WebhookConfig) error {
 		}
 		if config.URL != nil {
 			if _, err := validation.ValidateURL(*config.URL); err != nil {
-				return errors.Wrapf(err, "invalid 'url'")
+				return fmt.Errorf("invalid 'url': %w", err)
 			}
 		}
 
@@ -188,7 +187,7 @@ func validateWechatConfigs(configs []monitoringv1alpha1.WeChatConfig) error {
 	for _, config := range configs {
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -208,7 +207,7 @@ func validateEmailConfig(configs []monitoringv1alpha1.EmailConfig) error {
 		if config.Smarthost != "" {
 			_, _, err := net.SplitHostPort(config.Smarthost)
 			if err != nil {
-				return errors.Wrapf(err, "invalid field 'smarthost': %s", config.Smarthost)
+				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
 			}
 		}
 
@@ -255,7 +254,7 @@ func validateVictorOpsConfigs(configs []monitoringv1alpha1.VictorOpsConfig) erro
 
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrapf(err, "'apiURL' %s invalid", config.APIURL)
+				return fmt.Errorf("'apiURL' %s invalid: %w", config.APIURL, err)
 			}
 		}
 
@@ -269,11 +268,11 @@ func validateVictorOpsConfigs(configs []monitoringv1alpha1.VictorOpsConfig) erro
 func validatePushoverConfigs(configs []monitoringv1alpha1.PushoverConfig) error {
 	for _, config := range configs {
 		if config.UserKey == nil {
-			return errors.Errorf("mandatory field %q is empty", "userKey")
+			return fmt.Errorf("mandatory field %q is empty", "userKey")
 		}
 
 		if config.Token == nil {
-			return errors.Errorf("mandatory field %q is empty", "token")
+			return fmt.Errorf("mandatory field %q is empty", "token")
 		}
 
 		if err := config.HTTPConfig.Validate(); err != nil {
@@ -320,7 +319,7 @@ func validateWebexConfigs(configs []monitoringv1alpha1.WebexConfig) error {
 	for _, config := range configs {
 		if *config.APIURL != "" {
 			if _, err := validation.ValidateURL(string(*config.APIURL)); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -342,11 +341,11 @@ func validateAlertManagerRoutes(r *monitoringv1alpha1.Route, receivers, muteTime
 
 	if r.Receiver == "" {
 		if topLevelRoute {
-			return errors.Errorf("root route must define a receiver")
+			return errors.New("root route must define a receiver")
 		}
 	} else {
 		if _, found := receivers[r.Receiver]; !found {
-			return errors.Errorf("receiver %q not found", r.Receiver)
+			return fmt.Errorf("receiver %q not found", r.Receiver)
 		}
 	}
 
@@ -354,38 +353,38 @@ func validateAlertManagerRoutes(r *monitoringv1alpha1.Route, receivers, muteTime
 		groupedBy := make(map[string]struct{}, groupLen)
 		for _, str := range r.GroupBy {
 			if _, found := groupedBy[str]; found {
-				return errors.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
+				return fmt.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
 			}
 			groupedBy[str] = struct{}{}
 		}
 		if _, found := groupedBy["..."]; found && groupLen > 1 {
-			return errors.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
+			return fmt.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
 		}
 	}
 
 	for _, namedMuteTimeInterval := range r.MuteTimeIntervals {
 		if _, found := muteTimeIntervals[namedMuteTimeInterval]; !found {
-			return errors.Errorf("mute time interval %q not found", namedMuteTimeInterval)
+			return fmt.Errorf("mute time interval %q not found", namedMuteTimeInterval)
 		}
 	}
 
 	for _, namedActiveTimeInterval := range r.ActiveTimeIntervals {
 		if _, found := muteTimeIntervals[namedActiveTimeInterval]; !found {
-			return errors.Errorf("time interval %q not found", namedActiveTimeInterval)
+			return fmt.Errorf("time interval %q not found", namedActiveTimeInterval)
 		}
 	}
 
 	// validate that if defaults are set, they match regex
 	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
-		return errors.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
+		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
 
 	}
 	if r.GroupWait != "" && !durationRe.MatchString(r.GroupWait) {
-		return errors.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
+		return fmt.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
 	}
 
 	if r.RepeatInterval != "" && !durationRe.MatchString(r.RepeatInterval) {
-		return errors.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
+		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
 	}
 
 	children, err := r.ChildRoutes()
@@ -395,7 +394,7 @@ func validateAlertManagerRoutes(r *monitoringv1alpha1.Route, receivers, muteTime
 
 	for i := range children {
 		if err := validateAlertManagerRoutes(&children[i], receivers, muteTimeIntervals, false); err != nil {
-			return errors.Wrapf(err, "route[%d]", i)
+			return fmt.Errorf("route[%d]: %w", i, err)
 		}
 	}
 
@@ -407,7 +406,7 @@ func validateMuteTimeIntervals(muteTimeIntervals []monitoringv1alpha1.MuteTimeIn
 
 	for i, mti := range muteTimeIntervals {
 		if err := mti.Validate(); err != nil {
-			return nil, errors.Wrapf(err, "mute time interval[%d] is invalid", i)
+			return nil, fmt.Errorf("mute time interval[%d] is invalid: %w", i, err)
 		}
 		muteTimeIntervalNames[mti.Name] = struct{}{}
 	}

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -15,12 +15,11 @@
 package v1beta1
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
@@ -52,56 +51,56 @@ func validateReceivers(receivers []monitoringv1beta1.Receiver) (map[string]struc
 
 	for _, receiver := range receivers {
 		if _, found := receiverNames[receiver.Name]; found {
-			return nil, errors.Errorf("%q receiver is not unique", receiver.Name)
+			return nil, fmt.Errorf("%q receiver is not unique", receiver.Name)
 		}
 		receiverNames[receiver.Name] = struct{}{}
 
 		if err = validatePagerDutyConfigs(receiver.PagerDutyConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'pagerDutyConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'pagerDutyConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateOpsGenieConfigs(receiver.OpsGenieConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'opsGenieConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'opsGenieConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateSlackConfigs(receiver.SlackConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'slackConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'slackConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWebhookConfigs(receiver.WebhookConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'webhookConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'webhookConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWechatConfigs(receiver.WeChatConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'weChatConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'weChatConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateEmailConfig(receiver.EmailConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'emailConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'emailConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateVictorOpsConfigs(receiver.VictorOpsConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'victorOpsConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'victorOpsConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validatePushoverConfigs(receiver.PushoverConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'pushOverConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'pushOverConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateSnsConfigs(receiver.SNSConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'snsConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'snsConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateTelegramConfigs(receiver.TelegramConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'telegramConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'telegramConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateDiscordConfigs(receiver.DiscordConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'discordConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'discordConfig' - receiver %s: %w", receiver.Name, err)
 		}
 
 		if err := validateWebexConfigs(receiver.WebexConfigs); err != nil {
-			return nil, errors.Wrapf(err, "failed to validate 'webexConfig' - receiver %s", receiver.Name)
+			return nil, fmt.Errorf("failed to validate 'webexConfig' - receiver %s: %w", receiver.Name, err)
 		}
 	}
 
@@ -112,7 +111,7 @@ func validatePagerDutyConfigs(configs []monitoringv1beta1.PagerDutyConfig) error
 	for _, conf := range configs {
 		if conf.URL != "" {
 			if _, err := validation.ValidateURL(conf.URL); err != nil {
-				return errors.Wrap(err, "pagerduty validation failed for 'url'")
+				return fmt.Errorf("pagerduty validation failed for 'url': %w", err)
 			}
 		}
 		if conf.RoutingKey == nil && conf.ServiceKey == nil {
@@ -133,7 +132,7 @@ func validateOpsGenieConfigs(configs []monitoringv1beta1.OpsGenieConfig) error {
 		}
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -164,7 +163,7 @@ func validateWebhookConfigs(configs []monitoringv1beta1.WebhookConfig) error {
 		}
 		if config.URL != nil {
 			if _, err := validation.ValidateURL(*config.URL); err != nil {
-				return errors.Wrapf(err, "invalid 'url'")
+				return fmt.Errorf("invalid 'url': %w", err)
 			}
 		}
 
@@ -179,7 +178,7 @@ func validateWechatConfigs(configs []monitoringv1beta1.WeChatConfig) error {
 	for _, config := range configs {
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -199,7 +198,7 @@ func validateEmailConfig(configs []monitoringv1beta1.EmailConfig) error {
 		if config.Smarthost != "" {
 			_, _, err := net.SplitHostPort(config.Smarthost)
 			if err != nil {
-				return errors.Wrapf(err, "invalid field 'smarthost': %s", config.Smarthost)
+				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
 			}
 		}
 
@@ -246,7 +245,7 @@ func validateVictorOpsConfigs(configs []monitoringv1beta1.VictorOpsConfig) error
 
 		if config.APIURL != "" {
 			if _, err := validation.ValidateURL(config.APIURL); err != nil {
-				return errors.Wrapf(err, "'apiURL' %s invalid", config.APIURL)
+				return fmt.Errorf("'apiURL' %s invalid: %w", config.APIURL, err)
 			}
 		}
 
@@ -260,11 +259,11 @@ func validateVictorOpsConfigs(configs []monitoringv1beta1.VictorOpsConfig) error
 func validatePushoverConfigs(configs []monitoringv1beta1.PushoverConfig) error {
 	for _, config := range configs {
 		if config.UserKey == nil {
-			return errors.Errorf("mandatory field %q is empty", "userKey")
+			return fmt.Errorf("mandatory field %q is empty", "userKey")
 		}
 
 		if config.Token == nil {
-			return errors.Errorf("mandatory field %q is empty", "token")
+			return fmt.Errorf("mandatory field %q is empty", "token")
 		}
 
 		if err := config.HTTPConfig.Validate(); err != nil {
@@ -311,7 +310,7 @@ func validateWebexConfigs(configs []monitoringv1beta1.WebexConfig) error {
 	for _, config := range configs {
 		if *config.APIURL != "" {
 			if _, err := validation.ValidateURL(string(*config.APIURL)); err != nil {
-				return errors.Wrap(err, "invalid 'apiURL'")
+				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}
 		}
 
@@ -343,11 +342,11 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 
 	if r.Receiver == "" {
 		if topLevelRoute {
-			return errors.Errorf("root route must define a receiver")
+			return fmt.Errorf("root route must define a receiver")
 		}
 	} else {
 		if _, found := receivers[r.Receiver]; !found {
-			return errors.Errorf("receiver %q not found", r.Receiver)
+			return fmt.Errorf("receiver %q not found", r.Receiver)
 		}
 	}
 
@@ -355,38 +354,38 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 		groupedBy := make(map[string]struct{}, groupLen)
 		for _, str := range r.GroupBy {
 			if _, found := groupedBy[str]; found {
-				return errors.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
+				return fmt.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
 			}
 			groupedBy[str] = struct{}{}
 		}
 		if _, found := groupedBy["..."]; found && groupLen > 1 {
-			return errors.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
+			return fmt.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
 		}
 	}
 
 	for _, namedTimeInterval := range r.MuteTimeIntervals {
 		if _, found := timeIntervals[namedTimeInterval]; !found {
-			return errors.Errorf("time interval %q not found", namedTimeInterval)
+			return fmt.Errorf("time interval %q not found", namedTimeInterval)
 		}
 	}
 
 	for _, namedTimeInterval := range r.ActiveTimeIntervals {
 		if _, found := timeIntervals[namedTimeInterval]; !found {
-			return errors.Errorf("time interval %q not found", namedTimeInterval)
+			return fmt.Errorf("time interval %q not found", namedTimeInterval)
 		}
 	}
 
 	// validate that if defaults are set, they match regex
 	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
-		return errors.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
+		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
 
 	}
 	if r.GroupWait != "" && !durationRe.MatchString(r.GroupWait) {
-		return errors.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
+		return fmt.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
 	}
 
 	if r.RepeatInterval != "" && !durationRe.MatchString(r.RepeatInterval) {
-		return errors.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
+		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
 	}
 
 	children, err := r.ChildRoutes()
@@ -396,7 +395,7 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 
 	for i := range children {
 		if err := validateAlertManagerRoutes(&children[i], receivers, timeIntervals, false); err != nil {
-			return errors.Wrapf(err, "route[%d]", i)
+			return fmt.Errorf("route[%d]: %w", i, err)
 		}
 	}
 
@@ -408,7 +407,7 @@ func validateTimeIntervals(timeIntervals []monitoringv1beta1.TimeInterval) (map[
 
 	for i, ti := range timeIntervals {
 		if err := ti.Validate(); err != nil {
-			return nil, errors.Wrapf(err, "time interval[%d] is invalid", i)
+			return nil, fmt.Errorf("time interval[%d] is invalid: %w", i, err)
 		}
 		timeIntervalNames[ti.Name] = struct{}{}
 	}


### PR DESCRIPTION
## Description

@simonpasquier @slashpai, I was thinking about adding https://github.com/fatih/faillint to our CI to make sure we're not using certain functions/packages. 

This could help us to fix https://github.com/prometheus-operator/prometheus-operator/issues/4682, and to make sure we don't re-introduce unwanted packages in the future

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
