### PR TITLE
jsonnet: Create alert for config-reloader apply errors

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -82,7 +82,7 @@ groups:
       description: |-
         Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to apply config in {{$labels.namespace}} namespace.
         As a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.
-      summary: config-reloader sidecar was unable to apply new config for 5m
+      summary: config-reloader sidecar was unable to apply new config
     expr: |
       increase(reloader_config_apply_operations_failed_total{namespace=~".+"}[5m]) > 0
     for: 5m

--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -77,3 +77,14 @@ groups:
     for: 10m
     labels:
       severity: warning
+  - alert: ConfigReloaderSidecarApplyErrors
+    annotations:
+      description: |-
+        Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to apply config in {{$labels.namespace}} namespace.
+        As a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.
+      summary: config-reloader sidecar was unable to apply new config for 5m
+    expr: |
+      increase(reloader_config_apply_operations_failed_total{namespace=~".+"}[5m]) > 0
+    for: 5m
+    labels:
+      severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -121,6 +121,20 @@
             },
             'for': '10m',
           },
+          {
+            alert: 'ConfigReloaderSidecarApplyErrors',
+            expr: |||
+              increase(reloader_config_apply_operations_failed_total{%(configReloaderSelector)s}[5m]) > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to apply config in {{$labels.namespace}} namespace.\nAs a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.',
+              summary: 'config-reloader sidecar was unable to apply new config for 5m',
+            },
+            'for': '5m',
+          },
         ],
       },
     ],

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -131,7 +131,7 @@
             },
             annotations: {
               description: 'Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to apply config in {{$labels.namespace}} namespace.\nAs a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.',
-              summary: 'config-reloader sidecar was unable to apply new config for 5m',
+              summary: 'config-reloader sidecar was unable to apply new config',
             },
             'for': '5m',
           },


### PR DESCRIPTION
## Description

If a syntactically correct servicemonitor is deployed that contains some other error (such as missing variable expansion as described here: https://github.com/prometheus-operator/prometheus-operator/issues/3644), there is currently no alert to detect this.
In this case `reloader_last_reload_successful` is not set to `0` and therefore the `ConfigReloaderSidecarErrors` alert does not apply.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Create alert for config-reloader apply errors
```
