### PR TITLE
feat: add metrics tracking status updates

### DIFF
--- a/example/mixin/alerts.yaml
+++ b/example/mixin/alerts.yaml
@@ -31,9 +31,18 @@ groups:
   - alert: PrometheusOperatorReconcileErrors
     annotations:
       description: '{{ $value | humanizePercentage }} of reconciling operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.'
-      summary: Errors while reconciling controller.
+      summary: Errors while reconciling objects.
     expr: |
       (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator"}[5m]))) > 0.1
+    for: 10m
+    labels:
+      severity: warning
+  - alert: PrometheusOperatorStatusUpdateErrors
+    annotations:
+      description: '{{ $value | humanizePercentage }} of status update operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.'
+      summary: Errors while updating objects status.
+    expr: |
+      (sum by (controller,namespace) (rate(prometheus_operator_status_update_errors_total{job="prometheus-operator"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_status_update_operations_total{job="prometheus-operator"}[5m]))) > 0.1
     for: 10m
     labels:
       severity: warning

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -56,7 +56,21 @@
             },
             annotations: {
               description: '{{ $value | humanizePercentage }} of reconciling operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.',
-              summary: 'Errors while reconciling controller.',
+              summary: 'Errors while reconciling objects.',
+            },
+            'for': '10m',
+          },
+          {
+            alert: 'PrometheusOperatorStatusUpdateErrors',
+            expr: |||
+              (sum by (%(groupLabels)s) (rate(prometheus_operator_status_update_errors_total{%(prometheusOperatorSelector)s}[5m]))) / (sum by (%(groupLabels)s) (rate(prometheus_operator_status_update_operations_total{%(prometheusOperatorSelector)s}[5m]))) > 0.1
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: '{{ $value | humanizePercentage }} of status update operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.',
+              summary: 'Errors while updating objects status.',
             },
             'for': '10m',
           },


### PR DESCRIPTION
## Description

This commit introduces 2 new counters:
* `prometheus_operator_status_update_errors_total`
* `prometheus_operator_status_update_operations_total`

The metrics have a `controller` label whose value is one of `alertmanager`, `prometheus`, `prometheus-agent` or `thanos`.

It also adds a new alerting rule `PrometheusOperatorStatusUpdateErrors` to the mixin which fires when a controller fails to update the status of the objects that it manages.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add `prometheus_operator_status_update_errors_total` and `prometheus_operator_status_update_operations_total` metrics.
```
