### PR TITLE
chore: mark deprecated fields correctly

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
 
 issues:
   exclude-rules:
+  # Disable errcheck linter for test files.
   - path: _test.go
     linters:
     - errcheck

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -165,8 +165,7 @@ string
 <td>
 <p>Tag of Alertmanager container image to be deployed. Defaults to the value of <code>version</code>.
 Version is ignored if Tag is set.
-Deprecated: use &lsquo;image&rsquo; instead.  The image tag can be specified
-as part of the image URL.</p>
+Deprecated: use &lsquo;image&rsquo; instead. The image tag can be specified as part of the image URL.</p>
 </td>
 </tr>
 <tr>
@@ -180,8 +179,7 @@ string
 <p>SHA of Alertmanager container image to be deployed. Defaults to the value of <code>version</code>.
 Similar to a tag, but the SHA explicitly deploys an immutable container image.
 Version and Tag are ignored if SHA is set.
-Deprecated: use &lsquo;image&rsquo; instead.  The image digest can be specified
-as part of the image URL.</p>
+Deprecated: use &lsquo;image&rsquo; instead. The image digest can be specified as part of the image URL.</p>
 </td>
 </tr>
 <tr>
@@ -193,7 +191,7 @@ string
 </td>
 <td>
 <p>Base image that is used to deploy pods, without tag.
-Deprecated: use &lsquo;image&rsquo; instead</p>
+Deprecated: use &lsquo;image&rsquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -2568,7 +2566,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -2579,8 +2577,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s tag can be specified
-as part of the image name.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s tag can be specified as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -2591,8 +2588,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s digest can be
-specified as part of the image name.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s digest can be specified as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -2660,7 +2656,7 @@ Rules
 <p>Defines the list of PrometheusRule objects to which the namespace label
 enforcement doesn&rsquo;t apply.
 This is only relevant when <code>spec.enforcedNamespaceLabel</code> is set to true.
-<em>Deprecated: use <code>spec.excludedFromEnforcement</code> instead.</em></p>
+Deprecated: use <code>spec.excludedFromEnforcement</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -2831,7 +2827,7 @@ bool
 <td>
 <p>AllowOverlappingBlocks enables vertical compaction and vertical query
 merge in Prometheus.</p>
-<p><em>Deprecated: this flag has no effect for Prometheus &gt;= 2.39.0 where overlapping blocks are enabled by default.</em></p>
+<p>Deprecated: this flag has no effect for Prometheus &gt;= 2.39.0 where overlapping blocks are enabled by default.</p>
 </td>
 </tr>
 <tr>
@@ -4047,7 +4043,7 @@ string
 <td>
 <p>File to read bearer token for accessing apiserver.</p>
 <p>Cannot be set at the same time as <code>basicAuth</code>, <code>authorization</code>, or <code>bearerToken</code>.</p>
-<p><em>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</em></p>
+<p>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4090,7 +4086,7 @@ string
 <td>
 <p><em>Warning: this field shouldn&rsquo;t be used because the token value appears
 in clear-text. Prefer using <code>authorization</code>.</em></p>
-<p><em>Deprecated: this will be removed in a future release.</em></p>
+<p>Deprecated: this will be removed in a future release.</p>
 </td>
 </tr>
 </tbody>
@@ -4329,7 +4325,7 @@ string
 <td>
 <p>File to read bearer token for Alertmanager.</p>
 <p>Cannot be set at the same time as <code>basicAuth</code>, <code>authorization</code>, or <code>sigv4</code>.</p>
-<p><em>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</em></p>
+<p>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4600,8 +4596,7 @@ string
 <td>
 <p>Tag of Alertmanager container image to be deployed. Defaults to the value of <code>version</code>.
 Version is ignored if Tag is set.
-Deprecated: use &lsquo;image&rsquo; instead.  The image tag can be specified
-as part of the image URL.</p>
+Deprecated: use &lsquo;image&rsquo; instead. The image tag can be specified as part of the image URL.</p>
 </td>
 </tr>
 <tr>
@@ -4615,8 +4610,7 @@ string
 <p>SHA of Alertmanager container image to be deployed. Defaults to the value of <code>version</code>.
 Similar to a tag, but the SHA explicitly deploys an immutable container image.
 Version and Tag are ignored if SHA is set.
-Deprecated: use &lsquo;image&rsquo; instead.  The image digest can be specified
-as part of the image URL.</p>
+Deprecated: use &lsquo;image&rsquo; instead. The image digest can be specified as part of the image URL.</p>
 </td>
 </tr>
 <tr>
@@ -4628,7 +4622,7 @@ string
 </td>
 <td>
 <p>Base image that is used to deploy pods, without tag.
-Deprecated: use &lsquo;image&rsquo; instead</p>
+Deprecated: use &lsquo;image&rsquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -7358,7 +7352,7 @@ Kubernetes core/v1.PersistentVolumeClaimStatus
 </td>
 <td>
 <em>(Optional)</em>
-<p><em>Deprecated: this field is never set.</em></p>
+<p>Deprecated: this field is never set.</p>
 </td>
 </tr>
 </tbody>
@@ -10845,7 +10839,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -10856,8 +10850,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s tag can be specified
-as part of the image name.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s tag can be specified as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -10868,8 +10861,7 @@ string
 </em>
 </td>
 <td>
-<p><em>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s digest can be
-specified as part of the image name.</em></p>
+<p>Deprecated: use &lsquo;spec.image&rsquo; instead. The image&rsquo;s digest can be specified as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -10937,7 +10929,7 @@ Rules
 <p>Defines the list of PrometheusRule objects to which the namespace label
 enforcement doesn&rsquo;t apply.
 This is only relevant when <code>spec.enforcedNamespaceLabel</code> is set to true.
-<em>Deprecated: use <code>spec.excludedFromEnforcement</code> instead.</em></p>
+Deprecated: use <code>spec.excludedFromEnforcement</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -11108,7 +11100,7 @@ bool
 <td>
 <p>AllowOverlappingBlocks enables vertical compaction and vertical query
 merge in Prometheus.</p>
-<p><em>Deprecated: this flag has no effect for Prometheus &gt;= 2.39.0 where overlapping blocks are enabled by default.</em></p>
+<p>Deprecated: this flag has no effect for Prometheus &gt;= 2.39.0 where overlapping blocks are enabled by default.</p>
 </td>
 </tr>
 <tr>
@@ -11922,7 +11914,7 @@ string
 </td>
 <td>
 <p>File from which to read the bearer token for the URL.</p>
-<p><em>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</em></p>
+<p>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</p>
 </td>
 </tr>
 <tr>
@@ -11951,7 +11943,7 @@ string
 <td>
 <p><em>Warning: this field shouldn&rsquo;t be used because the token value appears
 in clear-text. Prefer using <code>authorization</code>.</em></p>
-<p><em>Deprecated: this will be removed in a future release.</em></p>
+<p>Deprecated: this will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -12158,7 +12150,7 @@ string
 </td>
 <td>
 <p>File from which to read bearer token for the URL.</p>
-<p><em>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</em></p>
+<p>Deprecated: this will be removed in a future release. Prefer using <code>authorization</code>.</p>
 </td>
 </tr>
 <tr>
@@ -12219,7 +12211,7 @@ string
 <td>
 <p><em>Warning: this field shouldn&rsquo;t be used because the token value appears
 in clear-text. Prefer using <code>authorization</code>.</em></p>
-<p><em>Deprecated: this will be removed in a future release.</em></p>
+<p>Deprecated: this will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -13131,7 +13123,7 @@ bool
 </em>
 </td>
 <td>
-<p><em>Deprecated: subPath usage will be removed in a future release.</em></p>
+<p>Deprecated: subPath usage will be removed in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -14206,8 +14198,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p><em>Deprecated: use &lsquo;image&rsquo; instead. The image&rsquo;s tag can be specified as
-part of the image name.</em></p>
+<p>Deprecated: use &lsquo;image&rsquo; instead. The image&rsquo;s tag can be specified as as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -14219,8 +14210,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p><em>Deprecated: use &lsquo;image&rsquo; instead.  The image digest can be specified
-as part of the image name.</em></p>
+<p>Deprecated: use &lsquo;image&rsquo; instead.  The image digest can be specified as part of the image name.</p>
 </td>
 </tr>
 <tr>
@@ -14232,7 +14222,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p><em>Deprecated: use &lsquo;image&rsquo; instead.</em></p>
+<p>Deprecated: use &lsquo;image&rsquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -14286,7 +14276,7 @@ bool
 </em>
 </td>
 <td>
-<p><em>Deprecated: use <code>grpcListenLocal</code> and <code>httpListenLocal</code> instead.</em></p>
+<p>Deprecated: use <code>grpcListenLocal</code> and <code>httpListenLocal</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -18481,7 +18471,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Whether to match on equality (false) or regular-expression (true).
-Deprecated as of AlertManager &gt;= v0.22.0 where a user should use MatchType instead.</p>
+Deprecated: for AlertManager &gt;= v0.22.0, <code>matchType</code> should be used instead.</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -78,9 +78,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -111,9 +111,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -5674,9 +5674,9 @@ spec:
                           minLength: 1
                           type: string
                         regex:
-                          description: Whether to match on equality (false) or regular-expression
-                            (true). Deprecated as of AlertManager >= v0.22.0 where
-                            a user should use MatchType instead.
+                          description: 'Whether to match on equality (false) or regular-expression
+                            (true). Deprecated: for AlertManager >= v0.22.0, `matchType`
+                            should be used instead.'
                           type: boolean
                         value:
                           description: Label value to match.
@@ -7294,7 +7294,7 @@ spec:
                 type: boolean
               baseImage:
                 description: 'Base image that is used to deploy pods, without tag.
-                  Deprecated: use ''image'' instead'
+                  Deprecated: use ''image'' instead.'
                 type: string
               clusterAdvertiseAddress:
                 description: 'ClusterAdvertiseAddress is the explicit address to advertise
@@ -10318,7 +10318,7 @@ spec:
                 description: 'SHA of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Similar to a tag, but the SHA
                   explicitly deploys an immutable container image. Version and Tag
-                  are ignored if SHA is set. Deprecated: use ''image'' instead.  The
+                  are ignored if SHA is set. Deprecated: use ''image'' instead. The
                   image digest can be specified as part of the image URL.'
                 type: string
               storage:
@@ -10326,8 +10326,8 @@ spec:
                   by the Alertmanager instances.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -10879,7 +10879,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -11024,7 +11024,7 @@ spec:
               tag:
                 description: 'Tag of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Version is ignored if Tag is
-                  set. Deprecated: use ''image'' instead.  The image tag can be specified
+                  set. Deprecated: use ''image'' instead. The image tag can be specified
                   as part of the image URL.'
                 type: string
               tolerations:
@@ -15637,13 +15637,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -19134,12 +19134,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -20075,8 +20075,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -20628,7 +20628,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -24218,8 +24218,8 @@ spec:
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
                             \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                            or `sigv4`. \n *Deprecated: this will be removed in a
-                            future release. Prefer using `authorization`.*"
+                            or `sigv4`. \n Deprecated: this will be removed in a future
+                            release. Prefer using `authorization`."
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -24460,9 +24460,9 @@ spec:
                 type: object
               allowOverlappingBlocks:
                 description: "AllowOverlappingBlocks enables vertical compaction and
-                  vertical query merge in Prometheus. \n *Deprecated: this flag has
+                  vertical query merge in Prometheus. \n Deprecated: this flag has
                   no effect for Prometheus >= 2.39.0 where overlapping blocks are
-                  enabled by default.*"
+                  enabled by default."
                 type: boolean
               apiserverConfig:
                 description: 'APIServerConfig allows specifying a host and auth methods
@@ -24553,13 +24553,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -24713,7 +24713,7 @@ spec:
                     type: boolean
                 type: object
               baseImage:
-                description: '*Deprecated: use ''spec.image'' instead.*'
+                description: 'Deprecated: use ''spec.image'' instead.'
                 type: string
               bodySizeLimit:
                 description: BodySizeLimit defines per-scrape on response body size.
@@ -27919,8 +27919,8 @@ spec:
               prometheusRulesExcludedFromEnforce:
                 description: 'Defines the list of PrometheusRule objects to which
                   the namespace label enforcement doesn''t apply. This is only relevant
-                  when `spec.enforcedNamespaceLabel` is set to true. *Deprecated:
-                  use `spec.excludedFromEnforcement` instead.*'
+                  when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use
+                  `spec.excludedFromEnforcement` instead.'
                 items:
                   description: PrometheusRuleExcludeConfig enables users to configure
                     excluded PrometheusRule names and their namespaces to be ignored
@@ -28070,12 +28070,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read the bearer token for the
-                        URL. \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        URL. \n Deprecated: this will be removed in a future release.
+                        Prefer using `authorization`."
                       type: string
                     filterExternalLabels:
                       description: "Whether to use the external labels as selectors
@@ -28506,12 +28506,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -29557,8 +29557,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               sha:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  digest can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  digest can be specified as part of the image name.'
                 type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
@@ -29577,8 +29577,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -30130,7 +30130,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -30273,8 +30273,8 @@ spec:
                     type: object
                 type: object
               tag:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  tag can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  tag can be specified as part of the image name.'
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped
@@ -30311,7 +30311,7 @@ spec:
                       type: object
                     type: array
                   baseImage:
-                    description: '*Deprecated: use ''image'' instead.*'
+                    description: 'Deprecated: use ''image'' instead.'
                     type: string
                   blockSize:
                     default: 2h
@@ -30488,8 +30488,8 @@ spec:
                       when the operator was released."
                     type: string
                   listenLocal:
-                    description: '*Deprecated: use `grpcListenLocal` and `httpListenLocal`
-                      instead.*'
+                    description: 'Deprecated: use `grpcListenLocal` and `httpListenLocal`
+                      instead.'
                     type: boolean
                   logFormat:
                     description: Log format for the Thanos sidecar.
@@ -30596,12 +30596,12 @@ spec:
                         type: object
                     type: object
                   sha:
-                    description: '*Deprecated: use ''image'' instead.  The image digest
-                      can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead.  The image digest
+                      can be specified as part of the image name.'
                     type: string
                   tag:
-                    description: '*Deprecated: use ''image'' instead. The image''s
-                      tag can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead. The image''s
+                      tag can be specified as as part of the image name.'
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos
@@ -39646,8 +39646,8 @@ spec:
                 description: Storage spec to specify how storage shall be used.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -40199,7 +40199,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -77,9 +77,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -110,9 +110,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -5673,9 +5673,9 @@ spec:
                           minLength: 1
                           type: string
                         regex:
-                          description: Whether to match on equality (false) or regular-expression
-                            (true). Deprecated as of AlertManager >= v0.22.0 where
-                            a user should use MatchType instead.
+                          description: 'Whether to match on equality (false) or regular-expression
+                            (true). Deprecated: for AlertManager >= v0.22.0, `matchType`
+                            should be used instead.'
                           type: boolean
                         value:
                           description: Label value to match.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1571,7 +1571,7 @@ spec:
                 type: boolean
               baseImage:
                 description: 'Base image that is used to deploy pods, without tag.
-                  Deprecated: use ''image'' instead'
+                  Deprecated: use ''image'' instead.'
                 type: string
               clusterAdvertiseAddress:
                 description: 'ClusterAdvertiseAddress is the explicit address to advertise
@@ -4595,7 +4595,7 @@ spec:
                 description: 'SHA of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Similar to a tag, but the SHA
                   explicitly deploys an immutable container image. Version and Tag
-                  are ignored if SHA is set. Deprecated: use ''image'' instead.  The
+                  are ignored if SHA is set. Deprecated: use ''image'' instead. The
                   image digest can be specified as part of the image URL.'
                 type: string
               storage:
@@ -4603,8 +4603,8 @@ spec:
                   by the Alertmanager instances.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -5156,7 +5156,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -5301,7 +5301,7 @@ spec:
               tag:
                 description: 'Tag of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Version is ignored if Tag is
-                  set. Deprecated: use ''image'' instead.  The image tag can be specified
+                  set. Deprecated: use ''image'' instead. The image tag can be specified
                   as part of the image URL.'
                 type: string
               tolerations:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -1036,13 +1036,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -4533,12 +4533,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -5474,8 +5474,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -6027,7 +6027,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1099,8 +1099,8 @@ spec:
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
                             \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                            or `sigv4`. \n *Deprecated: this will be removed in a
-                            future release. Prefer using `authorization`.*"
+                            or `sigv4`. \n Deprecated: this will be removed in a future
+                            release. Prefer using `authorization`."
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -1341,9 +1341,9 @@ spec:
                 type: object
               allowOverlappingBlocks:
                 description: "AllowOverlappingBlocks enables vertical compaction and
-                  vertical query merge in Prometheus. \n *Deprecated: this flag has
+                  vertical query merge in Prometheus. \n Deprecated: this flag has
                   no effect for Prometheus >= 2.39.0 where overlapping blocks are
-                  enabled by default.*"
+                  enabled by default."
                 type: boolean
               apiserverConfig:
                 description: 'APIServerConfig allows specifying a host and auth methods
@@ -1434,13 +1434,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -1594,7 +1594,7 @@ spec:
                     type: boolean
                 type: object
               baseImage:
-                description: '*Deprecated: use ''spec.image'' instead.*'
+                description: 'Deprecated: use ''spec.image'' instead.'
                 type: string
               bodySizeLimit:
                 description: BodySizeLimit defines per-scrape on response body size.
@@ -4800,8 +4800,8 @@ spec:
               prometheusRulesExcludedFromEnforce:
                 description: 'Defines the list of PrometheusRule objects to which
                   the namespace label enforcement doesn''t apply. This is only relevant
-                  when `spec.enforcedNamespaceLabel` is set to true. *Deprecated:
-                  use `spec.excludedFromEnforcement` instead.*'
+                  when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use
+                  `spec.excludedFromEnforcement` instead.'
                 items:
                   description: PrometheusRuleExcludeConfig enables users to configure
                     excluded PrometheusRule names and their namespaces to be ignored
@@ -4951,12 +4951,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read the bearer token for the
-                        URL. \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        URL. \n Deprecated: this will be removed in a future release.
+                        Prefer using `authorization`."
                       type: string
                     filterExternalLabels:
                       description: "Whether to use the external labels as selectors
@@ -5387,12 +5387,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -6438,8 +6438,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               sha:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  digest can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  digest can be specified as part of the image name.'
                 type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
@@ -6458,8 +6458,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -7011,7 +7011,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -7154,8 +7154,8 @@ spec:
                     type: object
                 type: object
               tag:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  tag can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  tag can be specified as part of the image name.'
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped
@@ -7192,7 +7192,7 @@ spec:
                       type: object
                     type: array
                   baseImage:
-                    description: '*Deprecated: use ''image'' instead.*'
+                    description: 'Deprecated: use ''image'' instead.'
                     type: string
                   blockSize:
                     default: 2h
@@ -7369,8 +7369,8 @@ spec:
                       when the operator was released."
                     type: string
                   listenLocal:
-                    description: '*Deprecated: use `grpcListenLocal` and `httpListenLocal`
-                      instead.*'
+                    description: 'Deprecated: use `grpcListenLocal` and `httpListenLocal`
+                      instead.'
                     type: boolean
                   logFormat:
                     description: Log format for the Thanos sidecar.
@@ -7477,12 +7477,12 @@ spec:
                         type: object
                     type: object
                   sha:
-                    description: '*Deprecated: use ''image'' instead.  The image digest
-                      can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead.  The image digest
+                      can be specified as part of the image name.'
                     type: string
                   tag:
-                    description: '*Deprecated: use ''image'' instead. The image''s
-                      tag can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead. The image''s
+                      tag can be specified as as part of the image name.'
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4290,8 +4290,8 @@ spec:
                 description: Storage spec to specify how storage shall be used.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -4843,7 +4843,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -78,9 +78,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -111,9 +111,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -5674,9 +5674,9 @@ spec:
                           minLength: 1
                           type: string
                         regex:
-                          description: Whether to match on equality (false) or regular-expression
-                            (true). Deprecated as of AlertManager >= v0.22.0 where
-                            a user should use MatchType instead.
+                          description: 'Whether to match on equality (false) or regular-expression
+                            (true). Deprecated: for AlertManager >= v0.22.0, `matchType`
+                            should be used instead.'
                           type: boolean
                         value:
                           description: Label value to match.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1572,7 +1572,7 @@ spec:
                 type: boolean
               baseImage:
                 description: 'Base image that is used to deploy pods, without tag.
-                  Deprecated: use ''image'' instead'
+                  Deprecated: use ''image'' instead.'
                 type: string
               clusterAdvertiseAddress:
                 description: 'ClusterAdvertiseAddress is the explicit address to advertise
@@ -4596,7 +4596,7 @@ spec:
                 description: 'SHA of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Similar to a tag, but the SHA
                   explicitly deploys an immutable container image. Version and Tag
-                  are ignored if SHA is set. Deprecated: use ''image'' instead.  The
+                  are ignored if SHA is set. Deprecated: use ''image'' instead. The
                   image digest can be specified as part of the image URL.'
                 type: string
               storage:
@@ -4604,8 +4604,8 @@ spec:
                   by the Alertmanager instances.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -5157,7 +5157,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -5302,7 +5302,7 @@ spec:
               tag:
                 description: 'Tag of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Version is ignored if Tag is
-                  set. Deprecated: use ''image'' instead.  The image tag can be specified
+                  set. Deprecated: use ''image'' instead. The image tag can be specified
                   as part of the image URL.'
                 type: string
               tolerations:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -1037,13 +1037,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -4534,12 +4534,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -5475,8 +5475,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -6028,7 +6028,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1100,8 +1100,8 @@ spec:
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
                             \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                            or `sigv4`. \n *Deprecated: this will be removed in a
-                            future release. Prefer using `authorization`.*"
+                            or `sigv4`. \n Deprecated: this will be removed in a future
+                            release. Prefer using `authorization`."
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -1342,9 +1342,9 @@ spec:
                 type: object
               allowOverlappingBlocks:
                 description: "AllowOverlappingBlocks enables vertical compaction and
-                  vertical query merge in Prometheus. \n *Deprecated: this flag has
+                  vertical query merge in Prometheus. \n Deprecated: this flag has
                   no effect for Prometheus >= 2.39.0 where overlapping blocks are
-                  enabled by default.*"
+                  enabled by default."
                 type: boolean
               apiserverConfig:
                 description: 'APIServerConfig allows specifying a host and auth methods
@@ -1435,13 +1435,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -1595,7 +1595,7 @@ spec:
                     type: boolean
                 type: object
               baseImage:
-                description: '*Deprecated: use ''spec.image'' instead.*'
+                description: 'Deprecated: use ''spec.image'' instead.'
                 type: string
               bodySizeLimit:
                 description: BodySizeLimit defines per-scrape on response body size.
@@ -4801,8 +4801,8 @@ spec:
               prometheusRulesExcludedFromEnforce:
                 description: 'Defines the list of PrometheusRule objects to which
                   the namespace label enforcement doesn''t apply. This is only relevant
-                  when `spec.enforcedNamespaceLabel` is set to true. *Deprecated:
-                  use `spec.excludedFromEnforcement` instead.*'
+                  when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use
+                  `spec.excludedFromEnforcement` instead.'
                 items:
                   description: PrometheusRuleExcludeConfig enables users to configure
                     excluded PrometheusRule names and their namespaces to be ignored
@@ -4952,12 +4952,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read the bearer token for the
-                        URL. \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        URL. \n Deprecated: this will be removed in a future release.
+                        Prefer using `authorization`."
                       type: string
                     filterExternalLabels:
                       description: "Whether to use the external labels as selectors
@@ -5388,12 +5388,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
                     headers:
                       additionalProperties:
@@ -6439,8 +6439,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               sha:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  digest can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  digest can be specified as part of the image name.'
                 type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
@@ -6459,8 +6459,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -7012,7 +7012,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -7155,8 +7155,8 @@ spec:
                     type: object
                 type: object
               tag:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  tag can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  tag can be specified as part of the image name.'
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped
@@ -7193,7 +7193,7 @@ spec:
                       type: object
                     type: array
                   baseImage:
-                    description: '*Deprecated: use ''image'' instead.*'
+                    description: 'Deprecated: use ''image'' instead.'
                     type: string
                   blockSize:
                     default: 2h
@@ -7370,8 +7370,8 @@ spec:
                       when the operator was released."
                     type: string
                   listenLocal:
-                    description: '*Deprecated: use `grpcListenLocal` and `httpListenLocal`
-                      instead.*'
+                    description: 'Deprecated: use `grpcListenLocal` and `httpListenLocal`
+                      instead.'
                     type: boolean
                   logFormat:
                     description: Log format for the Thanos sidecar.
@@ -7478,12 +7478,12 @@ spec:
                         type: object
                     type: object
                   sha:
-                    description: '*Deprecated: use ''image'' instead.  The image digest
-                      can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead.  The image digest
+                      can be specified as part of the image name.'
                     type: string
                   tag:
-                    description: '*Deprecated: use ''image'' instead. The image''s
-                      tag can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead. The image''s
+                      tag can be specified as as part of the image name.'
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4291,8 +4291,8 @@ spec:
                 description: Storage spec to specify how storage shall be used.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -4844,7 +4844,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -77,7 +77,7 @@
                                 "type": "string"
                               },
                               "regex": {
-                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
+                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.",
                                 "type": "boolean"
                               },
                               "value": {
@@ -113,7 +113,7 @@
                                 "type": "string"
                               },
                               "regex": {
-                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
+                                "description": "Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.",
                                 "type": "boolean"
                               },
                               "value": {
@@ -5878,7 +5878,7 @@
                               "type": "string"
                             },
                             "regex": {
-                              "description": "Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.",
+                              "description": "Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.",
                               "type": "boolean"
                             },
                             "value": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1448,7 +1448,7 @@
                     "type": "boolean"
                   },
                   "baseImage": {
-                    "description": "Base image that is used to deploy pods, without tag. Deprecated: use 'image' instead",
+                    "description": "Base image that is used to deploy pods, without tag. Deprecated: use 'image' instead.",
                     "type": "string"
                   },
                   "clusterAdvertiseAddress": {
@@ -4182,14 +4182,14 @@
                     "type": "string"
                   },
                   "sha": {
-                    "description": "SHA of Alertmanager container image to be deployed. Defaults to the value of `version`. Similar to a tag, but the SHA explicitly deploys an immutable container image. Version and Tag are ignored if SHA is set. Deprecated: use 'image' instead.  The image digest can be specified as part of the image URL.",
+                    "description": "SHA of Alertmanager container image to be deployed. Defaults to the value of `version`. Similar to a tag, but the SHA explicitly deploys an immutable container image. Version and Tag are ignored if SHA is set. Deprecated: use 'image' instead. The image digest can be specified as part of the image URL.",
                     "type": "string"
                   },
                   "storage": {
                     "description": "Storage is the definition of how storage will be used by the Alertmanager instances.",
                     "properties": {
                       "disableMountSubPath": {
-                        "description": "*Deprecated: subPath usage will be removed in a future release.*",
+                        "description": "Deprecated: subPath usage will be removed in a future release.",
                         "type": "boolean"
                       },
                       "emptyDir": {
@@ -4622,7 +4622,7 @@
                             "type": "object"
                           },
                           "status": {
-                            "description": "*Deprecated: this field is never set.*",
+                            "description": "Deprecated: this field is never set.",
                             "properties": {
                               "accessModes": {
                                 "description": "accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
@@ -4725,7 +4725,7 @@
                     "type": "object"
                   },
                   "tag": {
-                    "description": "Tag of Alertmanager container image to be deployed. Defaults to the value of `version`. Version is ignored if Tag is set. Deprecated: use 'image' instead.  The image tag can be specified as part of the image URL.",
+                    "description": "Tag of Alertmanager container image to be deployed. Defaults to the value of `version`. Version is ignored if Tag is set. Deprecated: use 'image' instead. The image tag can be specified as part of the image URL.",
                     "type": "string"
                   },
                   "tolerations": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -877,11 +877,11 @@
                         "type": "object"
                       },
                       "bearerToken": {
-                        "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*",
+                        "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release.",
                         "type": "string"
                       },
                       "bearerTokenFile": {
-                        "description": "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                        "description": "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                         "type": "string"
                       },
                       "host": {
@@ -4058,11 +4058,11 @@
                           "type": "object"
                         },
                         "bearerToken": {
-                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*",
+                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release.",
                           "type": "string"
                         },
                         "bearerTokenFile": {
-                          "description": "File from which to read bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                          "description": "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                           "type": "string"
                         },
                         "headers": {
@@ -4943,7 +4943,7 @@
                     "description": "Storage defines the storage used by Prometheus.",
                     "properties": {
                       "disableMountSubPath": {
-                        "description": "*Deprecated: subPath usage will be removed in a future release.*",
+                        "description": "Deprecated: subPath usage will be removed in a future release.",
                         "type": "boolean"
                       },
                       "emptyDir": {
@@ -5376,7 +5376,7 @@
                             "type": "object"
                           },
                           "status": {
-                            "description": "*Deprecated: this field is never set.*",
+                            "description": "Deprecated: this field is never set.",
                             "properties": {
                               "accessModes": {
                                 "description": "accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -926,7 +926,7 @@
                               "type": "object"
                             },
                             "bearerTokenFile": {
-                              "description": "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                              "description": "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                               "type": "string"
                             },
                             "enableHttp2": {
@@ -1193,7 +1193,7 @@
                     "type": "object"
                   },
                   "allowOverlappingBlocks": {
-                    "description": "AllowOverlappingBlocks enables vertical compaction and vertical query merge in Prometheus. \n *Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.*",
+                    "description": "AllowOverlappingBlocks enables vertical compaction and vertical query merge in Prometheus. \n Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.",
                     "type": "boolean"
                   },
                   "apiserverConfig": {
@@ -1286,11 +1286,11 @@
                         "type": "object"
                       },
                       "bearerToken": {
-                        "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*",
+                        "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release.",
                         "type": "string"
                       },
                       "bearerTokenFile": {
-                        "description": "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                        "description": "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                         "type": "string"
                       },
                       "host": {
@@ -1461,7 +1461,7 @@
                     "type": "object"
                   },
                   "baseImage": {
-                    "description": "*Deprecated: use 'spec.image' instead.*",
+                    "description": "Deprecated: use 'spec.image' instead.",
                     "type": "string"
                   },
                   "bodySizeLimit": {
@@ -4325,7 +4325,7 @@
                     "type": "string"
                   },
                   "prometheusRulesExcludedFromEnforce": {
-                    "description": "Defines the list of PrometheusRule objects to which the namespace label enforcement doesn't apply. This is only relevant when `spec.enforcedNamespaceLabel` is set to true. *Deprecated: use `spec.excludedFromEnforcement` instead.*",
+                    "description": "Defines the list of PrometheusRule objects to which the namespace label enforcement doesn't apply. This is only relevant when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use `spec.excludedFromEnforcement` instead.",
                     "items": {
                       "description": "PrometheusRuleExcludeConfig enables users to configure excluded PrometheusRule names and their namespaces to be ignored while enforcing namespace label for alerts and metrics.",
                       "properties": {
@@ -4476,11 +4476,11 @@
                           "type": "object"
                         },
                         "bearerToken": {
-                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*",
+                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release.",
                           "type": "string"
                         },
                         "bearerTokenFile": {
-                          "description": "File from which to read the bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                          "description": "File from which to read the bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                           "type": "string"
                         },
                         "filterExternalLabels": {
@@ -4948,11 +4948,11 @@
                           "type": "object"
                         },
                         "bearerToken": {
-                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*",
+                          "description": "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release.",
                           "type": "string"
                         },
                         "bearerTokenFile": {
-                          "description": "File from which to read bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*",
+                          "description": "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                           "type": "string"
                         },
                         "headers": {
@@ -5945,7 +5945,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "sha": {
-                    "description": "*Deprecated: use 'spec.image' instead. The image's digest can be specified as part of the image name.*",
+                    "description": "Deprecated: use 'spec.image' instead. The image's digest can be specified as part of the image name.",
                     "type": "string"
                   },
                   "shards": {
@@ -5957,7 +5957,7 @@
                     "description": "Storage defines the storage used by Prometheus.",
                     "properties": {
                       "disableMountSubPath": {
-                        "description": "*Deprecated: subPath usage will be removed in a future release.*",
+                        "description": "Deprecated: subPath usage will be removed in a future release.",
                         "type": "boolean"
                       },
                       "emptyDir": {
@@ -6390,7 +6390,7 @@
                             "type": "object"
                           },
                           "status": {
-                            "description": "*Deprecated: this field is never set.*",
+                            "description": "Deprecated: this field is never set.",
                             "properties": {
                               "accessModes": {
                                 "description": "accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
@@ -6493,7 +6493,7 @@
                     "type": "object"
                   },
                   "tag": {
-                    "description": "*Deprecated: use 'spec.image' instead. The image's tag can be specified as part of the image name.*",
+                    "description": "Deprecated: use 'spec.image' instead. The image's tag can be specified as part of the image name.",
                     "type": "string"
                   },
                   "targetLimit": {
@@ -6527,7 +6527,7 @@
                         "type": "array"
                       },
                       "baseImage": {
-                        "description": "*Deprecated: use 'image' instead.*",
+                        "description": "Deprecated: use 'image' instead.",
                         "type": "string"
                       },
                       "blockSize": {
@@ -6707,7 +6707,7 @@
                         "type": "string"
                       },
                       "listenLocal": {
-                        "description": "*Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.*",
+                        "description": "Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.",
                         "type": "boolean"
                       },
                       "logFormat": {
@@ -6825,11 +6825,11 @@
                         "type": "object"
                       },
                       "sha": {
-                        "description": "*Deprecated: use 'image' instead.  The image digest can be specified as part of the image name.*",
+                        "description": "Deprecated: use 'image' instead.  The image digest can be specified as part of the image name.",
                         "type": "string"
                       },
                       "tag": {
-                        "description": "*Deprecated: use 'image' instead. The image's tag can be specified as part of the image name.*",
+                        "description": "Deprecated: use 'image' instead. The image's tag can be specified as as part of the image name.",
                         "type": "string"
                       },
                       "tracingConfig": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3894,7 +3894,7 @@
                     "description": "Storage spec to specify how storage shall be used.",
                     "properties": {
                       "disableMountSubPath": {
-                        "description": "*Deprecated: subPath usage will be removed in a future release.*",
+                        "description": "Deprecated: subPath usage will be removed in a future release.",
                         "type": "boolean"
                       },
                       "emptyDir": {
@@ -4327,7 +4327,7 @@
                             "type": "object"
                           },
                           "status": {
-                            "description": "*Deprecated: this field is never set.*",
+                            "description": "Deprecated: this field is never set.",
                             "properties": {
                               "accessModes": {
                                 "description": "accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -83,17 +83,15 @@ type AlertmanagerSpec struct {
 	Version string `json:"version,omitempty"`
 	// Tag of Alertmanager container image to be deployed. Defaults to the value of `version`.
 	// Version is ignored if Tag is set.
-	// Deprecated: use 'image' instead.  The image tag can be specified
-	// as part of the image URL.
+	// Deprecated: use 'image' instead. The image tag can be specified as part of the image URL.
 	Tag string `json:"tag,omitempty"`
 	// SHA of Alertmanager container image to be deployed. Defaults to the value of `version`.
 	// Similar to a tag, but the SHA explicitly deploys an immutable container image.
 	// Version and Tag are ignored if SHA is set.
-	// Deprecated: use 'image' instead.  The image digest can be specified
-	// as part of the image URL.
+	// Deprecated: use 'image' instead. The image digest can be specified as part of the image URL.
 	SHA string `json:"sha,omitempty"`
 	// Base image that is used to deploy pods, without tag.
-	// Deprecated: use 'image' instead
+	// Deprecated: use 'image' instead.
 	BaseImage string `json:"baseImage,omitempty"`
 	// An optional list of references to secrets in the same namespace
 	// to use for pulling prometheus and alertmanager images from registries

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -702,13 +702,11 @@ func (l *PrometheusList) DeepCopyObject() runtime.Object {
 type PrometheusSpec struct {
 	CommonPrometheusFields `json:",inline"`
 
-	// *Deprecated: use 'spec.image' instead.*
+	// Deprecated: use 'spec.image' instead.
 	BaseImage string `json:"baseImage,omitempty"`
-	// *Deprecated: use 'spec.image' instead. The image's tag can be specified
-	// as part of the image name.*
+	// Deprecated: use 'spec.image' instead. The image's tag can be specified as part of the image name.
 	Tag string `json:"tag,omitempty"`
-	// *Deprecated: use 'spec.image' instead. The image's digest can be
-	// specified as part of the image name.*
+	// Deprecated: use 'spec.image' instead. The image's digest can be specified as part of the image name.
 	SHA string `json:"sha,omitempty"`
 
 	// How long to retain the Prometheus data.
@@ -726,8 +724,8 @@ type PrometheusSpec struct {
 	// Defines the list of PrometheusRule objects to which the namespace label
 	// enforcement doesn't apply.
 	// This is only relevant when `spec.enforcedNamespaceLabel` is set to true.
-	// *Deprecated: use `spec.excludedFromEnforcement` instead.*
 	// +optional
+	// Deprecated: use `spec.excludedFromEnforcement` instead.
 	PrometheusRulesExcludedFromEnforce []PrometheusRuleExcludeConfig `json:"prometheusRulesExcludedFromEnforce,omitempty"`
 	// PrometheusRule objects to be selected for rule evaluation. An empty
 	// label selector matches all objects. A null label selector matches no
@@ -807,7 +805,7 @@ type PrometheusSpec struct {
 	// AllowOverlappingBlocks enables vertical compaction and vertical query
 	// merge in Prometheus.
 	//
-	// *Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.*
+	// Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.
 	AllowOverlappingBlocks bool `json:"allowOverlappingBlocks,omitempty"`
 
 	// Exemplars related settings that are runtime reloadable.
@@ -921,7 +919,7 @@ type AlertingSpec struct {
 //
 // +k8s:openapi-gen=true
 type StorageSpec struct {
-	// *Deprecated: subPath usage will be removed in a future release.*
+	// Deprecated: subPath usage will be removed in a future release.
 	DisableMountSubPath bool `json:"disableMountSubPath,omitempty"`
 	// EmptyDirVolumeSource to be used by the StatefulSet.
 	// If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`.
@@ -1001,16 +999,14 @@ type ThanosSpec struct {
 	// +optional
 	Version *string `json:"version,omitempty"`
 
-	// *Deprecated: use 'image' instead. The image's tag can be specified as
-	// part of the image name.*
 	// +optional
+	// Deprecated: use 'image' instead. The image's tag can be specified as as part of the image name.
 	Tag *string `json:"tag,omitempty"`
-	// *Deprecated: use 'image' instead.  The image digest can be specified
-	// as part of the image name.*
 	// +optional
+	// Deprecated: use 'image' instead.  The image digest can be specified as part of the image name.
 	SHA *string `json:"sha,omitempty"`
-	// *Deprecated: use 'image' instead.*
 	// +optional
+	// Deprecated: use 'image' instead.
 	BaseImage *string `json:"baseImage,omitempty"`
 
 	// Defines the resources requests and limits of the Thanos sidecar.
@@ -1031,7 +1027,7 @@ type ThanosSpec struct {
 	// +optional
 	ObjectStorageConfigFile *string `json:"objectStorageConfigFile,omitempty"`
 
-	// *Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.*
+	// Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.
 	ListenLocal bool `json:"listenLocal,omitempty"`
 
 	// When true, the Thanos sidecar listens on the loopback interface instead
@@ -1183,7 +1179,7 @@ type RemoteWriteSpec struct {
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// File from which to read bearer token for the URL.
 	//
-	// *Deprecated: this will be removed in a future release. Prefer using `authorization`.*
+	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 	// Authorization section for the URL.
 	//
@@ -1214,7 +1210,7 @@ type RemoteWriteSpec struct {
 	// *Warning: this field shouldn't be used because the token value appears
 	// in clear-text. Prefer using `authorization`.*
 	//
-	// *Deprecated: this will be removed in a future release.*
+	// Deprecated: this will be removed in a future release.
 	BearerToken string `json:"bearerToken,omitempty"`
 
 	// TLS Config to use for the URL.
@@ -1373,7 +1369,7 @@ type RemoteReadSpec struct {
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// File from which to read the bearer token for the URL.
 	//
-	// *Deprecated: this will be removed in a future release. Prefer using `authorization`.*
+	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 	// Authorization section for the URL.
 	//
@@ -1387,7 +1383,7 @@ type RemoteReadSpec struct {
 	// *Warning: this field shouldn't be used because the token value appears
 	// in clear-text. Prefer using `authorization`.*
 	//
-	// *Deprecated: this will be removed in a future release.*
+	// Deprecated: this will be removed in a future release.
 	BearerToken string `json:"bearerToken,omitempty"`
 
 	// TLS Config to use for the URL.
@@ -1485,7 +1481,7 @@ type APIServerConfig struct {
 	//
 	// Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`.
 	//
-	// *Deprecated: this will be removed in a future release. Prefer using `authorization`.*
+	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// TLS Config to use for the API server.
@@ -1504,7 +1500,7 @@ type APIServerConfig struct {
 	// *Warning: this field shouldn't be used because the token value appears
 	// in clear-text. Prefer using `authorization`.*
 	//
-	// *Deprecated: this will be removed in a future release.*
+	// Deprecated: this will be removed in a future release.
 	BearerToken string `json:"bearerToken,omitempty"`
 }
 
@@ -1542,7 +1538,7 @@ type AlertmanagerEndpoints struct {
 	//
 	// Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`.
 	//
-	// *Deprecated: this will be removed in a future release. Prefer using `authorization`.*
+	// Deprecated: this will be removed in a future release. Prefer using `authorization`.
 	BearerTokenFile string `json:"bearerTokenFile,omitempty"`
 
 	// Authorization section for Alertmanager.

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -200,8 +200,8 @@ type EmbeddedPersistentVolumeClaim struct {
 	// +optional
 	Spec v1.PersistentVolumeClaimSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// *Deprecated: this field is never set.*
 	// +optional
+	// Deprecated: this field is never set.
 	Status v1.PersistentVolumeClaimStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -960,8 +960,8 @@ type Matcher struct {
 	// +optional
 	MatchType MatchType `json:"matchType,omitempty"`
 	// Whether to match on equality (false) or regular-expression (true).
-	// Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
 	// +optional
+	// Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.
 	Regex bool `json:"regex,omitempty"`
 }
 

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -156,6 +156,7 @@ func ValidateRemoteWriteSpec(spec monitoringv1.RemoteWriteSpec) error {
 func ValidateAlertmanagerEndpoints(am monitoringv1.AlertmanagerEndpoints) error {
 	var nonNilFields []string
 
+	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 	if am.BearerTokenFile != "" {
 		nonNilFields = append(nonNilFields, fmt.Sprintf("%q", "bearerTokenFile"))
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1551,10 +1551,12 @@ func (cg *ConfigGenerator) generateK8SSDConfig(
 
 		k8sSDConfig = cg.addBasicAuthToYaml(k8sSDConfig, "apiserver", store, apiserverConfig.BasicAuth)
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if apiserverConfig.BearerToken != "" {
 			k8sSDConfig = append(k8sSDConfig, yaml.MapItem{Key: "bearer_token", Value: apiserverConfig.BearerToken})
 		}
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if apiserverConfig.BearerTokenFile != "" {
 			k8sSDConfig = append(k8sSDConfig, yaml.MapItem{Key: "bearer_token_file", Value: apiserverConfig.BearerTokenFile})
 		}
@@ -1613,6 +1615,7 @@ func (cg *ConfigGenerator) generateAlertmanagerConfig(alerting *monitoringv1.Ale
 
 		cfg = append(cfg, cg.generateK8SSDConfig(monitoringv1.NamespaceSelector{}, am.Namespace, apiserverConfig, store, kubernetesSDRoleEndpoint, nil))
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if am.BearerTokenFile != "" {
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: am.BearerTokenFile})
 		}
@@ -1745,10 +1748,12 @@ func (cg *ConfigGenerator) generateRemoteReadConfig(
 
 		cfg = cg.addBasicAuthToYaml(cfg, fmt.Sprintf("remoteRead/%d", i), store, spec.BasicAuth)
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if spec.BearerToken != "" {
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token", Value: spec.BearerToken})
 		}
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if spec.BearerTokenFile != "" {
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: spec.BearerTokenFile})
 		}
@@ -1887,10 +1892,12 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(
 
 		cfg = cg.addBasicAuthToYaml(cfg, fmt.Sprintf("remoteWrite/%d", i), store, spec.BasicAuth)
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if spec.BearerToken != "" {
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token", Value: spec.BearerToken})
 		}
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if spec.BearerTokenFile != "" {
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: spec.BearerTokenFile})
 		}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1040,11 +1040,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		sset, err := makeStatefulSet(
 			ssetName,
 			p,
+			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 			p.Spec.Retention,
 			p.Spec.RetentionSize,
 			p.Spec.Rules,
 			p.Spec.Query,
+			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			p.Spec.AllowOverlappingBlocks,
 			p.Spec.EnableAdminAPI,
 			p.Spec.QueryLogFile,
@@ -1169,25 +1171,34 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 
 func logDeprecatedFields(logger log.Logger, p *monitoringv1.Prometheus) {
 	deprecationWarningf := "field %q is deprecated, field %q should be used instead"
+
+	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 	if p.Spec.BaseImage != "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.baseImage", "spec.image"))
 	}
 
+	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 	if p.Spec.Tag != "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.tag", "spec.image"))
 	}
 
+	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 	if p.Spec.SHA != "" {
 		level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.sha", "spec.image"))
 	}
 
 	if p.Spec.Thanos != nil {
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if p.Spec.BaseImage != "" {
 			level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.thanos.baseImage", "spec.thanos.image"))
 		}
+
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if p.Spec.Tag != "" {
 			level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.thanos.tag", "spec.thanos.image"))
 		}
+
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if p.Spec.SHA != "" {
 			level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.thanos.sha", "spec.thanos.image"))
 		}

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -639,10 +639,12 @@ func createThanosContainer(
 		}
 
 		var grpcBindAddress, httpBindAddress string
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if thanos.ListenLocal || thanos.GRPCListenLocal {
 			grpcBindAddress = "127.0.0.1"
 		}
 
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		if thanos.ListenLocal || thanos.HTTPListenLocal {
 			httpBindAddress = "127.0.0.1"
 		}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -62,11 +62,13 @@ func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulS
 	return makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -443,11 +445,13 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"volume-init-test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -900,11 +904,13 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -954,11 +960,13 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -1557,11 +1565,13 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -1612,11 +1622,13 @@ func TestSidecarResources(t *testing.T) {
 		sset, err := makeStatefulSet(
 			"test",
 			&p,
+			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 			p.Spec.Retention,
 			p.Spec.RetentionSize,
 			p.Spec.Rules,
 			p.Spec.Query,
+			//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 			p.Spec.AllowOverlappingBlocks,
 			p.Spec.EnableAdminAPI,
 			p.Spec.QueryLogFile,
@@ -2016,11 +2028,13 @@ func TestConfigReloader(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,
@@ -2092,11 +2106,13 @@ func TestConfigReloaderWithSignal(t *testing.T) {
 	sset, err := makeStatefulSet(
 		"test",
 		&p,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.BaseImage, p.Spec.Tag, p.Spec.SHA,
 		p.Spec.Retention,
 		p.Spec.RetentionSize,
 		p.Spec.Rules,
 		p.Spec.Query,
+		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		p.Spec.AllowOverlappingBlocks,
 		p.Spec.EnableAdminAPI,
 		p.Spec.QueryLogFile,


### PR DESCRIPTION
## Description

This change ensures that deprecated CRD fields are properly commented which make them reported by Go linters.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
