### PR TITLE
feat: remove deprecated metrics

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -434,41 +434,10 @@ func run() int {
 		}
 	}
 
-	validationTriggeredCounter := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_rule_validation_triggered_total",
-		Help: "DEPRECATED, removed in v0.57.0: Number of times a prometheusRule object triggered validation",
-	})
-
-	validationErrorsCounter := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_rule_validation_errors_total",
-		Help: "DEPRECATED, removed in v0.57.0: Number of errors that occurred while validating a prometheusRules object",
-	})
-
-	alertManagerConfigValidationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_alertmanager_config_validation_triggered_total",
-		Help: "DEPRECATED, removed in v0.57.0: Number of times an alertmanagerconfig object triggered validation",
-	})
-
-	alertManagerConfigValidationError := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_alertmanager_config_validation_errors_total",
-		Help: "DEPRECATED, removed in v0.57.0: Number of errors that occurred while validating a alertmanagerconfig object",
-	})
-
 	r.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		validationTriggeredCounter,
-		validationErrorsCounter,
-		alertManagerConfigValidationTriggered,
-		alertManagerConfigValidationError,
 		version.NewCollector("prometheus_operator"),
-	)
-
-	admit.RegisterMetrics(
-		validationTriggeredCounter,
-		validationErrorsCounter,
-		alertManagerConfigValidationTriggered,
-		alertManagerConfigValidationError,
 	)
 
 	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -28,7 +28,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/golden"
 	v1 "k8s.io/api/admission/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -324,29 +323,7 @@ func TestAlertmanagerConfigConversion(t *testing.T) {
 }
 
 func api() *Admission {
-	validationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_rule_validation_triggered_total",
-		Help: "Number of times a prometheusRule object triggered validation",
-	})
-
-	validationErrors := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_rule_validation_errors_total",
-		Help: "Number of errors that occurred while validating a prometheusRules object",
-	})
-	alertManagerConfigValidationTriggered := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_alertmanager_config_validation_triggered_total",
-		Help: "Number of times an alertmanagerconfig object triggered validation",
-	})
-
-	alertManagerConfigValidationError := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "prometheus_operator_alertmanager_config_validation_errors_total",
-		Help: "Number of errors that occurred while validating a alertmanagerconfig object",
-	})
-
-	a := New(level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)), level.AllowNone()))
-	a.RegisterMetrics(validationTriggered, validationErrors, alertManagerConfigValidationTriggered, alertManagerConfigValidationError)
-
-	return a
+	return New(level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)), level.AllowNone()))
 }
 
 func server(h http.HandlerFunc) *httptest.Server {


### PR DESCRIPTION
This commit removes the following metrics which have been deprecated since v0.55.0:
* prometheus_operator_rule_validation_triggered_total
* prometheus_operator_rule_validation_errors_total
* prometheus_operator_alertmanager_config_validation_triggered_total
* prometheus_operator_alertmanager_config_validation_errors_total

The same information is already available from the Kubernetes API (>= 1.16) with the `apiserver_admission_webhook_rejection_count` metric: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhook-metrics

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
