### PR TITLE
[WIP] feat: Support service names for individual Prometheus Instances

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5381,6 +5381,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              serviceName:
+                description: ServiceName is the name of the Service resource created
+                  for the PrometheusAgent instance.
+                type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
                   onto. `spec.replicas` multiplied by `spec.shards` is the total number
@@ -8376,6 +8380,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              serviceName:
+                description: ServiceName is the name of the Service resource associated
+                  with the Prometheus instance.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6357,6 +6357,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              serviceName:
+                description: ServiceName is the name of the Service resource created
+                  for the PrometheusAgent instance.
+                type: string
               sha:
                 description: '*Deprecated: use ''spec.image'' instead. The image''s
                   digest can be specified as part of the image name.*'
@@ -9775,6 +9779,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              serviceName:
+                description: ServiceName is the name of the Service resource associated
+                  with the Prometheus instance.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5382,6 +5382,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              serviceName:
+                description: ServiceName is the name of the Service resource created
+                  for the PrometheusAgent instance.
+                type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
                   onto. `spec.replicas` multiplied by `spec.shards` is the total number
@@ -8377,6 +8381,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              serviceName:
+                description: ServiceName is the name of the Service resource associated
+                  with the Prometheus instance.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6358,6 +6358,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              serviceName:
+                description: ServiceName is the name of the Service resource created
+                  for the PrometheusAgent instance.
+                type: string
               sha:
                 description: '*Deprecated: use ''spec.image'' instead. The image''s
                   digest can be specified as part of the image name.*'
@@ -9776,6 +9780,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              serviceName:
+                description: ServiceName is the name of the Service resource associated
+                  with the Prometheus instance.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4872,6 +4872,10 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic"
                   },
+                  "serviceName": {
+                    "description": "ServiceName is the name of the Service resource created for the PrometheusAgent instance.",
+                    "type": "string"
+                  },
                   "shards": {
                     "description": "EXPERIMENTAL: Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1",
                     "format": "int32",
@@ -7410,6 +7414,10 @@
                     "description": "Total number of non-terminated pods targeted by this Prometheus deployment (their labels match the selector).",
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "serviceName": {
+                    "description": "ServiceName is the name of the Service resource associated with the Prometheus instance.",
+                    "type": "string"
                   },
                   "shardStatuses": {
                     "description": "The list has one entry per shard. Each entry provides a summary of the shard status.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5882,6 +5882,10 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic"
                   },
+                  "serviceName": {
+                    "description": "ServiceName is the name of the Service resource created for the PrometheusAgent instance.",
+                    "type": "string"
+                  },
                   "sha": {
                     "description": "*Deprecated: use 'spec.image' instead. The image's digest can be specified as part of the image name.*",
                     "type": "string"
@@ -8841,6 +8845,10 @@
                     "description": "Total number of non-terminated pods targeted by this Prometheus deployment (their labels match the selector).",
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "serviceName": {
+                    "description": "ServiceName is the name of the Service resource associated with the Prometheus instance.",
+                    "type": "string"
                   },
                   "shardStatuses": {
                     "description": "The list has one entry per shard. Each entry provides a summary of the shard status.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -607,6 +607,9 @@ type CommonPrometheusFields struct {
 	//
 	// +optional
 	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	// ServiceName is the name of the Service resource created for the PrometheusAgent instance.
+	// +optional
+	ServiceName string `json:"serviceName,omitempty"`
 }
 
 // +genclient
@@ -861,6 +864,9 @@ type PrometheusStatus struct {
 	// +listMapKey=shardID
 	// +optional
 	ShardStatuses []ShardStatus `json:"shardStatuses,omitempty"`
+	// ServiceName is the name of the Service resource associated with the Prometheus
+	// instance.
+	ServiceName string `json:"serviceName,omitempty"`
 }
 
 // AlertingSpec defines parameters for alerting configuration of Prometheus servers.

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -100,6 +100,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	LabelNameLengthLimit            *uint64                                              `json:"labelNameLengthLimit,omitempty"`
 	LabelValueLengthLimit           *uint64                                              `json:"labelValueLengthLimit,omitempty"`
 	KeepDroppedTargets              *uint64                                              `json:"keepDroppedTargets,omitempty"`
+	ServiceName                     *string                                              `json:"serviceName,omitempty"`
 }
 
 // CommonPrometheusFieldsApplyConfiguration constructs an declarative configuration of the CommonPrometheusFields type for use with
@@ -759,5 +760,13 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelValueLengthLimit(val
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
 func (b *CommonPrometheusFieldsApplyConfiguration) WithKeepDroppedTargets(value uint64) *CommonPrometheusFieldsApplyConfiguration {
 	b.KeepDroppedTargets = &value
+	return b
+}
+
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithServiceName(value string) *CommonPrometheusFieldsApplyConfiguration {
+	b.ServiceName = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -710,6 +710,14 @@ func (b *PrometheusSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) 
 	return b
 }
 
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithServiceName(value string) *PrometheusSpecApplyConfiguration {
+	b.ServiceName = &value
+	return b
+}
+
 // WithBaseImage sets the BaseImage field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the BaseImage field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusstatus.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusstatus.go
@@ -26,6 +26,7 @@ type PrometheusStatusApplyConfiguration struct {
 	UnavailableReplicas *int32                          `json:"unavailableReplicas,omitempty"`
 	Conditions          []ConditionApplyConfiguration   `json:"conditions,omitempty"`
 	ShardStatuses       []ShardStatusApplyConfiguration `json:"shardStatuses,omitempty"`
+	ServiceName         *string                         `json:"serviceName,omitempty"`
 }
 
 // PrometheusStatusApplyConfiguration constructs an declarative configuration of the PrometheusStatus type for use with
@@ -97,5 +98,13 @@ func (b *PrometheusStatusApplyConfiguration) WithShardStatuses(values ...*ShardS
 		}
 		b.ShardStatuses = append(b.ShardStatuses, *values[i])
 	}
+	return b
+}
+
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *PrometheusStatusApplyConfiguration) WithServiceName(value string) *PrometheusStatusApplyConfiguration {
+	b.ServiceName = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -688,3 +688,11 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithKeepDroppedTargets(value uin
 	b.KeepDroppedTargets = &value
 	return b
 }
+
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *PrometheusAgentSpecApplyConfiguration) WithServiceName(value string) *PrometheusAgentSpecApplyConfiguration {
+	b.ServiceName = &value
+	return b
+}

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -429,9 +429,14 @@ func makeStatefulSetService(p *monitoringv1alpha1.PrometheusAgent, config operat
 		p.Spec.PortName = prompkg.DefaultPortName
 	}
 
+	serviceName := p.Spec.ServiceName
+	if serviceName == "" {
+		serviceName = governingServiceName
+	}
+
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: governingServiceName,
+			Name: serviceName,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name:       p.GetName(),

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -257,5 +257,12 @@ func (sr *StatusReporter) Process(ctx context.Context, p monitoringv1.Prometheus
 		sr.Reconciliations.GetCondition(key, p.GetObjectMeta().GetGeneration()),
 	)
 
+	if commonFields.ServiceName != "" {
+		pStatus.ServiceName = commonFields.ServiceName
+	} else {
+		const governingServiceName = "prometheus-agent-operated"
+		pStatus.ServiceName = governingServiceName
+	}
+
 	return &pStatus, nil
 }


### PR DESCRIPTION
## Description
This PR introduces the capability for each Prometheus instance managed by the Prometheus Operator to specify a `.spec.serviceName` in its configuration. This change allows individual instances to have their own dedicated Service resources. The motivation behind this feature is to provide modularity and stability by ensuring that changes to the Service configuration of one Prometheus instance do not affect other instances. This enhancement is particularly useful in environments where multiple Prometheus instances with different Thanos sidecar configurations are deployed.

Closes #6060 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added support for individual Service resources per Prometheus instance via .spec.serviceName, allowing for greater isolation and independent management of Prometheus instances within a cluster.
```
