### PR TITLE
feat: Add support for configuring STS persistentVolumeClaimRetentionPolicy

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1801,6 +1801,23 @@ container, that are generated as a result of StorageSpec objects.</p>
 </tr>
 <tr>
 <td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>web</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusWebSpec">
@@ -6008,6 +6025,23 @@ container, that are generated as a result of StorageSpec objects.</p>
 </tr>
 <tr>
 <td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>web</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusWebSpec">
@@ -9764,6 +9798,23 @@ volumes that are generated as a result of StorageSpec objects.</p>
 <p>VolumeMounts allows the configuration of additional VolumeMounts.</p>
 <p>VolumeMounts will be appended to other VolumeMounts in the &lsquo;prometheus&rsquo;
 container, that are generated as a result of StorageSpec objects.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
 </td>
 </tr>
 <tr>
@@ -15076,6 +15127,23 @@ container, that are generated as a result of StorageSpec objects.</p>
 </tr>
 <tr>
 <td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>web</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.PrometheusWebSpec">
@@ -18741,6 +18809,23 @@ volumes that are generated as a result of StorageSpec objects.</p>
 <p>VolumeMounts allows the configuration of additional VolumeMounts.</p>
 <p>VolumeMounts will be appended to other VolumeMounts in the &lsquo;prometheus&rsquo;
 container, that are generated as a result of StorageSpec objects.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -18201,6 +18201,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.
@@ -27001,6 +27023,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4084,6 +4084,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4452,6 +4452,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4084,6 +4084,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4452,6 +4452,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: PodMetadata configures labels and annotations which are
                   propagated to the Prometheus pods.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3656,6 +3656,20 @@
                     "description": "When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects.",
                     "type": "boolean"
                   },
+                  "persistentVolumeClaimRetentionPolicy": {
+                    "description": "The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet. The default behavior is all PVCs are retained. This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC feature gate.",
+                    "properties": {
+                      "whenDeleted": {
+                        "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.",
+                        "type": "string"
+                      },
+                      "whenScaled": {
+                        "description": "WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "podMetadata": {
                     "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods.",
                     "properties": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4032,6 +4032,20 @@
                     "description": "When a Prometheus deployment is paused, no actions except for deletion will be performed on the underlying objects.",
                     "type": "boolean"
                   },
+                  "persistentVolumeClaimRetentionPolicy": {
+                    "description": "The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet. The default behavior is all PVCs are retained. This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC feature gate.",
+                    "properties": {
+                      "whenDeleted": {
+                        "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.",
+                        "type": "string"
+                      },
+                      "whenScaled": {
+                        "description": "WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "podMetadata": {
                     "description": "PodMetadata configures labels and annotations which are propagated to the Prometheus pods.",
                     "properties": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -17,6 +17,7 @@ package v1
 import (
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -270,6 +271,14 @@ type CommonPrometheusFields struct {
 	// VolumeMounts will be appended to other VolumeMounts in the 'prometheus'
 	// container, that are generated as a result of StorageSpec objects.
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+
+	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+	// The default behavior is all PVCs are retained.
+	// This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+	// It requires enabling the StatefulSetAutoDeletePVC feature gate.
+	//
+	// +optional
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 
 	// Defines the configuration of the Prometheus web server.
 	Web *PrometheusWebSpec `json:"web,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -671,6 +672,11 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
+		**out = **in
 	}
 	if in.Web != nil {
 		in, out := &in.Web, &out.Web

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,81 +26,82 @@ import (
 // CommonPrometheusFieldsApplyConfiguration represents an declarative configuration of the CommonPrometheusFields type for use
 // with apply.
 type CommonPrometheusFieldsApplyConfiguration struct {
-	PodMetadata                     *EmbeddedObjectMetadataApplyConfiguration            `json:"podMetadata,omitempty"`
-	ServiceMonitorSelector          *metav1.LabelSelector                                `json:"serviceMonitorSelector,omitempty"`
-	ServiceMonitorNamespaceSelector *metav1.LabelSelector                                `json:"serviceMonitorNamespaceSelector,omitempty"`
-	PodMonitorSelector              *metav1.LabelSelector                                `json:"podMonitorSelector,omitempty"`
-	PodMonitorNamespaceSelector     *metav1.LabelSelector                                `json:"podMonitorNamespaceSelector,omitempty"`
-	ProbeSelector                   *metav1.LabelSelector                                `json:"probeSelector,omitempty"`
-	ProbeNamespaceSelector          *metav1.LabelSelector                                `json:"probeNamespaceSelector,omitempty"`
-	ScrapeConfigSelector            *metav1.LabelSelector                                `json:"scrapeConfigSelector,omitempty"`
-	ScrapeConfigNamespaceSelector   *metav1.LabelSelector                                `json:"scrapeConfigNamespaceSelector,omitempty"`
-	Version                         *string                                              `json:"version,omitempty"`
-	Paused                          *bool                                                `json:"paused,omitempty"`
-	Image                           *string                                              `json:"image,omitempty"`
-	ImagePullPolicy                 *corev1.PullPolicy                                   `json:"imagePullPolicy,omitempty"`
-	ImagePullSecrets                []corev1.LocalObjectReference                        `json:"imagePullSecrets,omitempty"`
-	Replicas                        *int32                                               `json:"replicas,omitempty"`
-	Shards                          *int32                                               `json:"shards,omitempty"`
-	ReplicaExternalLabelName        *string                                              `json:"replicaExternalLabelName,omitempty"`
-	PrometheusExternalLabelName     *string                                              `json:"prometheusExternalLabelName,omitempty"`
-	LogLevel                        *string                                              `json:"logLevel,omitempty"`
-	LogFormat                       *string                                              `json:"logFormat,omitempty"`
-	ScrapeInterval                  *monitoringv1.Duration                               `json:"scrapeInterval,omitempty"`
-	ScrapeTimeout                   *monitoringv1.Duration                               `json:"scrapeTimeout,omitempty"`
-	ExternalLabels                  map[string]string                                    `json:"externalLabels,omitempty"`
-	EnableRemoteWriteReceiver       *bool                                                `json:"enableRemoteWriteReceiver,omitempty"`
-	EnableFeatures                  []string                                             `json:"enableFeatures,omitempty"`
-	ExternalURL                     *string                                              `json:"externalUrl,omitempty"`
-	RoutePrefix                     *string                                              `json:"routePrefix,omitempty"`
-	Storage                         *StorageSpecApplyConfiguration                       `json:"storage,omitempty"`
-	Volumes                         []corev1.Volume                                      `json:"volumes,omitempty"`
-	VolumeMounts                    []corev1.VolumeMount                                 `json:"volumeMounts,omitempty"`
-	Web                             *PrometheusWebSpecApplyConfiguration                 `json:"web,omitempty"`
-	Resources                       *corev1.ResourceRequirements                         `json:"resources,omitempty"`
-	NodeSelector                    map[string]string                                    `json:"nodeSelector,omitempty"`
-	ServiceAccountName              *string                                              `json:"serviceAccountName,omitempty"`
-	Secrets                         []string                                             `json:"secrets,omitempty"`
-	ConfigMaps                      []string                                             `json:"configMaps,omitempty"`
-	Affinity                        *corev1.Affinity                                     `json:"affinity,omitempty"`
-	Tolerations                     []corev1.Toleration                                  `json:"tolerations,omitempty"`
-	TopologySpreadConstraints       []corev1.TopologySpreadConstraint                    `json:"topologySpreadConstraints,omitempty"`
-	RemoteWrite                     []RemoteWriteSpecApplyConfiguration                  `json:"remoteWrite,omitempty"`
-	SecurityContext                 *corev1.PodSecurityContext                           `json:"securityContext,omitempty"`
-	ListenLocal                     *bool                                                `json:"listenLocal,omitempty"`
-	Containers                      []corev1.Container                                   `json:"containers,omitempty"`
-	InitContainers                  []corev1.Container                                   `json:"initContainers,omitempty"`
-	AdditionalScrapeConfigs         *corev1.SecretKeySelector                            `json:"additionalScrapeConfigs,omitempty"`
-	APIServerConfig                 *APIServerConfigApplyConfiguration                   `json:"apiserverConfig,omitempty"`
-	PriorityClassName               *string                                              `json:"priorityClassName,omitempty"`
-	PortName                        *string                                              `json:"portName,omitempty"`
-	ArbitraryFSAccessThroughSMs     *ArbitraryFSAccessThroughSMsConfigApplyConfiguration `json:"arbitraryFSAccessThroughSMs,omitempty"`
-	OverrideHonorLabels             *bool                                                `json:"overrideHonorLabels,omitempty"`
-	OverrideHonorTimestamps         *bool                                                `json:"overrideHonorTimestamps,omitempty"`
-	IgnoreNamespaceSelectors        *bool                                                `json:"ignoreNamespaceSelectors,omitempty"`
-	EnforcedNamespaceLabel          *string                                              `json:"enforcedNamespaceLabel,omitempty"`
-	EnforcedSampleLimit             *uint64                                              `json:"enforcedSampleLimit,omitempty"`
-	EnforcedTargetLimit             *uint64                                              `json:"enforcedTargetLimit,omitempty"`
-	EnforcedLabelLimit              *uint64                                              `json:"enforcedLabelLimit,omitempty"`
-	EnforcedLabelNameLengthLimit    *uint64                                              `json:"enforcedLabelNameLengthLimit,omitempty"`
-	EnforcedLabelValueLengthLimit   *uint64                                              `json:"enforcedLabelValueLengthLimit,omitempty"`
-	EnforcedKeepDroppedTargets      *uint64                                              `json:"enforcedKeepDroppedTargets,omitempty"`
-	EnforcedBodySizeLimit           *monitoringv1.ByteSize                               `json:"enforcedBodySizeLimit,omitempty"`
-	MinReadySeconds                 *uint32                                              `json:"minReadySeconds,omitempty"`
-	HostAliases                     []HostAliasApplyConfiguration                        `json:"hostAliases,omitempty"`
-	AdditionalArgs                  []ArgumentApplyConfiguration                         `json:"additionalArgs,omitempty"`
-	WALCompression                  *bool                                                `json:"walCompression,omitempty"`
-	ExcludedFromEnforcement         []ObjectReferenceApplyConfiguration                  `json:"excludedFromEnforcement,omitempty"`
-	HostNetwork                     *bool                                                `json:"hostNetwork,omitempty"`
-	PodTargetLabels                 []string                                             `json:"podTargetLabels,omitempty"`
-	TracingConfig                   *PrometheusTracingConfigApplyConfiguration           `json:"tracingConfig,omitempty"`
-	BodySizeLimit                   *monitoringv1.ByteSize                               `json:"bodySizeLimit,omitempty"`
-	SampleLimit                     *uint64                                              `json:"sampleLimit,omitempty"`
-	TargetLimit                     *uint64                                              `json:"targetLimit,omitempty"`
-	LabelLimit                      *uint64                                              `json:"labelLimit,omitempty"`
-	LabelNameLengthLimit            *uint64                                              `json:"labelNameLengthLimit,omitempty"`
-	LabelValueLengthLimit           *uint64                                              `json:"labelValueLengthLimit,omitempty"`
-	KeepDroppedTargets              *uint64                                              `json:"keepDroppedTargets,omitempty"`
+	PodMetadata                          *EmbeddedObjectMetadataApplyConfiguration               `json:"podMetadata,omitempty"`
+	ServiceMonitorSelector               *metav1.LabelSelector                                   `json:"serviceMonitorSelector,omitempty"`
+	ServiceMonitorNamespaceSelector      *metav1.LabelSelector                                   `json:"serviceMonitorNamespaceSelector,omitempty"`
+	PodMonitorSelector                   *metav1.LabelSelector                                   `json:"podMonitorSelector,omitempty"`
+	PodMonitorNamespaceSelector          *metav1.LabelSelector                                   `json:"podMonitorNamespaceSelector,omitempty"`
+	ProbeSelector                        *metav1.LabelSelector                                   `json:"probeSelector,omitempty"`
+	ProbeNamespaceSelector               *metav1.LabelSelector                                   `json:"probeNamespaceSelector,omitempty"`
+	ScrapeConfigSelector                 *metav1.LabelSelector                                   `json:"scrapeConfigSelector,omitempty"`
+	ScrapeConfigNamespaceSelector        *metav1.LabelSelector                                   `json:"scrapeConfigNamespaceSelector,omitempty"`
+	Version                              *string                                                 `json:"version,omitempty"`
+	Paused                               *bool                                                   `json:"paused,omitempty"`
+	Image                                *string                                                 `json:"image,omitempty"`
+	ImagePullPolicy                      *corev1.PullPolicy                                      `json:"imagePullPolicy,omitempty"`
+	ImagePullSecrets                     []corev1.LocalObjectReference                           `json:"imagePullSecrets,omitempty"`
+	Replicas                             *int32                                                  `json:"replicas,omitempty"`
+	Shards                               *int32                                                  `json:"shards,omitempty"`
+	ReplicaExternalLabelName             *string                                                 `json:"replicaExternalLabelName,omitempty"`
+	PrometheusExternalLabelName          *string                                                 `json:"prometheusExternalLabelName,omitempty"`
+	LogLevel                             *string                                                 `json:"logLevel,omitempty"`
+	LogFormat                            *string                                                 `json:"logFormat,omitempty"`
+	ScrapeInterval                       *monitoringv1.Duration                                  `json:"scrapeInterval,omitempty"`
+	ScrapeTimeout                        *monitoringv1.Duration                                  `json:"scrapeTimeout,omitempty"`
+	ExternalLabels                       map[string]string                                       `json:"externalLabels,omitempty"`
+	EnableRemoteWriteReceiver            *bool                                                   `json:"enableRemoteWriteReceiver,omitempty"`
+	EnableFeatures                       []string                                                `json:"enableFeatures,omitempty"`
+	ExternalURL                          *string                                                 `json:"externalUrl,omitempty"`
+	RoutePrefix                          *string                                                 `json:"routePrefix,omitempty"`
+	Storage                              *StorageSpecApplyConfiguration                          `json:"storage,omitempty"`
+	Volumes                              []corev1.Volume                                         `json:"volumes,omitempty"`
+	VolumeMounts                         []corev1.VolumeMount                                    `json:"volumeMounts,omitempty"`
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
+	Web                                  *PrometheusWebSpecApplyConfiguration                    `json:"web,omitempty"`
+	Resources                            *corev1.ResourceRequirements                            `json:"resources,omitempty"`
+	NodeSelector                         map[string]string                                       `json:"nodeSelector,omitempty"`
+	ServiceAccountName                   *string                                                 `json:"serviceAccountName,omitempty"`
+	Secrets                              []string                                                `json:"secrets,omitempty"`
+	ConfigMaps                           []string                                                `json:"configMaps,omitempty"`
+	Affinity                             *corev1.Affinity                                        `json:"affinity,omitempty"`
+	Tolerations                          []corev1.Toleration                                     `json:"tolerations,omitempty"`
+	TopologySpreadConstraints            []corev1.TopologySpreadConstraint                       `json:"topologySpreadConstraints,omitempty"`
+	RemoteWrite                          []RemoteWriteSpecApplyConfiguration                     `json:"remoteWrite,omitempty"`
+	SecurityContext                      *corev1.PodSecurityContext                              `json:"securityContext,omitempty"`
+	ListenLocal                          *bool                                                   `json:"listenLocal,omitempty"`
+	Containers                           []corev1.Container                                      `json:"containers,omitempty"`
+	InitContainers                       []corev1.Container                                      `json:"initContainers,omitempty"`
+	AdditionalScrapeConfigs              *corev1.SecretKeySelector                               `json:"additionalScrapeConfigs,omitempty"`
+	APIServerConfig                      *APIServerConfigApplyConfiguration                      `json:"apiserverConfig,omitempty"`
+	PriorityClassName                    *string                                                 `json:"priorityClassName,omitempty"`
+	PortName                             *string                                                 `json:"portName,omitempty"`
+	ArbitraryFSAccessThroughSMs          *ArbitraryFSAccessThroughSMsConfigApplyConfiguration    `json:"arbitraryFSAccessThroughSMs,omitempty"`
+	OverrideHonorLabels                  *bool                                                   `json:"overrideHonorLabels,omitempty"`
+	OverrideHonorTimestamps              *bool                                                   `json:"overrideHonorTimestamps,omitempty"`
+	IgnoreNamespaceSelectors             *bool                                                   `json:"ignoreNamespaceSelectors,omitempty"`
+	EnforcedNamespaceLabel               *string                                                 `json:"enforcedNamespaceLabel,omitempty"`
+	EnforcedSampleLimit                  *uint64                                                 `json:"enforcedSampleLimit,omitempty"`
+	EnforcedTargetLimit                  *uint64                                                 `json:"enforcedTargetLimit,omitempty"`
+	EnforcedLabelLimit                   *uint64                                                 `json:"enforcedLabelLimit,omitempty"`
+	EnforcedLabelNameLengthLimit         *uint64                                                 `json:"enforcedLabelNameLengthLimit,omitempty"`
+	EnforcedLabelValueLengthLimit        *uint64                                                 `json:"enforcedLabelValueLengthLimit,omitempty"`
+	EnforcedKeepDroppedTargets           *uint64                                                 `json:"enforcedKeepDroppedTargets,omitempty"`
+	EnforcedBodySizeLimit                *monitoringv1.ByteSize                                  `json:"enforcedBodySizeLimit,omitempty"`
+	MinReadySeconds                      *uint32                                                 `json:"minReadySeconds,omitempty"`
+	HostAliases                          []HostAliasApplyConfiguration                           `json:"hostAliases,omitempty"`
+	AdditionalArgs                       []ArgumentApplyConfiguration                            `json:"additionalArgs,omitempty"`
+	WALCompression                       *bool                                                   `json:"walCompression,omitempty"`
+	ExcludedFromEnforcement              []ObjectReferenceApplyConfiguration                     `json:"excludedFromEnforcement,omitempty"`
+	HostNetwork                          *bool                                                   `json:"hostNetwork,omitempty"`
+	PodTargetLabels                      []string                                                `json:"podTargetLabels,omitempty"`
+	TracingConfig                        *PrometheusTracingConfigApplyConfiguration              `json:"tracingConfig,omitempty"`
+	BodySizeLimit                        *monitoringv1.ByteSize                                  `json:"bodySizeLimit,omitempty"`
+	SampleLimit                          *uint64                                                 `json:"sampleLimit,omitempty"`
+	TargetLimit                          *uint64                                                 `json:"targetLimit,omitempty"`
+	LabelLimit                           *uint64                                                 `json:"labelLimit,omitempty"`
+	LabelNameLengthLimit                 *uint64                                                 `json:"labelNameLengthLimit,omitempty"`
+	LabelValueLengthLimit                *uint64                                                 `json:"labelValueLengthLimit,omitempty"`
+	KeepDroppedTargets                   *uint64                                                 `json:"keepDroppedTargets,omitempty"`
 }
 
 // CommonPrometheusFieldsApplyConfiguration constructs an declarative configuration of the CommonPrometheusFields type for use with
@@ -359,6 +361,14 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithVolumeMounts(values ...co
 	for i := range values {
 		b.VolumeMounts = append(b.VolumeMounts, values[i])
 	}
+	return b
+}
+
+// WithPersistentVolumeClaimRetentionPolicy sets the PersistentVolumeClaimRetentionPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PersistentVolumeClaimRetentionPolicy field is set to the value of the last call.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithPersistentVolumeClaimRetentionPolicy(value appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) *CommonPrometheusFieldsApplyConfiguration {
+	b.PersistentVolumeClaimRetentionPolicy = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -307,6 +308,14 @@ func (b *PrometheusSpecApplyConfiguration) WithVolumeMounts(values ...corev1.Vol
 	for i := range values {
 		b.VolumeMounts = append(b.VolumeMounts, values[i])
 	}
+	return b
+}
+
+// WithPersistentVolumeClaimRetentionPolicy sets the PersistentVolumeClaimRetentionPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PersistentVolumeClaimRetentionPolicy field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithPersistentVolumeClaimRetentionPolicy(value appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) *PrometheusSpecApplyConfiguration {
+	b.PersistentVolumeClaimRetentionPolicy = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -286,6 +287,14 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithVolumeMounts(values ...corev
 	for i := range values {
 		b.VolumeMounts = append(b.VolumeMounts, values[i])
 	}
+	return b
+}
+
+// WithPersistentVolumeClaimRetentionPolicy sets the PersistentVolumeClaimRetentionPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PersistentVolumeClaimRetentionPolicy field is set to the value of the last call.
+func (b *PrometheusAgentSpecApplyConfiguration) WithPersistentVolumeClaimRetentionPolicy(value appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) *PrometheusAgentSpecApplyConfiguration {
+	b.PersistentVolumeClaimRetentionPolicy = &value
 	return b
 }
 

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -153,6 +153,10 @@ func makeStatefulSet(
 
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, cpf.Volumes...)
 
+	if cpf.PersistentVolumeClaimRetentionPolicy != nil {
+		statefulset.Spec.PersistentVolumeClaimRetentionPolicy = cpf.PersistentVolumeClaimRetentionPolicy
+	}
+
 	if cpf.HostNetwork {
 		statefulset.Spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -216,6 +216,10 @@ func makeStatefulSet(
 
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, cpf.Volumes...)
 
+	if cpf.PersistentVolumeClaimRetentionPolicy != nil {
+		statefulset.Spec.PersistentVolumeClaimRetentionPolicy = cpf.PersistentVolumeClaimRetentionPolicy
+	}
+
 	if cpf.HostNetwork {
 		statefulset.Spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -2806,3 +2806,26 @@ func TestPodHostNetworkConfig(t *testing.T) {
 		t.Fatalf("expected DNSPolicy configuration to match due to hostNetwork but failed")
 	}
 }
+
+func TestPersistentVolumeClaimRetentionPolicy(t *testing.T) {
+	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	if sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("expected persistentVolumeClaimDeletePolicy.WhenDeleted to be %s but got %s", appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+	}
+
+	if sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("expected persistentVolumeClaimDeletePolicy.WhenScaled to be %s but got %s", appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+	}
+}


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Allows configuring a Statefulsets persistentVolumeClaimRetentionPolicy which will allow for easier statefulset cleanups on deletion.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: Add `persistentVolumeClaimRetentionPolicy` field to the Prometheus and PrometheusAgent CRDs.
```
