### PR TITLE
Add UpdateScale and GetScale methods

### DIFF
--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -691,6 +691,8 @@ func (cpf *CommonPrometheusFields) WebRoutePrefix() string {
 // +kubebuilder:printcolumn:name="Paused",type="boolean",JSONPath=".status.paused",description="Whether the resource reconciliation is paused or not",priority=1
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.shards,statuspath=.status.shards,selectorpath=.status.selector
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 
 // Prometheus defines a Prometheus deployment.
 type Prometheus struct {

--- a/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+++ b/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
@@ -50,6 +50,8 @@ func (l *PrometheusAgent) GetStatus() monitoringv1.PrometheusStatus {
 // +kubebuilder:printcolumn:name="Paused",type="boolean",JSONPath=".status.paused",description="Whether the resource reconciliation is paused or not",priority=1
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.shards,statuspath=.status.shards,selectorpath=.status.selector
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 
 // PrometheusAgent defines a Prometheus agent deployment.
 type PrometheusAgent struct {

--- a/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheus.go
+++ b/pkg/client/versioned/typed/monitoring/v1/fake/fake_prometheus.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
@@ -184,4 +185,26 @@ func (c *FakePrometheuses) ApplyStatus(ctx context.Context, prometheus *monitori
 		return nil, err
 	}
 	return obj.(*v1.Prometheus), err
+}
+
+// GetScale takes name of the prometheus, and returns the corresponding scale object, and an error if there is any.
+func (c *FakePrometheuses) GetScale(ctx context.Context, prometheusName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(prometheusesResource, c.ns, "scale", prometheusName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakePrometheuses) UpdateScale(ctx context.Context, prometheusName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(prometheusesResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/pkg/client/versioned/typed/monitoring/v1/prometheus.go
+++ b/pkg/client/versioned/typed/monitoring/v1/prometheus.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
 	scheme "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/scheme"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -50,6 +51,9 @@ type PrometheusInterface interface {
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Prometheus, err error)
 	Apply(ctx context.Context, prometheus *monitoringv1.PrometheusApplyConfiguration, opts metav1.ApplyOptions) (result *v1.Prometheus, err error)
 	ApplyStatus(ctx context.Context, prometheus *monitoringv1.PrometheusApplyConfiguration, opts metav1.ApplyOptions) (result *v1.Prometheus, err error)
+	GetScale(ctx context.Context, prometheusName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(ctx context.Context, prometheusName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error)
+
 	PrometheusExpansion
 }
 
@@ -248,6 +252,35 @@ func (c *prometheuses) ApplyStatus(ctx context.Context, prometheus *monitoringv1
 		SubResource("status").
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
 		Body(data).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// GetScale takes name of the prometheus, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *prometheuses) GetScale(ctx context.Context, prometheusName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("prometheuses").
+		Name(prometheusName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *prometheuses) UpdateScale(ctx context.Context, prometheusName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("prometheuses").
+		Name(prometheusName).
+		SubResource("scale").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(scale).
 		Do(ctx).
 		Into(result)
 	return

--- a/pkg/client/versioned/typed/monitoring/v1alpha1/fake/fake_prometheusagent.go
+++ b/pkg/client/versioned/typed/monitoring/v1alpha1/fake/fake_prometheusagent.go
@@ -23,6 +23,7 @@ import (
 
 	v1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
@@ -184,4 +185,26 @@ func (c *FakePrometheusAgents) ApplyStatus(ctx context.Context, prometheusAgent 
 		return nil, err
 	}
 	return obj.(*v1alpha1.PrometheusAgent), err
+}
+
+// GetScale takes name of the prometheusAgent, and returns the corresponding scale object, and an error if there is any.
+func (c *FakePrometheusAgents) GetScale(ctx context.Context, prometheusAgentName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(prometheusagentsResource, c.ns, "scale", prometheusAgentName), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakePrometheusAgents) UpdateScale(ctx context.Context, prometheusAgentName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(prometheusagentsResource, "scale", c.ns, scale), &autoscalingv1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -267,7 +267,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PrometheusCRDValidation":                   testPrometheusCRDValidation,
 		"PromRemoteWriteWithTLS":                    testPromRemoteWriteWithTLS,
 		"PromCreateDeleteCluster":                   testPromCreateDeleteCluster,
-		"PromScaleUpDownCluster":                    testPromScaleUpDownCluster,
+		"PromScaleUpDownCluster":                    testPromScaleUpDownReplicas,
 		"PromNoServiceMonitorSelector":              testPromNoServiceMonitorSelector,
 		"PromResourceUpdate":                        testPromResourceUpdate,
 		"PromStorageLabelsAnnotations":              testPromStorageLabelsAnnotations,

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -828,7 +828,7 @@ func testPromCreateDeleteCluster(t *testing.T) {
 	}
 }
 
-func testPromScaleUpDownCluster(t *testing.T) {
+func testPromScaleUpDownReplicas(t *testing.T) {
 	t.Parallel()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
@@ -842,12 +842,12 @@ func testPromScaleUpDownCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err = framework.ScalePrometheusAndWaitUntilReady(context.Background(), p.Name, ns, *p.Spec.Replicas+1)
+	p, err = framework.UpdatePrometheusReplicasAndWaitUntilReady(context.Background(), p.Name, ns, *p.Spec.Replicas+1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = framework.ScalePrometheusAndWaitUntilReady(context.Background(), p.Name, ns, *p.Spec.Replicas-1)
+	_, err = framework.UpdatePrometheusReplicasAndWaitUntilReady(context.Background(), p.Name, ns, *p.Spec.Replicas-1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2035,7 +2035,7 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 	}
 
 	// Ensure resource reconciles
-	_, err = framework.ScalePrometheusAndWaitUntilReady(context.Background(), prometheusCRD.Name, ns, *prometheusCRD.Spec.Replicas+1)
+	_, err = framework.UpdatePrometheusReplicasAndWaitUntilReady(context.Background(), prometheusCRD.Name, ns, *prometheusCRD.Spec.Replicas+1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5067,6 +5067,7 @@ func testPrometheusStatusScale(t *testing.T) {
 	name := "test"
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
+	p.Spec.CommonPrometheusFields.Shards = proto.Int32(1)
 
 	p, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
 	if err != nil {
@@ -5077,7 +5078,7 @@ func testPrometheusStatusScale(t *testing.T) {
 		t.Fatalf("expected scale of 1 shard, got %d", p.Status.Shards)
 	}
 
-	p, err = framework.ScalePrometheusShardsAndWaitUntilReady(ctx, name, ns, 2)
+	p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,6 +157,7 @@ func testPrometheusAgentStatusScale(t *testing.T) {
 	name := "test"
 
 	pAgent := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
+	pAgent.Spec.CommonPrometheusFields.Shards = proto.Int32(1)
 
 	pAgent, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, pAgent)
 	if err != nil {
@@ -166,7 +168,7 @@ func testPrometheusAgentStatusScale(t *testing.T) {
 		t.Fatalf("expected scale of 1 shard, got %d", pAgent.Status.Shards)
 	}
 
-	pAgent, err = framework.ScalePrometheusAgentShardsAndWaitUntilReady(ctx, name, ns, 2)
+	pAgent, err = framework.ScalePrometheusAgentAndWaitUntilReady(ctx, name, ns, 2)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Addresses comment https://github.com/prometheus-operator/prometheus-operator/pull/5962#discussion_r1430123922



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
