### PR TITLE
documentation: mention additionalArgs

### DIFF
--- a/Documentation/user-guides/strategic-merge-patch.md
+++ b/Documentation/user-guides/strategic-merge-patch.md
@@ -105,7 +105,7 @@ spec:
 The following manifest injects an additional CLI argument in the default
 Prometheus argument list. Note the use of `.spec.additionalArgs` in this
 example.
-Using `.spec.containers[*].args` directly would instead overwrite the containers
+Using `.spec.containers[*].args` directly would instead overwrite the container's
 `args` list completely, including the default arguments.
 
 ```yaml

--- a/Documentation/user-guides/strategic-merge-patch.md
+++ b/Documentation/user-guides/strategic-merge-patch.md
@@ -100,7 +100,7 @@ spec:
     - "3600"
 ```
 
-## How to inject additional CLI arguments into the prometheus pods
+## How to inject additional CLI arguments into the prometheus container
 
 The following manifest injects an additional CLI argument in the default
 Prometheus argument list. Note the use of `.spec.additionalArgs` in this

--- a/Documentation/user-guides/strategic-merge-patch.md
+++ b/Documentation/user-guides/strategic-merge-patch.md
@@ -99,3 +99,22 @@ spec:
     - sleep
     - "3600"
 ```
+
+## How to inject additional CLI arguments into the prometheus pods
+
+The following manifest injects an additional CLI argument in the default
+Prometheus argument list. Note the use of `.spec.additionalArgs` in this
+example.
+Using `.spec.containers[*].args` directly would instead overwrite the containers
+`args` list completely, including the default arguments.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: additional-arguments
+spec:
+  additionalArgs:
+  - name: "scrape.timestamp-tolerance"
+    value: "15ms"
+```


### PR DESCRIPTION
## Description

For lists strategic merge patch can have surprising results where a list is replaced instead of added to. The operator offers workarounds for that, which should be explicitly mentioned.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
