### PR TITLE
Add e2e test on secret update for PrometheusAgent

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -319,6 +319,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PrometheusWithStatefulsetCreationFailure":  testPrometheusWithStatefulsetCreationFailure,
 		"PrometheusAgentCheckStorageClass":          testAgentCheckStorageClass,
 		"PrometheusAgentStatusScale":                testPrometheusAgentStatusScale,
+		"PrometheusAgentSecretUpdate":               testPrometheusAgentSecretUpdate,
 		"PrometheusStatusScale":                     testPrometheusStatusScale,
 	}
 

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -227,11 +227,12 @@ func testPrometheusAgentSecretUpdate(t *testing.T) {
 			},
 		},
 	}
-	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
+
+	finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc)
+	if err != nil {
 		t.Fatal(err)
-	} else {
-		testCtx.AddFinalizerFn(finalizerFn)
 	}
+	testCtx.AddFinalizerFn(finalizerFn)
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -269,7 +270,6 @@ func testPrometheusAgentSecretUpdate(t *testing.T) {
 	pAgent.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: matchLabels,
 	}
-	pAgent.Spec.ScrapeInterval = "1s"
 	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, pAgent)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It fixes #6414



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
