### PR TITLE
fix: remove deprecation on service monitor's targetPort

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -7775,9 +7775,9 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </em>
 </td>
 <td>
-<p>Name or number of the target port of the <code>Pod</code> object behind the Service, the
-port must be specified with container port property.</p>
-<p>Deprecated: use <code>port</code> instead.</p>
+<em>(Optional)</em>
+<p>Name or number of the target port of the <code>Pod</code> object behind the
+Service. The port must be specified with the container&rsquo;s port property.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -36260,9 +36260,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: "Name or number of the target port of the `Pod`
-                        object behind the Service, the port must be specified with
-                        container port property. \n Deprecated: use `port` instead."
+                      description: Name or number of the target port of the `Pod`
+                        object behind the Service. The port must be specified with
+                        the container's port property.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
                       description: TLS configuration to use when scraping the target.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -475,9 +475,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: "Name or number of the target port of the `Pod`
-                        object behind the Service, the port must be specified with
-                        container port property. \n Deprecated: use `port` instead."
+                      description: Name or number of the target port of the `Pod`
+                        object behind the Service. The port must be specified with
+                        the container's port property.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
                       description: TLS configuration to use when scraping the target.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -476,9 +476,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: "Name or number of the target port of the `Pod`
-                        object behind the Service, the port must be specified with
-                        container port property. \n Deprecated: use `port` instead."
+                      description: Name or number of the target port of the `Pod`
+                        object behind the Service. The port must be specified with
+                        the container's port property.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
                       description: TLS configuration to use when scraping the target.

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -476,7 +476,7 @@
                               "type": "string"
                             }
                           ],
-                          "description": "Name or number of the target port of the `Pod` object behind the Service, the port must be specified with container port property. \n Deprecated: use `port` instead.",
+                          "description": "Name or number of the target port of the `Pod` object behind the Service. The port must be specified with the container's port property.",
                           "x-kubernetes-int-or-string": true
                         },
                         "tlsConfig": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -366,10 +366,10 @@ type Endpoint struct {
 	// It takes precedence over `targetPort`.
 	Port string `json:"port,omitempty"`
 
-	// Name or number of the target port of the `Pod` object behind the Service, the
-	// port must be specified with container port property.
+	// Name or number of the target port of the `Pod` object behind the
+	// Service. The port must be specified with the container's port property.
 	//
-	// Deprecated: use `port` instead.
+	// +optional
 	TargetPort *intstr.IntOrString `json:"targetPort,omitempty"`
 
 	// HTTP path from which to scrape for metrics.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1337,18 +1337,18 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 			yaml.MapItem{Key: "source_labels", Value: sourceLabels},
 			{Key: "regex", Value: ep.Port},
 		})
-	} else if ep.TargetPort != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-		if ep.TargetPort.StrVal != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+	} else if ep.TargetPort != nil {
+		if ep.TargetPort.StrVal != "" {
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_name"}},
-				{Key: "regex", Value: ep.TargetPort.String()}, //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+				{Key: "regex", Value: ep.TargetPort.String()},
 			})
-		} else if ep.TargetPort.IntVal != 0 { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+		} else if ep.TargetPort.IntVal != 0 {
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_container_port_number"}},
-				{Key: "regex", Value: ep.TargetPort.String()}, //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+				{Key: "regex", Value: ep.TargetPort.String()},
 			})
 		}
 	}


### PR DESCRIPTION
## Description

Closes #6269

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove the deprecation warning on `targetPort` field for the `ServiceMonitor` CRD.
```
