### PR TITLE
fix: Thanos Sidecar object storage config documentation

### DIFF
--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -73,8 +73,9 @@ spec:
   thanos:
     image: quay.io/thanos/thanos:v0.28.1
     objectStorageConfig:
-      key: thanos.yaml
-      name: thanos-objstore-config
+      existingSecret:
+        key: thanos.yaml
+        name: thanos-objstore-config
 ...
 ```
 


### PR DESCRIPTION
## Description

There's a missing update in the `Documentation/thanos.md` file related to the values needed for configure the object storage. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix object storage config documentation for Thanos sidecar.
```
