### PR TITLE
Document PodMonitor, Probe and Thanos sidecar as stable

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -734,9 +734,11 @@ AlertmanagerConfiguration
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL: alertmanagerConfiguration specifies the configuration of Alertmanager.
-If defined, it takes precedence over the <code>configSecret</code> field.
-This field may change in future releases.</p>
+<em>(Optional)</em>
+<p>alertmanagerConfiguration specifies the configuration of Alertmanager.</p>
+<p>If defined, it takes precedence over the <code>configSecret</code> field.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -1519,9 +1521,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>PodMonitors to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -1557,9 +1558,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Probes to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>Probes to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -1580,7 +1580,7 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Namespaces to match for Probe discovery. An empty label
+<p>Namespaces to match for Probe discovery. An empty label
 selector matches all namespaces. A null label selector matches the
 current namespace only.</p>
 </td>
@@ -1595,9 +1595,9 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> ScrapeConfigs to be selected for target discovery. An
-empty label selector matches all objects. A null label selector matches
-no objects.</p>
+<em>(Optional)</em>
+<p>ScrapeConfigs to be selected for target discovery. An empty label
+selector matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -1606,6 +1606,7 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -1618,9 +1619,11 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
-current namespace only.</p>
+namespace only.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -2563,9 +2566,9 @@ PrometheusTracingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-experimental feature, it may change in any upcoming release in a
-breaking way.</p>
+<p>TracingConfig configures tracing in Prometheus.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -2700,8 +2703,10 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-This is experimental feature and might change in the future.</p>
+<p>List of scrape classes to expose to scraping objects such as
+PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -2939,8 +2944,6 @@ ThanosSpec
 <td>
 <em>(Optional)</em>
 <p>Defines the configuration of the optional Thanos sidecar.</p>
-<p>This section is experimental, it may change significantly without
-deprecation notice in any release.</p>
 </td>
 </tr>
 <tr>
@@ -3991,7 +3994,11 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.</p>
+<em>(Optional)</em>
+<p>TracingConfig configures tracing in Thanos.</p>
+<p><code>tracingConfigFile</code> takes precedence over this field.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -4002,8 +4009,11 @@ string
 </em>
 </td>
 <td>
-<p>TracingConfig specifies the path of the tracing configuration file.
-When used alongside with TracingConfig, TracingConfigFile takes precedence.</p>
+<em>(Optional)</em>
+<p>TracingConfig specifies the path of the tracing configuration file.</p>
+<p>This field takes precedence over <code>tracingConfig</code>.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -5391,9 +5401,11 @@ AlertmanagerConfiguration
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL: alertmanagerConfiguration specifies the configuration of Alertmanager.
-If defined, it takes precedence over the <code>configSecret</code> field.
-This field may change in future releases.</p>
+<em>(Optional)</em>
+<p>alertmanagerConfiguration specifies the configuration of Alertmanager.</p>
+<p>If defined, it takes precedence over the <code>configSecret</code> field.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -6029,9 +6041,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>PodMonitors to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -6067,9 +6078,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Probes to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>Probes to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -6090,7 +6100,7 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Namespaces to match for Probe discovery. An empty label
+<p>Namespaces to match for Probe discovery. An empty label
 selector matches all namespaces. A null label selector matches the
 current namespace only.</p>
 </td>
@@ -6105,9 +6115,9 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> ScrapeConfigs to be selected for target discovery. An
-empty label selector matches all objects. A null label selector matches
-no objects.</p>
+<em>(Optional)</em>
+<p>ScrapeConfigs to be selected for target discovery. An empty label
+selector matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -6116,6 +6126,7 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -6128,9 +6139,11 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
-current namespace only.</p>
+namespace only.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -7073,9 +7086,9 @@ PrometheusTracingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-experimental feature, it may change in any upcoming release in a
-breaking way.</p>
+<p>TracingConfig configures tracing in Prometheus.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -7210,8 +7223,10 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-This is experimental feature and might change in the future.</p>
+<p>List of scrape classes to expose to scraping objects such as
+PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 </tbody>
@@ -10126,9 +10141,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>PodMonitors to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -10164,9 +10178,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Probes to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>Probes to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -10187,7 +10200,7 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Namespaces to match for Probe discovery. An empty label
+<p>Namespaces to match for Probe discovery. An empty label
 selector matches all namespaces. A null label selector matches the
 current namespace only.</p>
 </td>
@@ -10202,9 +10215,9 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> ScrapeConfigs to be selected for target discovery. An
-empty label selector matches all objects. A null label selector matches
-no objects.</p>
+<em>(Optional)</em>
+<p>ScrapeConfigs to be selected for target discovery. An empty label
+selector matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -10213,6 +10226,7 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -10225,9 +10239,11 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
-current namespace only.</p>
+namespace only.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -11170,9 +11186,9 @@ PrometheusTracingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-experimental feature, it may change in any upcoming release in a
-breaking way.</p>
+<p>TracingConfig configures tracing in Prometheus.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -11307,8 +11323,10 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-This is experimental feature and might change in the future.</p>
+<p>List of scrape classes to expose to scraping objects such as
+PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -11546,8 +11564,6 @@ ThanosSpec
 <td>
 <em>(Optional)</em>
 <p>Defines the configuration of the optional Thanos sidecar.</p>
-<p>This section is experimental, it may change significantly without
-deprecation notice in any release.</p>
 </td>
 </tr>
 <tr>
@@ -12227,8 +12243,9 @@ bool
 </em>
 </td>
 <td>
-<p>Retry upon receiving a 429 status code from the remote-write storage.
-This is experimental feature and might change in the future.</p>
+<p>Retry upon receiving a 429 status code from the remote-write storage.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -14034,7 +14051,8 @@ Duration
 respect to the TSDB max time.</p>
 <p>An out-of-order/out-of-bounds sample is ingested into the TSDB as long as
 the timestamp of the sample is &gt;= (TSDB.MaxTime - outOfOrderTimeWindow).</p>
-<p>Out of order ingestion is an experimental feature.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 <p>It requires Prometheus &gt;= v2.39.0.</p>
 </td>
 </tr>
@@ -14568,7 +14586,11 @@ Kubernetes core/v1.SecretKeySelector
 </em>
 </td>
 <td>
-<p>TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.</p>
+<em>(Optional)</em>
+<p>TracingConfig configures tracing in Thanos.</p>
+<p><code>tracingConfigFile</code> takes precedence over this field.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -14579,8 +14601,11 @@ string
 </em>
 </td>
 <td>
-<p>TracingConfig specifies the path of the tracing configuration file.
-When used alongside with TracingConfig, TracingConfigFile takes precedence.</p>
+<em>(Optional)</em>
+<p>TracingConfig specifies the path of the tracing configuration file.</p>
+<p>This field takes precedence over <code>tracingConfig</code>.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -15067,10 +15092,10 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <em>(Optional)</em>
 <p>Defines the tracing configuration for the Thanos sidecar.</p>
+<p><code>tracingConfigFile</code> takes precedence over this field.</p>
 <p>More info: <a href="https://thanos.io/tip/thanos/tracing.md/">https://thanos.io/tip/thanos/tracing.md/</a></p>
-<p>This is an experimental feature, it may change in any upcoming release
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
 in a breaking way.</p>
-<p>tracingConfigFile takes precedence over this field.</p>
 </td>
 </tr>
 <tr>
@@ -15082,10 +15107,10 @@ string
 </td>
 <td>
 <p>Defines the tracing configuration file for the Thanos sidecar.</p>
+<p>This field takes precedence over <code>tracingConfig</code>.</p>
 <p>More info: <a href="https://thanos.io/tip/thanos/tracing.md/">https://thanos.io/tip/thanos/tracing.md/</a></p>
-<p>This is an experimental feature, it may change in any upcoming release
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
 in a breaking way.</p>
-<p>This field takes precedence over tracingConfig.</p>
 </td>
 </tr>
 <tr>
@@ -16039,9 +16064,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>PodMonitors to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -16077,9 +16101,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Probes to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>Probes to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -16100,7 +16123,7 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Namespaces to match for Probe discovery. An empty label
+<p>Namespaces to match for Probe discovery. An empty label
 selector matches all namespaces. A null label selector matches the
 current namespace only.</p>
 </td>
@@ -16115,9 +16138,9 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> ScrapeConfigs to be selected for target discovery. An
-empty label selector matches all objects. A null label selector matches
-no objects.</p>
+<em>(Optional)</em>
+<p>ScrapeConfigs to be selected for target discovery. An empty label
+selector matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -16126,6 +16149,7 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -16138,9 +16162,11 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
-current namespace only.</p>
+namespace only.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -17083,9 +17109,9 @@ PrometheusTracingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-experimental feature, it may change in any upcoming release in a
-breaking way.</p>
+<p>TracingConfig configures tracing in Prometheus.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -17220,8 +17246,10 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-This is experimental feature and might change in the future.</p>
+<p>List of scrape classes to expose to scraping objects such as
+PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 </table>
@@ -21182,9 +21210,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> PodMonitors to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>PodMonitors to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -21220,9 +21247,8 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Probes to be selected for target discovery. An empty
-label selector matches all objects. A null label selector matches no
-objects.</p>
+<p>Probes to be selected for target discovery. An empty label selector
+matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -21243,7 +21269,7 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> Namespaces to match for Probe discovery. An empty label
+<p>Namespaces to match for Probe discovery. An empty label
 selector matches all namespaces. A null label selector matches the
 current namespace only.</p>
 </td>
@@ -21258,9 +21284,9 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p><em>Experimental</em> ScrapeConfigs to be selected for target discovery. An
-empty label selector matches all objects. A null label selector matches
-no objects.</p>
+<em>(Optional)</em>
+<p>ScrapeConfigs to be selected for target discovery. An empty label
+selector matches all objects. A null label selector matches no objects.</p>
 <p>If <code>spec.serviceMonitorSelector</code>, <code>spec.podMonitorSelector</code>, <code>spec.probeSelector</code>
 and <code>spec.scrapeConfigSelector</code> are null, the Prometheus configuration is unmanaged.
 The Prometheus operator will ensure that the Prometheus configuration&rsquo;s
@@ -21269,6 +21295,7 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -21281,9 +21308,11 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
-current namespace only.</p>
+namespace only.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
 </td>
 </tr>
 <tr>
@@ -22226,9 +22255,9 @@ PrometheusTracingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-experimental feature, it may change in any upcoming release in a
-breaking way.</p>
+<p>TracingConfig configures tracing in Prometheus.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 <tr>
@@ -22363,8 +22392,10 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 </em>
 </td>
 <td>
-<p>EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-This is experimental feature and might change in the future.</p>
+<p>List of scrape classes to expose to scraping objects such as
+PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
+<p>This is an <em>experimental feature</em>, it may change in any upcoming release
+in a breaking way.</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -6890,9 +6890,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               alertmanagerConfiguration:
-                description: 'EXPERIMENTAL: alertmanagerConfiguration specifies the
-                  configuration of Alertmanager. If defined, it takes precedence over
-                  the `configSecret` field. This field may change in future releases.'
+                description: "alertmanagerConfiguration specifies the configuration
+                  of Alertmanager. \n If defined, it takes precedence over the `configSecret`
+                  field. \n This is an *experimental feature*, it may change in any
+                  upcoming release in a breaking way."
                 properties:
                   global:
                     description: Defines the global parameters of the Alertmanager
@@ -19396,17 +19397,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -19465,9 +19466,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -19512,9 +19513,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -19911,9 +19912,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -20281,9 +20283,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -20516,9 +20519,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -20563,17 +20567,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -21891,9 +21896,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values
@@ -28958,17 +28963,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -29027,9 +29032,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -29074,9 +29079,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -29896,9 +29901,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -30392,9 +30398,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -30627,9 +30634,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -30674,17 +30682,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -31793,9 +31802,7 @@ spec:
                 format: int64
                 type: integer
               thanos:
-                description: "Defines the configuration of the optional Thanos sidecar.
-                  \n This section is experimental, it may change significantly without
-                  deprecation notice in any release."
+                description: Defines the configuration of the optional Thanos sidecar.
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments
@@ -32115,10 +32122,10 @@ spec:
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n tracingConfigFile takes precedence
-                      over this field."
+                      sidecar. \n `tracingConfigFile` takes precedence over this field.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -32138,10 +32145,10 @@ spec:
                     x-kubernetes-map-type: atomic
                   tracingConfigFile:
                     description: "Defines the tracing configuration file for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n This field takes precedence over
-                      tracingConfig."
+                      sidecar. \n This field takes precedence over `tracingConfig`.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     type: string
                   version:
                     description: "Version of Thanos being deployed. The operator uses
@@ -32411,9 +32418,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values
@@ -32597,9 +32604,9 @@ spec:
                     description: "Configures how old an out-of-order/out-of-bounds
                       sample can be with respect to the TSDB max time. \n An out-of-order/out-of-bounds
                       sample is ingested into the TSDB as long as the timestamp of
-                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n Out
-                      of order ingestion is an experimental feature. \n It requires
-                      Prometheus >= v2.39.0."
+                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way. \n It requires Prometheus >= v2.39.0."
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
@@ -43474,9 +43481,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: TracingConfig configures tracing in Thanos. This is an
-                  experimental feature, it may change in any upcoming release in a
-                  breaking way.
+                description: "TracingConfig configures tracing in Thanos. \n `tracingConfigFile`
+                  takes precedence over this field. \n This is an *experimental feature*,
+                  it may change in any upcoming release in a breaking way."
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a
@@ -43494,9 +43501,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               tracingConfigFile:
-                description: TracingConfig specifies the path of the tracing configuration
-                  file. When used alongside with TracingConfig, TracingConfigFile
-                  takes precedence.
+                description: "TracingConfig specifies the path of the tracing configuration
+                  file. \n This field takes precedence over `tracingConfig`. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 type: string
               version:
                 description: Version of Thanos to be deployed.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1163,9 +1163,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               alertmanagerConfiguration:
-                description: 'EXPERIMENTAL: alertmanagerConfiguration specifies the
-                  configuration of Alertmanager. If defined, it takes precedence over
-                  the `configSecret` field. This field may change in future releases.'
+                description: "alertmanagerConfiguration specifies the configuration
+                  of Alertmanager. \n If defined, it takes precedence over the `configSecret`
+                  field. \n This is an *experimental feature*, it may change in any
+                  upcoming release in a breaking way."
                 properties:
                   global:
                     description: Defines the global parameters of the Alertmanager

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4401,17 +4401,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4470,9 +4470,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4517,9 +4517,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -4916,9 +4916,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -5286,9 +5287,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -5521,9 +5523,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -5568,17 +5571,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -6896,9 +6900,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -4832,17 +4832,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4901,9 +4901,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4948,9 +4948,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -5770,9 +5770,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -6266,9 +6267,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -6501,9 +6503,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -6548,17 +6551,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -7667,9 +7671,7 @@ spec:
                 format: int64
                 type: integer
               thanos:
-                description: "Defines the configuration of the optional Thanos sidecar.
-                  \n This section is experimental, it may change significantly without
-                  deprecation notice in any release."
+                description: Defines the configuration of the optional Thanos sidecar.
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments
@@ -7989,10 +7991,10 @@ spec:
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n tracingConfigFile takes precedence
-                      over this field."
+                      sidecar. \n `tracingConfigFile` takes precedence over this field.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -8012,10 +8014,10 @@ spec:
                     x-kubernetes-map-type: atomic
                   tracingConfigFile:
                     description: "Defines the tracing configuration file for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n This field takes precedence over
-                      tracingConfig."
+                      sidecar. \n This field takes precedence over `tracingConfig`.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     type: string
                   version:
                     description: "Version of Thanos being deployed. The operator uses
@@ -8285,9 +8287,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values
@@ -8471,9 +8473,9 @@ spec:
                     description: "Configures how old an out-of-order/out-of-bounds
                       sample can be with respect to the TSDB max time. \n An out-of-order/out-of-bounds
                       sample is ingested into the TSDB as long as the timestamp of
-                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n Out
-                      of order ingestion is an experimental feature. \n It requires
-                      Prometheus >= v2.39.0."
+                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way. \n It requires Prometheus >= v2.39.0."
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5429,9 +5429,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: TracingConfig configures tracing in Thanos. This is an
-                  experimental feature, it may change in any upcoming release in a
-                  breaking way.
+                description: "TracingConfig configures tracing in Thanos. \n `tracingConfigFile`
+                  takes precedence over this field. \n This is an *experimental feature*,
+                  it may change in any upcoming release in a breaking way."
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a
@@ -5449,9 +5449,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               tracingConfigFile:
-                description: TracingConfig specifies the path of the tracing configuration
-                  file. When used alongside with TracingConfig, TracingConfigFile
-                  takes precedence.
+                description: "TracingConfig specifies the path of the tracing configuration
+                  file. \n This field takes precedence over `tracingConfig`. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 type: string
               version:
                 description: Version of Thanos to be deployed.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1164,9 +1164,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               alertmanagerConfiguration:
-                description: 'EXPERIMENTAL: alertmanagerConfiguration specifies the
-                  configuration of Alertmanager. If defined, it takes precedence over
-                  the `configSecret` field. This field may change in future releases.'
+                description: "alertmanagerConfiguration specifies the configuration
+                  of Alertmanager. \n If defined, it takes precedence over the `configSecret`
+                  field. \n This is an *experimental feature*, it may change in any
+                  upcoming release in a breaking way."
                 properties:
                   global:
                     description: Defines the global parameters of the Alertmanager

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4402,17 +4402,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4471,9 +4471,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4518,9 +4518,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -4917,9 +4917,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -5287,9 +5288,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -5522,9 +5524,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -5569,17 +5572,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -6897,9 +6901,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -4833,17 +4833,17 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: "*Experimental* PodMonitors to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "PodMonitors to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4902,9 +4902,9 @@ spec:
                 description: Priority class assigned to the Pods.
                 type: string
               probeNamespaceSelector:
-                description: '*Experimental* Namespaces to match for Probe discovery.
-                  An empty label selector matches all namespaces. A null label selector
-                  matches the current namespace only.'
+                description: Namespaces to match for Probe discovery. An empty label
+                  selector matches all namespaces. A null label selector matches the
+                  current namespace only.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -4949,9 +4949,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: "*Experimental* Probes to be selected for target discovery.
-                  An empty label selector matches all objects. A null label selector
-                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                description: "Probes to be selected for target discovery. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
                   `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
                   Prometheus configuration is unmanaged. The Prometheus operator will
                   ensure that the Prometheus configuration's Secret exists, but it
@@ -5771,9 +5771,10 @@ spec:
                             i.e. amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: Retry upon receiving a 429 status code from
-                            the remote-write storage. This is experimental feature
-                            and might change in the future.
+                          description: "Retry upon receiving a 429 status code from
+                            the remote-write storage. \n This is an *experimental
+                            feature*, it may change in any upcoming release in a breaking
+                            way."
                           type: boolean
                         sampleAgeLimit:
                           description: SampleAgeLimit drops samples older than the
@@ -6267,9 +6268,10 @@ spec:
                 format: int64
                 type: integer
               scrapeClasses:
-                description: EXPERIMENTAL List of scrape classes to expose to monitors
-                  and other scrape configs. This is experimental feature and might
-                  change in the future.
+                description: "List of scrape classes to expose to scraping objects
+                  such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+                  \n This is an *experimental feature*, it may change in any upcoming
+                  release in a breaking way."
                 items:
                   properties:
                     default:
@@ -6502,9 +6504,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               scrapeConfigNamespaceSelector:
-                description: Namespaces to match for ScrapeConfig discovery. An empty
+                description: "Namespaces to match for ScrapeConfig discovery. An empty
                   label selector matches all namespaces. A null label selector matches
-                  the current current namespace only.
+                  the current namespace only. \n Note that the ScrapeConfig custom
+                  resource definition is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -6549,17 +6552,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scrapeConfigSelector:
-                description: "*Experimental* ScrapeConfigs to be selected for target
-                  discovery. An empty label selector matches all objects. A null label
-                  selector matches no objects. \n If `spec.serviceMonitorSelector`,
-                  `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector`
-                  are null, the Prometheus configuration is unmanaged. The Prometheus
-                  operator will ensure that the Prometheus configuration's Secret
-                  exists, but it is the responsibility of the user to provide the
-                  raw gzipped Prometheus configuration under the `prometheus.yaml.gz`
-                  key. This behavior is *deprecated* and will be removed in the next
-                  major version of the custom resource definition. It is recommended
-                  to use `spec.additionalScrapeConfigs` instead."
+                description: "ScrapeConfigs to be selected for target discovery. An
+                  empty label selector matches all objects. A null label selector
+                  matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`,
+                  `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the
+                  Prometheus configuration is unmanaged. The Prometheus operator will
+                  ensure that the Prometheus configuration's Secret exists, but it
+                  is the responsibility of the user to provide the raw gzipped Prometheus
+                  configuration under the `prometheus.yaml.gz` key. This behavior
+                  is *deprecated* and will be removed in the next major version of
+                  the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs`
+                  instead. \n Note that the ScrapeConfig custom resource definition
+                  is currently at Alpha level."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -7668,9 +7672,7 @@ spec:
                 format: int64
                 type: integer
               thanos:
-                description: "Defines the configuration of the optional Thanos sidecar.
-                  \n This section is experimental, it may change significantly without
-                  deprecation notice in any release."
+                description: Defines the configuration of the optional Thanos sidecar.
                 properties:
                   additionalArgs:
                     description: AdditionalArgs allows setting additional arguments
@@ -7990,10 +7992,10 @@ spec:
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n tracingConfigFile takes precedence
-                      over this field."
+                      sidecar. \n `tracingConfigFile` takes precedence over this field.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -8013,10 +8015,10 @@ spec:
                     x-kubernetes-map-type: atomic
                   tracingConfigFile:
                     description: "Defines the tracing configuration file for the Thanos
-                      sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/
-                      \n This is an experimental feature, it may change in any upcoming
-                      release in a breaking way. \n This field takes precedence over
-                      tracingConfig."
+                      sidecar. \n This field takes precedence over `tracingConfig`.
+                      \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way."
                     type: string
                   version:
                     description: "Version of Thanos being deployed. The operator uses
@@ -8286,9 +8288,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: 'EXPERIMENTAL: TracingConfig configures tracing in Prometheus.
-                  This is an experimental feature, it may change in any upcoming release
-                  in a breaking way.'
+                description: "TracingConfig configures tracing in Prometheus. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 properties:
                   clientType:
                     description: Client used to export the traces. Supported values
@@ -8472,9 +8474,9 @@ spec:
                     description: "Configures how old an out-of-order/out-of-bounds
                       sample can be with respect to the TSDB max time. \n An out-of-order/out-of-bounds
                       sample is ingested into the TSDB as long as the timestamp of
-                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n Out
-                      of order ingestion is an experimental feature. \n It requires
-                      Prometheus >= v2.39.0."
+                      the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n This
+                      is an *experimental feature*, it may change in any upcoming
+                      release in a breaking way. \n It requires Prometheus >= v2.39.0."
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5430,9 +5430,9 @@ spec:
                   type: object
                 type: array
               tracingConfig:
-                description: TracingConfig configures tracing in Thanos. This is an
-                  experimental feature, it may change in any upcoming release in a
-                  breaking way.
+                description: "TracingConfig configures tracing in Thanos. \n `tracingConfigFile`
+                  takes precedence over this field. \n This is an *experimental feature*,
+                  it may change in any upcoming release in a breaking way."
                 properties:
                   key:
                     description: The key of the secret to select from.  Must be a
@@ -5450,9 +5450,10 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               tracingConfigFile:
-                description: TracingConfig specifies the path of the tracing configuration
-                  file. When used alongside with TracingConfig, TracingConfigFile
-                  takes precedence.
+                description: "TracingConfig specifies the path of the tracing configuration
+                  file. \n This field takes precedence over `tracingConfig`. \n This
+                  is an *experimental feature*, it may change in any upcoming release
+                  in a breaking way."
                 type: string
               version:
                 description: Version of Thanos to be deployed.

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -916,7 +916,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "alertmanagerConfiguration": {
-                    "description": "EXPERIMENTAL: alertmanagerConfiguration specifies the configuration of Alertmanager. If defined, it takes precedence over the `configSecret` field. This field may change in future releases.",
+                    "description": "alertmanagerConfiguration specifies the configuration of Alertmanager. \n If defined, it takes precedence over the `configSecret` field. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "properties": {
                       "global": {
                         "description": "Defines the global parameters of the Alertmanager configuration.",

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3864,7 +3864,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "podMonitorSelector": {
-                    "description": "*Experimental* PodMonitors to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "PodMonitors to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -3923,7 +3923,7 @@
                     "type": "string"
                   },
                   "probeNamespaceSelector": {
-                    "description": "*Experimental* Namespaces to match for Probe discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only.",
+                    "description": "Namespaces to match for Probe discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -3966,7 +3966,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "probeSelector": {
-                    "description": "*Experimental* Probes to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "Probes to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -4366,7 +4366,7 @@
                               "type": "integer"
                             },
                             "retryOnRateLimit": {
-                              "description": "Retry upon receiving a 429 status code from the remote-write storage. This is experimental feature and might change in the future.",
+                              "description": "Retry upon receiving a 429 status code from the remote-write storage. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                               "type": "boolean"
                             },
                             "sampleAgeLimit": {
@@ -4759,7 +4759,7 @@
                     "type": "integer"
                   },
                   "scrapeClasses": {
-                    "description": "EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs. This is experimental feature and might change in the future.",
+                    "description": "List of scrape classes to expose to scraping objects such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "items": {
                       "properties": {
                         "default": {
@@ -5001,7 +5001,7 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "scrapeConfigNamespaceSelector": {
-                    "description": "Namespaces to match for ScrapeConfig discovery. An empty label selector matches all namespaces. A null label selector matches the current current namespace only.",
+                    "description": "Namespaces to match for ScrapeConfig discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only. \n Note that the ScrapeConfig custom resource definition is currently at Alpha level.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5044,7 +5044,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "scrapeConfigSelector": {
-                    "description": "*Experimental* ScrapeConfigs to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "ScrapeConfigs to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead. \n Note that the ScrapeConfig custom resource definition is currently at Alpha level.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5996,7 +5996,7 @@
                     "type": "array"
                   },
                   "tracingConfig": {
-                    "description": "EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+                    "description": "TracingConfig configures tracing in Prometheus. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "properties": {
                       "clientType": {
                         "description": "Client used to export the traces. Supported values are `http` or `grpc`.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4302,7 +4302,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "podMonitorSelector": {
-                    "description": "*Experimental* PodMonitors to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "PodMonitors to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -4361,7 +4361,7 @@
                     "type": "string"
                   },
                   "probeNamespaceSelector": {
-                    "description": "*Experimental* Namespaces to match for Probe discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only.",
+                    "description": "Namespaces to match for Probe discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -4404,7 +4404,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "probeSelector": {
-                    "description": "*Experimental* Probes to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "Probes to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5256,7 +5256,7 @@
                               "type": "integer"
                             },
                             "retryOnRateLimit": {
-                              "description": "Retry upon receiving a 429 status code from the remote-write storage. This is experimental feature and might change in the future.",
+                              "description": "Retry upon receiving a 429 status code from the remote-write storage. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                               "type": "boolean"
                             },
                             "sampleAgeLimit": {
@@ -5769,7 +5769,7 @@
                     "type": "integer"
                   },
                   "scrapeClasses": {
-                    "description": "EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs. This is experimental feature and might change in the future.",
+                    "description": "List of scrape classes to expose to scraping objects such as PodMonitors, ServiceMonitors, Probes and ScrapeConfigs. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "items": {
                       "properties": {
                         "default": {
@@ -6011,7 +6011,7 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "scrapeConfigNamespaceSelector": {
-                    "description": "Namespaces to match for ScrapeConfig discovery. An empty label selector matches all namespaces. A null label selector matches the current current namespace only.",
+                    "description": "Namespaces to match for ScrapeConfig discovery. An empty label selector matches all namespaces. A null label selector matches the current namespace only. \n Note that the ScrapeConfig custom resource definition is currently at Alpha level.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -6054,7 +6054,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "scrapeConfigSelector": {
-                    "description": "*Experimental* ScrapeConfigs to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead.",
+                    "description": "ScrapeConfigs to be selected for target discovery. An empty label selector matches all objects. A null label selector matches no objects. \n If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector` and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged. The Prometheus operator will ensure that the Prometheus configuration's Secret exists, but it is the responsibility of the user to provide the raw gzipped Prometheus configuration under the `prometheus.yaml.gz` key. This behavior is *deprecated* and will be removed in the next major version of the custom resource definition. It is recommended to use `spec.additionalScrapeConfigs` instead. \n Note that the ScrapeConfig custom resource definition is currently at Alpha level.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -6884,7 +6884,7 @@
                     "type": "integer"
                   },
                   "thanos": {
-                    "description": "Defines the configuration of the optional Thanos sidecar. \n This section is experimental, it may change significantly without deprecation notice in any release.",
+                    "description": "Defines the configuration of the optional Thanos sidecar.",
                     "properties": {
                       "additionalArgs": {
                         "description": "AdditionalArgs allows setting additional arguments for the Thanos container. The arguments are passed as-is to the Thanos container which may cause issues if they are invalid or not supported the given Thanos version. In case of an argument conflict (e.g. an argument which is already set by the operator itself) or when providing an invalid argument, the reconciliation will fail and an error will be logged.",
@@ -7215,7 +7215,7 @@
                         "type": "string"
                       },
                       "tracingConfig": {
-                        "description": "Defines the tracing configuration for the Thanos sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This is an experimental feature, it may change in any upcoming release in a breaking way. \n tracingConfigFile takes precedence over this field.",
+                        "description": "Defines the tracing configuration for the Thanos sidecar. \n `tracingConfigFile` takes precedence over this field. \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                         "properties": {
                           "key": {
                             "description": "The key of the secret to select from.  Must be a valid secret key.",
@@ -7237,7 +7237,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "tracingConfigFile": {
-                        "description": "Defines the tracing configuration file for the Thanos sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This is an experimental feature, it may change in any upcoming release in a breaking way. \n This field takes precedence over tracingConfig.",
+                        "description": "Defines the tracing configuration file for the Thanos sidecar. \n This field takes precedence over `tracingConfig`. \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                         "type": "string"
                       },
                       "version": {
@@ -7416,7 +7416,7 @@
                     "type": "array"
                   },
                   "tracingConfig": {
-                    "description": "EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+                    "description": "TracingConfig configures tracing in Prometheus. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "properties": {
                       "clientType": {
                         "description": "Client used to export the traces. Supported values are `http` or `grpc`.",
@@ -7625,7 +7625,7 @@
                     "description": "Defines the runtime reloadable configuration of the timeseries database (TSDB).",
                     "properties": {
                       "outOfOrderTimeWindow": {
-                        "description": "Configures how old an out-of-order/out-of-bounds sample can be with respect to the TSDB max time. \n An out-of-order/out-of-bounds sample is ingested into the TSDB as long as the timestamp of the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n Out of order ingestion is an experimental feature. \n It requires Prometheus >= v2.39.0.",
+                        "description": "Configures how old an out-of-order/out-of-bounds sample can be with respect to the TSDB max time. \n An out-of-order/out-of-bounds sample is ingested into the TSDB as long as the timestamp of the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow). \n This is an *experimental feature*, it may change in any upcoming release in a breaking way. \n It requires Prometheus >= v2.39.0.",
                         "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                         "type": "string"
                       }

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4660,7 +4660,7 @@
                     "type": "array"
                   },
                   "tracingConfig": {
-                    "description": "TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.",
+                    "description": "TracingConfig configures tracing in Thanos. \n `tracingConfigFile` takes precedence over this field. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "properties": {
                       "key": {
                         "description": "The key of the secret to select from.  Must be a valid secret key.",
@@ -4682,7 +4682,7 @@
                     "x-kubernetes-map-type": "atomic"
                   },
                   "tracingConfigFile": {
-                    "description": "TracingConfig specifies the path of the tracing configuration file. When used alongside with TracingConfig, TracingConfigFile takes precedence.",
+                    "description": "TracingConfig specifies the path of the tracing configuration file. \n This field takes precedence over `tracingConfig`. \n This is an *experimental feature*, it may change in any upcoming release in a breaking way.",
                     "type": "string"
                   },
                   "version": {

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -240,9 +240,14 @@ type AlertmanagerSpec struct {
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`
 	// Defines the web command line flags when starting Alertmanager.
 	Web *AlertmanagerWebSpec `json:"web,omitempty"`
-	// EXPERIMENTAL: alertmanagerConfiguration specifies the configuration of Alertmanager.
+	// alertmanagerConfiguration specifies the configuration of Alertmanager.
+	//
 	// If defined, it takes precedence over the `configSecret` field.
-	// This field may change in future releases.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
+	//
+	//+optional
 	AlertmanagerConfiguration *AlertmanagerConfiguration `json:"alertmanagerConfiguration,omitempty"`
 	// AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
 	// If the service account has `automountServiceAccountToken: true`, set the field to `false` to opt out of automounting API credentials.

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -121,9 +121,8 @@ type CommonPrometheusFields struct {
 	// namespace only.
 	ServiceMonitorNamespaceSelector *metav1.LabelSelector `json:"serviceMonitorNamespaceSelector,omitempty"`
 
-	// *Experimental* PodMonitors to be selected for target discovery. An empty
-	// label selector matches all objects. A null label selector matches no
-	// objects.
+	// PodMonitors to be selected for target discovery. An empty label selector
+	// matches all objects. A null label selector matches no objects.
 	//
 	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector`
 	// and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged.
@@ -139,9 +138,8 @@ type CommonPrometheusFields struct {
 	// namespace only.
 	PodMonitorNamespaceSelector *metav1.LabelSelector `json:"podMonitorNamespaceSelector,omitempty"`
 
-	// *Experimental* Probes to be selected for target discovery. An empty
-	// label selector matches all objects. A null label selector matches no
-	// objects.
+	// Probes to be selected for target discovery. An empty label selector
+	// matches all objects. A null label selector matches no objects.
 	//
 	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector`
 	// and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged.
@@ -152,14 +150,13 @@ type CommonPrometheusFields struct {
 	// of the custom resource definition. It is recommended to use
 	// `spec.additionalScrapeConfigs` instead.
 	ProbeSelector *metav1.LabelSelector `json:"probeSelector,omitempty"`
-	// *Experimental* Namespaces to match for Probe discovery. An empty label
+	// Namespaces to match for Probe discovery. An empty label
 	// selector matches all namespaces. A null label selector matches the
 	// current namespace only.
 	ProbeNamespaceSelector *metav1.LabelSelector `json:"probeNamespaceSelector,omitempty"`
 
-	// *Experimental* ScrapeConfigs to be selected for target discovery. An
-	// empty label selector matches all objects. A null label selector matches
-	// no objects.
+	// ScrapeConfigs to be selected for target discovery. An empty label
+	// selector matches all objects. A null label selector matches no objects.
 	//
 	// If `spec.serviceMonitorSelector`, `spec.podMonitorSelector`, `spec.probeSelector`
 	// and `spec.scrapeConfigSelector` are null, the Prometheus configuration is unmanaged.
@@ -169,10 +166,18 @@ type CommonPrometheusFields struct {
 	// This behavior is *deprecated* and will be removed in the next major version
 	// of the custom resource definition. It is recommended to use
 	// `spec.additionalScrapeConfigs` instead.
+	//
+	// Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+	//
+	// +optional
 	ScrapeConfigSelector *metav1.LabelSelector `json:"scrapeConfigSelector,omitempty"`
 	// Namespaces to match for ScrapeConfig discovery. An empty label selector
 	// matches all namespaces. A null label selector matches the current
-	// current namespace only.
+	// namespace only.
+	//
+	// Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+	//
+	// +optional
 	ScrapeConfigNamespaceSelector *metav1.LabelSelector `json:"scrapeConfigNamespaceSelector,omitempty"`
 
 	// Version of Prometheus being deployed. The operator uses this information
@@ -616,9 +621,10 @@ type CommonPrometheusFields struct {
 	// +optional
 	PodTargetLabels []string `json:"podTargetLabels,omitempty"`
 
-	// EXPERIMENTAL: TracingConfig configures tracing in Prometheus. This is an
-	// experimental feature, it may change in any upcoming release in a
-	// breaking way.
+	// TracingConfig configures tracing in Prometheus.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
 	//
 	// +optional
 	TracingConfig *PrometheusTracingConfig `json:"tracingConfig,omitempty"`
@@ -671,8 +677,12 @@ type CommonPrometheusFields struct {
 	// +kubebuilder:validation:Minimum=60
 	MaximumStartupDurationSeconds *int32 `json:"maximumStartupDurationSeconds,omitempty"`
 
-	// EXPERIMENTAL List of scrape classes to expose to monitors and other scrape configs.
-	// This is experimental feature and might change in the future.
+	// List of scrape classes to expose to scraping objects such as
+	// PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
+	//
 	// +listType=map
 	// +listMapKey=name
 	ScrapeClasses []ScrapeClass `json:"scrapeClasses,omitempty"`
@@ -842,8 +852,6 @@ type PrometheusSpec struct {
 
 	// Defines the configuration of the optional Thanos sidecar.
 	//
-	// This section is experimental, it may change significantly without
-	// deprecation notice in any release.
 	// +optional
 	Thanos *ThanosSpec `json:"thanos,omitempty"`
 
@@ -1106,22 +1114,23 @@ type ThanosSpec struct {
 
 	// Defines the tracing configuration for the Thanos sidecar.
 	//
+	// `tracingConfigFile` takes precedence over this field.
+	//
 	// More info: https://thanos.io/tip/thanos/tracing.md/
 	//
-	// This is an experimental feature, it may change in any upcoming release
+	// This is an *experimental feature*, it may change in any upcoming release
 	// in a breaking way.
 	//
-	// tracingConfigFile takes precedence over this field.
 	// +optional
 	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// Defines the tracing configuration file for the Thanos sidecar.
 	//
+	// This field takes precedence over `tracingConfig`.
+	//
 	// More info: https://thanos.io/tip/thanos/tracing.md/
 	//
-	// This is an experimental feature, it may change in any upcoming release
+	// This is an *experimental feature*, it may change in any upcoming release
 	// in a breaking way.
-	//
-	// This field takes precedence over tracingConfig.
 	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
 
 	// Configures the TLS parameters for the gRPC server providing the StoreAPI.
@@ -1320,7 +1329,9 @@ type QueueConfig struct {
 	// +optional
 	MaxBackoff *Duration `json:"maxBackoff,omitempty"`
 	// Retry upon receiving a 429 status code from the remote-write storage.
-	// This is experimental feature and might change in the future.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
 	RetryOnRateLimit bool `json:"retryOnRateLimit,omitempty"`
 	// SampleAgeLimit drops samples older than the limit.
 	// It requires Prometheus >= v2.50.0.
@@ -1705,7 +1716,8 @@ type TSDBSpec struct {
 	// An out-of-order/out-of-bounds sample is ingested into the TSDB as long as
 	// the timestamp of the sample is >= (TSDB.MaxTime - outOfOrderTimeWindow).
 	//
-	// Out of order ingestion is an experimental feature.
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
 	//
 	// It requires Prometheus >= v2.39.0.
 	OutOfOrderTimeWindow Duration `json:"outOfOrderTimeWindow,omitempty"`

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -197,10 +197,23 @@ type ThanosRulerSpec struct {
 	// of what the maintainers will support and by doing so, you accept that this behaviour may break
 	// at any time without notice.
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
-	// TracingConfig configures tracing in Thanos. This is an experimental feature, it may change in any upcoming release in a breaking way.
+	// TracingConfig configures tracing in Thanos.
+	//
+	// `tracingConfigFile` takes precedence over this field.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
+	//
+	//+optional
 	TracingConfig *v1.SecretKeySelector `json:"tracingConfig,omitempty"`
 	// TracingConfig specifies the path of the tracing configuration file.
-	// When used alongside with TracingConfig, TracingConfigFile takes precedence.
+	//
+	// This field takes precedence over `tracingConfig`.
+	//
+	// This is an *experimental feature*, it may change in any upcoming release
+	// in a breaking way.
+	//
+	//+optional
 	TracingConfigFile string `json:"tracingConfigFile,omitempty"`
 	// Labels configure the external label pairs to ThanosRuler. A default replica label
 	// `thanos_ruler_replica` will be always added  as a label with the value of the pod's name and it will be dropped in the alerts.


### PR DESCRIPTION
## Description

These 3 features have been there for so long that we agreed to remove the experimental warning on them.

This commit also makes the wording more consistent for all fields which are still considered experimental (either from the operator standpoint or from Prometheus standpoint).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Declare PodMonitor, Probe and Thanos sidecar as officially supported.
```
