### PR TITLE
fix: convert `continue` field between v1alpha1 and v1beta1 AlertmanagerConfig versions

### DIFF
--- a/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -32,6 +32,7 @@ func convertRouteFrom(in *v1alpha1.Route) (*Route, error) {
 
 	out := &Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,

--- a/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -32,6 +32,7 @@ func convertRouteTo(in *Route) (*v1alpha1.Route, error) {
 
 	out := &v1alpha1.Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -937,6 +937,7 @@ func testAlertmanagerConfigVersions(t *testing.T) {
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
 				Receiver: "webhook",
+				Continue: true,
 				Matchers: []monitoringv1alpha1.Matcher{{
 					Name:  "job",
 					Value: "webapp.+",
@@ -963,6 +964,8 @@ func testAlertmanagerConfigVersions(t *testing.T) {
 		t.Fatalf("expected %#v matcher, got %#v", expected, amcfgV1beta1Converted.Spec.Route.Matchers)
 	}
 
+	require.True(t, amcfgV1beta1Converted.Spec.Route.Continue)
+
 	amcfgV1beta1 := &monitoringv1beta1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "amcfg-v1beta1",
@@ -970,6 +973,7 @@ func testAlertmanagerConfigVersions(t *testing.T) {
 		Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 			Route: &monitoringv1beta1.Route{
 				Receiver: "webhook",
+				Continue: true,
 				Matchers: []monitoringv1beta1.Matcher{{
 					Name:      "job",
 					Value:     "webapp.+",
@@ -982,13 +986,19 @@ func testAlertmanagerConfigVersions(t *testing.T) {
 		},
 	}
 
-	if _, err := framework.MonClientV1beta1.AlertmanagerConfigs(alertmanager.Namespace).Create(context.Background(), amcfgV1beta1, metav1.CreateOptions{}); err != nil {
+	amcfgV1beta1, err = framework.MonClientV1beta1.AlertmanagerConfigs(alertmanager.Namespace).Create(context.Background(), amcfgV1beta1, metav1.CreateOptions{})
+	if err != nil {
 		t.Fatalf("failed to create v1beta1 AlertmanagerConfig object: %v", err)
 	}
 
-	if _, err := framework.MonClientV1alpha1.AlertmanagerConfigs(alertmanager.Namespace).Get(context.Background(), amcfgV1beta1.Name, metav1.GetOptions{}); err != nil {
+	require.True(t, amcfgV1beta1.Spec.Route.Continue)
+
+	amcfgV1alpha1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(alertmanager.Namespace).Get(context.Background(), amcfgV1beta1.Name, metav1.GetOptions{})
+	if err != nil {
 		t.Fatalf("failed to get v1alpha1 AlertmanagerConfig object: %v", err)
 	}
+
+	require.True(t, amcfgV1alpha1.Spec.Route.Continue)
 }
 
 // e2e test to validate that all possible fields in an AlertmanagerConfig CR are


### PR DESCRIPTION
## Description

The continue field was lost in the conversion between v1beta1 and v1alpha1. When creating a v1beta1 object with `continue: true`, the object was saved with `continue: false`.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix conversion of the `.spec.route.continue` field between v1alpha1 and v1beta1 AlertmanagerConfig versions
```
