### PR TITLE
chore(prometheus): Pass the 127.0.0.1 loopback address to Prometheus …

### DIFF
--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -536,7 +536,7 @@ func TestListenLocal(t *testing.T) {
 				Command: []string{
 					`sh`,
 					`-c`,
-					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl --fail %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
+					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl --fail %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://127.0.0.1:9090%s", probePath)),
 				},
 			},
 		}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -376,7 +376,7 @@ func ProbeHandler(probePath string, cpf monitoringv1.CommonPrometheusFields, web
 	if cpf.ListenLocal {
 		probeURL := url.URL{
 			Scheme: "http",
-			Host:   "localhost:9090",
+			Host:   "127.0.0.1:9090",
 			Path:   probePath,
 		}
 		handler.Exec = &v1.ExecAction{


### PR DESCRIPTION
…probes when ListenLocal is set

as Prometheus listens on 127.0.0.1:9090 in that case. Here: https://github.com/prometheus-operator/prometheus-operator/blob/48d3604507e082f4187f39edda9bc22935881a14/pkg/prometheus/statefulset.go#L242-L243

This avoid a first IPv6 name resolution attempt (for curl at least) that always fail.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
