### PR TITLE
dedicated field for cluster_label

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -589,7 +589,7 @@ string
 </td>
 <td>
 <p>Defines the identifier that uniquely identifies the Alertmanager cluster.
-You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
+You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
 </td>
 </tr>
 <tr>
@@ -5054,7 +5054,7 @@ string
 </td>
 <td>
 <p>Defines the identifier that uniquely identifies the Alertmanager cluster.
-You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
+You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -589,7 +589,7 @@ string
 </td>
 <td>
 <p>Defines the identifier that uniquely identifies the Alertmanager cluster.
-You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.</p>
+You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
 </td>
 </tr>
 <tr>
@@ -5054,7 +5054,7 @@ string
 </td>
 <td>
 <p>Defines the identifier that uniquely identifies the Alertmanager cluster.
-You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.</p>
+You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the <code>.spec.additionalPeers</code> field.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -582,6 +582,18 @@ GoDuration
 </tr>
 <tr>
 <td>
+<code>clusterLabel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Defines the identifier that uniquely identifies the Alertmanager cluster.
+You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>clusterPushpullInterval</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.GoDuration">
@@ -5031,6 +5043,18 @@ GoDuration
 </td>
 <td>
 <p>Interval between gossip attempts.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterLabel</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Defines the identifier that uniquely identifies the Alertmanager cluster.
+You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7308,7 +7308,9 @@ spec:
               clusterLabel:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
-                  more than one Alertmanager replicas.
+                  Alertmanager instances which are external to this Alertmanager resource.
+                  In practice, the addressed of the external instances are provided
+                  via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7309,7 +7309,7 @@ spec:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
                   Alertmanager instances which are external to this Alertmanager resource.
-                  In practice, the addressed of the external instances are provided
+                  In practice, the addresses of the external instances are provided
                   via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7305,6 +7305,11 @@ spec:
                 description: Interval between gossip attempts.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              clusterLabel:
+                description: Defines the identifier that uniquely identifies the Alertmanager
+                  cluster. You should only set it when the Alertmanager cluster includes
+                  more than one Alertmanager replicas.
+                type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1586,7 +1586,7 @@ spec:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
                   Alertmanager instances which are external to this Alertmanager resource.
-                  In practice, the addressed of the external instances are provided
+                  In practice, the addresses of the external instances are provided
                   via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1585,7 +1585,9 @@ spec:
               clusterLabel:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
-                  more than one Alertmanager replicas.
+                  Alertmanager instances which are external to this Alertmanager resource.
+                  In practice, the addressed of the external instances are provided
+                  via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1585,7 +1585,7 @@ spec:
               clusterLabel:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
-                  several Alertmanager objects.
+                  more than one Alertmanager replicas.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1583,7 +1583,9 @@ spec:
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterLabel:
-                description: Gossip with same ClusterLabels only.
+                description: Defines the identifier that uniquely identifies the Alertmanager
+                  cluster. You should only set it when the Alertmanager cluster includes
+                  several Alertmanager objects.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -7336,8 +7336,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - clusterLabel
             type: object
           status:
             description: 'Most recent observed status of the Alertmanager cluster.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1582,6 +1582,9 @@ spec:
                 description: Interval between gossip attempts.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              clusterLabel:
+                description: Gossip with same ClusterLabels only.
+                type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -7333,6 +7336,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - clusterLabel
             type: object
           status:
             description: 'Most recent observed status of the Alertmanager cluster.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1586,7 +1586,9 @@ spec:
               clusterLabel:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
-                  more than one Alertmanager replicas.
+                  Alertmanager instances which are external to this Alertmanager resource.
+                  In practice, the addressed of the external instances are provided
+                  via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1587,7 +1587,7 @@ spec:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
                   Alertmanager instances which are external to this Alertmanager resource.
-                  In practice, the addressed of the external instances are provided
+                  In practice, the addresses of the external instances are provided
                   via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1584,7 +1584,9 @@ spec:
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               clusterLabel:
-                description: Gossip with same ClusterLabels only.
+                description: Defines the identifier that uniquely identifies the Alertmanager
+                  cluster. You should only set it when the Alertmanager cluster includes
+                  several Alertmanager objects.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -7337,8 +7337,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - clusterLabel
             type: object
           status:
             description: 'Most recent observed status of the Alertmanager cluster.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1586,7 +1586,7 @@ spec:
               clusterLabel:
                 description: Defines the identifier that uniquely identifies the Alertmanager
                   cluster. You should only set it when the Alertmanager cluster includes
-                  several Alertmanager objects.
+                  more than one Alertmanager replicas.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1583,6 +1583,9 @@ spec:
                 description: Interval between gossip attempts.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              clusterLabel:
+                description: Gossip with same ClusterLabels only.
+                type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -7334,6 +7337,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - clusterLabel
             type: object
           status:
             description: 'Most recent observed status of the Alertmanager cluster.

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1461,7 +1461,7 @@
                     "type": "string"
                   },
                   "clusterLabel": {
-                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the `.spec.additionalPeers` field.",
+                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.",
                     "type": "string"
                   },
                   "clusterPeerTimeout": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1461,7 +1461,7 @@
                     "type": "string"
                   },
                   "clusterLabel": {
-                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.",
+                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the `.spec.additionalPeers` field.",
                     "type": "string"
                   },
                   "clusterPeerTimeout": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1460,6 +1460,10 @@
                     "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
                   },
+                  "clusterLabel": {
+                    "description": "Gossip with same ClusterLabels only.",
+                    "type": "string"
+                  },
                   "clusterPeerTimeout": {
                     "description": "Timeout for cluster peering.",
                     "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
@@ -6444,6 +6448,9 @@
                     "type": "object"
                   }
                 },
+                "required": [
+                  "clusterLabel"
+                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1461,7 +1461,7 @@
                     "type": "string"
                   },
                   "clusterLabel": {
-                    "description": "Gossip with same ClusterLabels only.",
+                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes several Alertmanager objects.",
                     "type": "string"
                   },
                   "clusterPeerTimeout": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -6448,9 +6448,6 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "clusterLabel"
-                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1461,7 +1461,7 @@
                     "type": "string"
                   },
                   "clusterLabel": {
-                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes several Alertmanager objects.",
+                    "description": "Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.",
                     "type": "string"
                   },
                   "clusterPeerTimeout": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -313,7 +313,6 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 	// connects with cluster A.
 	// --cluster.label flag was introduced in alertmanager v0.26, this helps to block
 	// any traffic that is not meant for the cluster.
-	// Specify ClusterLabel in case you are in need of sorting out Alertmanager traffic.
 	if version.GTE(semver.MustParse("0.26.0")) {
 		clusterLabel := fmt.Sprintf("%s/%s", a.Namespace, a.Name)
 		if a.Spec.ClusterLabel != nil {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -315,9 +315,11 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 	// any traffic that is not meant for the cluster.
 	// Specify ClusterLabel in case you are in need of sorting out Alertmanager traffic.
 	if version.GTE(semver.MustParse("0.26.0")) {
-		if a.Spec.ClusterLabel != "" {
-			amArgs = append(amArgs, fmt.Sprintf("--cluster.label=%s", a.Spec.ClusterLabel))
+		clusterLabel := fmt.Sprintf("%s/%s", a.Namespace, a.Name)
+		if a.Spec.ClusterLabel != nil {
+			clusterLabel = *a.Spec.ClusterLabel
 		}
+		amArgs = append(amArgs, fmt.Sprintf("--cluster.label=%s", clusterLabel))
 	}
 
 	isHTTPS := a.Spec.Web != nil && a.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("0.22.0"))

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -313,10 +313,11 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 	// connects with cluster A.
 	// --cluster.label flag was introduced in alertmanager v0.26, this helps to block
 	// any traffic that is not meant for the cluster.
-	// The value is hardcoded and the value is guaranteed to be unique in a given cluster but
-	// if there's a use case, we can consider a new field in the CRD.
+	// Specify ClusterLabel in case you are in need of sorting out Alertmanager traffic.
 	if version.GTE(semver.MustParse("0.26.0")) {
-		amArgs = append(amArgs, fmt.Sprintf("--cluster.label=%s/%s", a.Namespace, a.Name))
+		if a.Spec.ClusterLabel != "" {
+			amArgs = append(amArgs, fmt.Sprintf("--cluster.label=%s", a.Spec.ClusterLabel))
+		}
 	}
 
 	isHTTPS := a.Spec.Web != nil && a.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("0.22.0"))

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1199,7 +1199,7 @@ func TestClusterLabel(t *testing.T) {
 		version:                 "0.26.0",
 		expectedClusterLabelArg: true,
 	}, {
-		scenario:                "--cluster.label set if speficfied explicity",
+		scenario:                "--cluster.label set if specified explicitly",
 		version:                 "0.26.0",
 		expectedClusterLabelArg: true,
 		customClusterLabel:      "custom.cluster",

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1232,7 +1232,7 @@ func TestClusterLabel(t *testing.T) {
 			args := ss.Template.Spec.Containers[0].Args
 			if ts.expectedClusterLabelArg {
 				if ts.customClusterLabel != "" {
-					require.Contains(t, args, "--cluster.label=custom.cluster")
+					require.Contains(t, args, fmt.Sprintf("--cluster.label=%s", ts.customClusterLabel))
 					return
 				}
 				require.Contains(t, args, "--cluster.label=monitoring/alertmanager")

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1193,41 +1193,52 @@ func TestClusterLabel(t *testing.T) {
 		scenario                string
 		version                 string
 		expectedClusterLabelArg bool
-		clusterLabel            string
+		customClusterLabel      string
 	}{{
-		scenario:                "--cluster.label not set by default for version >= v0.26.0",
+		scenario:                "--cluster.label set by default for version >= v0.26.0",
 		version:                 "0.26.0",
-		expectedClusterLabelArg: false,
+		expectedClusterLabelArg: true,
+	}, {
+		scenario:                "--cluster.label set if speficfied explicity",
+		version:                 "0.26.0",
+		expectedClusterLabelArg: true,
+		customClusterLabel:      "custom.cluster",
 	}, {
 		scenario:                "no --cluster.label set for older versions",
 		version:                 "0.25.0",
 		expectedClusterLabelArg: false,
-	}, {
-		scenario:                "--cluster.label set if specified in spec.ClusterLabel and version >= v0.26.0",
-		version:                 "0.26.0",
-		expectedClusterLabelArg: true,
-		clusterLabel:            "custom.cluster",
 	}}
 
 	for _, ts := range tt {
 		t.Run(ts.scenario, func(t *testing.T) {
 			a := monitoringv1.Alertmanager{
-				Spec: monitoringv1.AlertmanagerSpec{
-					Replicas:     toPtr(int32(1)),
-					Version:      ts.version,
-					ClusterLabel: ts.clusterLabel,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alertmanager",
+					Namespace: "monitoring",
 				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					Replicas: toPtr(int32(1)),
+					Version:  ts.version,
+				},
+			}
+
+			if ts.customClusterLabel != "" {
+				a.Spec.ClusterLabel = &ts.customClusterLabel
 			}
 
 			ss, err := makeStatefulSetSpec(nil, &a, defaultTestConfig, nil)
 			require.NoError(t, err)
 
 			args := ss.Template.Spec.Containers[0].Args
-			if !ts.expectedClusterLabelArg {
-				require.NotContains(t, args, "--cluster.label")
+			if ts.expectedClusterLabelArg {
+				if ts.customClusterLabel != "" {
+					require.Contains(t, args, "--cluster.label=custom.cluster")
+					return
+				}
+				require.Contains(t, args, "--cluster.label=monitoring/alertmanager")
 				return
 			}
-			require.Contains(t, args, "--cluster.label=custom.cluster")
+			require.NotContains(t, args, "--cluster.label")
 		})
 	}
 }

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -207,7 +207,7 @@ type AlertmanagerSpec struct {
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Defines the identifier that uniquely identifies the Alertmanager cluster.
-	// You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.
+	// You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the `.spec.additionalPeers` field.
 	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -207,7 +207,7 @@ type AlertmanagerSpec struct {
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Defines the identifier that uniquely identifies the Alertmanager cluster.
-	// You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addressed of the external instances are provided via the `.spec.additionalPeers` field.
+	// You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
 	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -206,6 +206,8 @@ type AlertmanagerSpec struct {
 	ClusterAdvertiseAddress string `json:"clusterAdvertiseAddress,omitempty"`
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
+	// Gossip with same ClusterLabels only.
+	ClusterLabel string `json:"clusterLabel,lomitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`
 	// Timeout for cluster peering.

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -207,7 +207,7 @@ type AlertmanagerSpec struct {
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Defines the identifier that uniquely identifies the Alertmanager cluster.
-	// You should only set it when the Alertmanager cluster includes several Alertmanager objects.
+	// You should only set it when the Alertmanager cluster includes more than one Alertmanager replicas.
 	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -207,7 +207,7 @@ type AlertmanagerSpec struct {
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
 	// Gossip with same ClusterLabels only.
-	ClusterLabel string `json:"clusterLabel,lomitempty"`
+	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`
 	// Timeout for cluster peering.

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -206,7 +206,8 @@ type AlertmanagerSpec struct {
 	ClusterAdvertiseAddress string `json:"clusterAdvertiseAddress,omitempty"`
 	// Interval between gossip attempts.
 	ClusterGossipInterval GoDuration `json:"clusterGossipInterval,omitempty"`
-	// Gossip with same ClusterLabels only.
+	// Defines the identifier that uniquely identifies the Alertmanager cluster.
+	// You should only set it when the Alertmanager cluster includes several Alertmanager objects.
 	ClusterLabel *string `json:"clusterLabel,omitempty"`
 	// Interval between pushpull attempts.
 	ClusterPushpullInterval GoDuration `json:"clusterPushpullInterval,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -356,6 +356,11 @@ func (in *AlertmanagerSpec) DeepCopyInto(out *AlertmanagerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClusterLabel != nil {
+		in, out := &in.ClusterLabel, &out.ClusterLabel
+		*out = new(string)
+		**out = **in
+	}
 	if in.AlertmanagerConfigSelector != nil {
 		in, out := &in.AlertmanagerConfigSelector, &out.AlertmanagerConfigSelector
 		*out = new(metav1.LabelSelector)

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
@@ -60,6 +60,7 @@ type AlertmanagerSpecApplyConfiguration struct {
 	AdditionalPeers                     []string                                             `json:"additionalPeers,omitempty"`
 	ClusterAdvertiseAddress             *string                                              `json:"clusterAdvertiseAddress,omitempty"`
 	ClusterGossipInterval               *monitoringv1.GoDuration                             `json:"clusterGossipInterval,omitempty"`
+	ClusterLabel                        *string                                              `json:"clusterLabel,omitempty"`
 	ClusterPushpullInterval             *monitoringv1.GoDuration                             `json:"clusterPushpullInterval,omitempty"`
 	ClusterPeerTimeout                  *monitoringv1.GoDuration                             `json:"clusterPeerTimeout,omitempty"`
 	PortName                            *string                                              `json:"portName,omitempty"`
@@ -383,6 +384,14 @@ func (b *AlertmanagerSpecApplyConfiguration) WithClusterAdvertiseAddress(value s
 // If called multiple times, the ClusterGossipInterval field is set to the value of the last call.
 func (b *AlertmanagerSpecApplyConfiguration) WithClusterGossipInterval(value monitoringv1.GoDuration) *AlertmanagerSpecApplyConfiguration {
 	b.ClusterGossipInterval = &value
+	return b
+}
+
+// WithClusterLabel sets the ClusterLabel field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ClusterLabel field is set to the value of the last call.
+func (b *AlertmanagerSpecApplyConfiguration) WithClusterLabel(value string) *AlertmanagerSpecApplyConfiguration {
+	b.ClusterLabel = &value
 	return b
 }
 


### PR DESCRIPTION
## Description

Fixes #6158.

It adds a dedicated field for cluster.label option in alertmanager. Default is to leave it blank, if it is not set. More background is mentioned in #6158 


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
alertmanager `--cluster.label` (introduced `v0.26.0`) can be reconfigured with a dedicated field now.
```
