### PR TITLE
enhancement: include operator version in CRD annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ generate: k8s-gen generate-crds bundle.yaml example/mixin/alerts.yaml example/th
 .PHONY: generate-crds
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET) $(TYPES_V1BETA1_TARGET)
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./v1/. paths=./v1alpha1/. output:crd:dir=$(PWD)/example/prometheus-operator-crd/
+	find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '/^    controller-gen.kubebuilder.io.version.*/a \    prometheus-operator.dev\/version: $(VERSION)' {} +
 	find example/prometheus-operator-crd/ -name '*.yaml' -print0 | xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./... output:crd:dir=$(PWD)/example/prometheus-operator-crd-full
 	echo "// Code generated using 'make generate-crds'. DO NOT EDIT." > $(PWD)/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ generate: k8s-gen generate-crds bundle.yaml example/mixin/alerts.yaml example/th
 .PHONY: generate-crds
 generate-crds: $(CONTROLLER_GEN_BINARY) $(GOJSONTOYAML_BINARY) $(TYPES_V1_TARGET) $(TYPES_V1ALPHA1_TARGET) $(TYPES_V1BETA1_TARGET)
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./v1/. paths=./v1alpha1/. output:crd:dir=$(PWD)/example/prometheus-operator-crd/
-	find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '/^    controller-gen.kubebuilder.io.version.*/a \    prometheus-operator.dev\/version: $(VERSION)' {} +
+	VERSION=$(VERSION) ./scripts/generate/append-operator-version.sh
 	find example/prometheus-operator-crd/ -name '*.yaml' -print0 | xargs -0 -I{} sh -c '$(GOJSONTOYAML_BINARY) -yamltojson < "$$1" | jq > "$(PWD)/jsonnet/prometheus-operator/$$(basename $$1 | cut -d'_' -f2 | cut -d. -f1)-crd.json"' -- {}
 	cd pkg/apis/monitoring && $(CONTROLLER_GEN_BINARY) crd:crdVersions=v1 paths=./... output:crd:dir=$(PWD)/example/prometheus-operator-crd-full
 	echo "// Code generated using 'make generate-crds'. DO NOT EDIT." > $(PWD)/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
@@ -5672,6 +5673,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:
@@ -13083,6 +13085,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:
@@ -13774,6 +13777,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:
@@ -14507,6 +14511,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheusagents.monitoring.coreos.com
 spec:
@@ -22939,6 +22944,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
@@ -32707,6 +32713,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:
@@ -32838,6 +32845,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: scrapeconfigs.monitoring.coreos.com
 spec:
@@ -34107,6 +34115,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
@@ -34828,6 +34837,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
@@ -5673,7 +5673,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:
@@ -13085,7 +13085,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:
@@ -13777,7 +13777,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:
@@ -14511,7 +14511,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheusagents.monitoring.coreos.com
 spec:
@@ -22944,7 +22944,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
@@ -32713,7 +32713,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:
@@ -32845,7 +32845,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: scrapeconfigs.monitoring.coreos.com
 spec:
@@ -34115,7 +34115,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
@@ -34837,7 +34837,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/example/alertmanager-crd-conversion/patch.json
+++ b/example/alertmanager-crd-conversion/patch.json
@@ -3,7 +3,8 @@
    "kind": "CustomResourceDefinition",
    "metadata": {
       "annotations": {
-         "controller-gen.kubebuilder.io/version": "v0.11.1"
+         "controller-gen.kubebuilder.io/version": "v0.11.1",
+         "prometheus-operator.dev/version": "0.68.0"
       },
       "creationTimestamp": null,
       "name": "alertmanagerconfigs.monitoring.coreos.com"

--- a/example/alertmanager-crd-conversion/patch.json
+++ b/example/alertmanager-crd-conversion/patch.json
@@ -4,7 +4,7 @@
    "metadata": {
       "annotations": {
          "controller-gen.kubebuilder.io/version": "v0.11.1",
-         "prometheus-operator.dev/version": "0.68.0"
+         "operator.prometheus.io/version": "0.68.0"
       },
       "creationTimestamp": null,
       "name": "alertmanagerconfigs.monitoring.coreos.com"

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheusagents.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheusagents.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: scrapeconfigs.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: scrapeconfigs.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
+    prometheus-operator.dev/version: 0.68.0
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
-    prometheus-operator.dev/version: 0.68.0
+    operator.prometheus.io/version: 0.68.0
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "alertmanagerconfigs.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "alertmanagerconfigs.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "alertmanagers.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "alertmanagers.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "podmonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "podmonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "probes.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "probes.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheusagents.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheusagents.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheuses.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheuses.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheusrules-crd.json
+++ b/jsonnet/prometheus-operator/prometheusrules-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheusrules.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/prometheusrules-crd.json
+++ b/jsonnet/prometheus-operator/prometheusrules-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "prometheusrules.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "scrapeconfigs.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "scrapeconfigs.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "servicemonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "servicemonitors.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3,7 +3,8 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.11.1"
+      "controller-gen.kubebuilder.io/version": "v0.11.1",
+      "prometheus-operator.dev/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "thanosrulers.monitoring.coreos.com"

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4,7 +4,7 @@
   "metadata": {
     "annotations": {
       "controller-gen.kubebuilder.io/version": "v0.11.1",
-      "prometheus-operator.dev/version": "0.68.0"
+      "operator.prometheus.io/version": "0.68.0"
     },
     "creationTimestamp": null,
     "name": "thanosrulers.monitoring.coreos.com"

--- a/scripts/generate/append-operator-version.sh
+++ b/scripts/generate/append-operator-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '' -e "/^    controller-gen.kubebuilder.io.version.*/a\\
+    prometheus-operator.dev/version: $VERSION" {} +
+else
+  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    prometheus-operator.dev/version: $VERSION" {} +
+fi

--- a/scripts/generate/append-operator-version.sh
+++ b/scripts/generate/append-operator-version.sh
@@ -2,7 +2,7 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '' -e "/^    controller-gen.kubebuilder.io.version.*/a\\
-    prometheus-operator.dev/version: $VERSION" {} +
+    operator.prometheus.io/version: $VERSION" {} +
 else
-  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    prometheus-operator.dev/version: $VERSION" {} +
+  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    operator.prometheus.io/version: $VERSION" {} +
 fi


### PR DESCRIPTION
## Description

Include operator version in CRD annotations, PTAL https://github.com/prometheus-operator/prometheus-operator/pull/4498 for details.

Fixes: #4344.

***

This patch builds on top of @paulfantom's PR by (a) rebasing it against `main` and (b) adding support for the corresponding GNU `sed`-based behavior in MacOS using BSD `sed`.

***

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Include operator version in CRD annotations ("prometheus-operator.dev/version").
```