### PR TITLE
Prevent mistakes with testify lib

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   - gci
   - depguard
   - godot
+  - testifylint
 
 issues:
   exclude-rules:

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -90,7 +90,7 @@ func TestGetNodeAddresses(t *testing.T) {
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			addrs, errs := getNodeAddresses(c.nodes)
-			require.Equal(t, c.expectedErrors, len(errs))
+			require.Len(t, errs, c.expectedErrors)
 
 			ips := make([]string, 0)
 			for _, addr := range addrs {

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -28,7 +28,7 @@ func TestMap(t *testing.T) {
 	require.Equal(t, map[string]string{"foo": "xxx", "foo3": "bar3"}, m.Merge(map[string]string{"foo": "xxx", "foo3": "bar3"}))
 
 	require.NoError(t, m.Set("foo2=bar2,foo=bar"))
-	require.Equal(t, 2, len(m))
+	require.Len(t, m, 2)
 	require.Equal(t, []string{"foo", "foo2"}, m.SortedKeys())
 	require.Equal(t, "foo=bar,foo2=bar2", m.String())
 
@@ -103,8 +103,8 @@ func TestStringSet(t *testing.T) {
 	s = StringSet{}
 
 	require.NoError(t, s.Set("a,b,c"))
-	require.Equal(t, len(s), 3)
-	require.Equal(t, s.String(), "a,b,c")
+	require.Len(t, s, 3)
+	require.Equal(t, "a,b,c", s.String())
 	for _, k := range []string{"a", "b", "c"} {
 		_, found := s[k]
 		require.True(t, found)

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -387,7 +387,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Greater(t, len(sts.Spec.Template.Spec.TopologySpreadConstraints), 0)
+			assert.NotEmpty(t, sts.Spec.Template.Spec.TopologySpreadConstraints)
 			assert.Equal(t, tc.tsc, sts.Spec.Template.Spec.TopologySpreadConstraints[0])
 		})
 	}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -602,9 +602,9 @@ func TestSelectProbes(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.selected {
-				require.Equal(t, 1, len(probes))
+				require.Len(t, probes, 1)
 			} else {
-				require.Equal(t, 0, len(probes))
+				require.Empty(t, probes)
 			}
 		})
 	}
@@ -988,9 +988,9 @@ func TestSelectServiceMonitors(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.selected {
-				require.Equal(t, 1, len(sms))
+				require.Len(t, sms, 1)
 			} else {
-				require.Equal(t, 0, len(sms))
+				require.Empty(t, sms)
 			}
 		})
 	}
@@ -1087,9 +1087,9 @@ func TestSelectPodMonitors(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.selected {
-				require.Equal(t, 1, len(sms))
+				require.Len(t, sms, 1)
 			} else {
-				require.Equal(t, 0, len(sms))
+				require.Empty(t, sms)
 			}
 		})
 	}
@@ -1775,9 +1775,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.selected {
-				require.Equal(t, 1, len(sms))
+				require.Len(t, sms, 1)
 			} else {
-				require.Equal(t, 0, len(sms))
+				require.Empty(t, sms)
 			}
 		})
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -2552,7 +2552,7 @@ func TestPrometheusAdditionalArgsDuplicate(t *testing.T) {
 			},
 		},
 	})
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Fatalf("expected the following text to be present in the error msg: %s", expectedErrorMsg)
@@ -2584,7 +2584,7 @@ func TestPrometheusAdditionalBinaryArgsDuplicate(t *testing.T) {
 			},
 		},
 	})
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Fatalf("expected the following text to be present in the error msg: %s", expectedErrorMsg)
@@ -2619,7 +2619,7 @@ func TestPrometheusAdditionalNoPrefixArgsDuplicate(t *testing.T) {
 			},
 		},
 	})
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Fatalf("expected the following text to be present in the error msg: %s", expectedErrorMsg)
@@ -2696,7 +2696,7 @@ func TestThanosAdditionalArgsDuplicate(t *testing.T) {
 			},
 		},
 	})
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Fatalf("expected the following text to be present in the error msg: %s", expectedErrorMsg)
@@ -3070,7 +3070,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Greater(t, len(sts.Spec.Template.Spec.TopologySpreadConstraints), 0)
+			assert.NotEmpty(t, sts.Spec.Template.Spec.TopologySpreadConstraints)
 			assert.Equal(t, tc.tsc, sts.Spec.Template.Spec.TopologySpreadConstraints[0])
 		})
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -93,6 +93,6 @@ func TestStartupProbeTimeoutSeconds(t *testing.T) {
 
 		require.Equal(t, test.expectedStartupPeriodSeconds, startupPeriodSeconds)
 		require.Equal(t, test.expectedStartupFailureThreshold, startupFailureThreshold)
-		require.Equal(t, test.expectedStartupPeriodSeconds*test.expectedStartupFailureThreshold, test.expectedMaxStartupDuration)
+		require.Equal(t, test.expectedMaxStartupDuration, startupPeriodSeconds*startupFailureThreshold)
 	}
 }

--- a/pkg/versionutil/cli_test.go
+++ b/pkg/versionutil/cli_test.go
@@ -67,7 +67,7 @@ func TestShouldPrintVersion(t *testing.T) {
 			// when
 			versionutil.RegisterParseFlags()
 			// then
-			assert.Equal(t, true, versionutil.ShouldPrintVersion())
+			assert.True(t, versionutil.ShouldPrintVersion())
 
 			// when
 			var buf bytes.Buffer

--- a/test/e2e/config_reloader_test.go
+++ b/test/e2e/config_reloader_test.go
@@ -83,7 +83,7 @@ func testConfigReloaderResources(t *testing.T) {
 			resources = append(resources, c.Resources)
 		}
 	}
-	require.Equal(t, 2, len(resources))
+	require.Len(t, resources, 2)
 
 	for _, r := range resources {
 		require.True(t, cpuLimit.Equal(r.Limits[corev1.ResourceCPU]), "expected %s, got %s", cpuLimit, r.Limits[corev1.ResourceCPU])

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -352,11 +353,11 @@ func TestPrometheusRuleApply(t *testing.T) {
 			)
 
 			if tc.expectedErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, res.Spec.Groups)
 		})
 	}

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -249,7 +249,7 @@ func testPromOperatorStartsWithoutScrapeConfigCRD(t *testing.T) {
 
 	pl, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), opts)
 	require.NoError(t, err)
-	require.Equalf(t, 1, len(pl.Items), "expected 1 Prometheus Operator pods, but got %v", len(pl.Items))
+	require.Lenf(t, pl.Items, 1, "expected 1 Prometheus Operator pods, but got %v", len(pl.Items))
 
 	restarts, err := framework.GetPodRestartCount(context.Background(), ns, pl.Items[0].GetName())
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

By enabling the `testifylint` linter.

I'm particularly fond of this one as I think that testify is super ambiguous sometimes and easy to make mistakes 😬.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
