### PR TITLE
Feat: Add field PropagateOwnerReferences to PersistentVolumeClaim

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -7143,6 +7143,19 @@ Kubernetes core/v1.PersistentVolumeClaimStatus
 <p><em>Deprecated: this field is never set.</em></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>propagateOwnerReferences</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences
+in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.Endpoint">Endpoint

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10214,6 +10214,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -19844,6 +19850,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -29193,6 +29205,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -39038,6 +39056,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -4932,6 +4932,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5727,6 +5727,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6644,6 +6644,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4623,6 +4623,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4932,6 +4932,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5727,6 +5727,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6644,6 +6644,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4623,6 +4623,12 @@ spec:
                               updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
+                      propagateOwnerReferences:
+                        description: Controls whether the ownerReferences in the StatefulSet
+                          metadata should be set as ownerReferences in its PersistentVolumeClaims
+                          as well. If true then the ownerReferences will be propagated.
+                          Default is false.
+                        type: boolean
                       spec:
                         description: 'Defines the desired characteristics of a volume
                           requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -4445,6 +4445,10 @@
                             },
                             "type": "object"
                           },
+                          "propagateOwnerReferences": {
+                            "description": "Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.",
+                            "type": "boolean"
+                          },
                           "spec": {
                             "description": "Defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "properties": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5136,6 +5136,10 @@
                             },
                             "type": "object"
                           },
+                          "propagateOwnerReferences": {
+                            "description": "Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.",
+                            "type": "boolean"
+                          },
                           "spec": {
                             "description": "Defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "properties": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6088,6 +6088,10 @@
                             },
                             "type": "object"
                           },
+                          "propagateOwnerReferences": {
+                            "description": "Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.",
+                            "type": "boolean"
+                          },
                           "spec": {
                             "description": "Defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "properties": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4150,6 +4150,10 @@
                             },
                             "type": "object"
                           },
+                          "propagateOwnerReferences": {
+                            "description": "Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.",
+                            "type": "boolean"
+                          },
                           "spec": {
                             "description": "Defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                             "properties": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -162,6 +162,9 @@ func makeStatefulSet(am *monitoringv1.Alertmanager, config Config, inputHash str
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
+		if storageSpec.VolumeClaimTemplate.PropagateOwnerReferences {
+			pvcTemplate.OwnerReferences = statefulset.OwnerReferences
+		}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -203,6 +203,11 @@ type EmbeddedPersistentVolumeClaim struct {
 	// *Deprecated: this field is never set.*
 	// +optional
 	Status v1.PersistentVolumeClaimStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+
+	// Controls whether the ownerReferences in the StatefulSet metadata should be set as ownerReferences
+	// in its PersistentVolumeClaims as well. If true then the ownerReferences will be propagated. Default is false.
+	// +optional
+	PropagateOwnerReferences bool `json:"propagateOwnerReferences,omitempty" protobuf:"bytes,4,opt,name=propagateOwnerReferences"`
 }
 
 // EmbeddedObjectMetadata contains a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta

--- a/pkg/client/applyconfiguration/monitoring/v1/embeddedpersistentvolumeclaim.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/embeddedpersistentvolumeclaim.go
@@ -28,6 +28,7 @@ type EmbeddedPersistentVolumeClaimApplyConfiguration struct {
 	*EmbeddedObjectMetadataApplyConfiguration `json:"metadata,omitempty"`
 	Spec                                      *corev1.PersistentVolumeClaimSpec   `json:"spec,omitempty"`
 	Status                                    *corev1.PersistentVolumeClaimStatus `json:"status,omitempty"`
+	PropagateOwnerReferences                  *bool                               `json:"propagateOwnerReferences,omitempty"`
 }
 
 // EmbeddedPersistentVolumeClaimApplyConfiguration constructs an declarative configuration of the EmbeddedPersistentVolumeClaim type for use with
@@ -113,5 +114,13 @@ func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) WithSpec(value corev1.
 // If called multiple times, the Status field is set to the value of the last call.
 func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) WithStatus(value corev1.PersistentVolumeClaimStatus) *EmbeddedPersistentVolumeClaimApplyConfiguration {
 	b.Status = &value
+	return b
+}
+
+// WithPropagateOwnerReferences sets the PropagateOwnerReferences field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PropagateOwnerReferences field is set to the value of the last call.
+func (b *EmbeddedPersistentVolumeClaimApplyConfiguration) WithPropagateOwnerReferences(value bool) *EmbeddedPersistentVolumeClaimApplyConfiguration {
+	b.PropagateOwnerReferences = &value
 	return b
 }

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -146,6 +146,9 @@ func makeStatefulSet(
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
+		if storageSpec.VolumeClaimTemplate.PropagateOwnerReferences {
+			pvcTemplate.OwnerReferences = statefulset.OwnerReferences
+		}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -209,6 +209,9 @@ func makeStatefulSet(
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
+		if storageSpec.VolumeClaimTemplate.PropagateOwnerReferences {
+			pvcTemplate.OwnerReferences = statefulset.OwnerReferences
+		}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -142,6 +142,9 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapN
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
+		if storageSpec.VolumeClaimTemplate.PropagateOwnerReferences {
+			pvcTemplate.OwnerReferences = statefulset.OwnerReferences
+		}
 		pvcTemplate.Spec.Resources = storageSpec.VolumeClaimTemplate.Spec.Resources
 		pvcTemplate.Spec.Selector = storageSpec.VolumeClaimTemplate.Spec.Selector
 		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, *pvcTemplate)


### PR DESCRIPTION
This change adds a bool field `propagateOwnerReferences` in `volumeClaimTemplate`. If set to true, the operator will copy the ownerReferences set in a StatefulSet to the PersistenVolumeClaims created by it.

## Description

Different solution for the problem described in https://github.com/prometheus-operator/prometheus-operator/pull/5899#issuecomment-1717541223

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: Add PropagateOwnerReferences field to EmbeddedPersistentVolumeClaim
```
