### PR TITLE
chore: Move AlertmanagerEndpoints validation to pkg/prometheus/server

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -154,40 +154,6 @@ func ValidateRemoteWriteSpec(spec monitoringv1.RemoteWriteSpec) error {
 	return nil
 }
 
-func ValidateAlertmanagerEndpoints(am monitoringv1.AlertmanagerEndpoints, p *monitoringv1.Prometheus) error {
-	var nonNilFields []string
-
-	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-	if am.BearerTokenFile != "" {
-		nonNilFields = append(nonNilFields, fmt.Sprintf("%q", "bearerTokenFile"))
-	}
-
-	for k, v := range map[string]interface{}{
-		"basicAuth":     am.BasicAuth,
-		"authorization": am.Authorization,
-		"sigv4":         am.Sigv4,
-	} {
-		if reflect.ValueOf(v).IsNil() {
-			continue
-		}
-		nonNilFields = append(nonNilFields, fmt.Sprintf("%q", k))
-	}
-
-	if len(nonNilFields) > 1 {
-		return fmt.Errorf("%s can't be set at the same time, at most one of them must be defined", strings.Join(nonNilFields, " and "))
-	}
-
-	if err := validateRelabelConfigs(p, am.RelabelConfigs); err != nil {
-		return fmt.Errorf("invalid relabelings: %w", err)
-	}
-
-	if err := validateRelabelConfigs(p, am.AlertRelabelConfigs); err != nil {
-		return fmt.Errorf("invalid alertRelabelings: %w", err)
-	}
-
-	return nil
-}
-
 // Process will determine the Status of a Prometheus resource (server or agent) depending on its current state in the cluster.
 func (sr *StatusReporter) Process(ctx context.Context, p monitoringv1.PrometheusInterface, key string) (*monitoringv1.PrometheusStatus, error) {
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -112,7 +112,7 @@ func getScrapeClassConfig(p monitoringv1.PrometheusInterface) (map[string]monito
 	for _, scrapeClass := range cpf.ScrapeClasses {
 		scrapeClasses[scrapeClass.Name] = scrapeClass
 		// Validate all scrape class relabelings are correct.
-		if err := validateRelabelConfigs(p, scrapeClass.Relabelings); err != nil {
+		if err := ValidateRelabelConfigs(p, scrapeClass.Relabelings); err != nil {
 			return nil, "", fmt.Errorf("invalid relabelings for scrapeClass %s: %w", scrapeClass.Name, err)
 		}
 

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -177,12 +177,12 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 				break
 			}
 
-			if err = validateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
 				rejectFn(sm, fmt.Errorf("relabelConfigs: %w", err))
 				break
 			}
 
-			if err = validateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
 				rejectFn(sm, fmt.Errorf("metricRelabelConfigs: %w", err))
 				break
 			}
@@ -247,7 +247,7 @@ func validateScrapeIntervalAndTimeout(p monitoringv1.PrometheusInterface, scrape
 	return CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval)
 }
 
-func validateRelabelConfigs(p monitoringv1.PrometheusInterface, rcs []monitoringv1.RelabelConfig) error {
+func ValidateRelabelConfigs(p monitoringv1.PrometheusInterface, rcs []monitoringv1.RelabelConfig) error {
 	for i, rc := range rcs {
 		if err := validateRelabelConfig(p, rc); err != nil {
 			return fmt.Errorf("[%d]: %w", i, err)
@@ -454,12 +454,12 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 				break
 			}
 
-			if err = validateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, endpoint.RelabelConfigs); err != nil {
 				rejectFn(pm, fmt.Errorf("relabelConfigs: %w", err))
 				break
 			}
 
-			if err = validateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, endpoint.MetricRelabelConfigs); err != nil {
 				rejectFn(pm, fmt.Errorf("metricRelabelConfigs: %w", err))
 				break
 			}
@@ -603,14 +603,14 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 			continue
 		}
 
-		if err = validateRelabelConfigs(rs.p, probe.Spec.MetricRelabelConfigs); err != nil {
+		if err = ValidateRelabelConfigs(rs.p, probe.Spec.MetricRelabelConfigs); err != nil {
 			err = fmt.Errorf("metricRelabelConfigs: %w", err)
 			rejectFn(probe, err)
 			continue
 		}
 
 		if probe.Spec.Targets.StaticConfig != nil {
-			if err = validateRelabelConfigs(rs.p, probe.Spec.Targets.StaticConfig.RelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, probe.Spec.Targets.StaticConfig.RelabelConfigs); err != nil {
 				err = fmt.Errorf("targets.staticConfig.relabelConfigs: %w", err)
 				rejectFn(probe, err)
 				continue
@@ -618,7 +618,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 		}
 
 		if probe.Spec.Targets.Ingress != nil {
-			if err = validateRelabelConfigs(rs.p, probe.Spec.Targets.Ingress.RelabelConfigs); err != nil {
+			if err = ValidateRelabelConfigs(rs.p, probe.Spec.Targets.Ingress.RelabelConfigs); err != nil {
 				err = fmt.Errorf("targets.ingress.relabelConfigs: %w", err)
 				rejectFn(probe, err)
 				continue
@@ -759,7 +759,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 			continue
 		}
 
-		if err = validateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {
+		if err = ValidateRelabelConfigs(rs.p, sc.Spec.RelabelConfigs); err != nil {
 			rejectFn(sc, fmt.Errorf("relabelConfigs: %w", err))
 			continue
 		}
@@ -799,7 +799,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 			continue
 		}
 
-		if err = validateRelabelConfigs(rs.p, sc.Spec.MetricRelabelConfigs); err != nil {
+		if err = ValidateRelabelConfigs(rs.p, sc.Spec.MetricRelabelConfigs); err != nil {
 			rejectFn(sc, fmt.Errorf("metricRelabelConfigs: %w", err))
 			continue
 		}

--- a/pkg/prometheus/store.go
+++ b/pkg/prometheus/store.go
@@ -79,23 +79,6 @@ func AddRemoteReadsToStore(ctx context.Context, store *assets.StoreBuilder, name
 
 	return nil
 }
-
-func AddAlertmanagerEndpointsToStore(ctx context.Context, store *assets.StoreBuilder, namespace string, ams []monv1.AlertmanagerEndpoints) error {
-	for i, am := range ams {
-		if err := store.AddBasicAuth(ctx, namespace, am.BasicAuth); err != nil {
-			return fmt.Errorf("alertmanager %d: %w", i, err)
-		}
-		if err := store.AddSafeAuthorizationCredentials(ctx, namespace, am.Authorization, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
-			return fmt.Errorf("alertmanager %d: %w", i, err)
-		}
-		if err := store.AddSigV4(ctx, namespace, am.Sigv4, fmt.Sprintf("alertmanager/auth/%d", i)); err != nil {
-			return fmt.Errorf("alertmanager %d: %w", i, err)
-		}
-	}
-
-	return nil
-}
-
 func AddAPIServerConfigToStore(ctx context.Context, store *assets.StoreBuilder, namespace string, config *monv1.APIServerConfig) error {
 	if config == nil {
 		return nil


### PR DESCRIPTION
## Description

This PR moves the logic for storing AM endpoints to the store and the subsequent validation to pkg/prometheus/server as per comments on #6467.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
