### PR TITLE
Add node relabeling to pod and servicemonitors

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -801,6 +801,10 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_name"}},
 			{Key: "target_label", Value: "pod"},
 		},
+		{
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_node_name"}},
+			{Key: "target_label", Value: "node"},
+		},
 	}...)
 
 	// Relabel targetLabels from Pod onto target.
@@ -1284,6 +1288,10 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 		{
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_name"}},
 			{Key: "target_label", Value: "pod"},
+		},
+		{
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_node_name"}},
+			{Key: "target_label", Value: "node"},
 		},
 		{
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_name"}},

--- a/pkg/prometheus/testdata/BodySizeLimits_enforce0MB_v2.28.0.golden
+++ b/pkg/prometheus/testdata/BodySizeLimits_enforce0MB_v2.28.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/BodySizeLimits_enforce1000MB_v2.27.0.golden
+++ b/pkg/prometheus/testdata/BodySizeLimits_enforce1000MB_v2.27.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/BodySizeLimits_enforce1000MB_v2.28.0.golden
+++ b/pkg/prometheus/testdata/BodySizeLimits_enforce1000MB_v2.28.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/EmptyEndpointPorts.golden
+++ b/pkg/prometheus/testdata/EmptyEndpointPorts.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedPodMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedPodMonitor_Expected.golden
@@ -35,6 +35,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_label_example
     target_label: example
     regex: (.+)

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedServiceMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedServiceMonitor_Expected.golden
@@ -50,6 +50,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelPodMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelPodMonitor_Expected.golden
@@ -35,6 +35,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_label_example
     target_label: example
     regex: (.+)

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelServiceMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelServiceMonitor_Expected.golden
@@ -55,6 +55,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/GenerateRelabelConfig.golden
+++ b/pkg/prometheus/testdata/GenerateRelabelConfig.golden
@@ -50,6 +50,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/HonorLabelsOverriding.golden
+++ b/pkg/prometheus/testdata/HonorLabelsOverriding.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/HonorTimestampsOverriding.golden
+++ b/pkg/prometheus/testdata/HonorTimestampsOverriding.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/KeepDroppedTargets.golden
+++ b/pkg/prometheus/testdata/KeepDroppedTargets.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/KeepDroppedTargetsNotAddedInConfig.golden
+++ b/pkg/prometheus/testdata/KeepDroppedTargetsNotAddedInConfig.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/KeepDroppedTargetsOverridedWithEnforcedValue.golden
+++ b/pkg/prometheus/testdata/KeepDroppedTargetsOverridedWithEnforcedValue.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_Limit2000_v2.26.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_Limit2000_v2.26.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_Limit2000_v2.27.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_Limit2000_v2.27.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_Limit500_v2.26.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_Limit500_v2.26.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_Limit500_v2.27.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_Limit500_v2.27.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.26.0.golden
+++ b/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.26.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.26.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.26.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.27.0.golden
+++ b/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.27.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.27.0_enforceLimit1000.golden
+++ b/pkg/prometheus/testdata/LabelLimits_NoLimit_v2.27.0_enforceLimit1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforc1000_v2.26.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforc1000_v2.26.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce-1_v2.26.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce-1_v2.26.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce-1_v2.27.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce-1_v2.27.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce1000_v2.27.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit-1_Enforce1000_v2.27.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit2000_Enforce1000_v2.26.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit2000_Enforce1000_v2.26.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit2000_Enforce1000_v2.27.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit2000_Enforce1000_v2.27.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit500_Enforce1000_v2.26.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit500_Enforce1000_v2.26.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/LabelNameLengthLimits_Limit500_Enforce1000_v2.27.0.golden
+++ b/pkg/prometheus/testdata/LabelNameLengthLimits_Limit500_Enforce1000_v2.27.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/MatchExpressionsServiceMonitor.golden
+++ b/pkg/prometheus/testdata/MatchExpressionsServiceMonitor.golden
@@ -50,6 +50,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/NoEnforcedNamespaceLabelServiceMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/NoEnforcedNamespaceLabelServiceMonitor_Expected.golden
@@ -50,6 +50,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2False_v2.34.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2False_v2.34.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2False_v2.35.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2False_v2.35.0.golden
@@ -35,6 +35,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2True_v2.34.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2True_v2.34.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2True_v2.35.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointEnableHttp2_EnableHTTP2True_v2.35.0.golden
@@ -35,6 +35,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsFalse_v2.25.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsFalse_v2.25.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsFalse_v2.28.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsFalse_v2.28.0.golden
@@ -35,6 +35,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsTrue_v2.25.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsTrue_v2.25.0.golden
@@ -34,6 +34,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsTrue_v2.28.0.golden
+++ b/pkg/prometheus/testdata/PodMonitorEndpointFollowRedirects_FollowRedirectsTrue_v2.28.0.golden
@@ -35,6 +35,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: pod-monitor-ns/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodMonitorPhaseFilter.golden
+++ b/pkg/prometheus/testdata/PodMonitorPhaseFilter.golden
@@ -29,6 +29,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/PodTargetLabels.golden
+++ b/pkg/prometheus/testdata/PodTargetLabels.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/PodTargetLabelsFromPodMonitor.golden
+++ b/pkg/prometheus/testdata/PodTargetLabelsFromPodMonitor.golden
@@ -35,6 +35,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_label_example
     target_label: example
     regex: (.+)

--- a/pkg/prometheus/testdata/PodTargetLabelsFromPodMonitorAndGlobal.golden
+++ b/pkg/prometheus/testdata/PodTargetLabelsFromPodMonitorAndGlobal.golden
@@ -35,6 +35,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_label_local
     target_label: local
     regex: (.+)

--- a/pkg/prometheus/testdata/SampleLimits_Limit-1.golden
+++ b/pkg/prometheus/testdata/SampleLimits_Limit-1.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/SampleLimits_Limit2000.golden
+++ b/pkg/prometheus/testdata/SampleLimits_Limit2000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/SampleLimits_Limit500.golden
+++ b/pkg/prometheus/testdata/SampleLimits_Limit500.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/SampleLimits_NoLimit.golden
+++ b/pkg/prometheus/testdata/SampleLimits_NoLimit.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2False_v2.34.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2False_v2.34.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2False_v2.35.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2False_v2.35.0.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2True_v2.34.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2True_v2.34.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2True_v2.35.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointEnableHttp2_EnableHTTP2True_v2.35.0.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectFalse_v2.25.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectFalse_v2.25.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectFalse_v2.28.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectFalse_v2.28.0.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectTrue_v2.25.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectTrue_v2.25.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectTrue_v2.28.0.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorEndpointFollowRedirects_FollowRedirectTrue_v2.28.0.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/SettingHonorLabels.golden
+++ b/pkg/prometheus/testdata/SettingHonorLabels.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/SettingHonorTimestampsInPodMonitor.golden
+++ b/pkg/prometheus/testdata/SettingHonorTimestampsInPodMonitor.golden
@@ -36,6 +36,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_label_example
     target_label: example
     regex: (.+)

--- a/pkg/prometheus/testdata/SettingHonorTimestampsInServiceMonitor.golden
+++ b/pkg/prometheus/testdata/SettingHonorTimestampsInServiceMonitor.golden
@@ -46,6 +46,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLabels.golden
+++ b/pkg/prometheus/testdata/TargetLabels.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits-1_Versionv2.15.0.golden
+++ b/pkg/prometheus/testdata/TargetLimits-1_Versionv2.15.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits-1_Versionv2.21.0.golden
+++ b/pkg/prometheus/testdata/TargetLimits-1_Versionv2.21.0.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits-1_Versionv2.21.0_Enforce1000.golden
+++ b/pkg/prometheus/testdata/TargetLimits-1_Versionv2.21.0_Enforce1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits1000_Versionv2.21.0_Enforce1000.golden
+++ b/pkg/prometheus/testdata/TargetLimits1000_Versionv2.21.0_Enforce1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits2000_Versionv2.15.0_Enforce1000.golden
+++ b/pkg/prometheus/testdata/TargetLimits2000_Versionv2.15.0_Enforce1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits2000_Versionv2.21.0_Enforce1000.golden
+++ b/pkg/prometheus/testdata/TargetLimits2000_Versionv2.21.0_Enforce1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TargetLimits500_Versionv2.15.0_Enforce1000.golden
+++ b/pkg/prometheus/testdata/TargetLimits500_Versionv2.15.0_Enforce1000.golden
@@ -45,6 +45,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/TestServiceMonitorWithEndpointSliceEnable_Expected.golden
+++ b/pkg/prometheus/testdata/TestServiceMonitorWithEndpointSliceEnable_Expected.golden
@@ -55,6 +55,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop

--- a/pkg/prometheus/testdata/pod_monitor_with_oauth2.golden
+++ b/pkg/prometheus/testdata/pod_monitor_with_oauth2.golden
@@ -43,6 +43,9 @@ scrape_configs:
   - source_labels:
     - __meta_kubernetes_pod_name
     target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
   - target_label: job
     replacement: default/testpodmonitor1
   - target_label: endpoint

--- a/pkg/prometheus/testdata/service_monitor_with_oauth2.golden
+++ b/pkg/prometheus/testdata/service_monitor_with_oauth2.golden
@@ -54,6 +54,9 @@ scrape_configs:
     - __meta_kubernetes_pod_name
     target_label: pod
   - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+  - source_labels:
     - __meta_kubernetes_pod_container_name
     target_label: container
   - action: drop


### PR DESCRIPTION
## Description

This PR enhances the pod and service monitors by automatically relabelling the node label as having the node a pod is deployed could help pinpoint issues happening on one node


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add node label relabelling to pod and service monitors.
```
