### PR TITLE
feat: emit events for invalid configurations

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -99,6 +99,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/Documentation/user-guides/prometheus-agent.md
+++ b/Documentation/user-guides/prometheus-agent.md
@@ -99,6 +99,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -42729,6 +42729,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -241,6 +242,24 @@ func run(fs *flag.FlagSet) int {
 		return 1
 	}
 
+	canEmitEvents, reasons, err := k8sutil.IsAllowed(ctx, kclient.AuthorizationV1().SelfSubjectAccessReviews(), nil,
+		k8sutil.ResourceAttribute{
+			Group:    corev1.GroupName,
+			Version:  corev1.SchemeGroupVersion.Version,
+			Resource: corev1.SchemeGroupVersion.WithResource("events").Resource,
+			Verbs:    []string{"create", "patch"},
+		})
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to check Events support", "err", err)
+		cancel()
+		return 1
+	}
+	if !canEmitEvents {
+		for _, reason := range reasons {
+			level.Warn(logger).Log("msg", "missing permission to emit events", "reason", reason)
+		}
+	}
+
 	scrapeConfigSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -261,7 +280,7 @@ func run(fs *flag.FlagSet) int {
 		return 1
 	}
 
-	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusoperator"), r, scrapeConfigSupported, canReadStorageClass)
+	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusoperator"), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating prometheus controller failed", "err", err)
 		cancel()
@@ -296,7 +315,7 @@ func run(fs *flag.FlagSet) int {
 
 	var pao *prometheusagentcontroller.Operator
 	if prometheusAgentSupported {
-		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusagentoperator"), r, scrapeConfigSupported, canReadStorageClass)
+		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusagentoperator"), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 		if err != nil {
 			level.Error(logger).Log("msg", "instantiating prometheus-agent controller failed", "err", err)
 			cancel()
@@ -304,14 +323,14 @@ func run(fs *flag.FlagSet) int {
 		}
 	}
 
-	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "alertmanageroperator"), r, canReadStorageClass)
+	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "alertmanageroperator"), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating alertmanager controller failed", "err", err)
 		cancel()
 		return 1
 	}
 
-	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "thanosoperator"), r, canReadStorageClass)
+	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "thanosoperator"), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating thanos controller failed", "err", err)
 		cancel()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -280,7 +280,7 @@ func run(fs *flag.FlagSet) int {
 		return 1
 	}
 
-	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheuscontroller.OperatorName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
+	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheuscontroller.ControllerName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating prometheus controller failed", "err", err)
 		cancel()
@@ -315,7 +315,7 @@ func run(fs *flag.FlagSet) int {
 
 	var pao *prometheusagentcontroller.Operator
 	if prometheusAgentSupported {
-		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheusagentcontroller.OperatorName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
+		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheusagentcontroller.ControllerName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 		if err != nil {
 			level.Error(logger).Log("msg", "instantiating prometheus-agent controller failed", "err", err)
 			cancel()
@@ -323,14 +323,14 @@ func run(fs *flag.FlagSet) int {
 		}
 	}
 
-	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", alertmanagercontroller.OperatorName), r, canReadStorageClass, canEmitEvents)
+	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", alertmanagercontroller.ControllerName), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating alertmanager controller failed", "err", err)
 		cancel()
 		return 1
 	}
 
-	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", thanoscontroller.OperatorName), r, canReadStorageClass, canEmitEvents)
+	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", thanoscontroller.ControllerName), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating thanos controller failed", "err", err)
 		cancel()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -280,7 +280,7 @@ func run(fs *flag.FlagSet) int {
 		return 1
 	}
 
-	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusoperator"), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
+	po, err := prometheuscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheuscontroller.OperatorName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating prometheus controller failed", "err", err)
 		cancel()
@@ -315,7 +315,7 @@ func run(fs *flag.FlagSet) int {
 
 	var pao *prometheusagentcontroller.Operator
 	if prometheusAgentSupported {
-		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "prometheusagentoperator"), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
+		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, log.With(logger, "component", prometheusagentcontroller.OperatorName), r, scrapeConfigSupported, canReadStorageClass, canEmitEvents)
 		if err != nil {
 			level.Error(logger).Log("msg", "instantiating prometheus-agent controller failed", "err", err)
 			cancel()
@@ -323,14 +323,14 @@ func run(fs *flag.FlagSet) int {
 		}
 	}
 
-	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "alertmanageroperator"), r, canReadStorageClass, canEmitEvents)
+	ao, err := alertmanagercontroller.New(ctx, restConfig, cfg, log.With(logger, "component", alertmanagercontroller.OperatorName), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating alertmanager controller failed", "err", err)
 		cancel()
 		return 1
 	}
 
-	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", "thanosoperator"), r, canReadStorageClass, canEmitEvents)
+	to, err := thanoscontroller.New(ctx, restConfig, cfg, log.With(logger, "component", thanoscontroller.OperatorName), r, canReadStorageClass, canEmitEvents)
 	if err != nil {
 		level.Error(logger).Log("msg", "instantiating thanos controller failed", "err", err)
 		cancel()

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -77,6 +77,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+  - create
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -134,6 +134,11 @@ function(params) {
         verbs: ['get', 'list', 'watch'],
       },
       {
+        apiGroups: [''],
+        resources: ['events'],
+        verbs: ['patch', 'create'],
+      },
+      {
         apiGroups: ['networking.k8s.io'],
         resources: ['ingresses'],
         verbs: ['get', 'list', 'watch'],

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -57,8 +57,8 @@ import (
 )
 
 const (
-	resyncPeriod = 5 * time.Minute
-	OperatorName = "alertmanageroperator"
+	resyncPeriod   = 5 * time.Minute
+	ControllerName = "alertmanager-controller"
 )
 
 var (
@@ -148,7 +148,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 
 		metrics:             operator.NewMetrics(r),
 		reconciliations:     &operator.ReconciliationTracker{},
-		eventRecorder:       operator.NewEventRecorder(eventsClient, OperatorName),
+		eventRecorder:       operator.NewEventRecorder(eventsClient, ControllerName),
 		canReadStorageClass: canReadStorageClass,
 
 		config: Config{
@@ -1096,7 +1096,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			c.eventRecorder.Eventf(amc, v1.EventTypeWarning, "InvalidConfiguration", "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			c.eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -137,7 +137,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		logger:   logger,
 		accessor: operator.NewAccessor(logger),
 
-		metrics:             operator.NewMetrics(r),
+		metrics:             operator.NewMetrics(client, r),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 
@@ -1086,6 +1086,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
+			c.metrics.Recorder.Eventf(amc, v1.EventTypeWarning, "InvalidConfiguration", "AlertmanagerConfig %q/%q was rejected due to invalid configuration: %v", amc.GetNamespace(), amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -58,6 +58,7 @@ import (
 
 const (
 	resyncPeriod = 5 * time.Minute
+	OperatorName = "alertmanageroperator"
 )
 
 var (

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1238,7 +1238,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				mclient:    monitoringfake.NewSimpleClientset(),
 				ssarClient: &alwaysAllowed{},
 				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowInfo()),
-				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
+				metrics:    operator.NewMetrics(nil, prometheus.NewRegistry()),
 			}
 
 			err := o.bootstrap(

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1238,7 +1238,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				mclient:    monitoringfake.NewSimpleClientset(),
 				ssarClient: &alwaysAllowed{},
 				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowInfo()),
-				metrics:    operator.NewMetrics(nil, prometheus.NewRegistry()),
+				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
 			}
 
 			err := o.bootstrap(

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -37,7 +37,11 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
 )
 
-const PrometheusOperatorFieldManager = "PrometheusOperator"
+const (
+	PrometheusOperatorFieldManager = "PrometheusOperator"
+
+	InvalidConfigurationEvent = "InvalidConfiguration"
+)
 
 var (
 	syncsDesc = prometheus.NewDesc(
@@ -269,7 +273,7 @@ func NewEventRecorder(client kubernetes.Interface, component string) record.Even
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 
-	// Exclude initialization when testing.
+	// Client can be nil in tests or when the operator doesn't have permissions to create events.
 	if client != nil {
 		eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: client.CoreV1().Events("")})
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -24,12 +24,17 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
 )
 
 const PrometheusOperatorFieldManager = "PrometheusOperator"
@@ -201,6 +206,9 @@ type Metrics struct {
 	// mtx protects all fields below.
 	mtx       sync.RWMutex
 	resources map[resourceKey]map[string]int
+
+	// Emit events for critical metric changes.
+	Recorder record.EventRecorder
 }
 
 type resourceKey struct {
@@ -209,7 +217,17 @@ type resourceKey struct {
 }
 
 // NewMetrics initializes operator metrics and registers them with the given registerer.
-func NewMetrics(r prometheus.Registerer) *Metrics {
+func NewMetrics(client kubernetes.Interface, r prometheus.Registerer) *Metrics {
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+
+	// Exclude initialization when testing.
+	if client != nil {
+		eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: client.CoreV1().Events("")})
+	}
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "prometheus-operator"})
+
 	m := Metrics{
 		reg: r,
 		triggerByCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -243,6 +261,8 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		}),
 
 		resources: make(map[resourceKey]map[string]int),
+
+		Recorder: recorder,
 	}
 
 	m.reg.MustRegister(

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -43,13 +43,15 @@ const (
 )
 
 type PrometheusRuleSelector struct {
-	ruleFormat    RuleConfigurationFormat
-	version       semver.Version
-	ruleSelector  labels.Selector
-	nsLabeler     *namespacelabeler.Labeler
-	ruleInformer  *informers.ForResource
+	ruleFormat   RuleConfigurationFormat
+	version      semver.Version
+	ruleSelector labels.Selector
+	nsLabeler    *namespacelabeler.Labeler
+	ruleInformer *informers.ForResource
+
 	eventRecorder record.EventRecorder
-	logger        log.Logger
+
+	logger log.Logger
 }
 
 func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder record.EventRecorder, logger log.Logger) (*PrometheusRuleSelector, error) {
@@ -207,11 +209,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			if prs.canEmitEvents {
-				prs.eventRecorder.Eventf(promRule, v1.EventTypeWarning, "InvalidConfiguration", "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
-			} else {
-				level.Debug(prs.logger).Log("msg", "skipping event emission for InvalidConfiguration due to missing RBAC permissions")
-			}
+			prs.eventRecorder.Eventf(promRule, v1.EventTypeWarning, "InvalidConfiguration", "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -51,6 +51,7 @@ import (
 
 const (
 	resyncPeriod = 5 * time.Minute
+	OperatorName = "prometheusagentcontroller"
 )
 
 // Operator manages life cycle of Prometheus agent deployments and

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Annotations:                c.Annotations,
 			Labels:                     c.Labels,
 		},
-		metrics:               operator.NewMetrics(r),
+		metrics:               operator.NewMetrics(client, r),
 		reconciliations:       &operator.ReconciliationTracker{},
 		scrapeConfigSupported: scrapeConfigSupported,
 		canReadStorageClass:   canReadStorageClass,

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -78,7 +78,6 @@ type Operator struct {
 	rr *operator.ResourceReconciler
 
 	metrics         *operator.Metrics
-	eventRecorder   record.EventRecorder
 	reconciliations *operator.ReconciliationTracker
 
 	config                 prompkg.Config
@@ -86,11 +85,13 @@ type Operator struct {
 	scrapeConfigSupported  bool
 	canReadStorageClass    bool
 
+	eventRecorder record.EventRecorder
+
 	statusReporter prompkg.StatusReporter
 }
 
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, scrapeConfigSupported bool, canReadStorageClass bool) (*Operator, error) {
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, scrapeConfigSupported, canReadStorageClass, canEmitEvents bool) (*Operator, error) {
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
@@ -109,6 +110,11 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 	// All the metrics exposed by the controller get the controller="prometheus-agent" label.
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "prometheus-agent"}, r)
 
+	var eventsClient kubernetes.Interface
+	if canEmitEvents {
+		eventsClient = client
+	}
+
 	o := &Operator{
 		kclient:  client,
 		mdClient: mdClient,
@@ -123,10 +129,10 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Labels:                     c.Labels,
 		},
 		metrics:               operator.NewMetrics(r),
-		eventRecorder:         operator.NewEventRecorder(client, "prometheus-agent-controller"),
 		reconciliations:       &operator.ReconciliationTracker{},
 		scrapeConfigSupported: scrapeConfigSupported,
 		canReadStorageClass:   canReadStorageClass,
+		eventRecorder:         operator.NewEventRecorder(eventsClient, OperatorName),
 	}
 	o.metrics.MustRegister(
 		o.reconciliations,

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -50,8 +50,8 @@ import (
 )
 
 const (
-	resyncPeriod = 5 * time.Minute
-	OperatorName = "prometheusagentcontroller"
+	resyncPeriod   = 5 * time.Minute
+	ControllerName = "prometheusagent-controller"
 )
 
 // Operator manages life cycle of Prometheus agent deployments and
@@ -133,7 +133,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		reconciliations:       &operator.ReconciliationTracker{},
 		scrapeConfigSupported: scrapeConfigSupported,
 		canReadStorageClass:   canReadStorageClass,
-		eventRecorder:         operator.NewEventRecorder(eventsClient, OperatorName),
+		eventRecorder:         operator.NewEventRecorder(eventsClient, ControllerName),
 	}
 	o.metrics.MustRegister(
 		o.reconciliations,

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -48,8 +48,9 @@ type ResourceSelector struct {
 	store              *assets.Store
 	namespaceInformers cache.SharedIndexInformer
 	metrics            *operator.Metrics
-	eventRecorder      record.EventRecorder
 	accessor           *operator.Accessor
+
+	eventRecorder record.EventRecorder
 }
 
 type ListAllByNamespaceFn func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error
@@ -177,11 +178,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			if rs.canEmitEvents {
-				rs.eventRecorder.Eventf(sm, v1.EventTypeWarning, "InvalidConfiguration", "ServiceMonitor %s was rejected due to invalid configuration: %v", sm.GetName(), err)
-			} else {
-				level.Debug(rs.l).Log("msg", "skipping event emission for InvalidConfiguration due to missing RBAC permissions")
-			}
+			rs.eventRecorder.Eventf(sm, v1.EventTypeWarning, "InvalidConfiguration", "ServiceMonitor %s was rejected due to invalid configuration: %v", sm.GetName(), err)
 			continue
 		}
 
@@ -431,11 +428,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			if rs.canEmitEvents {
-				rs.eventRecorder.Eventf(pm, v1.EventTypeWarning, "InvalidConfiguration", "PodMonitor %s was rejected due to invalid configuration: %v", pm.GetName(), err)
-			} else {
-				level.Debug(rs.l).Log("msg", "skipping event emission for InvalidConfiguration due to missing RBAC permissions")
-			}
+			rs.eventRecorder.Eventf(pm, v1.EventTypeWarning, "InvalidConfiguration", "PodMonitor %s was rejected due to invalid configuration: %v", pm.GetName(), err)
 			continue
 		}
 
@@ -517,11 +510,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			if rs.canEmitEvents {
-				rs.eventRecorder.Eventf(probe, v1.EventTypeWarning, "InvalidConfiguration", "Probe %s was rejected due to invalid configuration: %v", probe.GetName(), err)
-			} else {
-				level.Debug(rs.l).Log("msg", "skipping event emission for InvalidConfiguration due to missing RBAC permissions")
-			}
+			rs.eventRecorder.Eventf(probe, v1.EventTypeWarning, "InvalidConfiguration", "Probe %s was rejected due to invalid configuration: %v", probe.GetName(), err)
 		}
 
 		if err = probe.Spec.Targets.Validate(); err != nil {
@@ -684,11 +673,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			if rs.canEmitEvents {
-				rs.eventRecorder.Eventf(sc, v1.EventTypeWarning, "InvalidConfiguration", "ScrapeConfig %s was rejected due to invalid configuration: %v", sc.GetName(), err)
-			} else {
-				level.Debug(rs.l).Log("msg", "skipping event emission for InvalidConfiguration due to missing RBAC permissions")
-			}
+			rs.eventRecorder.Eventf(sc, v1.EventTypeWarning, "InvalidConfiguration", "ScrapeConfig %s was rejected due to invalid configuration: %v", sc.GetName(), err)
 		}
 
 		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -178,7 +178,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			rs.eventRecorder.Eventf(sm, v1.EventTypeWarning, "InvalidConfiguration", "ServiceMonitor %s was rejected due to invalid configuration: %v", sm.GetName(), err)
+			rs.eventRecorder.Eventf(sm, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "ServiceMonitor %s was rejected due to invalid configuration: %v", sm.GetName(), err)
 			continue
 		}
 
@@ -428,7 +428,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			rs.eventRecorder.Eventf(pm, v1.EventTypeWarning, "InvalidConfiguration", "PodMonitor %s was rejected due to invalid configuration: %v", pm.GetName(), err)
+			rs.eventRecorder.Eventf(pm, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "PodMonitor %s was rejected due to invalid configuration: %v", pm.GetName(), err)
 			continue
 		}
 
@@ -510,7 +510,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			rs.eventRecorder.Eventf(probe, v1.EventTypeWarning, "InvalidConfiguration", "Probe %s was rejected due to invalid configuration: %v", probe.GetName(), err)
+			rs.eventRecorder.Eventf(probe, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "Probe %s was rejected due to invalid configuration: %v", probe.GetName(), err)
 		}
 
 		if err = probe.Spec.Targets.Validate(); err != nil {
@@ -673,7 +673,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
-			rs.eventRecorder.Eventf(sc, v1.EventTypeWarning, "InvalidConfiguration", "ScrapeConfig %s was rejected due to invalid configuration: %v", sc.GetName(), err)
+			rs.eventRecorder.Eventf(sc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "ScrapeConfig %s was rejected due to invalid configuration: %v", sc.GetName(), err)
 		}
 
 		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -173,6 +174,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(sm, v1.EventTypeWarning, "InvalidConfiguration", "ServiceMonitor %q/%q was rejected due to invalid configuration: %v", sm.GetNamespace(), sm.GetName(), err)
 			continue
 		}
 
@@ -422,6 +424,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(pm, v1.EventTypeWarning, "InvalidConfiguration", "PodMonitor %q/%q was rejected due to invalid configuration: %v", pm.GetNamespace(), pm.GetName(), err)
 			continue
 		}
 
@@ -503,6 +506,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(probe, v1.EventTypeWarning, "InvalidConfiguration", "Probe %q/%q was rejected due to invalid configuration: %v", probe.GetNamespace(), probe.GetName(), err)
 		}
 
 		if err = probe.Spec.Targets.Validate(); err != nil {
@@ -665,6 +669,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 				"namespace", objMeta.GetNamespace(),
 				"prometheus", objMeta.GetName(),
 			)
+			rs.metrics.Recorder.Eventf(sc, v1.EventTypeWarning, "InvalidConfiguration", "ScrapeConfig %q/%q was rejected due to invalid configuration: %v", sc.GetNamespace(), sc.GetName(), err)
 		}
 
 		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -576,7 +577,8 @@ func TestSelectProbes(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				record.NewFakeRecorder(1),
 			)
 
 			probe := &monitoringv1.Probe{
@@ -969,7 +971,8 @@ func TestSelectServiceMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				assets.NewStore(cs.CoreV1(), cs.CoreV1()),
 				nil,
-				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				record.NewFakeRecorder(1),
 			)
 
 			sm := &monitoringv1.ServiceMonitor{
@@ -1069,7 +1072,8 @@ func TestSelectPodMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				record.NewFakeRecorder(1),
 			)
 
 			pm := &monitoringv1.PodMonitor{
@@ -1757,7 +1761,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				},
 				assets.NewStore(cs.CoreV1(), cs.CoreV1()),
 				nil,
-				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				record.NewFakeRecorder(1),
 			)
 
 			sc := &monitoringv1alpha1.ScrapeConfig{

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -576,7 +576,7 @@ func TestSelectProbes(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			probe := &monitoringv1.Probe{
@@ -969,7 +969,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				assets.NewStore(cs.CoreV1(), cs.CoreV1()),
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			sm := &monitoringv1.ServiceMonitor{
@@ -1069,7 +1069,7 @@ func TestSelectPodMonitors(t *testing.T) {
 				&monitoringv1.Prometheus{},
 				nil,
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			pm := &monitoringv1.PodMonitor{
@@ -1757,7 +1757,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				},
 				assets.NewStore(cs.CoreV1(), cs.CoreV1()),
 				nil,
-				operator.NewMetrics(prometheus.NewPedanticRegistry()),
+				operator.NewMetrics(nil, prometheus.NewPedanticRegistry()),
 			)
 
 			sc := &monitoringv1alpha1.ScrapeConfig{

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -50,8 +50,8 @@ import (
 )
 
 const (
-	resyncPeriod = 5 * time.Minute
-	OperatorName = "prometheusoperator"
+	resyncPeriod   = 5 * time.Minute
+	ControllerName = "prometheus-controller"
 )
 
 // Operator manages life cycle of Prometheus deployments and
@@ -137,7 +137,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		scrapeConfigSupported: scrapeConfigSupported,
 		canReadStorageClass:   canReadStorageClass,
 
-		eventRecorder: operator.NewEventRecorder(eventsClient, OperatorName),
+		eventRecorder: operator.NewEventRecorder(eventsClient, ControllerName),
 	}
 	o.metrics.MustRegister(o.reconciliations)
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -122,7 +122,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Annotations:                c.Annotations,
 			Labels:                     c.Labels,
 		},
-		metrics:         operator.NewMetrics(r),
+		metrics:         operator.NewMetrics(client, r),
 		reconciliations: &operator.ReconciliationTracker{},
 
 		scrapeConfigSupported: scrapeConfigSupported,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -51,6 +51,7 @@ import (
 
 const (
 	resyncPeriod = 5 * time.Minute
+	OperatorName = "prometheusoperator"
 )
 
 // Operator manages life cycle of Prometheus deployments and

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -73,7 +73,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(namespaces)
+	newRules, rejected, err := promRuleSelector.Select(c.metrics.Recorder, namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -68,12 +68,12 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 	logger := log.With(c.logger, "prometheus", p.Name, "namespace", p.Namespace)
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 
-	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.PrometheusFormat, promVersion, p.Spec.RuleSelector, nsLabeler, c.ruleInfs, logger)
+	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.PrometheusFormat, promVersion, p.Spec.RuleSelector, nsLabeler, c.ruleInfs, c.eventRecorder, logger)
 	if err != nil {
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(c.metrics.Recorder, namespaces)
+	newRules, rejected, err := promRuleSelector.Select(namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -48,7 +48,7 @@ import (
 const (
 	resyncPeriod     = 5 * time.Minute
 	thanosRulerLabel = "thanos-ruler"
-	OperatorName     = "thanosoperator"
+	ControllerName   = "thanos-controller"
 )
 
 // Operator manages life cycle of Thanos deployments and
@@ -122,7 +122,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		logger:              logger,
 		accessor:            operator.NewAccessor(logger),
 		metrics:             operator.NewMetrics(r),
-		eventRecorder:       operator.NewEventRecorder(eventsClient, OperatorName),
+		eventRecorder:       operator.NewEventRecorder(eventsClient, ControllerName),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 		config: Config{

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1ac "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
@@ -69,6 +70,7 @@ type Operator struct {
 	nsRuleInf        cache.SharedIndexInformer
 
 	metrics             *operator.Metrics
+	eventRecorder       record.EventRecorder
 	reconciliations     *operator.ReconciliationTracker
 	canReadStorageClass bool
 
@@ -112,7 +114,8 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		mclient:             mclient,
 		logger:              logger,
 		accessor:            operator.NewAccessor(logger),
-		metrics:             operator.NewMetrics(client, r),
+		metrics:             operator.NewMetrics(r),
+		eventRecorder:       operator.NewEventRecorder(client, "thanos-controller"),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 		config: Config{

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -112,7 +112,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		mclient:             mclient,
 		logger:              logger,
 		accessor:            operator.NewAccessor(logger),
-		metrics:             operator.NewMetrics(r),
+		metrics:             operator.NewMetrics(client, r),
 		reconciliations:     &operator.ReconciliationTracker{},
 		canReadStorageClass: canReadStorageClass,
 		config: Config{

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -74,7 +74,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(namespaces)
+	newRules, rejected, err := promRuleSelector.Select(o.metrics.Recorder, namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -69,12 +69,12 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 	logger := log.With(o.logger, "thanos", t.Name, "namespace", t.Namespace)
 	thanosVersion := operator.StringValOrDefault(t.Spec.Version, operator.DefaultThanosVersion)
 
-	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, logger)
+	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, o.eventRecorder, logger)
 	if err != nil {
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}
 
-	newRules, rejected, err := promRuleSelector.Select(o.metrics.Recorder, namespaces)
+	newRules, rejected, err := promRuleSelector.Select(namespaces)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PrometheusRules failed: %w", err)
 	}


### PR DESCRIPTION
## Description

Continuation of the work started by @rexagod in #6030 

Fixes #3611 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Emit events when the controller rejects a resource, owing to an invalid configuration. These are:
* AlertmanagerConfig
* PodMonitor
* Probe
* PrometheusRule
* ScrapeConfig
* ServiceMonitor
```
