### PR TITLE
fix: don't fail metadata transform on unknown types

### DIFF
--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -89,10 +89,18 @@ func NewInformersForResourceWithTransform(ifs FactoriesForNamespaces, resource s
 // * ManagedFields
 // * Finalizers
 // * OwnerReferences.
+//
+// If the passed object isn't of type *v1.PartialObjectMetadata, it is returned unmodified.
+//
+// It matches the cache.TransformFunc type and can be used by informers
+// watching PartialObjectMetadata objects to reduce memory consumption.
+// See https://pkg.go.dev/k8s.io/client-go@v0.29.1/tools/cache#TransformFunc for details.
 func PartialObjectMetadataStrip(obj interface{}) (interface{}, error) {
 	partialMeta, ok := obj.(*v1.PartialObjectMetadata)
 	if !ok {
-		return nil, fmt.Errorf("internal error: cannot cast object %#+v to PartialObjectMetadata", obj)
+		// Don't do anything if the cast isn't successful.
+		// The object might be of type "cache.DeletedFinalStateUnknown".
+		return obj, nil
 	}
 
 	partialMeta.Annotations = nil


### PR DESCRIPTION
## Description

This change modifies the `PartialObjectMetadataStrip` function to return the object unmodified if casting to `*v1.PartialObjectMetadata` fails. When the informer processes a deleted object, its type can be `cache.DeletedFinalStateUnknown`.

The issue has been reported to me out of band. Prometheus operator's logs:

```
level=error ts=2024-02-09T10:27:27.971343994Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth
msg="github.com/coreos/prometheus-operator/pkg/informers/informers.go:110: Failed to watch *v1.PartialObjectMetadata: unable to sync list result: internal error: 
cannot cast object cache.DeletedFinalStateUnknown{Key:\"openshift-kube-apiserver/etcd-client-3\", Obj:(*v1.PartialObjectMetadata)(0xc000e69200)} to PartialObjectMetadata"
```


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed failure of metadata informers when processing deleted objects.
```
