### PR TITLE
Update stale workflow to close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,9 +11,10 @@ jobs:
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had any activity in the last 60 days. Thank you for your contributions.'
           close-issue-message: 'This issue was closed because it has not had any activity in the last 120 days. Please reopen if you feel this is still valid.'
+          close-pr-message: "This pull request is being closed because it has not had any activity in the last 180 days. This is not a signal from the maintainers that the PR has no value. We appreciate the time and effort that you put into this work. If you're willing to re-open it, the maintainers will do their best to review it."
           days-before-stale: 60
           days-before-issue-close: 120
-          days-before-pr-close: -1  # Prevent closing PRs
+          days-before-pr-close: 180
           exempt-issue-labels: 'kind/feature,help wanted,kind/bug,kind/documentation'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had any activity in the last 60 days. Thank you for your contributions.'
           close-issue-message: 'This issue was closed because it has not had any activity in the last 120 days. Please reopen if you feel this is still valid.'
-          close-pr-message: "This pull request is being closed because it has not had any activity in the last 180 days. This is not a signal from the maintainers that the PR has no value. We appreciate the time and effort that you put into this work. If you're willing to re-open it, the maintainers will do their best to review it."
+          close-pr-message: "This pull request is being closed because it had no activity in the last 180 days. This is not a signal from the maintainers that the PR has no value. We appreciate the time and effort that you put into this work. If you're willing to re-open it, the maintainers will do their best to review it."
           days-before-stale: 60
           days-before-issue-close: 120
           days-before-pr-close: 180


### PR DESCRIPTION
## Description

As discussed in the last office hours, let's start closing stale PRs :) 



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
