### PR TITLE
update BUILD_BRANCH for consistency with other Prometheus projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ BUILD_DATE=$(shell date +"%Y%m%d-%T")
 # source: https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 ifndef GITHUB_ACTIONS
 	BUILD_USER?=$(USER)
-	BUILD_BRANCH?=$(shell git branch --show-current)
+	BUILD_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 	BUILD_REVISION?=$(shell git rev-parse --short HEAD)
 else
 	BUILD_USER=Action-Run-ID-$(GITHUB_RUN_ID)


### PR DESCRIPTION
## Description
Most of the other Prometheus project repos use the `git rev-parse --abbrev-ref HEAD` for the branch info for non-github builds.  The `git branch --show-current` option is only available on newer versions of git which aren't available in a ton of build environments.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Update BUILD_BRANCH for non-github environments to a more sensible and consistent git command data source.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```
- Update BUILD_BRANCH for non-github environments to a more sensible and consistent git command data source
```
