### PR TITLE
Update default Thanos version

### DIFF
--- a/Documentation/compatibility.md
+++ b/Documentation/compatibility.md
@@ -90,5 +90,5 @@ The Prometheus Operator is compatible with Thanos v0.10 and above.
 The end-to-end tests are mostly tested against
 
 ```$ mdox-exec="go run ./cmd/po-docgen/. compatibility defaultThanosVersion"
-* v0.33.0
+* v0.34.1
 ```

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -25,7 +25,7 @@ const (
 	DefaultAlertmanagerImage = DefaultAlertmanagerBaseImage + ":" + DefaultAlertmanagerVersion
 
 	// DefaultThanosVersion is a default image tag for the Thanos long-term prometheus storage collector.
-	DefaultThanosVersion = "v0.33.0"
+	DefaultThanosVersion = "v0.34.1"
 	// DefaultThanosBaseImage is a base container registry address for the Thanos long-term prometheus
 	// storage collector.
 	DefaultThanosBaseImage = "quay.io/thanos/thanos"

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -245,7 +245,7 @@ func shouldDropRuleFiringForThanos(t *testing.T) {
 		}},
 	}
 
-	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
+	thanosVersion, _ := semver.ParseTolerant("v0.33.0")
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
 	if strings.Contains(content, "keep_firing_for") {
@@ -270,7 +270,7 @@ func shouldAcceptRuleFiringForThanos(t *testing.T) {
 		}},
 	}
 
-	thanosVersion, _ := semver.ParseTolerant("v0.34.0")
+	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
 	if !strings.Contains(content, "keep_firing_for") {


### PR DESCRIPTION
If we wait 2 days for the release, we can get Prometheus 2.50 as default prom version 🤔 