### PR TITLE
fix: add proxyURL validation for smon,pmon and probe

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -186,6 +186,11 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				rejectFn(sm, fmt.Errorf("metricRelabelConfigs: %w", err))
 				break
 			}
+
+			if err = validateProxyURL(endpoint.ProxyURL); err != nil {
+				rejectFn(sm, fmt.Errorf("proxyURL: %w", err))
+				break
+			}
 		}
 
 		if err != nil {
@@ -463,6 +468,11 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				rejectFn(pm, fmt.Errorf("metricRelabelConfigs: %w", err))
 				break
 			}
+
+			if err = validateProxyURL(endpoint.ProxyURL); err != nil {
+				rejectFn(pm, fmt.Errorf("proxyURL: %w", err))
+				break
+			}
 		}
 
 		if err != nil {
@@ -620,6 +630,11 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 			}
 		}
 
+		if err = validateProxyURL(&probe.Spec.ProberSpec.ProxyURL); err != nil {
+			rejectFn(probe, fmt.Errorf("proxyURL: %w", err))
+			continue
+		}
+
 		if err = validateProberURL(probe.Spec.ProberSpec.URL); err != nil {
 			err := fmt.Errorf("%s url specified in proberSpec is invalid, it should be of the format `hostname` or `hostname:port`: %w", probe.Spec.ProberSpec.URL, err)
 			rejectFn(probe, err)
@@ -641,6 +656,15 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 	}
 
 	return res, nil
+}
+
+func validateProxyURL(proxyurl *string) error {
+	if proxyurl == nil {
+		return nil
+	}
+
+	_, err := url.Parse(*proxyurl)
+	return err
 }
 
 func validateProberURL(url string) error {

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -490,6 +490,20 @@ func TestSelectProbes(t *testing.T) {
 			selected: true,
 		},
 		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.ProxyURL = "http://xxx-${dev}.svc.cluster.local:80"
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.ProxyURL = "123-proxy.example.com"
+			},
+			selected: true,
+		},
+		{
 			scenario: "valid metric relabeling config",
 			updateSpec: func(ps *monitoringv1.ProbeSpec) {
 				ps.MetricRelabelConfigs = []*monitoringv1.RelabelConfig{
@@ -991,6 +1005,24 @@ func TestSelectServiceMonitors(t *testing.T) {
 			selected: false,
 		},
 		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					ProxyURL: ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					ProxyURL: ptr.To("http://proxy.svc.cluster.local:80"),
+				})
+			},
+			selected: true,
+		},
+		{
 			scenario:    "inexistent Scrape Class",
 			scrapeClass: ptr.To("inexistent"),
 			updateSpec: func(_ *monitoringv1.ServiceMonitorSpec) {
@@ -1169,6 +1201,24 @@ func TestSelectPodMonitors(t *testing.T) {
 				})
 			},
 			selected: false,
+		},
+		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					ProxyURL: ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					ProxyURL: ptr.To("http://proxy.svc.cluster.local:80"),
+				})
+			},
+			selected: true,
 		},
 		{
 			scenario:    "Inexistent Scrape Class",


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

If a user specify a non-parsable proxyUrl it was not validated/rejected but will break reloading and restarting of Prometheus due to possible invalid syntax. This commit adds validation and rejects the invalid ones

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix: add proxyURL validation for servicemonitor, podmonitor and probe
```
