### PR TITLE
Check if controllers' CRDs are provided and manageable by operator

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -357,7 +357,7 @@ func run(fs *flag.FlagSet) int {
 		}
 	}
 
-	alertManagerSupported, err := checkPrerequisites(
+	alertmanagerSupported, err := checkPrerequisites(
 		ctx,
 		logger,
 		kclient,
@@ -384,7 +384,7 @@ func run(fs *flag.FlagSet) int {
 	}
 
 	var ao *alertmanagercontroller.Operator
-	if alertManagerSupported {
+	if alertmanagerSupported {
 		ao, err = alertmanagercontroller.New(ctx, restConfig, cfg, logger, r, canReadStorageClass, eventRecorderFactory)
 		if err != nil {
 			level.Error(logger).Log("msg", "instantiating alertmanager controller failed", "err", err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -429,12 +429,6 @@ func run(fs *flag.FlagSet) int {
 		}
 	}
 
-	if po == nil && pao == nil && ao == nil && to == nil {
-		level.Error(logger).Log("msg", "no controller is supported")
-		cancel()
-		return 1
-	}
-
 	var kec *kubelet.Controller
 	if kubeletObject != "" {
 		if kec, err = kubelet.New(
@@ -450,6 +444,12 @@ func run(fs *flag.FlagSet) int {
 			cancel()
 			return 1
 		}
+	}
+
+	if po == nil && pao == nil && ao == nil && to == nil && kec == nil {
+		level.Error(logger).Log("msg", "no controller can be started, check the RBAC permissions of the service account")
+		cancel()
+		return 1
 	}
 
 	// Setup the web server.


### PR DESCRIPTION
## Description

Only start each controller when its crd is provided and manageable by the operator, and fail the operator if no controllers start.

Fixes #6140


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Check locally with some crds not provided.

Before the change:
```
level=warn ts=2024-02-29T14:21:04.383739949Z caller=klog.go:118 component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: failed to list *v1.Prometheus: the server could not find the requested resource (get prometheuses.monitoring.coreos.com)"
level=error ts=2024-02-29T14:21:04.383844053Z caller=klog.go:126 component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: Failed to watch *v1.Prometheus: failed to list *v1.Prometheus: the server could not find the requested resource (get prometheuses.monitoring.coreos.com)"
```

With the change:
```
level=info ts=2024-02-29T14:27:23.197293317Z caller=operator.go:425 component=prometheusagent-controller msg="successfully synced all caches"
```

When no controllers are provided:
```
level=error ts=2024-02-29T14:46:33.051429048Z caller=main.go:431 msg="no controller is supported"
```


## Changelog entry

Only start each controller when its crd is provided and manageable by the operator, and fail the operator if no controllers start.