### PR TITLE
Use Prom-Op bot PAT token in dependabot workflow

### DIFF
--- a/.github/workflows/automerge-dependabot.yaml
+++ b/.github/workflows/automerge-dependabot.yaml
@@ -19,15 +19,16 @@ jobs:
         if: contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROM_OP_BOT_PAT }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Generate Documentation/compatibility.md
         if: contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
         run: |
+          export GITHUB_TOKEN="${{ secrets.PROM_OP_BOT_PAT }}"
           make generate --always-make
           if ! git diff --exit-code; then
-            git config --global user.email "support@github.com"
-            git config --global user.name "dependabot[bot]"
+            git config --global user.email "prom-op-bot@users.noreply.github.com"
+            git config --global user.name "Prometheus Operator Bot"
             git add Documentation/compatibility.md
             git commit -s -m "Generate Documentation/compatibility.md"
             git push


### PR DESCRIPTION
## Description

Another attempt to fully automate version bump of kubernetes go libraries (sorry for the amount of noise so far folks 😞)

As mentioned [here](https://github.com/prometheus-operator/prometheus-operator/pull/6091#issuecomment-1814334673), I've finally got a response from Github Support team telling me that they intentionally do not trigger CI workflows from commits coming from the `github-actions` user to avoid recursive loops.

This PR changes the token used to clone, commit and push during the workflow, using a PAT from [prom-op-bot](https://github.com/prom-op-bot).

Hopefully the last one of many 🤞 😢 

<details><summary>Github support response</summary>

<img width="1437" alt="image" src="https://github.com/prometheus-operator/prometheus-operator/assets/24193764/3a1ec8ec-d8b7-45ee-9323-d70b10a1676b">

</details>

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
