### PR TITLE
Ignore invalid CRDs and pick up valid CRDs without failing and add validation for relabeling and metricRelabeling fields for pod/svc monitors

### DIFF
--- a/pkg/apis/monitoring/v1/register.go
+++ b/pkg/apis/monitoring/v1/register.go
@@ -20,20 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
-	"os"
 )
 
-var PackageGroupName = func() string {
-	group := monitoring.GroupName
-	customGroupV1 := os.Getenv("PROMETHEUS_OPERATOR_V1_CUSTOM_GROUP")
-	if customGroupV1 != "" {
-		group = customGroupV1
-	}
-	return group
-}()
-
 // SchemeGroupVersion is the group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: PackageGroupName, Version: Version}
+var SchemeGroupVersion = schema.GroupVersion{Group: monitoring.GroupName, Version: Version}
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {

--- a/pkg/apis/monitoring/v1/register.go
+++ b/pkg/apis/monitoring/v1/register.go
@@ -20,10 +20,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
+	"os"
 )
 
+var PackageGroupName = func() string {
+	group := monitoring.GroupName
+	customGroupV1 := os.Getenv("PROMETHEUS_OPERATOR_V1_CUSTOM_GROUP")
+	if customGroupV1 != "" {
+		group = customGroupV1
+	}
+	return group
+}()
+
 // SchemeGroupVersion is the group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: monitoring.GroupName, Version: Version}
+var SchemeGroupVersion = schema.GroupVersion{Group: PackageGroupName, Version: Version}
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {


### PR DESCRIPTION
## Description

When a podmonitor/svcmonitor CRD has an erraneous field for regex in the relabeling/metric relabeling fields, the crd creation succeeds since it can be a valid string but not a valid regex( ex- .*( ). This causes any subsequent valid CRDs being created from getting picked up. Also, the current generatePodMonitorConfig/generateServiceMonitorConfig doesnt do any validation for relabeling/metricRelabeling. Can leverage the **validateRelabelConfig** method here - https://github.com/prometheus-operator/prometheus-operator/blob/dfc150aa362f0260060979d0b53a524efb974168/pkg/prometheus/resource_selector.go#L236

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry
```release-note
Add validation for relabeling/metricsRelabeling for pod/service monitor and continue picking up valid CRDs and ignore invalid CRDs
```
