### PR TITLE
Dynamic ThanosRuler governing service name

### DIFF
--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -932,9 +932,10 @@ func TestStatefulSetServiceName(t *testing.T) {
 			QueryEndpoints: emptyQueryEndpoints,
 		},
 	}
+	tr.Name = "test"
 
 	// assert set correctly
-	expect := governingServiceName
+	expect := serviceName(tr.Name)
 	spec, err := makeStatefulSetSpec(&tr, defaultTestConfig, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -199,9 +199,9 @@ func testTRPreserveUserAddedMetadata(t *testing.T) {
 		update func(object metav1.Object) (metav1.Object, error)
 	}{
 		{
-			name: "thanos-ruler-operated service",
+			name: "thanos-ruler operated service",
 			get: func() (metav1.Object, error) {
-				return svcClient.Get(context.Background(), "thanos-ruler-operated", metav1.GetOptions{})
+				return svcClient.Get(context.Background(), "thanos-ruler-test-operated", metav1.GetOptions{})
 			},
 			update: func(object metav1.Object) (metav1.Object, error) {
 				return svcClient.Update(context.Background(), asService(t, object), metav1.UpdateOptions{})


### PR DESCRIPTION
## Description

Currently it is not possible to run multiple instances of the ThanosRuler, as the service name is hardcoded. This change makes the generated service name dynamic, based on the name of the ThanosRuler resource.

## Type of change

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Tests pass.

## Changelog entry

```release-note
- ThanosRuler governing service name now includes the ThanosRuler resource name.
```
