### PR TITLE
Documentation: Remove experimental tag from sharding option

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1721,7 +1721,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: Number of shards to distribute targets onto. <code>spec.replicas</code>
+<p>Number of shards to distribute targets onto. <code>spec.replicas</code>
 multiplied by <code>spec.shards</code> is the total number of Pods created.</p>
 <p>Note that scaling down shards will not reshard data onto remaining
 instances, it must be manually moved. Increasing shards will not reshard
@@ -6231,7 +6231,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: Number of shards to distribute targets onto. <code>spec.replicas</code>
+<p>Number of shards to distribute targets onto. <code>spec.replicas</code>
 multiplied by <code>spec.shards</code> is the total number of Pods created.</p>
 <p>Note that scaling down shards will not reshard data onto remaining
 instances, it must be manually moved. Increasing shards will not reshard
@@ -10486,7 +10486,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: Number of shards to distribute targets onto. <code>spec.replicas</code>
+<p>Number of shards to distribute targets onto. <code>spec.replicas</code>
 multiplied by <code>spec.shards</code> is the total number of Pods created.</p>
 <p>Note that scaling down shards will not reshard data onto remaining
 instances, it must be manually moved. Increasing shards will not reshard
@@ -16399,7 +16399,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: Number of shards to distribute targets onto. <code>spec.replicas</code>
+<p>Number of shards to distribute targets onto. <code>spec.replicas</code>
 multiplied by <code>spec.shards</code> is the total number of Pods created.</p>
 <p>Note that scaling down shards will not reshard data onto remaining
 instances, it must be manually moved. Increasing shards will not reshard
@@ -21239,7 +21239,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: Number of shards to distribute targets onto. <code>spec.replicas</code>
+<p>Number of shards to distribute targets onto. <code>spec.replicas</code>
 multiplied by <code>spec.shards</code> is the total number of Pods created.</p>
 <p>Note that scaling down shards will not reshard data onto remaining
 instances, it must be manually moved. Increasing shards will not reshard

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -20923,13 +20923,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"
@@ -31038,13 +31038,13 @@ spec:
                   digest can be specified as part of the image name.'
                 type: string
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5932,13 +5932,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6916,13 +6916,13 @@ spec:
                   digest can be specified as part of the image name.'
                 type: string
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5933,13 +5933,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6917,13 +6917,13 @@ spec:
                   digest can be specified as part of the image name.'
                 type: string
               shards:
-                description: "EXPERIMENTAL: Number of shards to distribute targets
-                  onto. `spec.replicas` multiplied by `spec.shards` is the total number
-                  of Pods created. \n Note that scaling down shards will not reshard
-                  data onto remaining instances, it must be manually moved. Increasing
-                  shards will not reshard data either but it will continue to be available
-                  from the same instances. To query globally, use Thanos sidecar and
-                  Thanos querier or remote write data to a central location. \n Sharding
+                description: "Number of shards to distribute targets onto. `spec.replicas`
+                  multiplied by `spec.shards` is the total number of Pods created.
+                  \n Note that scaling down shards will not reshard data onto remaining
+                  instances, it must be manually moved. Increasing shards will not
+                  reshard data either but it will continue to be available from the
+                  same instances. To query globally, use Thanos sidecar and Thanos
+                  querier or remote write data to a central location. \n Sharding
                   is performed on the content of the `__address__` target meta-label
                   for PodMonitors and ServiceMonitors and `__param_target__` for Probes.
                   \n Default: 1"

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5330,7 +5330,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "shards": {
-                    "description": "EXPERIMENTAL: Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1",
+                    "description": "Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6344,7 +6344,7 @@
                     "type": "string"
                   },
                   "shards": {
-                    "description": "EXPERIMENTAL: Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1",
+                    "description": "Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1",
                     "format": "int32",
                     "type": "integer"
                   },

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -215,7 +215,7 @@ type CommonPrometheusFields struct {
 	// Default: 1
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
-	// EXPERIMENTAL: Number of shards to distribute targets onto. `spec.replicas`
+	// Number of shards to distribute targets onto. `spec.replicas`
 	// multiplied by `spec.shards` is the total number of Pods created.
 	//
 	// Note that scaling down shards will not reshard data onto remaining


### PR DESCRIPTION
 Remove experimental tag from sharding option

## Description

This commit changes the docs so that future prometheus operator users know the option is out of experimental. The sharding option is used for many years by multiple contributers.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

It is only a change to the docs. The nature of the change came from a discussion with the maintainers @ArthurSens  and @nicolastakashi  about the state of sharding done by the operator.

## Changelog entry

```release-note
 Remove experimental tag from sharding option in prometheus CRD
```
