### PR TITLE
chore: adding scrape classe

### DIFF
--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -58,7 +58,7 @@ It is proposed that the `Prometheus` and `PrometheusAgent` resources contain a n
 The rationale for defining scrape classes inline is that, in practice, the TLS file paths are closely related to the `volumeMounts`
 of the `Prometheus` spec. An alternative is outlined later, of factoring the class definitions into a separate resource.
 
-Define a scrape classes for use by the monitors, one class may be designated as the default class.
+One (and only one) scrape class may be designated as the default class.
 
 When a resource defines several default scrape classes, it should fail the reconciliation.
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -84,7 +84,7 @@ Any object references in the scrape class definition are assumed to refer to obj
 
 ### PodMonitor Resource
 
-Allow the user to select a scrape class for each endpoint.
+Allow the user to select a scrape class which applies to all endpoints.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -44,7 +44,7 @@ A scrape class defines TLS settings (and possibly other settings in future, e.g.
 One scrape class may be designated as the default class, in which case that class is applied to any scrape config that doesn't specify a value for `scrapeClass`.
 
 When defining a podmonitor/servicemonitor/probe/scrapeconfig, a user may assign a scrape class via the `scrapeClass` field.
-For monitors, each endpoint may be assigned a scrape class.
+When there's a match, a scrape class is assigned to all the endpoints.
 
 Class names are assumed to be installation-specific. In practice, some common class names like `istio-mtls` are likely to emerge.
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -74,6 +74,10 @@ spec:
   volumeMounts:
     - name: istio-certs
       mountPath: "/etc/istio-certs/"
+  volumes:
+    - name: istio-certs
+      secret:
+        secretName: istio-certs
 ```
 
 Any object references in the scrape class definition are assumed to refer to objects in the namespace of the `Prometheus` object.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -1,0 +1,217 @@
+## Scrape Classes
+
+* **Owners:**
+  * `nicolastakashi`
+  * `eronwright`
+
+* **Related Tickets:**
+  * https://github.com/prometheus-operator/prometheus-operator/issues/4121
+  * https://github.com/prometheus-operator/prometheus-operator/issues/3922
+  * https://github.com/prometheus-operator/prometheus-operator/issues/5947
+  * https://github.com/prometheus-operator/prometheus-operator/issues/5948
+
+This proposal introduces the concept of *scrape classes*, enabling users to utilize scrape configuration data provided by the administrator, through scrape objects such as PodMonitor, Probe, ServiceMonitor and ScrapeConfig.
+
+## Why
+
+Sometimes Prometheus administrators needs to provide default configurations for scrape objects, such as the definition of TLS certificates, when running Prometheus to scrape pods in an Istio mesh with strict mTLS as described in [Istio documentation](https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings).
+
+Another motivation is to improve feature parity amongst the monitor resources. The `PodMonitor` and `Probe` resources aren't at parity with `ServiceMonitor` because the latter allows for unsafe TLS settings.
+
+### Pitfalls of the current solution
+
+The only known solution for use cases where you'd need to use unsafe TLS settings is to use `additionalScrapeConfig`.
+The downside is obviously the loss of a great feature of the Prometheus Operator. The monitor resources make it possible
+to compose the scrape configurations in a Kubernetes way.
+
+## Goals
+
+- Allow for the administrator to define a named, reusable scrape configuration snippet, including unsafe elements such as file references.
+- Allow for a user to select a configuration snippet by name in their probe/podmonitor/servicemonitor endpoint configuration.
+- Avoid giving the user the ability to use arbirary files within the Prometheus pod.
+
+### Audience
+
+- Users who serve Prometheus as a service and want to give their customers autonomy in defining monitors, but want to provide a default configuration for scraping.
+
+## How
+
+The proposed solution is to introduce a notion of a *scrape class*, akin to a Kubernetes [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/).
+A scrape class defines TLS settings (and possibly other settings in future, e.g. sensitive authorization settings) to be applied to all scrape configs of that class.
+
+One scrape class may be designated as the default class, in which case that class is applied to any scrape config that doesn't specify a value for `scrapeClass`.
+
+When defining a podmonitor/servicemonitor/probe/scrapeconfig, a user may assign a scrape class via the `scrapeClass` field.
+For monitors, each endpoint may be assigned a scrape class.
+
+Class names are assumed to be installation-specific. In practice, some common class names like `istio-mtls` are likely to emerge.
+
+### Prometheus Resource
+
+It is proposed that the `Prometheus` and `PrometheusAgent` resources contain a new section for defining scrape classes.
+
+The rationale for defining scrape classes inline is that, in practice, the TLS file paths are closely related to the `volumeMounts`
+of the `Prometheus` spec. An alternative is outlined later, of factoring the class definitions into a separate resource.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+spec:
+  # define scrape classes for use by the monitors
+  # one class may be designated as the default class
+  scrapeClasses:
+    - name: istio-mtls
+      default: true
+      tlsConfig:
+        caFile: "/etc/istio-certs/root-cert.pem"
+        certFile: "/etc/istio-certs/cert-chain.pem"
+        keyFile: "/etc/istio-certs/key.pem"
+        insecureSkipVerify: true
+
+  # mount the certs from the istio sidecar (shown here for illustration purposes)
+  volumeMounts:
+    - name: istio-certs
+      mountPath: "/etc/istio-certs/"
+```
+
+Any object references in the scrape class definition are assumed to refer to objects in the namespace of the `Prometheus` object.
+
+### PodMonitor Resource
+
+Allow the user to select a scrape class for each endpoint.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+spec:
+  scrapeClass: istio-mtls
+  podMetricsEndpoints:
+  - port: http
+    path: /metrics
+```
+
+The proposed behavior is:
+1. the `tlsConfig` in the associated scrape class is automatically applied to the scrape configuration of the endpoint.
+2. the inline `tlsConfig` (if any) takes precedence over the `tlsConfig` in the scrape class.
+
+### Probe Resource
+
+Allow the user to select a scrape class for the probe.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+spec:
+  scrapeClass: istio-mtls
+```
+
+### ServiceMonitor Resource
+
+Allow the user to select a scrape class for each endpoint.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+spec:
+  scrapeClass: istio-mtls
+  endpoints:
+  - port: http
+    path: /metrics
+```
+
+Out-of-scope: deprecation of the unsafe TLS settings in `ServiceMonitor`.
+
+### ScrapeConfig
+
+Allow the user to select a scrape class for the generic scrape configuration.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: scrape-config
+spec:
+  scrapeClass: istio-mtls
+  staticConfigs:
+    [...]
+  httpSDConfig:
+    [...]
+  fileSDConfig:
+    [...]
+```
+
+## Test Plan
+
+1. Regression test; ensure no change to generated configs unless a scrape class is applied.
+2. Optionality of the default scrape class; ensure that it is an optional configuration element.
+3. Acceptance testing in Istio environment; ensure that the solution is effective for a key use case.
+
+## Alternatives
+
+### Global scrape TLS configuration
+
+An alternative solution would be to apply a default TLS configuration to all monitors.
+
+For example, via a hypothetical field `spec.scrapeTlsConfig`:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+spec:
+  scrapeTlsConfig:
+    caFile: "/etc/istio-certs/root-cert.pem"
+    certFile: "/etc/istio-certs/cert-chain.pem"
+    keyFile: "/etc/istio-certs/key.pem"
+    insecureSkipVerify: true
+```
+
+Objections:
+1. A singular default configuration may be too inflexible to effectively scrape a diverse set of pods. For example, in Istio,
+   some pods may be in STRICT mode.
+
+### Istio Permissive Mode
+
+An alternative for the Istio use case is to use PERMISSIVE mode (see [documentation](https://istio.io/latest/docs/concepts/security/#permissive-mode)),
+or to use `exclude` annotations on the pod such that the metrics endpoint bypasses mTLS.
+
+Objections:
+1. This solution is less secure at a transport level unless TLS is implemented at the application layer.
+2. Strict mTLS is the basis for [Istio authorization policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/), e.g. to explicitly allow access from prom to the metrics endpoint.
+
+### ScrapeClass Resource
+
+A variant of the proposed solution is to introduce a new custom resource for defining scrape classes.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeClass
+metadata:
+  name: istio-mtls
+spec:
+  tlsConfig:
+    caFile: "/etc/istio-certs/root-cert.pem"
+    certFile: "/etc/istio-certs/cert-chain.pem"
+    keyFile: "/etc/istio-certs/key.pem"
+    insecureSkipVerify: true
+```
+
+An open question is whether the resource would be cluster-scoped or namespace-scoped.
+
+Objections:
+1. Since the file paths are dependent on the volume mounts in the server, this approach may not achieve a meaningful decoupling.
+2. Extra complexity in defining a new CRD.
+
+### Non-Safe Monitors
+
+Another alternative would be to allow `PodMonitor` and `Probe` to use unsafe TLS settings.
+
+Objections:
+1. See [explanation](https://github.com/prometheus-operator/prometheus-operator/issues/3922#issuecomment-802899950) for why
+   unsafe settings were disallowed in the first place.
+
+## Action Plan
+
+* [ ] Change the Operator API to define scrape classes and for endpoint to select a scrape class
+* [ ] Update the scrape configuration generator to use the scrape class
+* [ ] Update documentation
+* [ ] Resolve issues #4121, #3922

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -155,7 +155,7 @@ If the monitor resource specifies a scrape class name that isn't defined in the 
 
 This behavior is consistent with the behavior of monitor resources referencing a non-existing secret for bearer token authentication.
 
-To ensure users will have proper information about the error, the operator will emit an event with the error message on the monitor resource and also update the status of the monitor resource with the error message.
+To ensure users will have proper information about the error, the operator may (in the future) emit an event with the error message on the monitor resource and also update the status of the monitor resource with the error message.
 
 ## Test Plan
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -32,7 +32,7 @@ to compose the scrape configurations in a Kubernetes way.
 
 ## Non-Goals
 
-- Allow Prometheus owners to override the configuration defined in the monitoring resources (at least in the first iteration).
+- Provide a way for Prometheus administrators to enforce/override settings on scrape configurations.
 
 - Deprecation of the unsafe TLS settings in `ServiceMonitor`.
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -29,6 +29,7 @@ to compose the scrape configurations in a Kubernetes way.
 - Allow for the administrator to define a named, reusable scrape configuration snippet, including unsafe elements such as file references.
 - Allow for a user to select a configuration snippet by name in their probe/podmonitor/servicemonitor endpoint configuration.
 - Avoid giving the user the ability to use arbirary files within the Prometheus pod.
+
 ## Non-Goals
 
 - Allow Prometheus owners to override the configuration defined in the monitoring resources (at least in the first iteration).

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -21,8 +21,8 @@ Another motivation is to improve feature parity amongst the monitor resources. T
 ### Pitfalls of the current solution
 
 The only known solution for use cases where you'd need to use unsafe TLS settings is to use `additionalScrapeConfig`.
-The downside is obviously the loss of a great feature of the Prometheus Operator. The monitor resources make it possible
-to compose the scrape configurations in a Kubernetes way.
+
+The downside is the loss of integration provided by Prometheus Operator through monitor resources to compose the scrape configurations in a Kubernetes way.
 
 ## Goals
 
@@ -64,6 +64,7 @@ kind: Prometheus
 spec:
   # define scrape classes for use by the monitors
   # one class may be designated as the default class
+  # when a resource defines several default scrape classes, it should fail the reconciliation.
   scrapeClasses:
     - name: istio-mtls
       default: true
@@ -78,9 +79,9 @@ spec:
     - name: istio-certs
       mountPath: "/etc/istio-certs/"
   volumes:
-    - name: istio-certs
-      secret:
-        secretName: istio-certs
+  - emptyDir:
+      medium: Memory
+    name: istio-certs
 ```
 
 Any object references in the scrape class definition are assumed to refer to objects in the namespace of the `Prometheus` object.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -218,7 +218,7 @@ Objections:
 
 ## Action Plan
 
-* [ ] Change the Operator API to define scrape classes and for endpoint to select a scrape class
+* [ ] Change the Operator API to define scrape classes and for scrape resources to select a scrape class
 * [ ] Update the scrape configuration generator to use the scrape class
 * [ ] Update documentation
 * [ ] Resolve issues #4121, #3922

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -44,7 +44,7 @@ The downside is the loss of integration provided by Prometheus Operator through 
 The proposed solution is to introduce a notion of a *scrape class*, akin to a Kubernetes [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/).
 A scrape class defines TLS settings (and possibly other settings in future, e.g. sensitive authorization settings) to be applied to all scrape configs of that class.
 
-One scrape class may be designated as the default class, in which case that class is applied to any scrape config that doesn't specify a value for `scrapeClass`.
+One scrape class may be designated as the default class, in which case that class is applied to any scrape resource that doesn't specify a value for `scrapeClassName`.
 
 When defining a podmonitor/servicemonitor/probe/scrapeconfig, a user may assign a scrape class via the `scrapeClass` field.
 When there's a match, a scrape class is assigned to all the endpoints.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -87,6 +87,14 @@ spec:
 
 Any object references in the scrape class definition are assumed to refer to objects in the namespace of the `Prometheus` object.
 
+### Monitoring Resource
+
+If the monitor resource specifies a scrape class name that isn't defined in the Prometheus/PrometheusAgent object, then the scrape resource is rejected by the operator.
+
+This behavior is consistent with the behavior of monitor resources referencing a non-existing secret for bearer token authentication.
+
+To ensure users will have proper information about the error, the operator may (in the future) emit an event with the error message on the monitor resource and also update the status of the monitor resource with the error message.
+
 ### PodMonitor Resource
 
 Allow the user to select a scrape class which applies to all endpoints.
@@ -102,10 +110,6 @@ spec:
 ```
 
 If the `Monitor` resource has a `tlsConfig` field defined, the Operator will use a merge strategy to combine the `tlsConfig` fields from the PodMonitor object with the `tlsConfig` fields of the scrape class, the `tlsConfig` fields in the `PodMonitor` resource take precedence.
-
-If the resource specifies a scrape class name that isn't defined in the Prometheus/PrometheusAgent object, then the scrape resource is dropped by the operator.
-
-If the resource doesn't specify a scrape class name and the Prometheus/PrometheusAgent object defines a default scrape class, the operator will act as if the PodMonitor resource specified the default scrape class name.
 
 ### Probe Resource
 
@@ -134,7 +138,7 @@ spec:
 
 ### ScrapeConfig
 
-Allow the user to select a scrape class for the generic scrape configuration.
+Allow the user to select a scrape class for the whole scrape configuration.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1
@@ -150,12 +154,6 @@ spec:
   fileSDConfig:
     [...]
 ```
-
-If the monitor resource specifies a scrape class name that isn't defined in the Prometheus/PrometheusAgent object, then the scrape resource is rejected by the operator.
-
-This behavior is consistent with the behavior of monitor resources referencing a non-existing secret for bearer token authentication.
-
-To ensure users will have proper information about the error, the operator may (in the future) emit an event with the error message on the monitor resource and also update the status of the monitor resource with the error message.
 
 ## Test Plan
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -104,7 +104,7 @@ If the `Monitor` resource has a `tlsConfig` field defined, the Operator will use
 
 ### Probe Resource
 
-Allow the user to select a scrape class for the probe.
+Allow the user to select a scrape class for the prober service.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -53,7 +53,7 @@ Class names are assumed to be installation-specific. In practice, some common cl
 
 ### Prometheus Resource
 
-It is proposed that the `Prometheus` and `PrometheusAgent` resources contain a new section for defining scrape classes.
+It is proposed that the `Prometheus` and `PrometheusAgent` resources contain a new field for defining scrape classes.
 
 The rationale for defining scrape classes inline is that, in practice, the TLS file paths are closely related to the `volumeMounts`
 of the `Prometheus` spec. An alternative is outlined later, of factoring the class definitions into a separate resource.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -28,7 +28,7 @@ The downside is the loss of integration provided by Prometheus Operator through 
 
 - Allow for the administrator to define a named, reusable scrape configuration snippet, including unsafe elements such as file references.
 - Allow for a user to select a configuration snippet by name in their probe/podmonitor/servicemonitor endpoint configuration.
-- Avoid giving the user the ability to use arbirary files within the Prometheus pod.
+- Avoid giving the user the ability to exflitrate arbitrary files within the Prometheus pod.
 
 ## Non-Goals
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -33,7 +33,6 @@ to compose the scrape configurations in a Kubernetes way.
 ## Non-Goals
 
 - Provide a way for Prometheus administrators to enforce/override settings on scrape configurations.
-
 - Deprecation of the unsafe TLS settings in `ServiceMonitor`.
 
 ### Audience

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -205,7 +205,6 @@ An open question is whether the resource would be cluster-scoped or namespace-sc
 Objections:
 
 1. Since the file paths are dependent on the volume mounts in the server, this approach may not achieve a meaningful decoupling.
-
 2. Extra complexity in defining a new CRD.
 
 ### Non-Safe Monitors

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -120,7 +120,7 @@ spec:
 
 ### ServiceMonitor Resource
 
-Allow the user to select a scrape class for each endpoint.
+Allow the user to select a scrape class for all endpoints.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -99,7 +99,7 @@ spec:
     path: /metrics
 ```
 
-If the `Monitor` resource has a `tlsConfig` field defined, the Operator will use a merge strategy to combine the `tlsConfig` with the `tlsConfig` of the scrape class, but the `tlsConfig` in the `Monitor` resource takes precedence.
+If the `Monitor` resource has a `tlsConfig` field defined, the Operator will use a merge strategy to combine the `tlsConfig` fields from the PodMonitor object with the `tlsConfig` fields of the scrape class, the `tlsConfig` fields in the `PodMonitor` resource take precedence.
 
 ### Probe Resource
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -29,7 +29,9 @@ to compose the scrape configurations in a Kubernetes way.
 - Allow for the administrator to define a named, reusable scrape configuration snippet, including unsafe elements such as file references.
 - Allow for a user to select a configuration snippet by name in their probe/podmonitor/servicemonitor endpoint configuration.
 - Avoid giving the user the ability to use arbirary files within the Prometheus pod.
+## Non-Goals
 
+- Allow Prometheus owners to override the configuration defined in the monitoring resources (at least in the first iteration).
 ### Audience
 
 - Users who serve Prometheus as a service and want to give their customers autonomy in defining monitors, but want to provide a default configuration for scraping.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -33,6 +33,7 @@ to compose the scrape configurations in a Kubernetes way.
 ## Non-Goals
 
 - Allow Prometheus owners to override the configuration defined in the monitoring resources (at least in the first iteration).
+
 ### Audience
 
 - Users who serve Prometheus as a service and want to give their customers autonomy in defining monitors, but want to provide a default configuration for scraping.

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -42,7 +42,7 @@ The downside is the loss of integration provided by Prometheus Operator through 
 ## How
 
 The proposed solution is to introduce a notion of a *scrape class*, akin to a Kubernetes [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/).
-A scrape class defines TLS settings (and possibly other settings in future, e.g. sensitive authorization settings) to be applied to all scrape configs of that class.
+A scrape class defines TLS settings (and possibly other settings in future, e.g. sensitive authorization settings) to be applied to all scrape resources (ServiceMonitor, PodMonitor, Probe and ScrapeConfig) of that class.
 
 One scrape class may be designated as the default class, in which case that class is applied to any scrape resource that doesn't specify a value for `scrapeClassName`.
 

--- a/Documentation/proposals/202305-scrapeclasses.md
+++ b/Documentation/proposals/202305-scrapeclasses.md
@@ -46,7 +46,7 @@ A scrape class defines TLS settings (and possibly other settings in future, e.g.
 
 One scrape class may be designated as the default class, in which case that class is applied to any scrape resource that doesn't specify a value for `scrapeClassName`.
 
-When defining a podmonitor/servicemonitor/probe/scrapeconfig, a user may assign a scrape class via the `scrapeClass` field.
+When defining a podmonitor/servicemonitor/probe/scrapeconfig, a user may assign a scrape class via the `scrapeClassName field.
 When there's a match, a scrape class is assigned to all the endpoints.
 
 Class names are assumed to be installation-specific. In practice, some common class names like `istio-mtls` are likely to emerge.


### PR DESCRIPTION
## Description

Taking over #5572 

Proposal to add scrape classes to facilitate the use of non-safe TLS elements in a scrape configuration, e.g. in the Istio use case.

A draft implementation is available: https://github.com/prometheus-operator/prometheus-operator/pull/5618. Links to significant code changes: [prom api](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-b4a3c944005e67c959c04552108ff3b629b572d7244d586b0558651bd96eacda), [scrape class](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-255c0aca616a1cdf4385c88d1d063a6c86360fedf99f7fc76bb967034e68897cR642-R652), [podmonitor api](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-ed302c709df2a336b5712f4f4442e4972be00571fd5293c61e0f65f752b9e10a), [operator](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-2297eaf6931eb847fb894df894f8f50ac9fb7cc823e440280d5908b5c9939104), [config generator](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-453ce9c721c51bf9591c2b212e9ce50157b9c40d1b211177bf502be268099656), and [tests](https://github.com/prometheus-operator/prometheus-operator/pull/5618/files#diff-40b00673aa9acb2e0dd5431cb36eedc1476124b086a3e070f5d6182709f8ea35).


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Adding Scrape Classe Proposal
```
