### PR TITLE
docs: correct example of scrapeConfigSelector in scrapeConfig doc

### DIFF
--- a/Documentation/user-guides/scrapeconfig.md
+++ b/Documentation/user-guides/scrapeconfig.md
@@ -27,7 +27,8 @@ labels to match `ScrapeConfigs`:
 ```yaml
 spec:
   scrapeConfigSelector:
-    prometheus: system-monitoring-prometheus
+    matchLabels:
+      prometheus: system-monitoring-prometheus
 ```
 
 With this example, all `ScrapeConfig` having the `prometheus` label set to `system-monitoring-prometheus` will be used
@@ -103,7 +104,8 @@ metadata:
     prometheus: system-monitoring-prometheus
 spec:
   scrapeConfigSelector:
-    prometheus: system-monitoring-prometheus
+    matchLabels:
+      prometheus: system-monitoring-prometheus
   configMaps:
     - scrape-file-sd-targets
 ```


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

In the docs for scrapeConfig, the example of scrapeConfig in prometheus CR was incorrect. In prometheus CR, in scrapeConfigSelector, there should be matchLabels and then the scrapeConfig label.

In the [docs](https://prometheus-operator.dev/docs/user-guides/scrapeconfig/#static_config), this is provided in the prometheus CR example.
```
spec:
  scrapeConfigSelector:
    prometheus: system-monitoring-prometheus
```

Instead, it should be:
```
spec:
  scrapeConfigSelector:
    matchLables:
      prometheus: system-monitoring-prometheus
```
fixes #6350

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
