### PR TITLE
fix: Crd AltermanagerConfig field muteTimeIntervals.timeIntervals.months regex pattern |[1-12] isn't correct (#6353)

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -165,7 +165,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)
                               type: string
                             type: array
                           times:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -164,7 +164,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)
                               type: string
                             type: array
                           times:
@@ -11266,7 +11266,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)
                               type: string
                             type: array
                           times:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -165,7 +165,7 @@ spec:
                                 by name (e.g 'January') by numerical month (e.g '1')
                                 or as an inclusive range (e.g 'January:March', '1:3',
                                 '1:March')
-                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                              pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)
                               type: string
                             type: array
                           times:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -173,7 +173,7 @@
                                 "description": "Months is a list of MonthRange",
                                 "items": {
                                   "description": "MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')",
-                                  "pattern": "^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)",
+                                  "pattern": "^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)",
                                   "type": "string"
                                 },
                                 "type": "array"

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -5774,7 +5774,7 @@
                             description: 'Months is a list of MonthRange',
                             items: {
                               description: "MonthRange is an inclusive range of months of the year beginning in January Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')",
-                              pattern: '^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)',
+                              pattern: '^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)',
                               type: 'string',
                             },
                             type: 'array',

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -1096,7 +1096,7 @@ type DayOfMonthRange struct {
 
 // MonthRange is an inclusive range of months of the year beginning in January
 // Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
-// +kubebuilder:validation:Pattern=`^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)`
+// +kubebuilder:validation:Pattern=`^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)`
 type MonthRange string
 
 // YearRange is an inclusive range of years

--- a/pkg/apis/monitoring/v1alpha1/validation.go
+++ b/pkg/apis/monitoring/v1alpha1/validation.go
@@ -221,16 +221,16 @@ func (w Weekday) Int() (int, error) {
 func (m Month) Int() (int, error) {
 	normaliseMonth := Month(strings.ToLower(string(m)))
 
-	day, found := months[normaliseMonth]
+	month, found := months[normaliseMonth]
 	if !found {
 		i, err := strconv.Atoi(string(normaliseMonth))
-		if err != nil {
-			return day, fmt.Errorf("%s is an invalid month", m)
+		if err != nil || i < 1 || i > 12 {
+			return month, fmt.Errorf("%s is an invalid month", m)
 		}
-		day = i
+		month = i
 	}
 
-	return day, nil
+	return month, nil
 }
 
 // Validate the DayOfMonthRange

--- a/pkg/apis/monitoring/v1alpha1/validation_test.go
+++ b/pkg/apis/monitoring/v1alpha1/validation_test.go
@@ -97,22 +97,37 @@ func TestMonthRange_Parse(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid months returns error",
+			name:      "Test invalid named months returns error",
 			in:        MonthRange("januarE"),
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid months in range returns error",
+			name:      "Test invalid numerical months returns error",
+			in:        MonthRange("13"),
+			expectErr: true,
+		},
+		{
+			name:      "Test invalid named months in range returns error",
 			in:        MonthRange("january:Merch"),
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid range - end before start returns error",
+			name:      "Test invalid numerical months in range returns error",
+			in:        MonthRange("1:13"),
+			expectErr: true,
+		},
+		{
+			name:      "Test invalid named range - end before start returns error",
 			in:        MonthRange("march:january"),
 			expectErr: true,
 		},
 		{
-			name: "Test happy path",
+			name:      "Test invalid numerical range - end before start returns error",
+			in:        MonthRange("3:1"),
+			expectErr: true,
+		},
+		{
+			name: "Test happy named path",
 			in:   MonthRange("january"),
 			expectResult: &ParsedRange{
 				Start: 1,
@@ -120,8 +135,40 @@ func TestMonthRange_Parse(t *testing.T) {
 			},
 		},
 		{
-			name: "Test happy path range",
+			name: "Test happy one digit numerical path",
+			in:   MonthRange("1"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   1,
+			},
+		},
+		{
+			name: "Test happy two digits numerical path",
+			in:   MonthRange("12"),
+			expectResult: &ParsedRange{
+				Start: 12,
+				End:   12,
+			},
+		},
+		{
+			name: "Test happy named path range",
 			in:   MonthRange("january:march"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   3,
+			},
+		},
+		{
+			name: "Test happy numerical path range",
+			in:   MonthRange("1:12"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   12,
+			},
+		},
+		{
+			name: "Test happy mixed path range",
+			in:   MonthRange("1:march"),
 			expectResult: &ParsedRange{
 				Start: 1,
 				End:   3,

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -1096,7 +1096,7 @@ type DayOfMonthRange struct {
 
 // MonthRange is an inclusive range of months of the year beginning in January
 // Months can be specified by name (e.g 'January') by numerical month (e.g '1') or as an inclusive range (e.g 'January:March', '1:3', '1:March')
-// +kubebuilder:validation:Pattern=`^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)`
+// +kubebuilder:validation:Pattern=`^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)`
 type MonthRange string
 
 // YearRange is an inclusive range of years

--- a/pkg/apis/monitoring/v1beta1/validation.go
+++ b/pkg/apis/monitoring/v1beta1/validation.go
@@ -221,16 +221,16 @@ func (w Weekday) Int() (int, error) {
 func (m Month) Int() (int, error) {
 	normaliseMonth := Month(strings.ToLower(string(m)))
 
-	day, found := months[normaliseMonth]
+	month, found := months[normaliseMonth]
 	if !found {
 		i, err := strconv.Atoi(string(normaliseMonth))
-		if err != nil {
-			return day, fmt.Errorf("%s is an invalid month", m)
+		if err != nil || i < 1 || i > 12 {
+			return month, fmt.Errorf("%s is an invalid month", m)
 		}
-		day = i
+		month = i
 	}
 
-	return day, nil
+	return month, nil
 }
 
 // Validate the DayOfMonthRange

--- a/pkg/apis/monitoring/v1beta1/validation_test.go
+++ b/pkg/apis/monitoring/v1beta1/validation_test.go
@@ -97,22 +97,37 @@ func TestMonthRange_Parse(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid months returns error",
+			name:      "Test invalid named months returns error",
 			in:        MonthRange("januarE"),
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid months in range returns error",
+			name:      "Test invalid numerical months returns error",
+			in:        MonthRange("13"),
+			expectErr: true,
+		},
+		{
+			name:      "Test invalid named months in range returns error",
 			in:        MonthRange("january:Merch"),
 			expectErr: true,
 		},
 		{
-			name:      "Test invalid range - end before start returns error",
+			name:      "Test invalid numerical months in range returns error",
+			in:        MonthRange("1:13"),
+			expectErr: true,
+		},
+		{
+			name:      "Test invalid named range - end before start returns error",
 			in:        MonthRange("march:january"),
 			expectErr: true,
 		},
 		{
-			name: "Test happy path",
+			name:      "Test invalid numerical range - end before start returns error",
+			in:        MonthRange("3:1"),
+			expectErr: true,
+		},
+		{
+			name: "Test happy named path",
 			in:   MonthRange("january"),
 			expectResult: &ParsedRange{
 				Start: 1,
@@ -120,8 +135,40 @@ func TestMonthRange_Parse(t *testing.T) {
 			},
 		},
 		{
-			name: "Test happy path range",
+			name: "Test happy one digit numerical path",
+			in:   MonthRange("1"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   1,
+			},
+		},
+		{
+			name: "Test happy two digits numerical path",
+			in:   MonthRange("12"),
+			expectResult: &ParsedRange{
+				Start: 12,
+				End:   12,
+			},
+		},
+		{
+			name: "Test happy named path range",
 			in:   MonthRange("january:march"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   3,
+			},
+		},
+		{
+			name: "Test happy numerical path range",
+			in:   MonthRange("1:12"),
+			expectResult: &ParsedRange{
+				Start: 1,
+				End:   12,
+			},
+		},
+		{
+			name: "Test happy mixed path range",
+			in:   MonthRange("1:march"),
 			expectResult: &ParsedRange{
 				Start: 1,
 				End:   3,


### PR DESCRIPTION
## Description

- fixes #6353
- fixes MonthRange regex.
- adds more unit tests to cover the numerical month values.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
unit test only, I left E2E for the CI.

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- fix AltermanagerConfig CRD field muteTimeIntervals.timeIntervals.months regex pattern.
```
