### PR TITLE
fix: ScrapeClass TLSConfig nil pointer exception

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -396,22 +396,23 @@ func (cg *ConfigGenerator) MergeTLSConfigWithScrapeClass(tlsConfig *monitoringv1
 	}
 
 	scrapeClass, found := cg.scrapeClasses[scrapeClassName]
-
 	if !found {
-		return tlsConfig
+		return tlsConfig // could be nil.
 	}
 
-	if tlsConfig == nil && !found {
+	// Found.
+
+	if tlsConfig == nil {
+		return scrapeClass.TLSConfig // could be nil.
+	}
+
+	// tlsConfig exists.
+
+	if scrapeClass.TLSConfig == nil {
 		return nil
 	}
 
-	if tlsConfig != nil && !found {
-		return tlsConfig
-	}
-
-	if tlsConfig == nil && found {
-		return scrapeClass.TLSConfig
-	}
+	// scrapeClass.TLSConfig exists.
 
 	if tlsConfig.CAFile == "" && tlsConfig.SafeTLSConfig.CA == (monitoringv1.SecretOrConfigMap{}) {
 		tlsConfig.CAFile = scrapeClass.TLSConfig.CAFile

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -395,12 +395,12 @@ func (cg *ConfigGenerator) MergeTLSConfigWithScrapeClass(tlsConfig *monitoringv1
 		scrapeClassName = scrapeClass.Name
 	}
 
-	scrapeClass, found := cg.scrapeClasses[scrapeClassName]
-	if !found {
+	scrapeClass = cg.scrapeClasses[scrapeClassName]
+	if scrapeClass == nil {
 		return tlsConfig // could be nil.
 	}
 
-	// Found.
+	// scrapeClass exists.
 
 	if tlsConfig == nil {
 		return scrapeClass.TLSConfig // could be nil.

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -8056,6 +8056,31 @@ func TestMergeTLSConfigWithScrapeClass(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "nil TLSConfig, non-nil ScrapeClass with nil TLSConfig",
+			tlsConfig: nil,
+			scrapeClass: &monitoringv1.ScrapeClass{
+				Name:      "default",
+				TLSConfig: nil,
+			},
+			expectedConfig: &monitoringv1.TLSConfig{
+				CAFile:   "defaultCAFile",
+				CertFile: "defaultCertFile",
+				KeyFile:  "defaultKeyFile",
+			},
+			cg: &ConfigGenerator{
+				defaultScrapeClassName: "default",
+				scrapeClasses: map[string]*monitoringv1.ScrapeClass{
+					"default": {
+						TLSConfig: &monitoringv1.TLSConfig{
+							CAFile:   "defaultCAFile",
+							CertFile: "defaultCertFile",
+							KeyFile:  "defaultKeyFile",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

## Description

When only `relabeling` is configured in a `ScrapeClass` object, the `TLSConfig` field is nil. This causes a panic when the `TLSConfig` field is accessed in the `ScrapeClass` object.

I'm not sure about the business logic of the `ScrapeClass` TLSConfig field, but from pure Go perspective, it should fix the panic.

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1ad78e1]

goroutine 386 [running]:
github.com/prometheus-operator/prometheus-operator/pkg/prometheus.(*ConfigGenerator).MergeTLSConfigWithScrapeClass(0x20d7080?, 0xc00172b420, 0xc000fe6d08?)
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/promcfg.go:417 +0x81
github.com/prometheus-operator/prometheus-operator/pkg/prometheus.(*ConfigGenerator).generateServiceMonitorConfig(_, _, {{0xc000a7c250, 0x5}, 0x0, {0xc000a7c128, 0x8}, {0xc000a7c255, 0x5}, 0x0, ...}, ...)
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/promcfg.go:1370 +0xd3d
github.com/prometheus-operator/prometheus-operator/pkg/prometheus.(*ConfigGenerator).appendServiceMonitorConfigs(0xc000c5a6c0, {0x0, 0x0, 0x0}, 0xc0014ae420, 0x0, 0xc000b4d500, 0x1)
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/promcfg.go:2298 +0x3e5
github.com/prometheus-operator/prometheus-operator/pkg/prometheus.(*ConfigGenerator).GenerateServerConfiguration(0xc000c5a6c0, {0x27b2620, 0xc00098b540}, {0xc000e372fd, 0x3}, {0x0, 0x0}, _, _, {{0x0, ...}}, ...)
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/promcfg.go:672 +0x3f5
github.com/prometheus-operator/prometheus-operator/pkg/prometheus/server.(*Operator).createOrUpdateConfigurationSecret(0xc000173688, {0x27b2620, 0xc00098b540}, 0xc0010aa308, 0xc000c5a6c0, {0xc001adc830, 0x1, 0x1}, 0xc000b4d500)
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/server/operator.go:1152 +0xa68
github.com/prometheus-operator/prometheus-operator/pkg/prometheus/server.(*Operator).sync(0xc000173688, {0x27b2620, 0xc00098b540}, {0xc00148a060, 0xe})
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/server/operator.go:778 +0x8c5
github.com/prometheus-operator/prometheus-operator/pkg/prometheus/server.(*Operator).Sync(0xc000173688, {0x27b2620?, 0xc00098b540?}, {0xc00148a060, 0xe})
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/prometheus/server/operator.go:725 +0x2c
github.com/prometheus-operator/prometheus-operator/pkg/operator.(*ResourceReconciler).processNextReconcileItem(0xc000066600, {0x27b2620, 0xc00098b540})
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/operator/resource_reconciler.go:449 +0x231
github.com/prometheus-operator/prometheus-operator/pkg/operator.(*ResourceReconciler).Run.func1()
        /home/runner/work/prometheus-operator/prometheus-operator/pkg/operator/resource_reconciler.go:412 +0x3f
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /home/runner/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 497
        /home/runner/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

Example config to reproduce the issue:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  name: k8s
spec:
  scrapeClasses:
    - name: base-scrape-class
      default: true
      relabelings:
        - targetLabel: cluster
          replacement: my-awesome-cluster
      # tlsConfig: {} # This would work.
```

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!--
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
[BUGFIX] Fix ScrapeClass TLSConfig nil pointer panic when only relabeling is configured.
```
