### PR TITLE
.github/workflow: make execution of e2e and unit tests conditional

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -1,0 +1,27 @@
+name: changed-files
+
+on:
+    workflow_call:
+      outputs:
+        non-markdown-files:
+          description: "changed files list"
+          value: ${{ jobs.changed-files.outputs.non-markdown-files }}
+
+jobs:
+  changed-files:
+    # Map the job outputs to step outputs
+    outputs:
+      non-markdown-files : ${{ steps.changed-files.outputs.non-markdown-files}}
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      id: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: get changed files
+      id: changed-files
+      run: |
+        echo non-markdown-files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -iv .md$ | xargs) >> $GITHUB_OUTPUT
+    - run: |
+        echo "${{ steps.changed-files.outputs.non-markdown-files}}"

--- a/.github/workflows/e2e-feature-gated.yaml
+++ b/.github/workflows/e2e-feature-gated.yaml
@@ -1,8 +1,6 @@
 name: e2e-feature-gated
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
   push:
     branches:
       - 'release-*'
@@ -10,15 +8,17 @@ on:
       - 'main'
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
 # To cancel running workflow when new commits pushed in a pull request
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  changed-files:
+     uses: ./.github/workflows/changed-files.yaml
   e2e-tests:
     name: E2E tests for feature gates
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,6 @@
 name: e2e
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
   push:
     branches:
       - 'release-*'
@@ -10,16 +8,18 @@ on:
       - 'main'
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
 # To cancel running workflow when new commits pushed in a pull request
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  changed-files:
+    uses: ./.github/workflows/changed-files.yaml
   e2e-tests:
     name: E2E tests
     runs-on: ubuntu-latest
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     strategy:
       matrix:
         suite: [alertmanager, prometheus, prometheusAllNS, thanosruler, operatorUpgrade]
@@ -105,8 +105,9 @@ jobs:
   # Added to summarize the matrix and allow easy branch protection rules setup
   e2e-tests-result:
     name: End-to-End Test Results
-    if: always()
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     needs:
+      - changed-files
       - e2e-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -17,9 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
+  changed-files:
+     uses: ./.github/workflows/changed-files.yaml
   unit-tests:
-    runs-on: ubuntu-latest
     name: Unit tests
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     steps:
     - uses: actions/checkout@v4
     - name: Import environment variables from file
@@ -32,6 +36,8 @@ jobs:
   extended-tests:
     runs-on: ubuntu-latest
     name: Extended tests
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     steps:
     - uses: actions/checkout@v4
     - name: Import environment variables from file


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

This will help to avoid blocking the merge on conditional execution of jobs. 
When there are only `.md` file update currently unit tests and e2e test won't run but they are required tests to merge
we cannot automatically merge as it will report those tests as pending.

See below screenshot
<img width="935" alt="github_checks" src="https://github.com/prometheus-operator/prometheus-operator/assets/5638849/4a301e47-c462-4045-97b1-83df0307594e">

With this change those tests will be skipped hence will report status as success even though it is a required test.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
