### PR TITLE
Allow extra relabelings to all service and pod monitors when scraped by Prometheus

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2389,6 +2389,21 @@ PodMonitor and ServiceMonitor objects.</p>
 </tr>
 <tr>
 <td>
+<code>extraRelabelings</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.RelabelConfig">
+[]RelabelConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExtraRelabelings allow setting extra default relabelings to all
+PodMonitor and ServiceMonitor objects targeted by Prometheus.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tracingConfig</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusTracingConfig">
@@ -6596,6 +6611,21 @@ PodMonitor and ServiceMonitor objects.</p>
 </tr>
 <tr>
 <td>
+<code>extraRelabelings</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.RelabelConfig">
+[]RelabelConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExtraRelabelings allow setting extra default relabelings to all
+PodMonitor and ServiceMonitor objects targeted by Prometheus.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tracingConfig</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusTracingConfig">
@@ -10356,6 +10386,21 @@ PodMonitor and ServiceMonitor objects.</p>
 </tr>
 <tr>
 <td>
+<code>extraRelabelings</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.RelabelConfig">
+[]RelabelConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExtraRelabelings allow setting extra default relabelings to all
+PodMonitor and ServiceMonitor objects targeted by Prometheus.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tracingConfig</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusTracingConfig">
@@ -11285,7 +11330,7 @@ This is experimental feature and might change in the future.</p>
 <h3 id="monitoring.coreos.com/v1.RelabelConfig">RelabelConfig
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.Endpoint">Endpoint</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.ProbeTargetIngress">ProbeTargetIngress</a>, <a href="#monitoring.coreos.com/v1.ProbeTargetStaticConfig">ProbeTargetStaticConfig</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.CommonPrometheusFields">CommonPrometheusFields</a>, <a href="#monitoring.coreos.com/v1.Endpoint">Endpoint</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.ProbeTargetIngress">ProbeTargetIngress</a>, <a href="#monitoring.coreos.com/v1.ProbeTargetStaticConfig">ProbeTargetStaticConfig</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>)
 </p>
 <div>
 <p>RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
@@ -15664,6 +15709,21 @@ PodMonitor and ServiceMonitor objects.</p>
 </tr>
 <tr>
 <td>
+<code>extraRelabelings</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.RelabelConfig">
+[]RelabelConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExtraRelabelings allow setting extra default relabelings to all
+PodMonitor and ServiceMonitor objects targeted by Prometheus.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tracingConfig</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusTracingConfig">
@@ -19329,6 +19389,21 @@ it (<a href="https://kubernetes.io/docs/concepts/configuration/overview/">https:
 <em>(Optional)</em>
 <p>PodTargetLabels are appended to the <code>spec.podTargetLabels</code> field of all
 PodMonitor and ServiceMonitor objects.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>extraRelabelings</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.RelabelConfig">
+[]RelabelConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExtraRelabelings allow setting extra default relabelings to all
+PodMonitor and ServiceMonitor objects targeted by Prometheus.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16764,6 +16764,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.
@@ -25564,6 +25637,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -2647,6 +2647,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3015,6 +3015,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -2647,6 +2647,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3015,6 +3015,79 @@ spec:
                   externally available. This is necessary to generate correct URLs
                   (for instance if Prometheus is accessible behind an Ingress resource).
                 type: string
+              extraRelabelings:
+                description: ExtraRelabelings allow setting extra default relabelings
+                  to all PodMonitor and ServiceMonitor objects targeted by Prometheus.
+                items:
+                  description: "RelabelConfig allows dynamic rewriting of the label
+                    set for targets, alerts, scraped samples and remote write samples.
+                    \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                  properties:
+                    action:
+                      default: replace
+                      description: "Action to perform based on the regex matching.
+                        \n `Uppercase` and `Lowercase` actions require Prometheus
+                        >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus
+                        >= v2.41.0. \n Default: \"Replace\""
+                      enum:
+                      - replace
+                      - Replace
+                      - keep
+                      - Keep
+                      - drop
+                      - Drop
+                      - hashmod
+                      - HashMod
+                      - labelmap
+                      - LabelMap
+                      - labeldrop
+                      - LabelDrop
+                      - labelkeep
+                      - LabelKeep
+                      - lowercase
+                      - Lowercase
+                      - uppercase
+                      - Uppercase
+                      - keepequal
+                      - KeepEqual
+                      - dropequal
+                      - DropEqual
+                      type: string
+                    modulus:
+                      description: "Modulus to take of the hash of the source label
+                        values. \n Only applicable when the action is `HashMod`."
+                      format: int64
+                      type: integer
+                    regex:
+                      description: Regular expression against which the extracted
+                        value is matched.
+                      type: string
+                    replacement:
+                      description: "Replacement value against which a Replace action
+                        is performed if the regular expression matches. \n Regex capture
+                        groups are available."
+                      type: string
+                    separator:
+                      description: Separator is the string between concatenated SourceLabels.
+                      type: string
+                    sourceLabels:
+                      description: The source labels select values from existing labels.
+                        Their content is concatenated using the configured Separator
+                        and matched against the configured regular expression.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, as well as underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                        type: string
+                      type: array
+                    targetLabel:
+                      description: "Label to which the resulting string is written
+                        in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                        `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+                        \n Regex capture groups are available."
+                      type: string
+                  type: object
+                type: array
               hostAliases:
                 description: Optional list of hosts and IPs that will be injected
                   into the Pod's hosts file if specified.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -2344,6 +2344,75 @@
                     "description": "The external URL under which the Prometheus service is externally available. This is necessary to generate correct URLs (for instance if Prometheus is accessible behind an Ingress resource).",
                     "type": "string"
                   },
+                  "extraRelabelings": {
+                    "description": "ExtraRelabelings allow setting extra default relabelings to all PodMonitor and ServiceMonitor objects targeted by Prometheus.",
+                    "items": {
+                      "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                      "properties": {
+                        "action": {
+                          "default": "replace",
+                          "description": "Action to perform based on the regex matching. \n `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0. \n Default: \"Replace\"",
+                          "enum": [
+                            "replace",
+                            "Replace",
+                            "keep",
+                            "Keep",
+                            "drop",
+                            "Drop",
+                            "hashmod",
+                            "HashMod",
+                            "labelmap",
+                            "LabelMap",
+                            "labeldrop",
+                            "LabelDrop",
+                            "labelkeep",
+                            "LabelKeep",
+                            "lowercase",
+                            "Lowercase",
+                            "uppercase",
+                            "Uppercase",
+                            "keepequal",
+                            "KeepEqual",
+                            "dropequal",
+                            "DropEqual"
+                          ],
+                          "type": "string"
+                        },
+                        "modulus": {
+                          "description": "Modulus to take of the hash of the source label values. \n Only applicable when the action is `HashMod`.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "regex": {
+                          "description": "Regular expression against which the extracted value is matched.",
+                          "type": "string"
+                        },
+                        "replacement": {
+                          "description": "Replacement value against which a Replace action is performed if the regular expression matches. \n Regex capture groups are available.",
+                          "type": "string"
+                        },
+                        "separator": {
+                          "description": "Separator is the string between concatenated SourceLabels.",
+                          "type": "string"
+                        },
+                        "sourceLabels": {
+                          "description": "The source labels select values from existing labels. Their content is concatenated using the configured Separator and matched against the configured regular expression.",
+                          "items": {
+                            "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "targetLabel": {
+                          "description": "Label to which the resulting string is written in a replacement. \n It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions. \n Regex capture groups are available.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "hostAliases": {
                     "description": "Optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.",
                     "items": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2720,6 +2720,75 @@
                     "description": "The external URL under which the Prometheus service is externally available. This is necessary to generate correct URLs (for instance if Prometheus is accessible behind an Ingress resource).",
                     "type": "string"
                   },
+                  "extraRelabelings": {
+                    "description": "ExtraRelabelings allow setting extra default relabelings to all PodMonitor and ServiceMonitor objects targeted by Prometheus.",
+                    "items": {
+                      "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                      "properties": {
+                        "action": {
+                          "default": "replace",
+                          "description": "Action to perform based on the regex matching. \n `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0. \n Default: \"Replace\"",
+                          "enum": [
+                            "replace",
+                            "Replace",
+                            "keep",
+                            "Keep",
+                            "drop",
+                            "Drop",
+                            "hashmod",
+                            "HashMod",
+                            "labelmap",
+                            "LabelMap",
+                            "labeldrop",
+                            "LabelDrop",
+                            "labelkeep",
+                            "LabelKeep",
+                            "lowercase",
+                            "Lowercase",
+                            "uppercase",
+                            "Uppercase",
+                            "keepequal",
+                            "KeepEqual",
+                            "dropequal",
+                            "DropEqual"
+                          ],
+                          "type": "string"
+                        },
+                        "modulus": {
+                          "description": "Modulus to take of the hash of the source label values. \n Only applicable when the action is `HashMod`.",
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "regex": {
+                          "description": "Regular expression against which the extracted value is matched.",
+                          "type": "string"
+                        },
+                        "replacement": {
+                          "description": "Replacement value against which a Replace action is performed if the regular expression matches. \n Regex capture groups are available.",
+                          "type": "string"
+                        },
+                        "separator": {
+                          "description": "Separator is the string between concatenated SourceLabels.",
+                          "type": "string"
+                        },
+                        "sourceLabels": {
+                          "description": "The source labels select values from existing labels. Their content is concatenated using the configured Separator and matched against the configured regular expression.",
+                          "items": {
+                            "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "targetLabel": {
+                          "description": "Label to which the resulting string is written in a replacement. \n It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions. \n Regex capture groups are available.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
                   "hostAliases": {
                     "description": "Optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.",
                     "items": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -554,6 +554,12 @@ type CommonPrometheusFields struct {
 	// +optional
 	PodTargetLabels []string `json:"podTargetLabels,omitempty"`
 
+	// ExtraRelabelings allow setting extra default relabelings to all
+	// PodMonitor and ServiceMonitor objects targeted by Prometheus.
+	//
+	// +optional
+	ExtraRelabelings []*RelabelConfig `json:"extraRelabelings,omitempty"`
+
 	// EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
 	// experimental feature, it may change in any upcoming release in a
 	// breaking way.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -813,6 +813,17 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraRelabelings != nil {
+		in, out := &in.ExtraRelabelings, &out.ExtraRelabelings
+		*out = make([]*RelabelConfig, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(RelabelConfig)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.TracingConfig != nil {
 		in, out := &in.TracingConfig, &out.TracingConfig
 		*out = new(PrometheusTracingConfig)

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -92,6 +92,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	ExcludedFromEnforcement         []ObjectReferenceApplyConfiguration                  `json:"excludedFromEnforcement,omitempty"`
 	HostNetwork                     *bool                                                `json:"hostNetwork,omitempty"`
 	PodTargetLabels                 []string                                             `json:"podTargetLabels,omitempty"`
+	ExtraRelabelings                []*monitoringv1.RelabelConfig                        `json:"extraRelabelings,omitempty"`
 	TracingConfig                   *PrometheusTracingConfigApplyConfiguration           `json:"tracingConfig,omitempty"`
 	BodySizeLimit                   *monitoringv1.ByteSize                               `json:"bodySizeLimit,omitempty"`
 	SampleLimit                     *uint64                                              `json:"sampleLimit,omitempty"`
@@ -694,6 +695,19 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithHostNetwork(value bool) *
 func (b *CommonPrometheusFieldsApplyConfiguration) WithPodTargetLabels(values ...string) *CommonPrometheusFieldsApplyConfiguration {
 	for i := range values {
 		b.PodTargetLabels = append(b.PodTargetLabels, values[i])
+	}
+	return b
+}
+
+// WithExtraRelabelings adds the given value to the ExtraRelabelings field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the ExtraRelabelings field.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithExtraRelabelings(values ...**monitoringv1.RelabelConfig) *CommonPrometheusFieldsApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithExtraRelabelings")
+		}
+		b.ExtraRelabelings = append(b.ExtraRelabelings, *values[i])
 	}
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -646,6 +646,19 @@ func (b *PrometheusSpecApplyConfiguration) WithPodTargetLabels(values ...string)
 	return b
 }
 
+// WithExtraRelabelings adds the given value to the ExtraRelabelings field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the ExtraRelabelings field.
+func (b *PrometheusSpecApplyConfiguration) WithExtraRelabelings(values ...**monitoringv1.RelabelConfig) *PrometheusSpecApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithExtraRelabelings")
+		}
+		b.ExtraRelabelings = append(b.ExtraRelabelings, *values[i])
+	}
+	return b
+}
+
 // WithTracingConfig sets the TracingConfig field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TracingConfig field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -625,6 +625,19 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithPodTargetLabels(values ...st
 	return b
 }
 
+// WithExtraRelabelings adds the given value to the ExtraRelabelings field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the ExtraRelabelings field.
+func (b *PrometheusAgentSpecApplyConfiguration) WithExtraRelabelings(values ...**monitoringv1.RelabelConfig) *PrometheusAgentSpecApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithExtraRelabelings")
+		}
+		b.ExtraRelabelings = append(b.ExtraRelabelings, *values[i])
+	}
+	return b
+}
+
 // WithTracingConfig sets the TracingConfig field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TracingConfig field is set to the value of the last call.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -814,6 +814,11 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 		})
 	}
 
+	// Add user extra relabelings if specified.
+	if cpf.ExtraRelabelings != nil {
+		relabelings = append(relabelings, generateRelabelConfig(cpf.ExtraRelabelings)...)
+	}
+
 	// By default, generate a safe job name from the PodMonitor. We also keep
 	// this around if a jobLabel is set in case the targets don't actually have a
 	// value for it. A single pod may potentially have multiple metrics
@@ -1313,6 +1318,11 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 			{Key: "regex", Value: "(.+)"},
 			{Key: "replacement", Value: "${1}"},
 		})
+	}
+
+	// Add user extra relabelings if specified.
+	if cpf.ExtraRelabelings != nil {
+		relabelings = append(relabelings, generateRelabelConfig(cpf.ExtraRelabelings)...)
 	}
 
 	// By default, generate a safe job name from the service name.  We also keep

--- a/pkg/prometheus/testdata/PodMonitorExtraRelabelings.golden
+++ b/pkg/prometheus/testdata/PodMonitorExtraRelabelings.golden
@@ -1,0 +1,54 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: podMonitor/default/testpodmonitor1/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+    action: replace
+  - target_label: job
+    replacement: default/testpodmonitor1
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __address__
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
+  metric_relabel_configs: []

--- a/pkg/prometheus/testdata/ServiceMonitorExtraRelabelings.golden
+++ b/pkg/prometheus/testdata/ServiceMonitorExtraRelabelings.golden
@@ -1,0 +1,73 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: serviceMonitor/default/testservicemonitor1/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_pod_node_name
+    target_label: node
+    action: replace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __address__
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep
+  metric_relabel_configs: []


### PR DESCRIPTION
## Description

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/3255

This PR allows users of the operator to ensure a set of custom relabelings to all their pod/service monitors.

This would supersed this PR https://github.com/prometheus-operator/prometheus-operator/pull/5972

Notable examples would be adding the node label using __meta_kubernetes_pod_node_name but it could be used for other organization purposes such as:

```
- sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
  action: "replace"
  targetLabel: app
```

This feature could in the future be added to Scrape Classes as well

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Allow addition of extra relabelings to all service and pod monitors
```
