### PR TITLE
Disable dependabot automation targeting k8s libs

### DIFF
--- a/.github/workflows/automerge-dependabot.yaml
+++ b/.github/workflows/automerge-dependabot.yaml
@@ -15,24 +15,6 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Checkout
-        if: contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PROM_OP_BOT_PAT }}
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Generate Documentation/compatibility.md
-        if: contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
-        run: |
-          export GITHUB_TOKEN="${{ secrets.PROM_OP_BOT_PAT }}"
-          make generate --always-make
-          if ! git diff --exit-code; then
-            git config --global user.email "prom-op-bot@users.noreply.github.com"
-            git config --global user.name "Prometheus Operator Bot"
-            git add Documentation/compatibility.md
-            git commit -s -m "Generate Documentation/compatibility.md"
-            git push
-          fi
       - name: Enable auto-merge for Dependabot PRs
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: |


### PR DESCRIPTION
## Description

After months of trying to make this automation work, I declare myself defeated 😓 

I'll way for Github to provide support for running scripts in Dependabot PRs out-of-the-box

Thanks for your patience and sorry for the trouble @simonpasquier and @philipgough 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
