### PR TITLE
fix: make automountServiceAccountToken configurable

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2021,6 +2021,21 @@ Prometheus Pods.</p>
 </tr>
 <tr>
 <td>
+<code>automountServiceAccountToken</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+If the field isn&rsquo;t set, the operator mounts the service account token by default.</p>
+<p><strong>Warning:</strong> be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+It is possible to use strategic merge patch to project the service account token into the &lsquo;prometheus&rsquo; container.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secrets</code><br/>
 <em>
 []string
@@ -6544,6 +6559,21 @@ Prometheus Pods.</p>
 </tr>
 <tr>
 <td>
+<code>automountServiceAccountToken</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+If the field isn&rsquo;t set, the operator mounts the service account token by default.</p>
+<p><strong>Warning:</strong> be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+It is possible to use strategic merge patch to project the service account token into the &lsquo;prometheus&rsquo; container.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secrets</code><br/>
 <em>
 []string
@@ -10650,6 +10680,21 @@ string
 <td>
 <p>ServiceAccountName is the name of the ServiceAccount to use to run the
 Prometheus Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>automountServiceAccountToken</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+If the field isn&rsquo;t set, the operator mounts the service account token by default.</p>
+<p><strong>Warning:</strong> be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+It is possible to use strategic merge patch to project the service account token into the &lsquo;prometheus&rsquo; container.</p>
 </td>
 </tr>
 <tr>
@@ -16577,6 +16622,21 @@ string
 <td>
 <p>ServiceAccountName is the name of the ServiceAccount to use to run the
 Prometheus Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>automountServiceAccountToken</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+If the field isn&rsquo;t set, the operator mounts the service account token by default.</p>
+<p><strong>Warning:</strong> be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+It is possible to use strategic merge patch to project the service account token into the &lsquo;prometheus&rsquo; container.</p>
 </td>
 </tr>
 <tr>
@@ -22635,6 +22695,21 @@ string
 <td>
 <p>ServiceAccountName is the name of the ServiceAccount to use to run the
 Prometheus Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>automountServiceAccountToken</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+If the field isn&rsquo;t set, the operator mounts the service account token by default.</p>
+<p><strong>Warning:</strong> be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+It is possible to use strategic merge patch to project the service account token into the &lsquo;prometheus&rsquo; container.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16803,6 +16803,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               bodySizeLimit:
                 description: |-
                   BodySizeLimit defines per-scrape on response body size.
@@ -26743,6 +26752,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               baseImage:
                 description: 'Deprecated: use ''spec.image'' instead.'
                 type: string

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -1305,6 +1305,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               bodySizeLimit:
                 description: |-
                   BodySizeLimit defines per-scrape on response body size.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1752,6 +1752,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               baseImage:
                 description: 'Deprecated: use ''spec.image'' instead.'
                 type: string

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -1306,6 +1306,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               bodySizeLimit:
                 description: |-
                   BodySizeLimit defines per-scrape on response body size.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1753,6 +1753,15 @@ spec:
                   deny:
                     type: boolean
                 type: object
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+                  If the field isn't set, the operator mounts the service account token by default.
+
+
+                  **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+                  It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+                type: boolean
               baseImage:
                 description: 'Deprecated: use ''spec.image'' instead.'
                 type: string

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -1115,6 +1115,10 @@
                     },
                     "type": "object"
                   },
+                  "automountServiceAccountToken": {
+                    "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.\nIf the field isn't set, the operator mounts the service account token by default.\n\n\n**Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.\nIt is possible to use strategic merge patch to project the service account token into the 'prometheus' container.",
+                    "type": "boolean"
+                  },
                   "bodySizeLimit": {
                     "description": "BodySizeLimit defines per-scrape on response body size.\nOnly valid in Prometheus versions 2.45.0 and newer.",
                     "pattern": "(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -1524,6 +1524,10 @@
                     },
                     "type": "object"
                   },
+                  "automountServiceAccountToken": {
+                    "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.\nIf the field isn't set, the operator mounts the service account token by default.\n\n\n**Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.\nIt is possible to use strategic merge patch to project the service account token into the 'prometheus' container.",
+                    "type": "boolean"
+                  },
                   "baseImage": {
                     "description": "Deprecated: use 'spec.image' instead.",
                     "type": "string"

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -356,6 +356,14 @@ type CommonPrometheusFields struct {
 	// Prometheus Pods.
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
+	// AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod.
+	// If the field isn't set, the operator mounts the service account token by default.
+	//
+	// **Warning:** be aware that by default, Prometheus requires the service account token for Kubernetes service discovery.
+	// It is possible to use strategic merge patch to project the service account token into the 'prometheus' container.
+	// +optional
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
+
 	// Secrets is a list of Secrets in the same namespace as the Prometheus
 	// object, which shall be mounted into the Prometheus Pods.
 	// Each Secret is added to the StatefulSet definition as a volume named `secret-<secret-name>`.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -740,6 +740,11 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 			(*out)[key] = val
 		}
 	}
+	if in.AutomountServiceAccountToken != nil {
+		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Secrets != nil {
 		in, out := &in.Secrets, &out.Secrets
 		*out = make([]string, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -62,6 +62,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	Resources                            *corev1.ResourceRequirements                            `json:"resources,omitempty"`
 	NodeSelector                         map[string]string                                       `json:"nodeSelector,omitempty"`
 	ServiceAccountName                   *string                                                 `json:"serviceAccountName,omitempty"`
+	AutomountServiceAccountToken         *bool                                                   `json:"automountServiceAccountToken,omitempty"`
 	Secrets                              []string                                                `json:"secrets,omitempty"`
 	ConfigMaps                           []string                                                `json:"configMaps,omitempty"`
 	Affinity                             *corev1.Affinity                                        `json:"affinity,omitempty"`
@@ -421,6 +422,14 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithNodeSelector(entries map[
 // If called multiple times, the ServiceAccountName field is set to the value of the last call.
 func (b *CommonPrometheusFieldsApplyConfiguration) WithServiceAccountName(value string) *CommonPrometheusFieldsApplyConfiguration {
 	b.ServiceAccountName = &value
+	return b
+}
+
+// WithAutomountServiceAccountToken sets the AutomountServiceAccountToken field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AutomountServiceAccountToken field is set to the value of the last call.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithAutomountServiceAccountToken(value bool) *CommonPrometheusFieldsApplyConfiguration {
+	b.AutomountServiceAccountToken = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -367,6 +367,14 @@ func (b *PrometheusSpecApplyConfiguration) WithServiceAccountName(value string) 
 	return b
 }
 
+// WithAutomountServiceAccountToken sets the AutomountServiceAccountToken field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AutomountServiceAccountToken field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithAutomountServiceAccountToken(value bool) *PrometheusSpecApplyConfiguration {
+	b.AutomountServiceAccountToken = &value
+	return b
+}
+
 // WithSecrets adds the given value to the Secrets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Secrets field.

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -346,6 +346,14 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithServiceAccountName(value str
 	return b
 }
 
+// WithAutomountServiceAccountToken sets the AutomountServiceAccountToken field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AutomountServiceAccountToken field is set to the value of the last call.
+func (b *PrometheusAgentSpecApplyConfiguration) WithAutomountServiceAccountToken(value bool) *PrometheusAgentSpecApplyConfiguration {
+	b.AutomountServiceAccountToken = &value
+	return b
+}
+
 // WithSecrets adds the given value to the Secrets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Secrets field.

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -370,7 +370,7 @@ func makeStatefulSetSpec(
 				InitContainers:               initContainers,
 				SecurityContext:              cpf.SecurityContext,
 				ServiceAccountName:           cpf.ServiceAccountName,
-				AutomountServiceAccountToken: ptr.To(true),
+				AutomountServiceAccountToken: ptr.To(ptr.Deref(cpf.AutomountServiceAccountToken, true)),
 				NodeSelector:                 cpf.NodeSelector,
 				PriorityClassName:            cpf.PriorityClassName,
 				// Prometheus may take quite long to shut down to checkpoint existing data.

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -393,3 +393,47 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestAutomountServiceAccountToken(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		automountServiceAccountToken *bool
+		expectedValue                bool
+	}{
+		{
+			name:                         "automountServiceAccountToken not set",
+			automountServiceAccountToken: nil,
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to true",
+			automountServiceAccountToken: ptr.To(true),
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to false",
+			automountServiceAccountToken: ptr.To(false),
+			expectedValue:                false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: monitoringv1alpha1.PrometheusAgentSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						AutomountServiceAccountToken: tc.automountServiceAccountToken,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			if sset.Spec.Template.Spec.AutomountServiceAccountToken == nil {
+				t.Fatalf("expected automountServiceAccountToken to be set")
+			}
+
+			if *sset.Spec.Template.Spec.AutomountServiceAccountToken != tc.expectedValue {
+				t.Fatalf("expected automountServiceAccountToken to be %v", tc.expectedValue)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -473,7 +473,7 @@ func makeStatefulSetSpec(
 				InitContainers:               initContainers,
 				SecurityContext:              cpf.SecurityContext,
 				ServiceAccountName:           cpf.ServiceAccountName,
-				AutomountServiceAccountToken: ptr.To(true),
+				AutomountServiceAccountToken: ptr.To(ptr.Deref(cpf.AutomountServiceAccountToken, true)),
 				NodeSelector:                 cpf.NodeSelector,
 				PriorityClassName:            cpf.PriorityClassName,
 				// Prometheus may take quite long to shut down to checkpoint existing data.

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -3157,3 +3157,47 @@ func TestIfThanosVersionDontHaveHttpClientFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestAutomountServiceAccountToken(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		automountServiceAccountToken *bool
+		expectedValue                bool
+	}{
+		{
+			name:                         "automountServiceAccountToken not set",
+			automountServiceAccountToken: nil,
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to true",
+			automountServiceAccountToken: ptr.To(true),
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to false",
+			automountServiceAccountToken: ptr.To(false),
+			expectedValue:                false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						AutomountServiceAccountToken: tc.automountServiceAccountToken,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			if sset.Spec.Template.Spec.AutomountServiceAccountToken == nil {
+				t.Fatalf("expected automountServiceAccountToken to be set")
+			}
+
+			if *sset.Spec.Template.Spec.AutomountServiceAccountToken != tc.expectedValue {
+				t.Fatalf("expected automountServiceAccountToken to be %v", tc.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/prometheus-operator/prometheus-operator/issues/6270

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Make `automountServiceAccountToken` configurable for the Prometheus Operator StatefulSet
```
