### PR TITLE
Consider draft PRs electable for staleness

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
           days-before-stale: 60
           days-before-issue-close: 120
           days-before-pr-close: 180
-          exempt-issue-labels: 'kind/feature,help wanted,kind/bug,kind/documentation'
+          exempt-issue-labels: 'kind/feature,help wanted,kind/bug,kind/documentation,needs-triage'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           operations-per-run: 500

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,5 +18,4 @@ jobs:
           exempt-issue-labels: 'kind/feature,help wanted,kind/bug,kind/documentation'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-draft-pr: true
           operations-per-run: 500


### PR DESCRIPTION
## Description

I was going through the list of open PRs today and noticed that we have many abandoned draft PRs where the majority have merge conflicts.

I was confused since we have workflows closing stale issues and PRs, until I noticed that we have an exception for drafts in our workflow.

I'm creating this PR to start a discussion about whether we want to close stale draft PRs as well. 
(I'm in favor)