### PR TITLE
Split registry image path correctly in e2e tests

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -387,9 +387,9 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 		// Override operator image used, if specified when running tests.
 		deploy.Spec.Template.Spec.Containers[0].Image = f.opImage
 		parts := strings.Split(f.opImage, ":")
-		if len(parts) > 4 && len(parts) < 2 {
+		if len(parts) < 2 {
 			return nil, fmt.Errorf(
-				"expected image '%v' split by colon to result in two to four substrings but got '%v'",
+				"expected image '%v' split by colon to return at least two substrings but got '%v'",
 				f.opImage,
 				parts,
 			)
@@ -771,9 +771,9 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 		// Override operator image used, if specified when running tests.
 		deploy.Spec.Template.Spec.Containers[0].Image = image
 		parts := strings.Split(image, ":")
-		if len(parts) > 4 && len(parts) < 2 {
+		if len(parts) < 2 {
 			return nil, nil, fmt.Errorf(
-				"expected image '%v' split by colon to result in two to four substrings but got '%v'",
+				"expected image '%v' split by colon to return at least two substrings but got '%v'",
 				image,
 				parts,
 			)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -386,23 +386,25 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 	if f.opImage != "" {
 		// Override operator image used, if specified when running tests.
 		deploy.Spec.Template.Spec.Containers[0].Image = f.opImage
-		repoAndTag := strings.Split(f.opImage, ":")
-		if len(repoAndTag) != 2 {
+		parts := strings.Split(f.opImage, ":")
+		if len(parts) > 4 && len(parts) < 2 {
 			return nil, fmt.Errorf(
-				"expected operator image '%v' split by colon to result in two substrings but got '%v'",
+				"expected image '%v' split by colon to result in two to four substrings but got '%v'",
 				f.opImage,
-				repoAndTag,
+				parts,
 			)
 		}
+		// Assume that the final colon precedes the image's tag
+		tag := parts[len(parts)-1]
 		// Override Prometheus config reloader image
 		for i, arg := range deploy.Spec.Template.Spec.Containers[0].Args {
 			if strings.Contains(arg, "--prometheus-config-reloader=") {
 				deploy.Spec.Template.Spec.Containers[0].Args[i] = "--prometheus-config-reloader=" +
 					"quay.io/prometheus-operator/prometheus-config-reloader:" +
-					repoAndTag[1]
+					tag
 			}
 		}
-		webhookServerImage = "quay.io/prometheus-operator/admission-webhook:" + repoAndTag[1]
+		webhookServerImage = "quay.io/prometheus-operator/admission-webhook:" + tag
 	}
 
 	deploy.Name = prometheusOperatorServiceDeploymentName
@@ -768,12 +770,12 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 	if image != "" {
 		// Override operator image used, if specified when running tests.
 		deploy.Spec.Template.Spec.Containers[0].Image = image
-		repoAndTag := strings.Split(image, ":")
-		if len(repoAndTag) != 2 {
+		parts := strings.Split(image, ":")
+		if len(parts) > 4 && len(parts) < 2 {
 			return nil, nil, fmt.Errorf(
-				"expected image '%v' split by colon to result in two substrings but got '%v'",
+				"expected image '%v' split by colon to result in two to four substrings but got '%v'",
 				image,
-				repoAndTag,
+				parts,
 			)
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #6017

This fixes the edge case of splitting user-supplied registry image path like `[http://]localhost:3200/prometheus-operator:foo`



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Check locally with `make test-e2e`

## Changelog entry
test-e2e: Split registry image path correctly