### PR TITLE
Fix: Empty replacement is not possible when Action is Replace

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -12371,6 +12371,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Replacement value against which a Replace action is performed if the
 regular expression matches.</p>
 <p>Regex capture groups are available.</p>

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1536,6 +1536,8 @@ type RelabelConfig struct {
 	// regular expression matches.
 	//
 	// Regex capture groups are available.
+	//
+	//+optional
 	Replacement *string `json:"replacement,omitempty"`
 
 	// Action to perform based on the regex matching.

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1536,7 +1536,7 @@ type RelabelConfig struct {
 	// regular expression matches.
 	//
 	// Regex capture groups are available.
-	Replacement string `json:"replacement,omitempty"`
+	Replacement *string `json:"replacement,omitempty"`
 
 	// Action to perform based on the regex matching.
 	//

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2328,6 +2328,11 @@ func (in *RelabelConfig) DeepCopyInto(out *RelabelConfig) {
 		*out = make([]LabelName, len(*in))
 		copy(*out, *in)
 	}
+	if in.Replacement != nil {
+		in, out := &in.Replacement, &out.Replacement
+		*out = new(string)
+		**out = **in
+	}
 	if in.Separator != nil {
 		in, out := &in.Separator, &out.Separator
 		*out = new(string)

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2328,13 +2328,13 @@ func (in *RelabelConfig) DeepCopyInto(out *RelabelConfig) {
 		*out = make([]LabelName, len(*in))
 		copy(*out, *in)
 	}
-	if in.Replacement != nil {
-		in, out := &in.Replacement, &out.Replacement
+	if in.Separator != nil {
+		in, out := &in.Separator, &out.Separator
 		*out = new(string)
 		**out = **in
 	}
-	if in.Separator != nil {
-		in, out := &in.Separator, &out.Separator
+	if in.Replacement != nil {
+		in, out := &in.Replacement, &out.Replacement
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/namespacelabeler/labeler.go
+++ b/pkg/namespacelabeler/labeler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -141,13 +142,12 @@ func (l *Labeler) GetRelabelingConfigs(monitorTypeMeta metav1.TypeMeta, monitorO
 		return rc
 	}
 
-	namespace := monitorObjectMeta.GetNamespace()
 	// Because of security risks, whenever enforcedNamespaceLabel is set, we want to append it to the
 	// relabel configurations as the last relabeling, to ensure it overrides any other relabelings.
 	return append(rc,
 		&monitoringv1.RelabelConfig{
 			TargetLabel: l.GetEnforcedNamespaceLabel(),
-			Replacement: &namespace,
+			Replacement: ptr.To(monitorObjectMeta.GetNamespace()),
 		},
 	)
 }

--- a/pkg/namespacelabeler/labeler.go
+++ b/pkg/namespacelabeler/labeler.go
@@ -141,12 +141,13 @@ func (l *Labeler) GetRelabelingConfigs(monitorTypeMeta metav1.TypeMeta, monitorO
 		return rc
 	}
 
+	namespace := monitorObjectMeta.GetNamespace()
 	// Because of security risks, whenever enforcedNamespaceLabel is set, we want to append it to the
 	// relabel configurations as the last relabeling, to ensure it overrides any other relabelings.
 	return append(rc,
 		&monitoringv1.RelabelConfig{
 			TargetLabel: l.GetEnforcedNamespaceLabel(),
-			Replacement: monitorObjectMeta.GetNamespace(),
+			Replacement: &namespace,
 		},
 	)
 }

--- a/pkg/namespacelabeler/labeler_test.go
+++ b/pkg/namespacelabeler/labeler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -295,13 +296,13 @@ func TestEnforceNamespaceLabelOnPrometheusMonitors(t *testing.T) {
 				MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
 					{
 						TargetLabel: "namespace",
-						Replacement: "bar",
+						Replacement: ptr.To("bar"),
 					},
 				},
 				RelabelConfigs: []*monitoringv1.RelabelConfig{
 					{
 						TargetLabel: "namespace",
-						Replacement: "bar",
+						Replacement: ptr.To("bar"),
 					},
 				},
 			}),

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1668,8 +1668,8 @@ func generateRelabelConfig(rc []*monitoringv1.RelabelConfig) []yaml.MapSlice {
 			relabeling = append(relabeling, yaml.MapItem{Key: "modulus", Value: c.Modulus})
 		}
 
-		if c.Replacement != "" {
-			relabeling = append(relabeling, yaml.MapItem{Key: "replacement", Value: c.Replacement})
+		if c.Replacement != nil {
+			relabeling = append(relabeling, yaml.MapItem{Key: "replacement", Value: *c.Replacement})
 		}
 
 		if c.Action != "" {
@@ -2056,8 +2056,8 @@ func (cg *ConfigGenerator) generateRemoteWriteConfig(
 					relabeling = append(relabeling, yaml.MapItem{Key: "modulus", Value: c.Modulus})
 				}
 
-				if c.Replacement != "" {
-					relabeling = append(relabeling, yaml.MapItem{Key: "replacement", Value: c.Replacement})
+				if c.Replacement != nil {
+					relabeling = append(relabeling, yaml.MapItem{Key: "replacement", Value: *c.Replacement})
 				}
 
 				if c.Action != "" {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5018,6 +5018,12 @@ func TestGenerateRelabelConfig(t *testing.T) {
 									Regex:        "container_fs*",
 									SourceLabels: []monitoringv1.LabelName{"__name__"},
 								},
+								{
+                                    // Test empty replacement
+									Action:      "Replace",
+									Replacement: ptr.To(""),
+									TargetLabel: "job",
+								},
 							},
 							RelabelConfigs: []*monitoringv1.RelabelConfig{
 								{
@@ -5035,6 +5041,12 @@ func TestGenerateRelabelConfig(t *testing.T) {
 								{
 									Action:      "Replace",
 									Replacement: ptr.To("crio"),
+									TargetLabel: "job",
+								},
+								{
+                                    // Test empty replacement
+									Action:      "Replace",
+									Replacement: ptr.To(""),
 									TargetLabel: "job",
 								},
 							},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5101,7 +5101,7 @@ func TestProbeSpecConfig(t *testing.T) {
 							{
 								TargetLabel: "foo",
 								Replacement: ptr.To("bar"),
-								Action: "replace",
+								Action:      "replace",
 							},
 						},
 					},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -664,7 +664,7 @@ func TestProbeIngressSDConfigGeneration(t *testing.T) {
 							RelabelConfigs: []*monitoringv1.RelabelConfig{
 								{
 									TargetLabel: "foo",
-									Replacement: "bar",
+									Replacement: ptr.To("bar"),
 									Action:      "replace",
 								},
 							},
@@ -730,7 +730,7 @@ func TestProbeIngressSDConfigGenerationWithShards(t *testing.T) {
 							RelabelConfigs: []*monitoringv1.RelabelConfig{
 								{
 									TargetLabel: "foo",
-									Replacement: "bar",
+									Replacement: ptr.To("bar"),
 									Action:      "replace",
 								},
 							},
@@ -795,7 +795,7 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 							RelabelConfigs: []*monitoringv1.RelabelConfig{
 								{
 									TargetLabel: "foo",
-									Replacement: "bar",
+									Replacement: ptr.To("bar"),
 									Action:      "replace",
 								},
 							},
@@ -1380,13 +1380,13 @@ func TestNoEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.+)(?::d+)",
-									Replacement:  "$1:9537",
+									Replacement:  ptr.To("$1:9537"),
 									SourceLabels: []monitoringv1.LabelName{"__address__"},
 									TargetLabel:  "__address__",
 								},
 								{
 									Action:      "replace",
-									Replacement: "crio",
+									Replacement: ptr.To("crio"),
 									TargetLabel: "job",
 								},
 							},
@@ -1458,7 +1458,7 @@ func TestServiceMonitorWithEndpointSliceEnable(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.*)",
-									Replacement:  "$1",
+									Replacement:  ptr.To("$1"),
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 								},
 							},
@@ -1522,7 +1522,7 @@ func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.*)",
-									Replacement:  "$1",
+									Replacement:  ptr.To("$1"),
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 								},
 							},
@@ -1596,7 +1596,7 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.*)",
-									Replacement:  "$1",
+									Replacement:  ptr.To("$1"),
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 								},
 							},
@@ -1666,7 +1666,7 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.*)",
-									Replacement:  "$1",
+									Replacement:  ptr.To("$1"),
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 								},
 							},
@@ -1744,7 +1744,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 								{
 									Action:       "replace",
 									Regex:        "(.*)",
-									Replacement:  "$1",
+									Replacement:  ptr.To("$1"),
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 								},
 							},
@@ -2864,14 +2864,14 @@ func makeServiceMonitors() map[string]*monitoringv1.ServiceMonitor {
 						{
 							Action:       "replace",
 							Regex:        "(.*)",
-							Replacement:  "$1",
+							Replacement:  ptr.To("$1"),
 							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 							TargetLabel:  "pod_ready",
 						},
 						{
 							Action:       "replace",
 							Regex:        "(.*)",
-							Replacement:  "$1",
+							Replacement:  ptr.To("$1"),
 							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_node_name"},
 							TargetLabel:  "nodename",
 						},
@@ -3019,14 +3019,14 @@ func makePodMonitors() map[string]*monitoringv1.PodMonitor {
 						{
 							Action:       "replace",
 							Regex:        "(.*)",
-							Replacement:  "$1",
+							Replacement:  ptr.To("$1"),
 							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_ready"},
 							TargetLabel:  "pod_ready",
 						},
 						{
 							Action:       "replace",
 							Regex:        "(.*)",
-							Replacement:  "$1",
+							Replacement:  ptr.To("$1"),
 							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_node_name"},
 							TargetLabel:  "nodename",
 						},
@@ -5028,13 +5028,13 @@ func TestGenerateRelabelConfig(t *testing.T) {
 								{
 									Action:       "Replace",
 									Regex:        "(.+)(?::d+)",
-									Replacement:  "$1:9537",
+									Replacement:  ptr.To("$1:9537"),
 									SourceLabels: []monitoringv1.LabelName{"__address__"},
 									TargetLabel:  "__address__",
 								},
 								{
 									Action:      "Replace",
-									Replacement: "crio",
+									Replacement: ptr.To("crio"),
 									TargetLabel: "job",
 								},
 							},
@@ -5100,8 +5100,8 @@ func TestProbeSpecConfig(t *testing.T) {
 						RelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								TargetLabel: "foo",
-								Replacement: "bar",
-								Action:      "replace",
+								Replacement: ptr.To("bar"),
+								Action: "replace",
 							},
 						},
 					},
@@ -5295,7 +5295,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					{
 						Action:       "Replace",
 						Regex:        "(.+)(?::d+)",
-						Replacement:  "$1:9537",
+						Replacement:  ptr.To("$1:9537"),
 						SourceLabels: []monitoringv1.LabelName{"__address__"},
 						TargetLabel:  "__address__",
 					},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5019,7 +5019,7 @@ func TestGenerateRelabelConfig(t *testing.T) {
 									SourceLabels: []monitoringv1.LabelName{"__name__"},
 								},
 								{
-                                    // Test empty replacement
+									// Test empty replacement
 									Action:      "Replace",
 									Replacement: ptr.To(""),
 									TargetLabel: "job",
@@ -5044,7 +5044,7 @@ func TestGenerateRelabelConfig(t *testing.T) {
 									TargetLabel: "job",
 								},
 								{
-                                    // Test empty replacement
+									// Test empty replacement
 									Action:      "Replace",
 									Replacement: ptr.To(""),
 									TargetLabel: "job",
@@ -5113,6 +5113,12 @@ func TestProbeSpecConfig(t *testing.T) {
 							{
 								TargetLabel: "foo",
 								Replacement: ptr.To("bar"),
+								Action:      "replace",
+							},
+							// Empty replacement case
+							{
+								TargetLabel: "foobar",
+								Replacement: ptr.To(""),
 								Action:      "replace",
 							},
 						},

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -301,13 +301,13 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
 
-	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement || rc.Replacement == nil) {
+	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !(rc.Replacement == nil || *rc.Replacement == relabel.DefaultRelabelConfig.Replacement) {
 		return fmt.Errorf("'replacement' can not be set for %s action", rc.Action)
 	}
 
 	if action == string(relabel.LabelMap) {
 		if rc.Replacement != nil && !relabelTarget.MatchString(*rc.Replacement) {
-			return fmt.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
+			return fmt.Errorf("%q is invalid 'replacement' for %s action", *rc.Replacement, rc.Action)
 		}
 	}
 
@@ -321,8 +321,7 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
 			!(rc.Separator == nil ||
 				*rc.Separator == relabel.DefaultRelabelConfig.Separator) ||
-			!(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
-				rc.Replacement == nil) {
+			!(rc.Replacement == nil || *rc.Replacement == relabel.DefaultRelabelConfig.Replacement) {
 			return fmt.Errorf("%s action requires only 'source_labels' and `target_label`, and no other fields", rc.Action)
 		}
 	}
@@ -335,8 +334,8 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
 			!(rc.Separator == nil ||
 				*rc.Separator == relabel.DefaultRelabelConfig.Separator) ||
-			!(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
-				rc.Replacement == nil) {
+			!(rc.Replacement == nil ||
+				*rc.Replacement == relabel.DefaultRelabelConfig.Replacement) {
 			return fmt.Errorf("%s action requires only 'regex', and no other fields", rc.Action)
 		}
 	}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -301,12 +301,12 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
 	}
 
-	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !(rc.Replacement == relabel.DefaultRelabelConfig.Replacement || rc.Replacement == "") {
+	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement || rc.Replacement == nil) {
 		return fmt.Errorf("'replacement' can not be set for %s action", rc.Action)
 	}
 
 	if action == string(relabel.LabelMap) {
-		if rc.Replacement != "" && !relabelTarget.MatchString(rc.Replacement) {
+		if rc.Replacement != nil && !relabelTarget.MatchString(*rc.Replacement) {
 			return fmt.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
 		}
 	}
@@ -321,8 +321,8 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
 			!(rc.Separator == nil ||
 				*rc.Separator == relabel.DefaultRelabelConfig.Separator) ||
-			!(rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
-				rc.Replacement == "") {
+			!(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
+				rc.Replacement == nil) {
 			return fmt.Errorf("%s action requires only 'source_labels' and `target_label`, and no other fields", rc.Action)
 		}
 	}
@@ -335,8 +335,8 @@ func validateRelabelConfig(p monitoringv1.PrometheusInterface, rc monitoringv1.R
 				rc.Modulus == relabel.DefaultRelabelConfig.Modulus) ||
 			!(rc.Separator == nil ||
 				*rc.Separator == relabel.DefaultRelabelConfig.Separator) ||
-			!(rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
-				rc.Replacement == "") {
+			!(*rc.Replacement == relabel.DefaultRelabelConfig.Replacement ||
+				rc.Replacement == nil) {
 			return fmt.Errorf("%s action requires only 'regex', and no other fields", rc.Action)
 		}
 	}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -135,7 +135,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			scenario: "replacement set for uppercase action",
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "uppercase",
-				Replacement: "some-replace-value",
+				Replacement: ptr.To("some-replace-value"),
 			},
 			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
@@ -158,7 +158,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "labelmap",
 				Regex:       "__meta_kubernetes_service_label_(.+)",
-				Replacement: "some-name-value",
+				Replacement: ptr.To("some-name-value"),
 			},
 			prometheus:  defaultPrometheusSpec,
 			expectedErr: true,
@@ -178,7 +178,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 			relabelConfig: monitoringv1.RelabelConfig{
 				Action:      "labelmap",
 				Regex:       "__meta_kubernetes_service_label_(.+)",
-				Replacement: "${2}",
+				Replacement: ptr.To("${2}"),
 			},
 			prometheus: defaultPrometheusSpec,
 		},
@@ -210,6 +210,17 @@ func TestValidateRelabelConfig(t *testing.T) {
 			},
 			prometheus: defaultPrometheusSpec,
 		},
+		// Test valid relabel config with empty replacement
+		{
+			scenario: "valid replace config with empty replacement",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "replace",
+				TargetLabel: "dummyTarget",
+				Regex:       "replica",
+				Replacement: ptr.To(""),
+			},
+			prometheus: defaultPrometheusSpec,
+		},
 		{
 			scenario: "valid labeldrop config with default values",
 			relabelConfig: monitoringv1.RelabelConfig{
@@ -218,7 +229,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				TargetLabel:  relabel.DefaultRelabelConfig.TargetLabel,
 				Regex:        defaultRegex,
 				Modulus:      relabel.DefaultRelabelConfig.Modulus,
-				Replacement:  relabel.DefaultRelabelConfig.Replacement,
+				Replacement:  &relabel.DefaultRelabelConfig.Replacement,
 				Action:       "labeldrop",
 			},
 			prometheus: defaultPrometheusSpec,
@@ -241,7 +252,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				SourceLabels: []monitoringv1.LabelName{"__address__"},
 				Action:       "replace",
 				Regex:        "([^:]+)(?::\\d+)?",
-				Replacement:  "$1:80",
+				Replacement:  ptr.To("$1:80"),
 				TargetLabel:  "__address__",
 			},
 			prometheus: defaultPrometheusSpec,
@@ -374,7 +385,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				TargetLabel:  "__port1",
 				Separator:    ptr.To("^"),
 				Regex:        "validregex",
-				Replacement:  "replacevalue",
+				Replacement:  ptr.To("replacevalue"),
 				Action:       "keepequal",
 			},
 			prometheus: monitoringv1.Prometheus{
@@ -395,7 +406,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Separator:    ptr.To(relabel.DefaultRelabelConfig.Separator),
 				Regex:        relabel.DefaultRelabelConfig.Regex.String(),
 				Modulus:      relabel.DefaultRelabelConfig.Modulus,
-				Replacement:  relabel.DefaultRelabelConfig.Replacement,
+				Replacement:  &relabel.DefaultRelabelConfig.Replacement,
 				Action:       "keepequal",
 			},
 			prometheus: monitoringv1.Prometheus{

--- a/pkg/prometheus/testdata/GenerateRelabelConfig.golden
+++ b/pkg/prometheus/testdata/GenerateRelabelConfig.golden
@@ -75,6 +75,9 @@ scrape_configs:
   - target_label: job
     replacement: crio
     action: replace
+  - target_label: job
+    replacement: ""
+    action: replace
   - source_labels:
     - __address__
     target_label: __tmp_hash
@@ -89,3 +92,6 @@ scrape_configs:
     - __name__
     regex: container_fs*
     action: drop
+  - target_label: job
+    replacement: ""
+    action: replace

--- a/pkg/prometheus/testdata/ProbeSpecConfig_targets_static_config.golden
+++ b/pkg/prometheus/testdata/ProbeSpecConfig_targets_static_config.golden
@@ -30,6 +30,9 @@ scrape_configs:
   - target_label: foo
     replacement: bar
     action: replace
+  - target_label: foobar
+    replacement: ""
+    action: replace
   - source_labels:
     - __param_target
     target_label: __tmp_hash

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -4071,6 +4071,21 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 			},
 		},
 		{
+			// override label using the replace action with empty replacement.
+			relabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "namespace",
+					Replacement: ptr.To(""),
+				},
+			},
+			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "namespace",
+					Replacement: ptr.To(""),
+				},
+			},
+		},
+		{
 			// override label using the labelmap action.
 			relabelConfigs: []*monitoringv1.RelabelConfig{
 				{

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -4060,13 +4060,13 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 			relabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 		},
@@ -4075,14 +4075,14 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 			relabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "temp_namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					Action:      "labelmap",
 					Regex:       "temp_namespace",
-					Replacement: "namespace",
+					Replacement: ptr.To("namespace"),
 				},
 				{
 					Action: "labeldrop",
@@ -4203,13 +4203,13 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 			relabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 			expectedNamespace: "ns1",
@@ -4219,14 +4219,14 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 			relabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					TargetLabel: "temp_namespace",
-					Replacement: "ns1",
+					Replacement: ptr.To("ns1"),
 				},
 			},
 			metricRelabelConfigs: []*monitoringv1.RelabelConfig{
 				{
 					Action:      "labelmap",
 					Regex:       "temp_namespace",
-					Replacement: "namespace",
+					Replacement: ptr.To("namespace"),
 				},
 				{
 					Action: "labeldrop",
@@ -4647,7 +4647,7 @@ func testRelabelConfigCRDValidation(t *testing.T) {
 					SourceLabels: []monitoringv1.LabelName{"__address__"},
 					Action:       "replace",
 					Regex:        "([^:]+)(?::\\d+)?",
-					Replacement:  "$1:80",
+					Replacement:  ptr.To("$1:80"),
 					TargetLabel:  "__address__",
 				},
 			},
@@ -4659,7 +4659,7 @@ func testRelabelConfigCRDValidation(t *testing.T) {
 					SourceLabels: []monitoringv1.LabelName{"__address__"},
 					Separator:    ptr.To(","),
 					Regex:        "([^:]+)(?::\\d+)?",
-					Replacement:  "$1:80",
+					Replacement:  ptr.To("$1:80"),
 					TargetLabel:  "__address__",
 				},
 			},


### PR DESCRIPTION
## Description
Replacement field with `""` value was omitted in the generated config earlier. This bug was fixed by checking for a nil value of its pointer, rather than the string value.

Closes #6443 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
