### PR TITLE
Allow lowercase in ScrapeConfig

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -17440,7 +17440,7 @@ string
 </td>
 <td>
 <p>Role of the Kubernetes entities that should be discovered.
-Currently the only supported role is &ldquo;Node&rdquo;.</p>
+Currently the only supported role is &ldquo;node&rdquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -32807,6 +32807,8 @@ spec:
                       enum:
                       - HTTP
                       - HTTPS
+                      - http
+                      - https
                       type: string
                     server:
                       description: A valid string consisting of a hostname or IP followed
@@ -33339,9 +33341,10 @@ spec:
                   properties:
                     role:
                       description: Role of the Kubernetes entities that should be
-                        discovered. Currently the only supported role is "Node".
+                        discovered. Currently the only supported role is "node".
                       enum:
                       - Node
+                      - node
                       type: string
                   required:
                   - role
@@ -33535,6 +33538,8 @@ spec:
                 enum:
                 - HTTP
                 - HTTPS
+                - http
+                - https
                 type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -360,6 +360,8 @@ spec:
                       enum:
                       - HTTP
                       - HTTPS
+                      - http
+                      - https
                       type: string
                     server:
                       description: A valid string consisting of a hostname or IP followed
@@ -895,9 +897,10 @@ spec:
                   properties:
                     role:
                       description: Role of the Kubernetes entities that should be
-                        discovered. Currently the only supported role is "Node".
+                        discovered. Currently the only supported role is "node".
                       enum:
                       - Node
+                      - node
                       type: string
                   required:
                   - role
@@ -1091,6 +1094,8 @@ spec:
                 enum:
                 - HTTP
                 - HTTPS
+                - http
+                - https
                 type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -359,6 +359,8 @@ spec:
                       enum:
                       - HTTP
                       - HTTPS
+                      - http
+                      - https
                       type: string
                     server:
                       description: A valid string consisting of a hostname or IP followed
@@ -891,9 +893,10 @@ spec:
                   properties:
                     role:
                       description: Role of the Kubernetes entities that should be
-                        discovered. Currently the only supported role is "Node".
+                        discovered. Currently the only supported role is "node".
                       enum:
                       - Node
+                      - node
                       type: string
                   required:
                   - role
@@ -1087,6 +1090,8 @@ spec:
                 enum:
                 - HTTP
                 - HTTPS
+                - http
+                - https
                 type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -394,7 +394,9 @@
                           "description": "HTTP Scheme default \"http\"",
                           "enum": [
                             "HTTP",
-                            "HTTPS"
+                            "HTTPS",
+                            "http",
+                            "https"
                           ],
                           "type": "string"
                         },
@@ -982,9 +984,10 @@
                       "description": "KubernetesSDConfig allows retrieving scrape targets from Kubernetes' REST API. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config",
                       "properties": {
                         "role": {
-                          "description": "Role of the Kubernetes entities that should be discovered. Currently the only supported role is \"Node\".",
+                          "description": "Role of the Kubernetes entities that should be discovered. Currently the only supported role is \"node\".",
                           "enum": [
-                            "Node"
+                            "Node",
+                            "node"
                           ],
                           "type": "string"
                         }
@@ -1173,7 +1176,9 @@
                     "description": "Configures the protocol scheme used for requests. If empty, Prometheus uses HTTP by default.",
                     "enum": [
                       "HTTP",
-                      "HTTPS"
+                      "HTTPS",
+                      "http",
+                      "https"
                     ],
                     "type": "string"
                   },

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -120,7 +120,7 @@ type ScrapeConfigSpec struct {
 	Params map[string][]string `json:"params,omitempty"`
 	// Configures the protocol scheme used for requests.
 	// If empty, Prometheus uses HTTP by default.
-	// +kubebuilder:validation:Enum=HTTP;HTTPS
+	// +kubebuilder:validation:Enum=HTTP;HTTPS;http;https
 	// +optional
 	Scheme *string `json:"scheme,omitempty"`
 	// BasicAuth information to use on every scrape request.
@@ -219,8 +219,8 @@ type HTTPSDConfig struct {
 // +k8s:openapi-gen=true
 type KubernetesSDConfig struct {
 	// Role of the Kubernetes entities that should be discovered.
-	// Currently the only supported role is "Node".
-	// +kubebuilder:validation:Enum=Node
+	// Currently the only supported role is "node".
+	// +kubebuilder:validation:Enum=Node;node
 	// +required
 	Role string `json:"role"`
 }
@@ -246,7 +246,7 @@ type ConsulSDConfig struct {
 	// +optional
 	Partition *string `json:"partition,omitempty"`
 	// HTTP Scheme default "http"
-	// +kubebuilder:validation:Enum=HTTP;HTTPS
+	// +kubebuilder:validation:Enum=HTTP;HTTPS;http;https
 	// +optional
 	Scheme *string `json:"scheme,omitempty"`
 	// A list of services for which targets are retrieved. If omitted, all services are scraped.

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -90,7 +90,7 @@ func testScrapeConfigCreation(t *testing.T) {
 			spec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
-						Role: "Node",
+						Role: "node",
 					},
 				},
 			},
@@ -331,7 +331,7 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 
 	sc.Spec.KubernetesSDConfigs = []monitoringv1alpha1.KubernetesSDConfig{
 		{
-			Role: "Node",
+			Role: "node",
 		},
 	}
 	_, err = framework.CreateScrapeConfig(context.Background(), ns, sc)


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Due to how CRDs are defined, Kube API Server will reject ScrapeConfig CRs with lowercase keys. This in turn is confusing to end user as prometheus documentation mentions those keys as lowercase everywhere.

This PR is changing CRD validations to allow for lowercase values in ScrapeConfig fields of `spec.ConsulSDConfig.scheme`, `spec.kubernetesSDConfigs[].role`, and `spec.scheme`. It also preserves previous values to maintain backwards compatibility.

Without this change we can get the following response:

```
$ k apply -f manifests/kubernetesControlPlane/scrapeConfigKubeletSLIS.yaml
The ScrapeConfig "kubelet-slis" is invalid: 
* spec.kubernetesSDConfigs[0].role: Unsupported value: "node": supported values: "Node"
* spec.scheme: Unsupported value: "https": supported values: "HTTP", "HTTPS"
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Allow lowercase values for `.ConsulSDConfig.scheme`, `.kubernetesSDConfigs[].role`, and `.scheme` ScrapeConfig CRs spec.
```
