### PR TITLE
feat: add version check for thanos. keep_firing_for now available

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -107,6 +107,7 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 	component := "Prometheus"
 
 	if prs.ruleFormat == ThanosFormat {
+		minVersionKeepFiringFor = semver.MustParse("0.34.0")
 		minVersionLimits = semver.MustParse("0.24.0")
 		component = "Thanos"
 	}
@@ -130,10 +131,9 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 					level.Warn(logger).Log("msg", fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
 				}
 			case ThanosFormat:
-				// keep_firing_for is not yet supported in thanos https://github.com/thanos-io/thanos/issues/6165
-				if promRuleSpec.Groups[i].Rules[j].KeepFiringFor != nil {
+				if promRuleSpec.Groups[i].Rules[j].KeepFiringFor != nil && prs.version.LT(minVersionKeepFiringFor) {
 					promRuleSpec.Groups[i].Rules[j].KeepFiringFor = nil
-					level.Warn(logger).Log("msg", "ignoring `keep_firing_for` as it is not yet supported in thanos, see https://github.com/thanos-io/thanos/issues/6165")
+					level.Warn(logger).Log("msg", fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Added version check for thanos in the context of keep_firing_for. starting from thanos v0.34.0 keep_firing_for is available.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

```
feat: add version check for thanos. keep_firing_for now available
```

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->
