### PR TITLE
prometheus: Add AWS sigv4 auth to Alertmanager endpoints

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -4234,7 +4234,7 @@ BasicAuth
 <td>
 <em>(Optional)</em>
 <p>BasicAuth configuration for Alertmanager.</p>
-<p>Cannot be set at the same time as <code>bearerTokenFile</code>, or <code>authorization</code>.</p>
+<p>Cannot be set at the same time as <code>bearerTokenFile</code>, <code>authorization</code> or <code>sigv4</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4246,7 +4246,7 @@ string
 </td>
 <td>
 <p>File to read bearer token for Alertmanager.</p>
-<p>Cannot be set at the same time as <code>basicAuth</code>, or <code>authorization</code>.</p>
+<p>Cannot be set at the same time as <code>basicAuth</code>, <code>authorization</code>, or <code>sigv4</code>.</p>
 <p><em>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</em></p>
 </td>
 </tr>
@@ -4262,7 +4262,23 @@ SafeAuthorization
 <td>
 <em>(Optional)</em>
 <p>Authorization section for Alertmanager.</p>
-<p>Cannot be set at the same time as <code>basicAuth</code>, or <code>bearerTokenFile</code>.</p>
+<p>Cannot be set at the same time as <code>basicAuth</code>, <code>bearerTokenFile</code> or <code>sigv4</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sigv4</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.Sigv4">
+Sigv4
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sigv4 allows to configures AWS&rsquo;s Signature Verification 4 for the URL.</p>
+<p>It requires Prometheus &gt;= v2.48.0.</p>
+<p>Cannot be set at the same time as <code>basicAuth</code>, <code>bearerTokenFile</code> or <code>authorization</code>.</p>
 </td>
 </tr>
 <tr>
@@ -12615,7 +12631,7 @@ int32
 <h3 id="monitoring.coreos.com/v1.Sigv4">Sigv4
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.SNSConfig">SNSConfig</a>, <a href="#monitoring.coreos.com/v1beta1.SNSConfig">SNSConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.SNSConfig">SNSConfig</a>, <a href="#monitoring.coreos.com/v1beta1.SNSConfig">SNSConfig</a>)
 </p>
 <div>
 <p>Sigv4 optionally configures AWS&rsquo;s Signature Verification 4 signing process to

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -23568,7 +23568,8 @@ spec:
                           type: string
                         authorization:
                           description: "Authorization section for Alertmanager. \n
-                            Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`."
+                            Cannot be set at the same time as `basicAuth`, `bearerTokenFile`
+                            or `sigv4`."
                           properties:
                             credentials:
                               description: Selects a key of a Secret in the namespace
@@ -23600,7 +23601,7 @@ spec:
                         basicAuth:
                           description: "BasicAuth configuration for Alertmanager.
                             \n Cannot be set at the same time as `bearerTokenFile`,
-                            or `authorization`."
+                            `authorization` or `sigv4`."
                           properties:
                             password:
                               description: The secret in the service monitor namespace
@@ -23647,9 +23648,9 @@ spec:
                           type: object
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
-                            \n Cannot be set at the same time as `basicAuth`, or `authorization`.
-                            \n *Deprecated: this will be removed in a future release.
-                            Prefer using `authorization`.*"
+                            \n Cannot be set at the same time as `basicAuth`, `authorization`,
+                            or `sigv4`. \n *Deprecated: this will be removed in a
+                            future release. Prefer using `authorization`.*"
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -23673,6 +23674,68 @@ spec:
                         scheme:
                           description: Scheme to use when firing alerts.
                           type: string
+                        sigv4:
+                          description: "Sigv4 allows to configures AWS's Signature
+                            Verification 4 for the URL. \n It requires Prometheus
+                            >= v2.48.0. \n Cannot be set at the same time as `basicAuth`,
+                            `bearerTokenFile` or `authorization`."
+                          properties:
+                            accessKey:
+                              description: AccessKey is the AWS API key. If not specified,
+                                the environment variable `AWS_ACCESS_KEY_ID` is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            profile:
+                              description: Profile is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            region:
+                              description: Region is the AWS region. If blank, the
+                                region from the default credentials chain used.
+                              type: string
+                            roleArn:
+                              description: RoleArn is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            secretKey:
+                              description: SecretKey is the AWS API secret. If not
+                                specified, the environment variable `AWS_SECRET_ACCESS_KEY`
+                                is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1019,7 +1019,8 @@ spec:
                           type: string
                         authorization:
                           description: "Authorization section for Alertmanager. \n
-                            Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`."
+                            Cannot be set at the same time as `basicAuth`, `bearerTokenFile`
+                            or `sigv4`."
                           properties:
                             credentials:
                               description: Selects a key of a Secret in the namespace
@@ -1051,7 +1052,7 @@ spec:
                         basicAuth:
                           description: "BasicAuth configuration for Alertmanager.
                             \n Cannot be set at the same time as `bearerTokenFile`,
-                            or `authorization`."
+                            `authorization` or `sigv4`."
                           properties:
                             password:
                               description: The secret in the service monitor namespace
@@ -1098,9 +1099,9 @@ spec:
                           type: object
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
-                            \n Cannot be set at the same time as `basicAuth`, or `authorization`.
-                            \n *Deprecated: this will be removed in a future release.
-                            Prefer using `authorization`.*"
+                            \n Cannot be set at the same time as `basicAuth`, `authorization`,
+                            or `sigv4`. \n *Deprecated: this will be removed in a
+                            future release. Prefer using `authorization`.*"
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -1124,6 +1125,68 @@ spec:
                         scheme:
                           description: Scheme to use when firing alerts.
                           type: string
+                        sigv4:
+                          description: "Sigv4 allows to configures AWS's Signature
+                            Verification 4 for the URL. \n It requires Prometheus
+                            >= v2.48.0. \n Cannot be set at the same time as `basicAuth`,
+                            `bearerTokenFile` or `authorization`."
+                          properties:
+                            accessKey:
+                              description: AccessKey is the AWS API key. If not specified,
+                                the environment variable `AWS_ACCESS_KEY_ID` is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            profile:
+                              description: Profile is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            region:
+                              description: Region is the AWS region. If blank, the
+                                region from the default credentials chain used.
+                              type: string
+                            roleArn:
+                              description: RoleArn is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            secretKey:
+                              description: SecretKey is the AWS API secret. If not
+                                specified, the environment variable `AWS_SECRET_ACCESS_KEY`
+                                is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1019,7 +1019,8 @@ spec:
                           type: string
                         authorization:
                           description: "Authorization section for Alertmanager. \n
-                            Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`."
+                            Cannot be set at the same time as `basicAuth`, `bearerTokenFile`
+                            or `sigv4`."
                           properties:
                             credentials:
                               description: Selects a key of a Secret in the namespace
@@ -1051,7 +1052,7 @@ spec:
                         basicAuth:
                           description: "BasicAuth configuration for Alertmanager.
                             \n Cannot be set at the same time as `bearerTokenFile`,
-                            or `authorization`."
+                            `authorization` or `sigv4`."
                           properties:
                             password:
                               description: The secret in the service monitor namespace
@@ -1098,9 +1099,9 @@ spec:
                           type: object
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
-                            \n Cannot be set at the same time as `basicAuth`, or `authorization`.
-                            \n *Deprecated: this will be removed in a future release.
-                            Prefer using `authorization`.*"
+                            \n Cannot be set at the same time as `basicAuth`, `authorization`,
+                            or `sigv4`. \n *Deprecated: this will be removed in a
+                            future release. Prefer using `authorization`.*"
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -1124,6 +1125,68 @@ spec:
                         scheme:
                           description: Scheme to use when firing alerts.
                           type: string
+                        sigv4:
+                          description: "Sigv4 allows to configures AWS's Signature
+                            Verification 4 for the URL. \n It requires Prometheus
+                            >= v2.48.0. \n Cannot be set at the same time as `basicAuth`,
+                            `bearerTokenFile` or `authorization`."
+                          properties:
+                            accessKey:
+                              description: AccessKey is the AWS API key. If not specified,
+                                the environment variable `AWS_ACCESS_KEY_ID` is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            profile:
+                              description: Profile is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            region:
+                              description: Region is the AWS region. If blank, the
+                                region from the default credentials chain used.
+                              type: string
+                            roleArn:
+                              description: RoleArn is the named AWS profile used to
+                                authenticate.
+                              type: string
+                            secretKey:
+                              description: SecretKey is the AWS API secret. If not
+                                specified, the environment variable `AWS_SECRET_ACCESS_KEY`
+                                is used.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         timeout:
                           description: Timeout is a per-target Alertmanager timeout
                             when pushing alerts.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -844,7 +844,7 @@
                               "type": "string"
                             },
                             "authorization": {
-                              "description": "Authorization section for Alertmanager. \n Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`.",
+                              "description": "Authorization section for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `sigv4`.",
                               "properties": {
                                 "credentials": {
                                   "description": "Selects a key of a Secret in the namespace that contains the credentials for authentication.",
@@ -876,7 +876,7 @@
                               "type": "object"
                             },
                             "basicAuth": {
-                              "description": "BasicAuth configuration for Alertmanager. \n Cannot be set at the same time as `bearerTokenFile`, or `authorization`.",
+                              "description": "BasicAuth configuration for Alertmanager. \n Cannot be set at the same time as `bearerTokenFile`, `authorization` or `sigv4`.",
                               "properties": {
                                 "password": {
                                   "description": "The secret in the service monitor namespace that contains the password for authentication.",
@@ -926,7 +926,7 @@
                               "type": "object"
                             },
                             "bearerTokenFile": {
-                              "description": "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, or `authorization`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                              "description": "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
                               "type": "string"
                             },
                             "enableHttp2": {
@@ -960,6 +960,68 @@
                             "scheme": {
                               "description": "Scheme to use when firing alerts.",
                               "type": "string"
+                            },
+                            "sigv4": {
+                              "description": "Sigv4 allows to configures AWS's Signature Verification 4 for the URL. \n It requires Prometheus >= v2.48.0. \n Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `authorization`.",
+                              "properties": {
+                                "accessKey": {
+                                  "description": "AccessKey is the AWS API key. If not specified, the environment variable `AWS_ACCESS_KEY_ID` is used.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "profile": {
+                                  "description": "Profile is the named AWS profile used to authenticate.",
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "description": "Region is the AWS region. If blank, the region from the default credentials chain used.",
+                                  "type": "string"
+                                },
+                                "roleArn": {
+                                  "description": "RoleArn is the named AWS profile used to authenticate.",
+                                  "type": "string"
+                                },
+                                "secretKey": {
+                                  "description": "SecretKey is the AWS API secret. If not specified, the environment variable `AWS_SECRET_ACCESS_KEY` is used.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
                             },
                             "timeout": {
                               "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1457,24 +1457,33 @@ type AlertmanagerEndpoints struct {
 
 	// BasicAuth configuration for Alertmanager.
 	//
-	// Cannot be set at the same time as `bearerTokenFile`, or `authorization`.
+	// Cannot be set at the same time as `bearerTokenFile`, `authorization` or `sigv4`.
 	//
 	// +optional
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 
 	// File to read bearer token for Alertmanager.
 	//
-	// Cannot be set at the same time as `basicAuth`, or `authorization`.
+	// Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`.
 	//
 	// *Deprecated: this will be removed in a future release. Prefer using `authorization`.*
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// Authorization section for Alertmanager.
 	//
-	// Cannot be set at the same time as `basicAuth`, or `bearerTokenFile`.
+	// Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `sigv4`.
 	//
 	// +optional
 	Authorization *SafeAuthorization `json:"authorization,omitempty"`
+
+	// Sigv4 allows to configures AWS's Signature Verification 4 for the URL.
+	//
+	// It requires Prometheus >= v2.48.0.
+	//
+	// Cannot be set at the same time as `basicAuth`, `bearerTokenFile` or `authorization`.
+	//
+	// +optional
+	Sigv4 *Sigv4 `json:"sigv4,omitempty"`
 
 	// Version of the Alertmanager API that Prometheus uses to send alerts.
 	// It can be "v1" or "v2".

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -157,6 +157,11 @@ func (in *AlertmanagerEndpoints) DeepCopyInto(out *AlertmanagerEndpoints) {
 		*out = new(SafeAuthorization)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Sigv4 != nil {
+		in, out := &in.Sigv4, &out.Sigv4
+		*out = new(Sigv4)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(Duration)

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerendpoints.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerendpoints.go
@@ -33,6 +33,7 @@ type AlertmanagerEndpointsApplyConfiguration struct {
 	BasicAuth       *BasicAuthApplyConfiguration         `json:"basicAuth,omitempty"`
 	BearerTokenFile *string                              `json:"bearerTokenFile,omitempty"`
 	Authorization   *SafeAuthorizationApplyConfiguration `json:"authorization,omitempty"`
+	Sigv4           *Sigv4ApplyConfiguration             `json:"sigv4,omitempty"`
 	APIVersion      *string                              `json:"apiVersion,omitempty"`
 	Timeout         *monitoringv1.Duration               `json:"timeout,omitempty"`
 	EnableHttp2     *bool                                `json:"enableHttp2,omitempty"`
@@ -113,6 +114,14 @@ func (b *AlertmanagerEndpointsApplyConfiguration) WithBearerTokenFile(value stri
 // If called multiple times, the Authorization field is set to the value of the last call.
 func (b *AlertmanagerEndpointsApplyConfiguration) WithAuthorization(value *SafeAuthorizationApplyConfiguration) *AlertmanagerEndpointsApplyConfiguration {
 	b.Authorization = value
+	return b
+}
+
+// WithSigv4 sets the Sigv4 field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Sigv4 field is set to the value of the last call.
+func (b *AlertmanagerEndpointsApplyConfiguration) WithSigv4(value *Sigv4ApplyConfiguration) *AlertmanagerEndpointsApplyConfiguration {
+	b.Sigv4 = value
 	return b
 }
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -122,6 +122,31 @@ func ValidateRemoteWriteSpec(spec monitoringv1.RemoteWriteSpec) error {
 	return nil
 }
 
+func ValidateAlertmanagerEndpoints(am monitoringv1.AlertmanagerEndpoints) error {
+	var nonNilFields []string
+
+	if am.BearerTokenFile != "" {
+		nonNilFields = append(nonNilFields, fmt.Sprintf("%q", "bearerTokenFile"))
+	}
+
+	for k, v := range map[string]interface{}{
+		"basicAuth":     am.BasicAuth,
+		"authorization": am.Authorization,
+		"sigv4":         am.Sigv4,
+	} {
+		if reflect.ValueOf(v).IsNil() {
+			continue
+		}
+		nonNilFields = append(nonNilFields, fmt.Sprintf("%q", k))
+	}
+
+	if len(nonNilFields) > 1 {
+		return fmt.Errorf("%s can't be set at the same time, at most one of them must be defined", strings.Join(nonNilFields, " and "))
+	}
+
+	return nil
+}
+
 // Process will determine the Status of a Prometheus resource (server or agent) depending on its current state in the cluster
 func (sr *StatusReporter) Process(ctx context.Context, p monitoringv1.PrometheusInterface, key string) (*monitoringv1.PrometheusStatus, error) {
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -339,6 +339,35 @@ func (cg *ConfigGenerator) addBasicAuthToYaml(cfg yaml.MapSlice,
 	return cg.WithKeyVals("component", strings.Split(assetStoreKey, "/")[0]).AppendMapItem(cfg, "basic_auth", authCfg)
 }
 
+func (cg *ConfigGenerator) addSigv4ToYaml(cfg yaml.MapSlice,
+	assetStoreKey string,
+	store *assets.Store,
+	sigv4 *monitoringv1.Sigv4,
+) yaml.MapSlice {
+	if sigv4 == nil {
+		return cfg
+	}
+
+	sigv4Cfg := yaml.MapSlice{}
+	if sigv4.Region != "" {
+		sigv4Cfg = append(sigv4Cfg, yaml.MapItem{Key: "region", Value: sigv4.Region})
+	}
+	if store.SigV4Assets[assetStoreKey].AccessKeyID != "" {
+		sigv4Cfg = append(sigv4Cfg, yaml.MapItem{Key: "access_key", Value: store.SigV4Assets[assetStoreKey].AccessKeyID})
+	}
+	if store.SigV4Assets[assetStoreKey].SecretKeyID != "" {
+		sigv4Cfg = append(sigv4Cfg, yaml.MapItem{Key: "secret_key", Value: store.SigV4Assets[assetStoreKey].SecretKeyID})
+	}
+	if sigv4.Profile != "" {
+		sigv4Cfg = append(sigv4Cfg, yaml.MapItem{Key: "profile", Value: sigv4.Profile})
+	}
+	if sigv4.RoleArn != "" {
+		sigv4Cfg = append(sigv4Cfg, yaml.MapItem{Key: "role_arn", Value: sigv4.RoleArn})
+	}
+
+	return cg.WithKeyVals("component", strings.Split(assetStoreKey, "/")[0]).AppendMapItem(cfg, "sigv4", sigv4Cfg)
+}
+
 func (cg *ConfigGenerator) addSafeAuthorizationToYaml(
 	cfg yaml.MapSlice,
 	assetStoreKey string,
@@ -1576,6 +1605,8 @@ func (cg *ConfigGenerator) generateAlertmanagerConfig(alerting *monitoringv1.Ale
 
 		cfg = cg.addSafeAuthorizationToYaml(cfg, fmt.Sprintf("alertmanager/auth/%d", i), store, am.Authorization)
 
+		cfg = cg.WithMinimumVersion("2.48.0").addSigv4ToYaml(cfg, fmt.Sprintf("alertmanager/auth/%d", i), store, am.Sigv4)
+
 		if am.APIVersion == "v1" || am.APIVersion == "v2" {
 			cfg = cg.WithMinimumVersion("2.11.0").AppendMapItem(cfg, "api_version", am.APIVersion)
 		}
@@ -1848,27 +1879,7 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(
 			cfg = append(cfg, yaml.MapItem{Key: "proxy_url", Value: spec.ProxyURL})
 		}
 
-		if spec.Sigv4 != nil {
-			sigV4 := yaml.MapSlice{}
-			if spec.Sigv4.Region != "" {
-				sigV4 = append(sigV4, yaml.MapItem{Key: "region", Value: spec.Sigv4.Region})
-			}
-			key := fmt.Sprintf("remoteWrite/%d", i)
-			if store.SigV4Assets[key].AccessKeyID != "" {
-				sigV4 = append(sigV4, yaml.MapItem{Key: "access_key", Value: store.SigV4Assets[key].AccessKeyID})
-			}
-			if store.SigV4Assets[key].SecretKeyID != "" {
-				sigV4 = append(sigV4, yaml.MapItem{Key: "secret_key", Value: store.SigV4Assets[key].SecretKeyID})
-			}
-			if spec.Sigv4.Profile != "" {
-				sigV4 = append(sigV4, yaml.MapItem{Key: "profile", Value: spec.Sigv4.Profile})
-			}
-			if spec.Sigv4.RoleArn != "" {
-				sigV4 = append(sigV4, yaml.MapItem{Key: "role_arn", Value: spec.Sigv4.RoleArn})
-			}
-
-			cfg = cg.WithMinimumVersion("2.26.0").AppendMapItem(cfg, "sigv4", sigV4)
-		}
+		cfg = cg.WithMinimumVersion("2.26.0").addSigv4ToYaml(cfg, fmt.Sprintf("remoteWrite/%d", i), store, spec.Sigv4)
 
 		if spec.AzureAD != nil {
 			azureAd := yaml.MapSlice{

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1518,13 +1518,8 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 
 	if p.Spec.Alerting != nil {
-		for i, am := range p.Spec.Alerting.Alertmanagers {
-			if err := store.AddBasicAuth(ctx, p.GetNamespace(), am.BasicAuth, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
-				return fmt.Errorf("alerting: %w", err)
-			}
-			if err := store.AddSafeAuthorizationCredentials(ctx, p.GetNamespace(), am.Authorization, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
-				return fmt.Errorf("alerting: %w", err)
-			}
+		if err := prompkg.AddAlertmanagerEndpointsToStore(ctx, store, p.GetNamespace(), p.Spec.Alerting.Alertmanagers); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/prometheus/store.go
+++ b/pkg/prometheus/store.go
@@ -67,6 +67,25 @@ func AddRemoteReadsToStore(ctx context.Context, store *assets.Store, namespace s
 	return nil
 }
 
+func AddAlertmanagerEndpointsToStore(ctx context.Context, store *assets.Store, namespace string, ams []monv1.AlertmanagerEndpoints) error {
+	for i, am := range ams {
+		if err := ValidateAlertmanagerEndpoints(am); err != nil {
+			return fmt.Errorf("alertmanager %d: %w", i, err)
+		}
+		if err := store.AddBasicAuth(ctx, namespace, am.BasicAuth, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
+			return fmt.Errorf("alertmanager %d: %w", i, err)
+		}
+		if err := store.AddSafeAuthorizationCredentials(ctx, namespace, am.Authorization, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
+			return fmt.Errorf("alertmanager %d: %w", i, err)
+		}
+		if err := store.AddSigV4(ctx, namespace, am.Sigv4, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
+			return fmt.Errorf("alertmanager %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
 func AddAPIServerConfigToStore(ctx context.Context, store *assets.Store, namespace string, config *monv1.APIServerConfig) error {
 	if config == nil {
 		return nil

--- a/pkg/prometheus/testdata/AlertmanagerSigv4_Invalid_Prom_Version.golden
+++ b/pkg/prometheus/testdata/AlertmanagerSigv4_Invalid_Prom_Version.golden
@@ -1,0 +1,28 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - default
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: alertmanager-main
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_endpoint_port_name
+      regex: web

--- a/pkg/prometheus/testdata/AlertmanagerSigv4_Valid_Prom_Version.golden
+++ b/pkg/prometheus/testdata/AlertmanagerSigv4_Valid_Prom_Version.golden
@@ -1,0 +1,34 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - default
+    sigv4:
+      region: us-central-0
+      access_key: access-key
+      secret_key: secret-key
+      profile: profilename
+      role_arn: arn:aws:iam::123456789012:instance-profile/prometheus
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: alertmanager-main
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_endpoint_port_name
+      regex: web


### PR DESCRIPTION
## Description

Fixes: #6033



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add AWS sigv4 auth to Prometheus's Alertmanager endpoints
```
