### PR TITLE
feat: support remaining roles in kubernetesSD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -17519,15 +17519,6 @@ the inhibition to take effect.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="monitoring.coreos.com/v1alpha1.K8SRole">K8SRole
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.K8SSelectorConfig">K8SSelectorConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>)
-</p>
-<div>
-<p>K8SRole is role of the service in Kubernetes.
-Currently the only supported role is &ldquo;Node&rdquo;.</p>
-</div>
 <h3 id="monitoring.coreos.com/v1alpha1.K8SSelectorConfig">K8SSelectorConfig
 </h3>
 <p>
@@ -17548,8 +17539,8 @@ Currently the only supported role is &ldquo;Node&rdquo;.</p>
 <td>
 <code>role</code><br/>
 <em>
-<a href="#monitoring.coreos.com/v1alpha1.K8SRole">
-K8SRole
+<a href="#monitoring.coreos.com/v1alpha1.Role">
+Role
 </a>
 </em>
 </td>
@@ -17639,8 +17630,8 @@ See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configur
 <td>
 <code>role</code><br/>
 <em>
-<a href="#monitoring.coreos.com/v1alpha1.K8SRole">
-K8SRole
+<a href="#monitoring.coreos.com/v1alpha1.Role">
+Role
 </a>
 </em>
 </td>
@@ -20170,6 +20161,14 @@ It requires Alertmanager &gt;= 0.26.0.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1alpha1.Role">Role
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.K8SSelectorConfig">K8SSelectorConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>)
+</p>
+<div>
+<p>Role is role of the service in Kubernetes.</p>
+</div>
 <h3 id="monitoring.coreos.com/v1alpha1.Route">Route
 </h3>
 <p>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -33848,6 +33848,16 @@ spec:
                       enum:
                       - Node
                       - node
+                      - Service
+                      - service
+                      - Pod
+                      - pod
+                      - Endpoints
+                      - endpoints
+                      - EndpointSlice
+                      - endpointslice
+                      - Ingress
+                      - ingress
                       type: string
                     selectors:
                       description: Selector to select objects.
@@ -33859,11 +33869,20 @@ spec:
                           label:
                             type: string
                           role:
-                            description: K8SRole is role of the service in Kubernetes.
-                              Currently the only supported role is "Node".
+                            description: Role is role of the service in Kubernetes.
                             enum:
                             - Node
                             - node
+                            - Service
+                            - service
+                            - Pod
+                            - pod
+                            - Endpoints
+                            - endpoints
+                            - EndpointSlice
+                            - endpointslice
+                            - Ingress
+                            - ingress
                             type: string
                         required:
                         - role

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -922,6 +922,16 @@ spec:
                       enum:
                       - Node
                       - node
+                      - Service
+                      - service
+                      - Pod
+                      - pod
+                      - Endpoints
+                      - endpoints
+                      - EndpointSlice
+                      - endpointslice
+                      - Ingress
+                      - ingress
                       type: string
                     selectors:
                       description: Selector to select objects.
@@ -933,11 +943,20 @@ spec:
                           label:
                             type: string
                           role:
-                            description: K8SRole is role of the service in Kubernetes.
-                              Currently the only supported role is "Node".
+                            description: Role is role of the service in Kubernetes.
                             enum:
                             - Node
                             - node
+                            - Service
+                            - service
+                            - Pod
+                            - pod
+                            - Endpoints
+                            - endpoints
+                            - EndpointSlice
+                            - endpointslice
+                            - Ingress
+                            - ingress
                             type: string
                         required:
                         - role

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -919,6 +919,16 @@ spec:
                       enum:
                       - Node
                       - node
+                      - Service
+                      - service
+                      - Pod
+                      - pod
+                      - Endpoints
+                      - endpoints
+                      - EndpointSlice
+                      - endpointslice
+                      - Ingress
+                      - ingress
                       type: string
                     selectors:
                       description: Selector to select objects.
@@ -930,11 +940,20 @@ spec:
                           label:
                             type: string
                           role:
-                            description: K8SRole is role of the service in Kubernetes.
-                              Currently the only supported role is "Node".
+                            description: Role is role of the service in Kubernetes.
                             enum:
                             - Node
                             - node
+                            - Service
+                            - service
+                            - Pod
+                            - pod
+                            - Endpoints
+                            - endpoints
+                            - EndpointSlice
+                            - endpointslice
+                            - Ingress
+                            - ingress
                             type: string
                         required:
                         - role

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -1013,7 +1013,17 @@
                           "description": "Role of the Kubernetes entities that should be discovered.",
                           "enum": [
                             "Node",
-                            "node"
+                            "node",
+                            "Service",
+                            "service",
+                            "Pod",
+                            "pod",
+                            "Endpoints",
+                            "endpoints",
+                            "EndpointSlice",
+                            "endpointslice",
+                            "Ingress",
+                            "ingress"
                           ],
                           "type": "string"
                         },
@@ -1029,10 +1039,20 @@
                                 "type": "string"
                               },
                               "role": {
-                                "description": "K8SRole is role of the service in Kubernetes. Currently the only supported role is \"Node\".",
+                                "description": "Role is role of the service in Kubernetes.",
                                 "enum": [
                                   "Node",
-                                  "node"
+                                  "node",
+                                  "Service",
+                                  "service",
+                                  "Pod",
+                                  "pod",
+                                  "Endpoints",
+                                  "endpoints",
+                                  "EndpointSlice",
+                                  "endpointslice",
+                                  "Ingress",
+                                  "ingress"
                                 ],
                                 "type": "string"
                               }

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -40,17 +40,16 @@ type EC2Filter struct {
 	Values []string `json:"values"`
 }
 
-// K8SRole is role of the service in Kubernetes.
-// Currently the only supported role is "Node".
-// +kubebuilder:validation:Enum=Node;node
-type K8SRole string
+// Role is role of the service in Kubernetes.
+// +kubebuilder:validation:Enum=Node;node;Service;service;Pod;pod;Endpoints;endpoints;EndpointSlice;endpointslice;Ingress;ingress
+type Role string
 
 // K8SSelectorConfig is Kubernetes Selector Config
 type K8SSelectorConfig struct {
 	// +kubebuilder:validation:Required
-	Role  K8SRole `json:"role"`
-	Label string  `json:"label,omitempty"`
-	Field string  `json:"field,omitempty"`
+	Role  Role   `json:"role"`
+	Label string `json:"label,omitempty"`
+	Field string `json:"field,omitempty"`
 }
 
 // +genclient
@@ -239,7 +238,7 @@ type HTTPSDConfig struct {
 type KubernetesSDConfig struct {
 	// Role of the Kubernetes entities that should be discovered.
 	// +required
-	Role K8SRole `json:"role"`
+	Role Role `json:"role"`
 	// Selector to select objects.
 	// +optional
 	// +listType=map

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/k8sselectorconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/k8sselectorconfig.go
@@ -23,9 +23,9 @@ import (
 // K8SSelectorConfigApplyConfiguration represents an declarative configuration of the K8SSelectorConfig type for use
 // with apply.
 type K8SSelectorConfigApplyConfiguration struct {
-	Role  *v1alpha1.K8SRole `json:"role,omitempty"`
-	Label *string           `json:"label,omitempty"`
-	Field *string           `json:"field,omitempty"`
+	Role  *v1alpha1.Role `json:"role,omitempty"`
+	Label *string        `json:"label,omitempty"`
+	Field *string        `json:"field,omitempty"`
 }
 
 // K8SSelectorConfigApplyConfiguration constructs an declarative configuration of the K8SSelectorConfig type for use with
@@ -37,7 +37,7 @@ func K8SSelectorConfig() *K8SSelectorConfigApplyConfiguration {
 // WithRole sets the Role field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Role field is set to the value of the last call.
-func (b *K8SSelectorConfigApplyConfiguration) WithRole(value v1alpha1.K8SRole) *K8SSelectorConfigApplyConfiguration {
+func (b *K8SSelectorConfigApplyConfiguration) WithRole(value v1alpha1.Role) *K8SSelectorConfigApplyConfiguration {
 	b.Role = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/kubernetessdconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/kubernetessdconfig.go
@@ -23,7 +23,7 @@ import (
 // KubernetesSDConfigApplyConfiguration represents an declarative configuration of the KubernetesSDConfig type for use
 // with apply.
 type KubernetesSDConfigApplyConfiguration struct {
-	Role      *v1alpha1.K8SRole                     `json:"role,omitempty"`
+	Role      *v1alpha1.Role                        `json:"role,omitempty"`
 	Selectors []K8SSelectorConfigApplyConfiguration `json:"selectors,omitempty"`
 }
 
@@ -36,7 +36,7 @@ func KubernetesSDConfig() *KubernetesSDConfigApplyConfiguration {
 // WithRole sets the Role field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Role field is set to the value of the last call.
-func (b *KubernetesSDConfigApplyConfiguration) WithRole(value v1alpha1.K8SRole) *KubernetesSDConfigApplyConfiguration {
+func (b *KubernetesSDConfigApplyConfiguration) WithRole(value v1alpha1.Role) *KubernetesSDConfigApplyConfiguration {
 	b.Role = &value
 	return b
 }

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -90,7 +90,7 @@ func testScrapeConfigCreation(t *testing.T) {
 			spec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
-						Role: monitoringv1alpha1.K8SRole("Node"),
+						Role: monitoringv1alpha1.Role("Node"),
 					},
 				},
 			},
@@ -331,7 +331,7 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 
 	sc.Spec.KubernetesSDConfigs = []monitoringv1alpha1.KubernetesSDConfig{
 		{
-			Role: monitoringv1alpha1.K8SRole("Node"),
+			Role: monitoringv1alpha1.Role("Node"),
 		},
 	}
 	_, err = framework.CreateScrapeConfig(context.Background(), ns, sc)


### PR DESCRIPTION
add service,pod,endpoints,endpointslice,ingress roles
to KubernetesSDConfigs in ScrapeConfig CRD

Fixes #6086

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat:  support service,pod,endpoints,endpointslice,ingress roles
to KubernetesSDConfigs in ScrapeConfig CRD
