### PR TITLE
fixes race condition when deleting alertmanager, prometheus and thanosruler instances

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -640,12 +640,12 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to set Alertmanager type information: %w", err)
 	}
 
-	if am.Spec.Paused {
+	// Check if the Alertmanager instance is marked for deletion.
+	if c.rr.DeletionInProgress(am) {
 		return nil
 	}
 
-	// Check if the Alertmanager instance is marked for deletion.
-	if !am.ObjectMeta.DeletionTimestamp.IsZero() {
+	if am.Spec.Paused {
 		return nil
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -644,6 +644,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
+	// Check if the Alertmanager instance is marked for deletion.
+	if !am.ObjectMeta.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	logger := log.With(c.logger, "key", key)
 	logDeprecatedFields(logger, am)
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -517,7 +517,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	// Check if the Agent instance is marked for deletion.
 	if c.rr.DeletionInProgress(p) {
-		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
 		return nil
 	}
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -514,6 +514,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	logger := log.With(c.logger, "key", key)
+
+	// Check if the Agent instance is marked for deletion.
+	if c.rr.DeletionInProgress(p) {
+		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
+		return nil
+	}
+
 	if p.Spec.Paused {
 		level.Info(logger).Log("msg", "the resource is paused, not reconciling")
 		return nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1175,6 +1175,12 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
+	// Check if the Prometheus instance is marked for deletion.
+	if !p.ObjectMeta.DeletionTimestamp.IsZero() {
+		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
+		return nil
+	}
+
 	level.Info(logger).Log("msg", "sync prometheus")
 	ruleConfigMapNames, err := c.createOrUpdateRuleConfigMaps(ctx, p)
 	if err != nil {

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1166,18 +1166,18 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := log.With(c.logger, "key", key)
 	logDeprecatedFields(logger, p)
 
+	// Check if the Prometheus instance is marked for deletion.
+	if c.rr.DeletionInProgress(p) {
+		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
+		return nil
+	}
+
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, p.Spec.Storage); err != nil {
 		return err
 	}
 
 	if p.Spec.Paused {
 		level.Info(logger).Log("msg", "the resource is paused, not reconciling")
-		return nil
-	}
-
-	// Check if the Prometheus instance is marked for deletion.
-	if !p.ObjectMeta.DeletionTimestamp.IsZero() {
-		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
 		return nil
 	}
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1168,7 +1168,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	// Check if the Prometheus instance is marked for deletion.
 	if c.rr.DeletionInProgress(p) {
-		level.Info(logger).Log("msg", "the resource is deleting, not reconciling")
 		return nil
 	}
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -533,6 +533,11 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return errors.Wrap(err, "failed to set ThanosRuler type information")
 	}
 
+	// Check if the Thanos instance is marked for deletion.
+	if o.rr.DeletionInProgress(tr) {
+		return nil
+	}
+
 	if tr.Spec.Paused {
 		return nil
 	}


### PR DESCRIPTION
## Description

A race condition in appears when using [Pulumi](https://www.pulumi.com/) to delete a prometheus instance custom resouce from a Kubernetes cluster.

I've created a demo repo https://github.com/mheers/pulumi-prometheus-operator-race-condition to reproduce the behaviour.

Deleting the CR with pulumi will get the operator stuck in a loop. The operator will try to delete the prometheus instance but will fail with errors exported to https://github.com/mheers/pulumi-prometheus-operator-race-condition/blob/main/logs/operator.log

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Fixes race condition when deleting alertmanager or prometheus instances
```
