### PR TITLE
feat: optimize memory usage of secret/configmap informers

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -42063,6 +42063,9 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.69.1
+        env:
+        - name: GOGC
+          value: "30"
         image: quay.io/prometheus-operator/prometheus-operator:v0.69.1
         name: prometheus-operator
         ports:

--- a/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
@@ -27,6 +27,9 @@ spec:
       - args:
         - --kubelet-service=kube-system/kubelet
         - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.69.1
+        env:
+        - name: GOGC
+          value: "30"
         image: quay.io/prometheus-operator/prometheus-operator:v0.69.1
         name: prometheus-operator
         ports:

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -10,6 +10,7 @@ local defaults = {
     requests: { cpu: '', memory: '' },
   },
   enableReloaderProbes: false,
+  goGC: '30',
   port: 8080,
   resources: {
     limits: { cpu: '200m', memory: '200Mi' },
@@ -168,6 +169,7 @@ function(params) {
         name: 'http',
       }],
       resources: po.config.resources,
+      env: [{ name: 'GOGC', value: po.config.goGC }],
       securityContext: {
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -221,7 +221,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 		return fmt.Errorf("can not parse secrets selector value: %w", err)
 	}
 
-	c.secrInfs, err = informers.NewInformersForResource(
+	c.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
 			c.config.Namespaces.AlertmanagerConfigAllowList,
 			c.config.Namespaces.DenyList,
@@ -232,6 +232,7 @@ func (c *Operator) bootstrap(ctx context.Context) error {
 			},
 		),
 		v1.SchemeGroupVersion.WithResource("secrets"),
+		informers.PartialObjectMetadataStrip,
 	)
 	if err != nil {
 		return fmt.Errorf("error creating secret informers: %w", err)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -220,7 +220,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		}
 	}
 
-	c.cmapInfs, err = informers.NewInformersForResource(
+	c.cmapInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
 			c.config.Namespaces.PrometheusAllowList,
 			c.config.Namespaces.DenyList,
@@ -231,12 +231,13 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		informers.PartialObjectMetadataStrip,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating configmap informers: %w", err)
 	}
 
-	c.secrInfs, err = informers.NewInformersForResource(
+	c.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
 			c.config.Namespaces.PrometheusAllowList,
 			c.config.Namespaces.DenyList,
@@ -247,6 +248,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		informers.PartialObjectMetadataStrip,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating secrets informers: %w", err)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -58,6 +58,7 @@ type Operator struct {
 	kclient  kubernetes.Interface
 	mdClient metadata.Interface
 	mclient  monitoringclient.Interface
+
 	logger   log.Logger
 	accessor *operator.Accessor
 
@@ -272,7 +273,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		return nil, fmt.Errorf("error creating prometheusrule informers: %w", err)
 	}
 
-	c.cmapInfs, err = informers.NewInformersForResource(
+	c.cmapInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
 			c.config.Namespaces.PrometheusAllowList,
 			c.config.Namespaces.DenyList,
@@ -283,12 +284,13 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		informers.PartialObjectMetadataStrip,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating configmap informers: %w", err)
 	}
 
-	c.secrInfs, err = informers.NewInformersForResource(
+	c.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
 			c.config.Namespaces.PrometheusAllowList,
 			c.config.Namespaces.DenyList,
@@ -299,6 +301,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		informers.PartialObjectMetadataStrip,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating secrets informers: %w", err)


### PR DESCRIPTION
## Description

The secrets and configmaps informers only need to store the name, namespace and resource version of the objects: the event handlers don't look at the other metadata fields. By stripping the rest of the metadata, we can save a fair share of memory on clusters with lots of secrets/configmaps.

Example with a kind cluster running 16,384 secrets (in 128 namespaces), each secret has 4 annotations of 1,024 chars each.

## Before the change

![image](https://github.com/prometheus-operator/prometheus-operator/assets/2587585/508327a9-ee93-41b3-91c7-a160394b7f4b)

## After this change

![image](https://github.com/prometheus-operator/prometheus-operator/assets/2587585/163cef5a-984a-48d4-be72-2424ff297da7)

In all cases, we see a big spike at the start of the operator which is expected because it fetches all data for the informers from the Kubernetes API. Depending on when the GC kicks in, the max allocated memory can remain high for longer:

![image](https://github.com/prometheus-operator/prometheus-operator/assets/2587585/4bcaa73d-cd89-4205-8d54-e41234ad20af)

The maximum memory usage with/without the change is similar but once the situation settles, we see a ~80% decrease in memory usage with this PR (from 300MB -> 50MB).

To take full advantage of this optimization, we can also tune the GOGC variable to reclaim the memory faster after startup.

With `GOGC=50`:

![image](https://github.com/prometheus-operator/prometheus-operator/assets/2587585/044ccd85-4759-487a-a9e2-615b584300b4)

With `GOGC=30`:

![image](https://github.com/prometheus-operator/prometheus-operator/assets/2587585/9d2277bd-4862-4077-b4c0-fb1caa157db6)

I didn't observe significant changes to the CPU usage.

The optimization has been inspired by https://github.com/cert-manager/cert-manager/pull/5966

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Reduce memory usage for clusters with large number of secrets and/or configmaps.
```
