### PR TITLE
Alertmanager ttl

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -2611,6 +2611,10 @@ spec:
                               Either `token` or `tokenFile` is required. It requires
                               Alertmanager >= v0.26.0.
                             type: string
+                          ttl:
+                            description: time to live for the alert notification
+                            format: int64
+                            type: integer
                           url:
                             description: A supplementary URL shown alongside the message.
                             type: string
@@ -8175,6 +8179,10 @@ spec:
                               Either `token` or `tokenFile` is required. It requires
                               Alertmanager >= v0.26.0.
                             type: string
+                          ttl:
+                            description: time to live for the alert notification
+                            format: int64
+                            type: integer
                           url:
                             description: A supplementary URL shown alongside the message.
                             type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -2612,6 +2612,10 @@ spec:
                               Either `token` or `tokenFile` is required. It requires
                               Alertmanager >= v0.26.0.
                             type: string
+                          ttl:
+                            description: time to live for the alert notification
+                            format: int64
+                            type: integer
                           url:
                             description: A supplementary URL shown alongside the message.
                             type: string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-operator/prometheus-operator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -2721,6 +2721,11 @@
                                 "description": "The token file that contains the registered application's API token, see https://pushover.net/apps. Either `token` or `tokenFile` is required. It requires Alertmanager >= v0.26.0.",
                                 "type": "string"
                               },
+                              "ttl": {
+                                "description": "time to live for the alert notification",
+                                "format": "int64",
+                                "type": "integer"
+                              },
                               "url": {
                                 "description": "A supplementary URL shown alongside the message.",
                                 "type": "string"

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -2567,6 +2567,11 @@
                             description: "The token file that contains the registered application's API token, see https://pushover.net/apps. Either `token` or `tokenFile` is required. It requires Alertmanager >= v0.26.0.",
                             type: 'string',
                           },
+                          ttl: {
+                            description: 'time to live for the alert notification',
+                            format: 'int64',
+                            type: 'integer',
+                          },
                           url: {
                             description: 'A supplementary URL shown alongside the message.',
                             type: 'string',

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -29,6 +29,7 @@ import (
 // https://github.com/prometheus/alertmanager/issues/1985
 type alertmanagerConfig struct {
 	Global            *globalConfig   `yaml:"global,omitempty" json:"global,omitempty"`
+	TTL 			  duration        `yaml:"ttl,omitempty" json:"ttl,omitempty"`
 	Route             *route          `yaml:"route,omitempty" json:"route,omitempty"`
 	InhibitRules      []*inhibitRule  `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
 	Receivers         []*receiver     `yaml:"receivers,omitempty" json:"receivers,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -785,7 +786,7 @@ type PushoverConfig struct {
 	Title string `json:"title,omitempty"`
 	// time to live for the alert notification
 	// +optional
-	TTL duration `json:"ttl,omitempty"`
+	TTL time.Duration `json:"ttl,omitempty"`
 	// Notification message.
 	// +optional
 	Message string `json:"message,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -783,6 +783,9 @@ type PushoverConfig struct {
 	// Notification title.
 	// +optional
 	Title string `json:"title,omitempty"`
+	// time to live for the alert notification
+	// +optional
+	TTL duration `json:"ttl,omitempty"`
 	// Notification message.
 	// +optional
 	Message string `json:"message,omitempty"`

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -780,7 +781,7 @@ type PushoverConfig struct {
 	Message string `json:"message,omitempty"`
 	// time to live for the alert notification
 	// +optional
-	TTL duration `json:"ttl,omitempty"`
+	TTL time.Duration `json:"ttl,omitempty"`
 	// A supplementary URL shown alongside the message.
 	// +optional
 	URL string `json:"url,omitempty"`

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -778,6 +778,9 @@ type PushoverConfig struct {
 	// Notification message.
 	// +optional
 	Message string `json:"message,omitempty"`
+	// time to live for the alert notification
+	// +optional
+	TTL duration `json:"ttl,omitempty"`
 	// A supplementary URL shown alongside the message.
 	// +optional
 	URL string `json:"url,omitempty"`


### PR DESCRIPTION
## Description

Add TTL field to alertmanager config
solves: https://github.com/prometheus-operator/prometheus-operator/issues/6360

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry



<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add ttl to alertmanagerConfig
```
