### PR TITLE
Make AlertManager matchType CRD spec YAML 1.1 compatible

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -69,7 +69,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -102,7 +102,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -5665,7 +5665,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - !!str=
                           - =~
                           - '!~'
                           type: string

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -68,7 +68,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -101,7 +101,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -5664,7 +5664,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - !!str=
                           - =~
                           - '!~'
                           type: string
@@ -5769,7 +5769,7 @@ spec:
                               >= v0.22.0.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -5798,7 +5798,7 @@ spec:
                               >= v0.22.0.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -11182,7 +11182,7 @@ spec:
                             >= v0.22.0.
                           enum:
                           - '!='
-                          - =
+                          - !!str=
                           - =~
                           - '!~'
                           type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -69,7 +69,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -102,7 +102,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - !!str=
                             - =~
                             - '!~'
                             type: string
@@ -5665,7 +5665,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - !!str=
                           - =~
                           - '!~'
                           type: string

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -956,7 +956,7 @@ type Matcher struct {
 	Value string `json:"value"`
 	// Match operation available with AlertManager >= v0.22.0 and
 	// takes precedence over Regex (deprecated) if non-empty.
-	// +kubebuilder:validation:Enum=!=;=;=~;!~
+	// +kubebuilder:validation:Enum=!=;!!str=;=~;!~
 	// +optional
 	MatchType MatchType `json:"matchType,omitempty"`
 	// Whether to match on equality (false) or regular-expression (true).

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -949,7 +949,7 @@ type Matcher struct {
 	// Match operator, one of `=` (equal to), `!=` (not equal to), `=~` (regex
 	// match) or `!~` (not regex match).
 	// Negative operators (`!=` and `!~`) require Alertmanager >= v0.22.0.
-	// +kubebuilder:validation:Enum=!=;=;=~;!~
+	// +kubebuilder:validation:Enum=!=;!!str=;=~;!~
 	MatchType MatchType `json:"matchType,omitempty"`
 }
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Try to make AlertManager  `matchType` CRD specs compatible with YAML 1.1 syntax so PyYAML library can parse them.

Although this has already been discussed in previous PRs, none tried to fix using the `!!str` prefix instead of wrapping the equal sign in single quotes as suggested in https://github.com/yaml/pyyaml/issues/683#issuecomment-1341296436.

I've tried to update both the source code and the generated example YAMLs as failing to get a correct kubeBuilder syntax was often mentioned as the reason to reject previous PRs.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.
Not sure the `=` value for `matchType` is covered in existing integration tests. I'll happily implement one with guidance though.
The manually edited CRD YAML for AlertManager was successfully applied with otherwise failing Ansible playbook. 

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
[FEATURE] Make AlertManager matchType CRD spec YAML 1.1 compatible.
```
