### PR TITLE
feat(rules): when naming rules files use clear namespace separation

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -175,7 +175,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				return
 			}
 
-			promRules[fmt.Sprintf("%v--%v--%v.yaml", promRule.Namespace, promRule.Name, promRule.UID)] = promRule
+			promRules[fmt.Sprintf("%v,%v,%v.yaml", promRule.Namespace, promRule.Name, promRule.UID)] = promRule
 		})
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to list prometheus rules in namespace %s: %w", ns, err)

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -175,7 +175,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				return
 			}
 
-			promRules[fmt.Sprintf("%v-%v-%v.yaml", promRule.Namespace, promRule.Name, promRule.UID)] = promRule
+			promRules[fmt.Sprintf("%v--%v--%v.yaml", promRule.Namespace, promRule.Name, promRule.UID)] = promRule
 		})
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to list prometheus rules in namespace %s: %w", ns, err)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1733,7 +1733,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 					KubeClient.
 					CoreV1().
 					ConfigMaps(ns).
-					Get(context.Background(), "prometheus-"+prometheusName+"-rulefiles-0", metav1.GetOptions{})
+					Get(context.Background(), "prometheus-"+prometheusName+",rulefiles,0", metav1.GetOptions{})
 			},
 			// The Prometheus Operator first creates the ConfigMap for the
 			// given Prometheus stateful set and then updates it with the matching


### PR DESCRIPTION
## Description

Ref: https://github.com/prometheus-operator/prometheus-operator/issues/3468

I ran into the same issue that @janotav did with [this comment](https://github.com/prometheus-operator/prometheus-operator/issues/3468#issuecomment-687038724). I want to be able to identify metrics from the Thanos Ruler around rule execution and failures and narrow them down to the `Namespace` and `PrometheusRule` that they come from. The problem is the current naming pattern of `$namespace-$rulename-$uid` doesn't account for resources that have `-`'s in the names... ie, the following rule creates a file named `my-namespace-some-rule-thing-xxx-xxx-xxx-xxx-xxx`:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: some-rule-thing
  namespace: my-namespace
  resourceVersion: "1146"
  uid: xxx-xxx-xxx-xxx-xxx
```

The string `my-namespace-some-rule-thing-xxx-xxx-xxx-xxx-xxx` cannot be parsed through [metric relabelings](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) because you cannot definitively pull out the `namespace` and `name` fields from the filename.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Due to https://github.com/prometheus-operator/prometheus-operator/issues/6284 - I was unable to fully test this locally.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Use "--" to separate namespace, resource name and UID in Prometheus Rules filenames
```
