### PR TITLE
ruler: add subpath to volumeMounts if specified

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -374,9 +374,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		})
 	}
 
-	for _, thanosRulerVM := range tr.Spec.VolumeMounts {
-		trVolumeMounts = append(trVolumeMounts, thanosRulerVM)
-	}
+	trVolumeMounts = append(trVolumeMounts, tr.Spec.VolumeMounts...)
 
 	operatorContainers := append([]v1.Container{
 		{

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -375,11 +375,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	for _, thanosRulerVM := range tr.Spec.VolumeMounts {
-		trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
-			Name:      thanosRulerVM.Name,
-			MountPath: thanosRulerVM.MountPath,
-			SubPath:   thanosRulerVM.SubPath,
-		})
+		trVolumeMounts = append(trVolumeMounts, thanosRulerVM)
 	}
 
 	operatorContainers := append([]v1.Container{

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -378,6 +378,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
 			Name:      thanosRulerVM.Name,
 			MountPath: thanosRulerVM.MountPath,
+			SubPath:   thanosRulerVM.SubPath,
 		})
 	}
 


### PR DESCRIPTION
The SubPath attribute is needed in a VolumeMount if a user wants to mount a single file instead of a directory.

## Description

If adding a SubPath in the ThanosRuler spec, it is not added to the final ruler statefulset. This should fix that bug.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
This is an incredibly simple change, and just adds the missing key in the volumeMounts map


## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Generate missing SubPath field in statefulset for spec.volumeMounts in ThanosRuler
```
