### PR TITLE
Fix: ScrapeConfigs Selection Issue Across Different Namespaces

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -850,6 +850,21 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 			c.rr.EnqueueForReconciliation(p)
 			return
 		}
+		// Check for Prometheus instances selecting ScrapeConfigs in
+		// the NS.
+		scrapeConfigNSSelector, err := metav1.LabelSelectorAsSelector(p.Spec.ScrapeConfigNamespaceSelector)
+		if err != nil {
+			level.Error(c.logger).Log(
+				"msg", fmt.Sprintf("failed to convert ScrapeConfigNamespaceSelector of %q to selector", p.Name),
+				"err", err,
+			)
+			return
+		}
+
+		if scrapeConfigNSSelector.Matches(labels.Set(ns.Labels)) {
+			c.rr.EnqueueForReconciliation(p)
+			return
+		}
 	})
 	if err != nil {
 		level.Error(c.logger).Log(

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -372,12 +372,13 @@ func TestDenylist(t *testing.T) {
 func TestPromInstanceNs(t *testing.T) {
 	skipPrometheusTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"AllNs":                   testPrometheusInstanceNamespacesAllNs,
-		"AllowList":               testPrometheusInstanceNamespacesAllowList,
-		"DenyList":                testPrometheusInstanceNamespacesDenyList,
-		"NamespaceNotFound":       testPrometheusInstanceNamespacesNamespaceNotFound,
-		"ScrapeConfigLifecycle":   testScrapeConfigLifecycle,
-		"ConfigReloaderResources": testConfigReloaderResources,
+		"AllNs":                              testPrometheusInstanceNamespacesAllNs,
+		"AllowList":                          testPrometheusInstanceNamespacesAllowList,
+		"DenyList":                           testPrometheusInstanceNamespacesDenyList,
+		"NamespaceNotFound":                  testPrometheusInstanceNamespacesNamespaceNotFound,
+		"ScrapeConfigLifecycle":              testScrapeConfigLifecycle,
+		"ScrapeConfigLifecycleInDifferentNs": testScrapeConfigLifecycleInDifferentNS,
+		"ConfigReloaderResources":            testConfigReloaderResources,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -151,7 +151,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 
 	// create Prometheus custom resource in the "instance" namespace.
 	// This one must be reconciled.
-	// Let this Prometheus custom resource match service monitors in namespaces having the label `"monitored": "true"`.
+	// Let this Prometheus custom resource match service monitors in namespaces having the label `"group": "monitored"`.
 	// This will match the service monitors created in the "denied" namespace.
 	// Also create a service monitor in this namespace. This one must not be reconciled.
 	// Expose the created Prometheus service.

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -249,8 +249,8 @@ func testScrapeConfigLifecycleInDifferentNS(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-    // Make a prometheus object in promns which will select any ScrapeConfig resource with
-    // "role": "scrapeconfig" and/or "kubernetes.io/metadata.name": "<scns>"
+	// Make a prometheus object in promns which will select any ScrapeConfig resource with
+	// "role": "scrapeconfig" and/or "kubernetes.io/metadata.name": "<scns>"
 	p := framework.MakeBasicPrometheus(promns, "prom", scns, 1)
 	p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -246,20 +246,19 @@ func testScrapeConfigLifecycleInDifferentNS(t *testing.T) {
 		nil,
 		false,
 		true, // clusterrole
-		true,)
+		true,
+	)
 	require.NoError(t, err)
 
 	// Make a prometheus object in promns which will select any ScrapeConfig resource with
-	// "role": "scrapeconfig" and/or "kubernetes.io/metadata.name": "<scns>"
-	p := framework.MakeBasicPrometheus(promns, "prom", "scns", 1)
+	// "group": "sc" and/or "kubernetes.io/metadata.name": <scns>
+	p := framework.MakeBasicPrometheus(promns, "prom", scns, 1)
 	p.Spec.ScrapeConfigNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"kubernetes.io/metadata.name": scns,
 		},
 	}
 
-    // Set label selector too, along with namespace selector. Nil value does not detect the
-    // ScrapeConfig
 	p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"group": "sc",

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -280,7 +280,7 @@ func testScrapeConfigLifecycleInDifferentNS(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the targets appear in Prometheus
-	err = framework.WaitForActiveTargets(context.Background(), promns, "prometheus-operated", 2)
+	err = framework.WaitForActiveTargets(context.Background(), scns, "prometheus-operated", 2)
 	require.NoError(t, err)
 
 	// 2. Update the ScrapeConfig and add a target. Then, check that 3 targets appear in Prometheus.

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -278,6 +278,9 @@ func testScrapeConfigLifecycleInDifferentNS(t *testing.T) {
 
 	// 1. Create a ScrapeConfig in scns and check that its targets appear in Prometheus
 	sc := framework.MakeBasicScrapeConfig(scns, "scrape-config")
+	sc.ObjectMeta.Labels = map[string]string{
+		"group": "sc"}
+
 	sc.Spec.StaticConfigs = []monitoringv1alpha1.StaticConfig{
 		{
 			Targets: []monitoringv1alpha1.Target{"target1:9090", "target2:9090"},

--- a/test/framework/scrapeconfig.go
+++ b/test/framework/scrapeconfig.go
@@ -31,7 +31,7 @@ func (f *Framework) MakeBasicScrapeConfig(ns, name string) *monitoringv1alpha1.S
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"role": "scrapeconfig",
+				"group": "sc",
 			},
 		},
 		Spec: monitoringv1alpha1.ScrapeConfigSpec{},

--- a/test/framework/scrapeconfig.go
+++ b/test/framework/scrapeconfig.go
@@ -31,7 +31,7 @@ func (f *Framework) MakeBasicScrapeConfig(ns, name string) *monitoringv1alpha1.S
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"group": "sc",
+				"role":  "scrapeconfig",
 			},
 		},
 		Spec: monitoringv1alpha1.ScrapeConfigSpec{},

--- a/test/framework/scrapeconfig.go
+++ b/test/framework/scrapeconfig.go
@@ -31,7 +31,7 @@ func (f *Framework) MakeBasicScrapeConfig(ns, name string) *monitoringv1alpha1.S
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				"role":  "scrapeconfig",
+				"role": "scrapeconfig",
 			},
 		},
 		Spec: monitoringv1alpha1.ScrapeConfigSpec{},


### PR DESCRIPTION
## Description

The ScrapeConfigs added in a different namespace from the Prometheus CR that selects them are not being picked up. We suspect it might be because of how the `enqueueForNamespace()` function works. This PR aims to prove that this is indeed the issue and consequentially also fix it.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Tests added to `main_test.go`

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix ScrapeConfig not picked up bug
```
