### PR TITLE
change: define enableFeatures list as a set

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1868,10 +1868,13 @@ For more information see <a href="https://prometheus.io/docs/prometheus/latest/q
 <td>
 <code>enableFeatures</code><br/>
 <em>
-[]string
+<a href="#monitoring.coreos.com/v1.EnableFeature">
+[]EnableFeature
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Enable access to Prometheus feature flags. By default, no features are enabled.</p>
 <p>Enabling features which are disabled by default is entirely outside the
 scope of what the maintainers will support and by doing so, you accept
@@ -6388,10 +6391,13 @@ For more information see <a href="https://prometheus.io/docs/prometheus/latest/q
 <td>
 <code>enableFeatures</code><br/>
 <em>
-[]string
+<a href="#monitoring.coreos.com/v1.EnableFeature">
+[]EnableFeature
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Enable access to Prometheus feature flags. By default, no features are enabled.</p>
 <p>Enabling features which are disabled by default is entirely outside the
 scope of what the maintainers will support and by doing so, you accept
@@ -7892,6 +7898,13 @@ Kubernetes core/v1.PersistentVolumeClaimStatus
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1.EnableFeature">EnableFeature
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+</p>
+<div>
+</div>
 <h3 id="monitoring.coreos.com/v1.Endpoint">Endpoint
 </h3>
 <p>
@@ -10488,10 +10501,13 @@ For more information see <a href="https://prometheus.io/docs/prometheus/latest/q
 <td>
 <code>enableFeatures</code><br/>
 <em>
-[]string
+<a href="#monitoring.coreos.com/v1.EnableFeature">
+[]EnableFeature
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Enable access to Prometheus feature flags. By default, no features are enabled.</p>
 <p>Enabling features which are disabled by default is entirely outside the
 scope of what the maintainers will support and by doing so, you accept
@@ -16411,10 +16427,13 @@ For more information see <a href="https://prometheus.io/docs/prometheus/latest/q
 <td>
 <code>enableFeatures</code><br/>
 <em>
-[]string
+<a href="#monitoring.coreos.com/v1.EnableFeature">
+[]EnableFeature
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Enable access to Prometheus feature flags. By default, no features are enabled.</p>
 <p>Enabling features which are disabled by default is entirely outside the
 scope of what the maintainers will support and by doing so, you accept
@@ -22466,10 +22485,13 @@ For more information see <a href="https://prometheus.io/docs/prometheus/latest/q
 <td>
 <code>enableFeatures</code><br/>
 <em>
-[]string
+<a href="#monitoring.coreos.com/v1.EnableFeature">
+[]EnableFeature
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Enable access to Prometheus feature flags. By default, no features are enabled.</p>
 <p>Enabling features which are disabled by default is entirely outside the
 scope of what the maintainers will support and by doing so, you accept

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -17684,8 +17684,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient
@@ -27231,8 +27233,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -2688,8 +2688,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3100,8 +3100,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -2689,8 +2689,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3101,8 +3101,10 @@ spec:
                   will support and by doing so, you accept that this behaviour may
                   break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/"
                 items:
+                  minLength: 1
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               enableRemoteWriteReceiver:
                 description: "Enable Prometheus to be used as a receiver for the Prometheus
                   remote write protocol. \n WARNING: This is not considered an efficient

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -2336,9 +2336,11 @@
                   "enableFeatures": {
                     "description": "Enable access to Prometheus feature flags. By default, no features are enabled. \n Enabling features which are disabled by default is entirely outside the scope of what the maintainers will support and by doing so, you accept that this behaviour may break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/",
                     "items": {
+                      "minLength": 1,
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
                   },
                   "enableRemoteWriteReceiver": {
                     "description": "Enable Prometheus to be used as a receiver for the Prometheus remote write protocol. \n WARNING: This is not considered an efficient way of ingesting samples. Use it with caution for specific low-volume use cases. It is not suitable for replacing the ingestion via scraping and turning Prometheus into a push-based metrics collection system. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#remote-write-receiver \n It requires Prometheus >= v2.33.0.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -2757,9 +2757,11 @@
                   "enableFeatures": {
                     "description": "Enable access to Prometheus feature flags. By default, no features are enabled. \n Enabling features which are disabled by default is entirely outside the scope of what the maintainers will support and by doing so, you accept that this behaviour may break at any time without notice. \n For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/",
                     "items": {
+                      "minLength": 1,
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
                   },
                   "enableRemoteWriteReceiver": {
                     "description": "Enable Prometheus to be used as a receiver for the Prometheus remote write protocol. \n WARNING: This is not considered an efficient way of ingesting samples. Use it with caution for specific low-volume use cases. It is not suitable for replacing the ingestion via scraping and turning Prometheus into a push-based metrics collection system. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#remote-write-receiver \n It requires Prometheus >= v2.33.0.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -88,6 +88,9 @@ type TopologySpreadConstraint struct {
 	AdditionalLabelSelectors *AdditionalLabelSelectors `json:"additionalLabelSelectors,omitempty"`
 }
 
+// +kubebuilder:validation:MinLength:=1
+type EnableFeature string
+
 // CommonPrometheusFields are the options available to both the Prometheus server and agent.
 // +k8s:deepcopy-gen=true
 type CommonPrometheusFields struct {
@@ -302,7 +305,10 @@ type CommonPrometheusFields struct {
 	// that this behaviour may break at any time without notice.
 	//
 	// For more information see https://prometheus.io/docs/prometheus/latest/feature_flags/
-	EnableFeatures []string `json:"enableFeatures,omitempty"`
+	//
+	// +listType:=set
+	// +optional
+	EnableFeatures []EnableFeature `json:"enableFeatures,omitempty"`
 
 	// The external URL under which the Prometheus service is externally
 	// available. This is necessary to generate correct URLs (for instance if

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -700,7 +700,7 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 	}
 	if in.EnableFeatures != nil {
 		in, out := &in.EnableFeatures, &out.EnableFeatures
-		*out = make([]string, len(*in))
+		*out = make([]EnableFeature, len(*in))
 		copy(*out, *in)
 	}
 	if in.Storage != nil {

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -51,7 +51,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	ScrapeProtocols                      []monitoringv1.ScrapeProtocol                           `json:"scrapeProtocols,omitempty"`
 	ExternalLabels                       map[string]string                                       `json:"externalLabels,omitempty"`
 	EnableRemoteWriteReceiver            *bool                                                   `json:"enableRemoteWriteReceiver,omitempty"`
-	EnableFeatures                       []string                                                `json:"enableFeatures,omitempty"`
+	EnableFeatures                       []monitoringv1.EnableFeature                            `json:"enableFeatures,omitempty"`
 	ExternalURL                          *string                                                 `json:"externalUrl,omitempty"`
 	RoutePrefix                          *string                                                 `json:"routePrefix,omitempty"`
 	Storage                              *StorageSpecApplyConfiguration                          `json:"storage,omitempty"`
@@ -327,7 +327,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnableRemoteWriteReceiver
 // WithEnableFeatures adds the given value to the EnableFeatures field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnableFeatures field.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnableFeatures(values ...string) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnableFeatures(values ...monitoringv1.EnableFeature) *CommonPrometheusFieldsApplyConfiguration {
 	for i := range values {
 		b.EnableFeatures = append(b.EnableFeatures, values[i])
 	}

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -270,7 +270,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnableRemoteWriteReceiver(value b
 // WithEnableFeatures adds the given value to the EnableFeatures field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnableFeatures field.
-func (b *PrometheusSpecApplyConfiguration) WithEnableFeatures(values ...string) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnableFeatures(values ...monitoringv1.EnableFeature) *PrometheusSpecApplyConfiguration {
 	for i := range values {
 		b.EnableFeatures = append(b.EnableFeatures, values[i])
 	}

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -249,7 +249,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnableRemoteWriteReceiver(va
 // WithEnableFeatures adds the given value to the EnableFeatures field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnableFeatures field.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnableFeatures(values ...string) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnableFeatures(values ...monitoringv1.EnableFeature) *PrometheusAgentSpecApplyConfiguration {
 	for i := range values {
 		b.EnableFeatures = append(b.EnableFeatures, values[i])
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -1888,7 +1888,7 @@ func TestEnableFeaturesWithOneFeature(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				EnableFeatures: []string{"exemplar-storage"},
+				EnableFeatures: []monitoringv1.EnableFeature{"exemplar-storage"},
 			},
 		},
 	})
@@ -1910,7 +1910,7 @@ func TestEnableFeaturesWithMultipleFeature(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				EnableFeatures: []string{"exemplar-storage1", "exemplar-storage2"},
+				EnableFeatures: []monitoringv1.EnableFeature{"exemplar-storage1", "exemplar-storage2"},
 			},
 		},
 	})

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -222,7 +222,11 @@ func BuildCommonPrometheusArgs(cpf monitoringv1.CommonPrometheusFields, cg *Conf
 	}
 
 	if len(cpf.EnableFeatures) > 0 {
-		promArgs = cg.WithMinimumVersion("2.25.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "enable-feature", Value: strings.Join(cpf.EnableFeatures[:], ",")})
+		efs := make([]string, len(cpf.EnableFeatures))
+		for i := range cpf.EnableFeatures {
+			efs[i] = string(cpf.EnableFeatures[i])
+		}
+		promArgs = cg.WithMinimumVersion("2.25.0").AppendCommandlineArgument(promArgs, monitoringv1.Argument{Name: "enable-feature", Value: strings.Join(efs, ",")})
 	}
 
 	if cpf.ExternalURL != "" {

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -285,7 +285,7 @@ func (prwtc PromRemoteWriteTestConfig) AddRemoteWriteWithTLSToPrometheus(p *moni
 }
 
 func (f *Framework) EnableRemoteWriteReceiverWithTLS(p *monitoringv1.Prometheus) {
-	p.Spec.EnableFeatures = []string{"remote-write-receiver"}
+	p.Spec.EnableFeatures = []monitoringv1.EnableFeature{"remote-write-receiver"}
 
 	p.Spec.Web = &monitoringv1.PrometheusWebSpec{
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{


### PR DESCRIPTION
## Description

It allows different actors to manipulate the list of enabled features using server-side apply.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
define `.spec.enableFeatures` list as a set of unique values.
```
