### PR TITLE
Enable depguard in e2e tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ linters-settings:
         - "**/thanos/*.go"
         - "**/versionutil/*.go"
         - "**/webconfig/*.go"
+        - "**/e2e/*.go"
         deny:
         - pkg: "github.com/pkg/errors"
           dsc: Should be replaced with standard lib errors or fmt.Errorf

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -16,10 +16,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -133,7 +133,7 @@ func testDenyServiceMonitor(t *testing.T) {
 
 		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), denied, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -155,7 +155,7 @@ func testDenyServiceMonitor(t *testing.T) {
 
 		svc := framework.MakePrometheusService("allowed", "allowed", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowed, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -16,9 +16,9 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +138,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), deniedNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -183,7 +183,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -286,7 +286,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -310,7 +310,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -436,7 +436,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 
 		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -455,7 +455,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 
 		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
-			t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/proto"
@@ -301,7 +300,7 @@ func createK8sAppMonitoring(name, ns string, prwtc testFramework.PromRemoteWrite
 	}
 
 	if _, err = framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), sm, metav1.CreateOptions{}); err != nil {
-		return nil, prometheusRecieverSvc, errors.Wrap(err, "creating ServiceMonitor failed")
+		return nil, prometheusRecieverSvc, fmt.Errorf("creating ServiceMonitor failed: %w", err)
 	}
 
 	// Create prometheus receiver for remote writes
@@ -1035,10 +1034,10 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 		for _, vct := range sts.Items[0].Spec.VolumeClaimTemplates {
 			if vct.Name == "prometheus-"+name+"-db" {
 				if val := vct.Labels["test-label"]; val != "foo" {
-					return false, errors.Errorf("incorrect volume claim label on sts, want: %v, got: %v", "foo", val)
+					return false, fmt.Errorf("incorrect volume claim label on sts, want: %v, got: %v", "foo", val)
 				}
 				if val := vct.Annotations["test-annotation"]; val != "bar" {
-					return false, errors.Errorf("incorrect volume claim annotation on sts, want: %v, got: %v", "bar", val)
+					return false, fmt.Errorf("incorrect volume claim annotation on sts, want: %v, got: %v", "bar", val)
 				}
 				return true, nil
 			}
@@ -1240,7 +1239,7 @@ scrape_configs:
 
 	cfg, err := framework.KubeClient.CoreV1().Secrets(ns).Get(context.Background(), cfg.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "could not retrieve previous secret"))
+		t.Fatal(fmt.Errorf("could not retrieve previous secret: %w", err))
 	}
 
 	cfg.Data["prometheus.yaml.gz"] = secondConfigCompressed
@@ -1299,7 +1298,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1357,7 +1356,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1386,7 +1385,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "validating Prometheus Alertmanager configuration failed"))
+		t.Fatal(fmt.Errorf("validating Prometheus Alertmanager configuration failed: %w", err))
 	}
 }
 
@@ -1415,7 +1414,7 @@ func testPromReloadRules(t *testing.T) {
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1473,7 +1472,7 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1529,7 +1528,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), rootNS, pSVC); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1600,7 +1599,7 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 
 	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1879,7 +1878,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 
 	pSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -1896,7 +1895,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 
 	err = framework.WaitForDiscoveryWorking(context.Background(), ns, pSVC.Name, prometheus.Name)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+		t.Fatal(fmt.Errorf("validating Prometheus target discovery failed: %w", err))
 	}
 
 	if err := framework.DeletePrometheusAndWaitUntilGone(context.Background(), ns, name); err != nil {
@@ -2170,7 +2169,7 @@ func testPromDiscovery(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2182,7 +2181,7 @@ func testPromDiscovery(t *testing.T) {
 
 	err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+		t.Fatal(fmt.Errorf("validating Prometheus target discovery failed: %w", err))
 	}
 }
 
@@ -2263,7 +2262,7 @@ func testShardingProvisioning(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2334,7 +2333,7 @@ func testResharding(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2419,7 +2418,7 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2439,12 +2438,12 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 	}
 
 	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, amsvc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating Alertmanager service failed"))
+		t.Fatal(fmt.Errorf("creating Alertmanager service failed: %w", err))
 	}
 
 	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 18*time.Minute, false, isAlertmanagerDiscoveryWorking(ns, svc.Name, alertmanagerName))
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "validating Prometheus Alertmanager discovery failed"))
+		t.Fatal(fmt.Errorf("validating Prometheus Alertmanager discovery failed: %w", err))
 	}
 }
 
@@ -2517,7 +2516,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2529,7 +2528,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 
 	err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+		t.Fatal(fmt.Errorf("validating Prometheus target discovery failed: %w", err))
 	}
 }
 
@@ -2573,7 +2572,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), prometheusNSName, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -2888,7 +2887,7 @@ func testOperatorNSScope(t *testing.T) {
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), mainNS, pSVC); err != nil {
-			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -2959,7 +2958,7 @@ func testOperatorNSScope(t *testing.T) {
 
 		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), prometheusNS, pSVC); err != nil {
-			t.Fatal(errors.Wrap(err, "creating Prometheus service failed"))
+			t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 		} else {
 			testCtx.AddFinalizerFn(finalizerFn)
 		}
@@ -3478,7 +3477,7 @@ func testPromStaticProbe(t *testing.T) {
 	}
 
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-		t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+		t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 	} else {
 		testCtx.AddFinalizerFn(finalizerFn)
 	}
@@ -4158,7 +4157,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 			}
 
 			if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-				t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+				t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 			} else {
 				ctx.AddFinalizerFn(finalizerFn)
 			}
@@ -4170,7 +4169,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 
 			err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 			if err != nil {
-				t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+				t.Fatal(fmt.Errorf("validating Prometheus target discovery failed: %w", err))
 			}
 
 			// Check that the namespace label is enforced to the correct value.
@@ -4183,7 +4182,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 				loopErr = nil
 				res, err := framework.PrometheusQuery(ns, svc.Name, "http", "prometheus_build_info")
 				if err != nil {
-					loopErr = errors.Wrap(err, "failed to query Prometheus")
+					loopErr = fmt.Errorf("failed to query Prometheus: %w", err)
 					return false, nil
 				}
 
@@ -4310,7 +4309,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 			}
 
 			if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
-				t.Fatal(errors.Wrap(err, "creating prometheus service failed"))
+				t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 			} else {
 				ctx.AddFinalizerFn(finalizerFn)
 			}
@@ -4322,7 +4321,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 
 			err = framework.WaitForDiscoveryWorking(context.Background(), ns, svc.Name, prometheusName)
 			if err != nil {
-				t.Fatal(errors.Wrap(err, "validating Prometheus target discovery failed"))
+				t.Fatal(fmt.Errorf("validating Prometheus target discovery failed: %w", err))
 			}
 
 			// Check that the namespace label isn't enforced.
@@ -4335,7 +4334,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 				loopErr = nil
 				res, err := framework.PrometheusQuery(ns, svc.Name, "http", "prometheus_build_info")
 				if err != nil {
-					loopErr = errors.Wrap(err, "failed to query Prometheus")
+					loopErr = fmt.Errorf("failed to query Prometheus: %w", err)
 					return false, nil
 				}
 
@@ -4819,7 +4818,7 @@ func testPromUnavailableConditionStatus(t *testing.T) {
 			}
 
 			if cond.Status != monitoringv1.ConditionFalse {
-				pollErr = errors.Errorf(
+				pollErr = fmt.Errorf(
 					"expected Available condition to be 'False', got %q (reason %s, %q)",
 					cond.Status,
 					cond.Reason,
@@ -4829,7 +4828,7 @@ func testPromUnavailableConditionStatus(t *testing.T) {
 			}
 
 			if cond.Reason != "NoPodReady" {
-				pollErr = errors.Errorf(
+				pollErr = fmt.Errorf(
 					"expected Available condition's reason to be 'NoPodReady',  got %s (message %q)",
 					cond.Reason,
 					cond.Message,
@@ -4840,7 +4839,7 @@ func testPromUnavailableConditionStatus(t *testing.T) {
 			return true, nil
 		}
 
-		pollErr = errors.Errorf("failed to find Available condition in status subresource")
+		pollErr = fmt.Errorf("failed to find Available condition in status subresource")
 		return false, nil
 	})
 
@@ -4895,7 +4894,7 @@ func testPromDegradedConditionStatus(t *testing.T) {
 			}
 
 			if cond.Status != monitoringv1.ConditionDegraded {
-				pollErr = errors.Errorf(
+				pollErr = fmt.Errorf(
 					"expected Available condition to be 'Degraded', got %q (reason %s, %q)",
 					cond.Status,
 					cond.Reason,
@@ -4905,7 +4904,7 @@ func testPromDegradedConditionStatus(t *testing.T) {
 			}
 
 			if cond.Reason != "SomePodsNotReady" {
-				pollErr = errors.Errorf(
+				pollErr = fmt.Errorf(
 					"expected Available condition's reason to be 'SomePodsNotReady',  got %s (message %q)",
 					cond.Reason,
 					cond.Message,
@@ -4914,7 +4913,7 @@ func testPromDegradedConditionStatus(t *testing.T) {
 			}
 
 			if !strings.Contains(cond.Message, "bad-image") {
-				pollErr = errors.Errorf(
+				pollErr = fmt.Errorf(
 					"expected Available condition's message to contain 'bad-image', got %q",
 					cond.Message,
 				)
@@ -4924,7 +4923,7 @@ func testPromDegradedConditionStatus(t *testing.T) {
 			return true, nil
 		}
 
-		pollErr = errors.Errorf("failed to find Available condition in status subresource")
+		pollErr = fmt.Errorf("failed to find Available condition in status subresource")
 		return false, nil
 	})
 


### PR DESCRIPTION
## Description

Related to https://github.com/prometheus-operator/prometheus-operator/issues/4682

(only one PR left!!!)



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
