### PR TITLE
chore: Log deprecated field additionalScrapeConfigs (#5965)

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1224,6 +1224,11 @@ func logDeprecatedFields(logger log.Logger, p *monitoringv1.Prometheus) {
 		}
 	}
 
+	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+	if p.Spec.AdditionalScrapeConfigs != nil {
+		level.Warn(logger).Log("msg", fmt.Sprintf(deprecationWarningf, "spec.additionalScrapeConfigs", "newScrapeConfigCrd"))
+	}
+	
 	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil && p.Spec.ProbeSelector == nil && p.Spec.ScrapeConfigSelector == nil {
 
 		level.Warn(logger).Log("msg", "neither serviceMonitorSelector nor podMonitorSelector, nor probeSelector specified. Custom configuration is deprecated, use additionalScrapeConfigs instead")


### PR DESCRIPTION
## Description

Log deprecated field additionalScrapeConfigs

Fixes #5965 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
using go test

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```
Log deprecated field additionalScrapeConfigs

```
