### PR TITLE
test(e2e-alertmanager): add alertmanager e2e test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -232,6 +232,7 @@ func TestAllNS(t *testing.T) {
 func testAllNSAlertmanager(t *testing.T) {
 	skipAlertmanagerTests(t)
 	testFuncs := map[string]func(t *testing.T){
+		"AlertmanagerConfigMatcherStrategy":       testAlertmanagerConfigMatcherStrategy,
 		"AlertmanagerCRD":                         testAlertmanagerCRDValidation,
 		"AMCreateDeleteCluster":                   testAMCreateDeleteCluster,
 		"AMWithStatefulsetCreationFailure":        testAlertmanagerWithStatefulsetCreationFailure,


### PR DESCRIPTION
Added a e2e test for alertmanager field "AlertmanagerConfigMatcherStrategy"

Fixes #5705
Signed-off-by: Patrick Niederlöhner <16616161+Pati93@users.noreply.github.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Added a e2e test for alertmanager field "AlertmanagerConfigMatcherStrategy"


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add a e2e test for alertmanager field "AlertmanagerConfigMatcherStrategy"
```
