### PR TITLE
Add structure for feature flags

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -49,6 +49,8 @@ Usage of ./operator:
     	Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
+  -feature-gates value
+    	Feature gates are a set of key=value pairs that describe Prometheus-Operator features. At the moment there are no feature gates available.
   -key-file string
     	- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.
   -kubelet-node-address-priority value

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	k8sflag "k8s.io/component-base/cli/flag"
+	"k8s.io/utils/ptr"
 
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
 	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
@@ -114,6 +116,8 @@ var (
 	kubeletObject       string
 	kubeletSelector     operator.LabelSelector
 	nodeAddressPriority operator.NodeAddressPriority
+
+	featureGates *k8sflag.MapStringBool
 )
 
 func parseFlags(fs *flag.FlagSet) {
@@ -166,6 +170,11 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	fs.Var(&cfg.SecretListWatchSelector, "secret-field-selector", "Field selector to filter Secrets to watch")
 
+	featureGates = k8sflag.NewMapStringBool(ptr.To(make(map[string]bool)))
+	fs.Var(featureGates, "feature-gates", "Feature gates are a set of key=value pairs that describe Prometheus-Operator features. At the moment there are no feature gates available.")
+	// Once the first feature gate is added, the line below should be uncommented and the line above deleted.
+	//fs.Var(featureGates, "feature-gates", fmt.Sprintf("Feature gates are a set of key=value pairs that describe Prometheus-Operator features. Available features: %q.", operator.AvailableFeatureGates()))
+
 	logging.RegisterFlags(fs, &logConfig)
 	versionutil.RegisterFlags(fs)
 
@@ -193,8 +202,17 @@ func run(fs *flag.FlagSet) int {
 		level.Warn(logger).Log("msg", "Failed to set GOMAXPROCS automatically", "err", err)
 	}
 
+	gates, err := operator.ValidateFeatureGates(featureGates)
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "error validating feature gates",
+			"error", err)
+		return 1
+	}
+
 	level.Info(logger).Log("msg", "Starting Prometheus Operator", "version", version.Info())
 	level.Info(logger).Log("build_context", version.BuildContext())
+	level.Info(logger).Log("feature_gates", gates)
 
 	if len(cfg.Namespaces.AllowList) > 0 && len(cfg.Namespaces.DenyList) > 0 {
 		level.Error(logger).Log(

--- a/pkg/operator/feature_gates.go
+++ b/pkg/operator/feature_gates.go
@@ -1,0 +1,63 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	k8sflag "k8s.io/component-base/cli/flag"
+)
+
+// At the moment, the are no feature gates available.
+var defaultFeatureGates = map[string]bool{}
+
+// ValidateFeatureGates merges the feature gate default values with
+// the values provided by the user.
+func ValidateFeatureGates(flags *k8sflag.MapStringBool) (string, error) {
+	gates := defaultFeatureGates
+	if flags.Empty() {
+		return mapToString(gates), nil
+	}
+
+	imgs := *flags.Map
+	for k, v := range imgs {
+		if _, ok := gates[k]; !ok {
+			return "", fmt.Errorf("feature gate %v is unknown", k)
+		}
+		gates[k] = v
+	}
+	return mapToString(gates), nil
+}
+
+func AvailableFeatureGates() []string {
+	i := 0
+	gates := make([]string, len(defaultFeatureGates))
+	for k := range defaultFeatureGates {
+		gates[i] = k
+		i++
+	}
+	slices.Sort(gates)
+	return gates
+}
+
+func mapToString(m map[string]bool) string {
+	var s []string
+	for k, v := range m {
+		s = append(s, fmt.Sprintf("%s=%t", k, v))
+	}
+	return strings.Join(s, ",")
+}


### PR DESCRIPTION
## Description

As discussed in the last office hours, we want to start to provide a few features behind feature flags. This PR introduces the concept, but still no feature flags are available.

They will be added as need in following PRs.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
