### PR TITLE
Fix unicode error due to missing quote in enum declaration

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -69,8 +69,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -102,8 +102,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -5665,8 +5665,8 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
-                          - =~
+                          - '='
+                          - '=~'
                           - '!~'
                           type: string
                         name:


### PR DESCRIPTION
## Description

Buf described here #6159


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix unicode string error when deploying from ansible K8S module
```
