### PR TITLE
fix: monitoring in config reloader (#6310)

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -740,7 +740,7 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 		operator.CreateConfigReloader(
 			"init-config-reloader",
 			operator.ReloaderConfig(config.ReloaderConfig),
-			operator.ReloaderRunOnce(),
+			operator.ReloaderMonitor(),
 			operator.LogFormat(a.Spec.LogFormat),
 			operator.LogLevel(a.Spec.LogLevel),
 			operator.WatchedDirectories(watchedDirectories),

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -74,6 +74,13 @@ func ReloaderRunOnce() ReloaderOption {
 	}
 }
 
+// ReloaderMonitor set the runOnce option to false for the config-reloader container.
+func ReloaderMonitor() ReloaderOption {
+	return func(c *ConfigReloader) {
+		c.runOnce = false
+	}
+}
+
 // WatchedDirectories sets the watchedDirectories option for the config-reloader container.
 func WatchedDirectories(watchedDirectories []string) ReloaderOption {
 	return func(c *ConfigReloader) {

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -431,7 +431,7 @@ func BuildConfigReloader(
 	name := "config-reloader"
 	if initContainer {
 		name = "init-config-reloader"
-		reloaderOptions = append(reloaderOptions, operator.ReloaderRunOnce())
+		reloaderOptions = append(reloaderOptions, operator.ReloaderMonitor())
 		return operator.CreateConfigReloader(name, reloaderOptions...)
 	}
 


### PR DESCRIPTION
## Description

fixes: #6310 
config-reloader does not successfully reload after an invalid additionalScrapeConfigs is fixed



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
make test

## Changelog entry



```
enabled monitoring in config reloader
```
