### PR TITLE
fix: add --cluster.label to alertmanager

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -306,6 +306,17 @@ func makeStatefulSetSpec(a *monitoringv1.Alertmanager, config Config, tlsAssetSe
 		amArgs = append(amArgs, fmt.Sprintf("--cluster.peer-timeout=%s", a.Spec.ClusterPeerTimeout))
 	}
 
+	// If multiple Alertmanager clusters are deployed on the same cluster, it can happen
+	// that because pod IP addresses are recycled, an Alertmanager instance from cluster B
+	// connects with cluster A.
+	// --cluster.label flag was introduced in alertmanager v0.26, this helps to block
+	// any traffic that is not meant for the cluster.
+	// The value is hardcoded and the value is guaranteed to be unique in a given cluster but
+	// if there's a use case, we can consider a new field in the CRD.
+	if version.GTE(semver.MustParse("0.26.0")) {
+		amArgs = append(amArgs, fmt.Sprintf("--cluster.label=%s/%s", a.Namespace, a.Name))
+	}
+
 	isHTTPS := a.Spec.Web != nil && a.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("0.22.0"))
 
 	livenessProbeHandler := v1.ProbeHandler{


### PR DESCRIPTION
If multiple Alertmanager clusters are deployed on the same cluster, it can happen
that because pod IP addresses are recycled, an Alertmanager instance from cluster B
connects with cluster A.

 `--cluster.label`  flag was introduced in alertmanager `v0.26`, this helps to block
any traffic that is not meant for the cluster.

The value is hardcoded and the value is guaranteed to be unique in a given cluster but
if there's a use case, we can consider a new field in the CRD.

This commit sets default `--cluster.label` flag as namespace/name
when Alertmanager version used is >= v0.26

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add --cluster.label to alertmanager which prevents alertmanager pod joining cluster not expected
```
