### PR TITLE
[WIP] Change logs to `os.Stdout`

### DIFF
--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -196,7 +196,6 @@ func main() {
 	}, func(error) {})
 
 	if err := g.Run(); err != nil {
-		// fmt.Fprintln(os.Stderr, err)
 		level.Error(logger).Log("msg", "Failed to run", "err", err)
 		os.Exit(1)
 	}

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -98,7 +98,7 @@ func main() {
 	versionutil.RegisterIntoKingpinFlags(app)
 
 	if _, err := app.Parse(os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stdout, err)
 		os.Exit(2)
 	}
 
@@ -196,7 +196,8 @@ func main() {
 	}, func(error) {})
 
 	if err := g.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// fmt.Fprintln(os.Stderr, err)
+		level.Error(logger).Log("msg", "Failed to run", "err", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1237,7 +1237,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				kclient:    c,
 				mclient:    monitoringfake.NewSimpleClientset(),
 				ssarClient: &alwaysAllowed{},
-				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowInfo()),
+				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowInfo()),
 				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
 				config: Config{
 					Namespaces: operator.Namespaces{

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -187,7 +187,7 @@ func TestWALCompression(t *testing.T) {
 }
 
 func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowWarn())
+	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 }
 
 func makeStatefulSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.StatefulSet, error) {

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowWarn())
+	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 }
 
 func TestValidateRelabelConfig(t *testing.T) {

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stderr), level.AllowWarn())
+	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 }
 
 func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulSet, error) {


### PR DESCRIPTION
## Description

According #6035 it's necessary change to `os.Stdout` instead `os.Stderr` and change `fmt.Print*` to `level` in logs.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
