### PR TITLE
chore: fix field name to comply with conventions

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -12598,7 +12598,7 @@ MetadataConfig
 </tr>
 <tr>
 <td>
-<code>enableHttp2</code><br/>
+<code>enableHTTP2</code><br/>
 <em>
 bool
 </em>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -19157,7 +19157,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:
@@ -28558,7 +28558,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4549,7 +4549,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5403,7 +5403,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4550,7 +4550,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5404,7 +5404,7 @@ spec:
                         \n Deprecated: this will be removed in a future release. Prefer
                         using `authorization`."
                       type: string
-                    enableHttp2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2.
                       type: boolean
                     headers:

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4071,7 +4071,7 @@
                           "description": "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                           "type": "string"
                         },
-                        "enableHttp2": {
+                        "enableHTTP2": {
                           "description": "Whether to enable HTTP2.",
                           "type": "boolean"
                         },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4961,7 +4961,7 @@
                           "description": "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`.",
                           "type": "string"
                         },
-                        "enableHttp2": {
+                        "enableHTTP2": {
                           "description": "Whether to enable HTTP2.",
                           "type": "boolean"
                         },

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1266,7 +1266,7 @@ type RemoteWriteSpec struct {
 
 	// Whether to enable HTTP2.
 	// +optional
-	EnableHttp2 *bool `json:"enableHttp2,omitempty"`
+	EnableHttp2 *bool `json:"enableHTTP2,omitempty"`
 }
 
 // QueueConfig allows the tuning of remote write's queue_config parameters.

--- a/pkg/client/applyconfiguration/monitoring/v1/remotewritespec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/remotewritespec.go
@@ -41,7 +41,7 @@ type RemoteWriteSpecApplyConfiguration struct {
 	ProxyURL             *string                           `json:"proxyUrl,omitempty"`
 	QueueConfig          *QueueConfigApplyConfiguration    `json:"queueConfig,omitempty"`
 	MetadataConfig       *MetadataConfigApplyConfiguration `json:"metadataConfig,omitempty"`
-	EnableHttp2          *bool                             `json:"enableHttp2,omitempty"`
+	EnableHttp2          *bool                             `json:"enableHTTP2,omitempty"`
 }
 
 // RemoteWriteSpecApplyConfiguration constructs an declarative configuration of the RemoteWriteSpec type for use with


### PR DESCRIPTION
## Description

The Kubernetes API conventions say:

> All letters in the acronym should have the same case, using the
> appropriate case for the situation.

Since no release includes the field yet, it's ok to change the name.

Follow-up of #6192 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
