### PR TITLE
feat: emit events for invalid configurations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -139,7 +139,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		logger:   logger,
 		accessor: operator.NewAccessor(logger),
 
-		metrics:             operator.NewMetrics(r),
+		metrics:             operator.NewMetrics(client, r),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 		config: Config{
@@ -1100,6 +1100,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
+			c.metrics.Recorder.Eventf(amc, v1.EventTypeWarning, "InvalidConfiguration", "AlertmanagerConfig %q/%q was rejected due to invalid configuration: %v", amc.GetNamespace(), amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1238,7 +1238,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				mclient:    monitoringfake.NewSimpleClientset(),
 				ssarClient: &alwaysAllowed{},
 				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowInfo()),
-				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
+				metrics:    operator.NewMetrics(nil, prometheus.NewRegistry()),
 				config: Config{
 					Namespaces: operator.Namespaces{
 						AlertmanagerConfigAllowList: map[string]struct{}{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -24,12 +24,17 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
 )
 
 const PrometheusOperatorFieldManager = "PrometheusOperator"
@@ -201,6 +206,9 @@ type Metrics struct {
 	// mtx protects all fields below.
 	mtx       sync.RWMutex
 	resources map[resourceKey]map[string]int
+
+	// Emit events for critical metric changes.
+	Recorder record.EventRecorder
 }
 
 type resourceKey struct {
@@ -209,7 +217,17 @@ type resourceKey struct {
 }
 
 // NewMetrics initializes operator metrics and registers them with the given registerer.
-func NewMetrics(r prometheus.Registerer) *Metrics {
+func NewMetrics(client kubernetes.Interface, r prometheus.Registerer) *Metrics {
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+
+	// Exclude initialization when testing.
+	if client != nil {
+		eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: client.CoreV1().Events("")})
+	}
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "prometheus-operator"})
+
 	m := Metrics{
 		reg: r,
 		triggerByCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -243,6 +261,8 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		}),
 
 		resources: make(map[resourceKey]map[string]int),
+
+		Recorder: recorder,
 	}
 
 	m.reg.MustRegister(

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -122,7 +122,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		mclient:               mclient,
 		logger:                logger,
 		config:                conf,
-		metrics:               operator.NewMetrics(r),
+		metrics:               operator.NewMetrics(client, r),
 		reconciliations:       &operator.ReconciliationTracker{},
 		scrapeConfigSupported: scrapeConfigSupported,
 		canReadStorageClass:   canReadStorageClass,

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -172,6 +173,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(sm, v1.EventTypeWarning, "InvalidConfiguration", "ServiceMonitor %q/%q was rejected due to invalid configuration: %v", sm.GetNamespace(), sm.GetName(), err)
 			continue
 		}
 
@@ -419,6 +421,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(pm, v1.EventTypeWarning, "InvalidConfiguration", "PodMonitor %q/%q was rejected due to invalid configuration: %v", pm.GetNamespace(), pm.GetName(), err)
 			continue
 		}
 
@@ -500,6 +503,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(probe, v1.EventTypeWarning, "InvalidConfiguration", "Probe %q/%q was rejected due to invalid configuration: %v", probe.GetNamespace(), probe.GetName(), err)
 		}
 
 		if err = probe.Spec.Targets.Validate(); err != nil {
@@ -662,6 +666,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(sc, v1.EventTypeWarning, "InvalidConfiguration", "ScrapeConfig %q/%q was rejected due to invalid configuration: %v", sc.GetNamespace(), sc.GetName(), err)
 		}
 
 		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -576,7 +576,7 @@ func TestSelectProbes(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			probe := &monitoringv1.Probe{
@@ -770,7 +770,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			sm := &monitoringv1.ServiceMonitor{
@@ -870,7 +870,7 @@ func TestSelectPodMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			pm := &monitoringv1.PodMonitor{
@@ -1176,7 +1176,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				},
 				assets.NewStore(cs.CoreV1(), cs.CoreV1()),
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			sc := &monitoringv1alpha1.ScrapeConfig{

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -147,7 +147,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		kubeletObjectNamespace: kubeletObjectNamespace,
 		kubeletSyncEnabled:     kubeletSyncEnabled,
 		config:                 conf,
-		metrics:                operator.NewMetrics(r),
+		metrics:                operator.NewMetrics(client, r),
 		reconciliations:        &operator.ReconciliationTracker{},
 		nodeAddressLookupErrors: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_operator_node_address_lookup_errors_total",

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -73,7 +73,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(namespaces)
+	newRules, rejected, err := promRuleSelector.Select(c.metrics.Recorder, namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, restConfig *rest.Config, conf operator.Config, log
 		mclient:             mclient,
 		logger:              logger,
 		accessor:            operator.NewAccessor(logger),
-		metrics:             operator.NewMetrics(r),
+		metrics:             operator.NewMetrics(client, r),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 		config: Config{

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -74,7 +74,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(namespaces)
+	newRules, rejected, err := promRuleSelector.Select(o.metrics.Recorder, namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}


### PR DESCRIPTION
## Description

Emit events when the controller rejects a resource, owing to an invalid configuration.

Fixes: #3611

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Emit events when the controller rejects a resource, owing to an invalid configuration. These are:
* AlertmanagerConfig
* PodMonitor
* Probe
* PrometheusRule
* ScrapeConfig
* ServiceMonitor
```
