### PR TITLE
Docs: Include Local Deployment in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,39 @@ second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various
 Git tools.
 
+# Local Deployment
+
+If you want to run Prometheus Operator on your local environment, you can follow the steps below.
+
+1. First start a Kubernetes cluster. We recommend [KinD](https://kind.sigs.k8s.io/) because it is lightweight (it can run on small notebooks) and this is what the project's CI uses. [MiniKube](https://minikube.sigs.k8s.io/docs/start/) is also another option.
+
+2. Run the utility script [scripts/run-external.sh](scripts/run-external.sh), it will check all the requirements and run your local version of the Prometheus Operator on your Kind cluster.
+
+```
+./scripts/run-external.sh -c
+```
+3. You should now be able to see the logs from the operator in your CLI instance. The Operator is successully running in your local system and can be debugged, checked for behaviour etc.
+
+## Deploying/Checking-out by version
+
+Additionally, you can also checkout to a particular version of Prometheus-Operator to reproduce and fix bugs from an earlier version of the operator.
+
+1. Run `git checkout tags/<version> -b <branch-name>` to checkout a particular tagged version into a separate branch in your local machine.
+
+2. Make sure a local cluster is running and the correct branch checked-out, and run `./scripts/run-external.sh -c`. (-c flag uses default context settings).
+
+For example,
+
+```
+git checkout tags/v0.71.0 -b branch-v0.71.0
+```
+
+```
+./scripts/run-external.sh -c
+```
+
+Will checkout `v0.71.0` into branch `branch-v0.71.0` and deploy this version locally.
+
 # Proposal Process
 
 The Prometheus Operator project accepts proposals for new features, enhancements and design documents.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various
 Git tools.
 
-# Local Deployment
+# Local Development
 
 If you want to run Prometheus Operator on your local environment, you can follow the steps below.
 
@@ -119,27 +119,9 @@ If you want to run Prometheus Operator on your local environment, you can follow
 ```
 ./scripts/run-external.sh -c
 ```
-3. You should now be able to see the logs from the operator in your CLI instance. The Operator is successully running in your local system and can be debugged, checked for behaviour etc.
+3. You should now be able to see the logs from the operator in your terminal. The Operator is successully running in your local system and can be debugged, checked for behaviour etc.
 
-## Deploying/Checking-out by version
-
-Additionally, you can also checkout to a particular version of Prometheus-Operator to reproduce and fix bugs from an earlier version of the operator.
-
-1. Run `git checkout tags/<version> -b <branch-name>` to checkout a particular tagged version into a separate branch in your local machine.
-
-2. Make sure a local cluster is running and the correct branch checked-out, and run `./scripts/run-external.sh -c`. (-c flag uses default context settings).
-
-For example,
-
-```
-git checkout tags/v0.71.0 -b branch-v0.71.0
-```
-
-```
-./scripts/run-external.sh -c
-```
-
-Will checkout `v0.71.0` into branch `branch-v0.71.0` and deploy this version locally.
+Similarly, if you work on a specific branch, you can run the `scripts/run-external.sh` script in this branch to deploy it.
 
 # Proposal Process
 


### PR DESCRIPTION
## Description

Documentation on deploying the local code in a local cluster seems like a good fit in [CONTRIBUTING.md](https://github.com/prometheus-operator/prometheus-operator/blob/main/CONTRIBUTING.md). However, it has not been removed from [TESTING.md](https://github.com/prometheus-operator/prometheus-operator/blob/main/TESTING.md) where it was originally part of, because it seems relevant there too.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
