### PR TITLE
WIP: Split Select*() functions

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -146,7 +146,7 @@ func (rs *ResourceSelector) filterServiceMonitors(ctx context.Context, serviceMo
 
 	for namespaceAndName, sm := range serviceMonitors {
 		var err error
-		rejectFn := func(serviceMonitor *monitoringv1.ServiceMonitor, err error) { //delete unused argument
+		rejectFn := func(serviceMonitor *monitoringv1.ServiceMonitor, err error) { //delete unused argument?
 			rejected++
 			level.Warn(rs.l).Log(
 				"msg", "skipping servicemonitor",


### PR DESCRIPTION
## Description

The Select*() functions in resource selector are currently too long and do more than just select. This splits those functions into smaller functions for readability.

Fixes #5420


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


## Verification

No tests broken


## Changelog entry

Split Select*() functions for readability