### PR TITLE
fix: get IMPERSONATE_USER from current environment

### DIFF
--- a/scripts/run-external.sh
+++ b/scripts/run-external.sh
@@ -13,7 +13,7 @@ declare SHOW_USAGE=false
 declare SKIP_OPERATOR_RUN_CHECK=false
 declare USE_DEFAULT_CONTEXT=false
 declare API_SERVER=""
-declare IMPERSONATE_USER=""
+declare IMPERSONATE_USER="${IMPERSONATE_USER:-}"
 
 # tmp operator files that needs to be cleaned up
 declare -r CA_FILE="tmp/CA_FILE"


### PR DESCRIPTION
## Description

This change allows to run the operator locally as a different user:

```
export IMPERSONATE_USER=system:serviceaccount:default:system
./run/run-external.sh -c
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

_not classifying it as a bug fix because it's not relevant for end users._

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
