### PR TITLE
Fixing #5338 | Add OCI labels in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,9 @@ COPY operator /bin/operator
 # On busybox 'nobody' has uid `65534'
 USER 65534
 
+LABEL org.opencontainers.image.source="https://github.com/prometheus-operator/prometheus-operator" \
+    org.opencontainers.image.url="https://prometheus-operator.dev/" \
+    org.opencontainers.image.documentation="https://prometheus-operator.dev/" \
+    org.opencontainers.image.licenses="Apache-2.0"
+
 ENTRYPOINT ["/bin/operator"]


### PR DESCRIPTION
## Description

* Fixing #5338
* Add OCI labels in the Dockerfile

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Add OCI labels in the Dockerfile
```
