### PR TITLE
chore: Template string allowed for Responder.Type (#4882)

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1666,12 +1666,6 @@ spec:
                                   type: string
                                 type:
                                   description: Type of responder.
-                                  enum:
-                                  - team
-                                  - teams
-                                  - user
-                                  - escalation
-                                  - schedule
                                   minLength: 1
                                   type: string
                                 username:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1665,12 +1665,6 @@ spec:
                                   type: string
                                 type:
                                   description: Type of responder.
-                                  enum:
-                                  - team
-                                  - teams
-                                  - user
-                                  - escalation
-                                  - schedule
                                   minLength: 1
                                   type: string
                                 username:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1666,12 +1666,6 @@ spec:
                                   type: string
                                 type:
                                   description: Type of responder.
-                                  enum:
-                                  - team
-                                  - teams
-                                  - user
-                                  - escalation
-                                  - schedule
                                   minLength: 1
                                   type: string
                                 username:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -1744,13 +1744,6 @@
                                     },
                                     "type": {
                                       "description": "Type of responder.",
-                                      "enum": [
-                                        "team",
-                                        "teams",
-                                        "user",
-                                        "escalation",
-                                        "schedule"
-                                      ],
                                       "minLength": 1,
                                       "type": "string"
                                     },

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -429,6 +429,7 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 											ID:       "a",
 											Name:     "b",
 											Username: "c",
+											Type:     "user",
 										},
 									},
 								},

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
+	"regexp"
 	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -561,9 +563,12 @@ type OpsGenieConfigResponder struct {
 	Username string `json:"username,omitempty"`
 	// Type of responder.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Enum=team;teams;user;escalation;schedule
 	Type string `json:"type"`
 }
+
+const opsgenieValidTypesRe = `^(team|teams|user|escalation|schedule)$`
+
+var opsgenieTypeMatcher = regexp.MustCompile(opsgenieValidTypesRe)
 
 // Validate ensures OpsGenieConfigResponder is valid.
 func (r *OpsGenieConfigResponder) Validate() error {
@@ -571,7 +576,18 @@ func (r *OpsGenieConfigResponder) Validate() error {
 		return errors.New("responder must have at least an ID, a Name or an Username defined")
 	}
 
-	return nil
+	if strings.Contains(r.Type, "{{") {
+		_, err := template.New("").Parse(r.Type)
+		if err != nil {
+			return fmt.Errorf("responder %v type is not a valid template: %w", r, err)
+		}
+		return nil
+	}
+
+	if opsgenieTypeMatcher.MatchString(strings.ToLower(r.Type)) {
+		return nil
+	}
+	return fmt.Errorf("opsGenieConfig responder %v type does not match valid options %s", r, opsgenieValidTypesRe)
 }
 
 // HTTPConfig defines a client HTTP configuration.

--- a/pkg/apis/monitoring/v1alpha1/validation_test.go
+++ b/pkg/apis/monitoring/v1alpha1/validation_test.go
@@ -343,3 +343,65 @@ func TestYearRange_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestOpsGenieConfigResponder_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		in          *OpsGenieConfigResponder
+		expectedErr bool
+	}{
+		{
+			name: "Test nil ID, Name and Username",
+			in: &OpsGenieConfigResponder{
+				Type: "user",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test invalid template string type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "{{.GroupLabels",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test valid template string type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "{{.GroupLabels}}",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Test invalid type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "username",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test valid type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "user",
+			},
+			expectedErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.Validate()
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected err but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error but got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/apis/monitoring/v1beta1/validation_test.go
+++ b/pkg/apis/monitoring/v1beta1/validation_test.go
@@ -343,3 +343,65 @@ func TestYearRange_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestOpsGenieConfigResponder_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		in          *OpsGenieConfigResponder
+		expectedErr bool
+	}{
+		{
+			name: "Test nil ID, Name and Username",
+			in: &OpsGenieConfigResponder{
+				Type: "user",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test invalid template string type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "{{.GroupLabels",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test valid template string type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "{{.GroupLabels}}",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Test invalid type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "username",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Test valid type",
+			in: &OpsGenieConfigResponder{
+				Name: "responder",
+				Type: "user",
+			},
+			expectedErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.Validate()
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected err but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error but got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

fixes: #4882
Template string allowed for Responder.Type




## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry





```
Template string allowed for Responder.Type

```
