### PR TITLE
chore: fix e2e tests compilation

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2616,7 +2616,7 @@ func testAlertmanagerConfigMatcherStrategy(t *testing.T) {
 	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
-			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
+			lastErr = fmt.Errorf("failed to get generated configuration secret: %w", err)
 			return false, nil
 		}
 
@@ -2654,7 +2654,7 @@ receivers:
 templates: []
 `, ns, ns, ns)
 		if diff := cmp.Diff(uncompressed, expected); diff != "" {
-			lastErr = errors.Errorf("got(-), want(+):\n%s", diff)
+			lastErr = fmt.Errorf("got(-), want(+):\n%s", diff)
 			return false, nil
 		}
 
@@ -2673,7 +2673,7 @@ templates: []
 	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, amConfigSecretName, metav1.GetOptions{})
 		if err != nil {
-			lastErr = errors.Wrap(err, "failed to get generated configuration secret")
+			lastErr = fmt.Errorf("failed to get generated configuration secret: %w", err)
 			return false, nil
 		}
 
@@ -2709,7 +2709,7 @@ receivers:
 templates: []
 `, ns, ns)
 		if diff := cmp.Diff(uncompressed, expected); diff != "" {
-			lastErr = errors.Errorf("got(-), want(+):\n%s", diff)
+			lastErr = fmt.Errorf("got(-), want(+):\n%s", diff)
 			return false, nil
 		}
 


### PR DESCRIPTION
## Description

The last merged PR #5983 broke the test compilation.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
