### PR TITLE
add flag to enable liveness and readiness for the config-reloader container from jsonnet

### DIFF
--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -9,6 +9,7 @@ local defaults = {
     limits: { cpu: '', memory: '' },
     requests: { cpu: '', memory: '' },
   },
+  enableReloaderProbes: false,
   port: 8080,
   resources: {
     limits: { cpu: '200m', memory: '200Mi' },
@@ -147,6 +148,8 @@ function(params) {
   deployment:
     local reloaderResourceArg(arg, value) =
       if value != '' then [arg + '=' + value] else [];
+    local enableReloaderProbesArg(value) =
+      if value == true then ['--enable-config-reloader-probes=true'] else [];
 
     local container = {
       name: po.config.name,
@@ -158,7 +161,8 @@ function(params) {
             reloaderResourceArg('--config-reloader-cpu-limit', po.config.configReloaderResources.limits.cpu) +
             reloaderResourceArg('--config-reloader-memory-limit', po.config.configReloaderResources.limits.memory) +
             reloaderResourceArg('--config-reloader-cpu-request', po.config.configReloaderResources.requests.cpu) +
-            reloaderResourceArg('--config-reloader-memory-request', po.config.configReloaderResources.requests.memory),
+            reloaderResourceArg('--config-reloader-memory-request', po.config.configReloaderResources.requests.memory) +
+            enableReloaderProbesArg(po.config.enableReloaderProbes),
       ports: [{
         containerPort: po.config.port,
         name: 'http',


### PR DESCRIPTION
## Description

Adds flag to enable liveness and readiness for the config-reloader container from jsonnet.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Expose flag to enable the reloader probes in the jsonnet configuration.
```
