### PR TITLE
fix(shards): Skip adding shard relabel rules automatically if already set

### DIFF
--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_one_prometheus_shard.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_one_prometheus_shard.golden
@@ -20,3 +20,22 @@ scrape_configs:
     source_labels:
     - __meta_gce_label_app
     regex: my_app
+- job_name: gce_app_bar_custom_shard_relabeling
+  scrape_interval: 5s
+  gce_sd_config:
+  - project: foo_custom_shard_relabeling
+    zone: us-central1
+  relabel_configs:
+  - action: keep
+    source_labels:
+    - __meta_gce_label_app
+    regex: my_app
+  - source_labels:
+    - __address__
+    target_label: __tmp_hash
+    modulus: 999
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep

--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_sharded prometheus.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_sharded prometheus.golden
@@ -39,3 +39,22 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+- job_name: gce_app_bar_custom_shard_relabeling
+  scrape_interval: 5s
+  gce_sd_config:
+  - project: foo_custom_shard_relabeling
+    zone: us-central1
+  relabel_configs:
+  - action: keep
+    source_labels:
+    - __meta_gce_label_app
+    regex: my_app
+  - source_labels:
+    - __address__
+    target_label: __tmp_hash
+    modulus: 999
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep

--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_unsharded_prometheus.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_unsharded_prometheus.golden
@@ -20,3 +20,22 @@ scrape_configs:
     source_labels:
     - __meta_gce_label_app
     regex: my_app
+- job_name: gce_app_bar_custom_shard_relabeling
+  scrape_interval: 5s
+  gce_sd_config:
+  - project: foo_custom_shard_relabeling
+    zone: us-central1
+  relabel_configs:
+  - action: keep
+    source_labels:
+    - __meta_gce_label_app
+    regex: my_app
+  - source_labels:
+    - __address__
+    target_label: __tmp_hash
+    modulus: 999
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    regex: $(SHARD)
+    action: keep

--- a/pkg/prometheus/testdata/TestAdditionalScrapeConfigsAdditionalScrapeConfig.golden
+++ b/pkg/prometheus/testdata/TestAdditionalScrapeConfigsAdditionalScrapeConfig.golden
@@ -12,3 +12,22 @@
       source_labels:
         - __meta_gce_label_app
       regex: my_app
+- job_name: gce_app_bar_custom_shard_relabeling
+  scrape_interval: 5s
+  gce_sd_config:
+    - project: foo_custom_shard_relabeling
+      zone: us-central1
+  relabel_configs:
+    - action: keep
+      source_labels:
+        - __meta_gce_label_app
+      regex: my_app
+    - source_labels:
+      - __address__
+      target_label: __tmp_hash
+      modulus: 999
+      action: hashmod
+    - source_labels:
+      - __tmp_hash
+      regex: $(SHARD)
+      action: keep


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Currently sharding relabels are automatically added to additional scrape configs. However, users might have custom sharding relabels similar to the issue in #6063. We should skip those if we find an action with the value `hashmod` already there.

Fixes #6063.

Without this change the sharded tests would have duplicate hashmod functions.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix(shards): Skip adding shard relabel rules automatically if already set
```
