### PR TITLE
Enable depguard in more packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,10 @@ linters-settings:
         - "**/operator/*.go"
         - "**/prometheus/*.go"
         - "**/prometheus/**/*.go"
+        - "**/server/*.go"
+        - "**/thanos/*.go"
+        - "**/versionutil/*.go"
+        - "**/webconfig/*.go"
         deny:
         - pkg: "github.com/pkg/errors"
           dsc: Should be replaced with standard lib errors or fmt.Errorf

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -15,13 +15,13 @@
 package thanos
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -159,7 +159,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 
 	thanosVersion := operator.StringValOrDefault(tr.Spec.Version, operator.DefaultThanosVersion)
 	if _, err := semver.ParseTolerant(thanosVersion); err != nil {
-		return nil, errors.Wrap(err, "failed to parse Thanos version")
+		return nil, fmt.Errorf("failed to parse Thanos version: %w", err)
 
 	}
 
@@ -171,7 +171,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		"",
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build image path")
+		return nil, fmt.Errorf("failed to build image path: %w", err)
 	}
 
 	trCLIArgs := []monitoringv1.Argument{
@@ -422,7 +422,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 
 	containers, err := k8sutil.MergePatchContainers(operatorContainers, tr.Spec.Containers)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge containers spec")
+		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
 	}
 
 	terminationGracePeriod := int64(120)


### PR DESCRIPTION
## Description

Related to https://github.com/prometheus-operator/prometheus-operator/issues/4682



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
