### PR TITLE
Add testing steps for podman with kind

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -65,8 +65,10 @@ For manual testing, you can use the utility script [scripts/run-external.sh](scr
 ```
 ./scripts/run-external.sh -c
 ```
+### Building Images and Loading them into your cluster
 
-Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster (for KinD cluster):
+#### Using docker with Kind
+Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster: 
 
 ```
 make image
@@ -74,7 +76,21 @@ make image
 for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook"; do kind load docker-image "quay.io/prometheus-operator/$n:$(git rev-parse --short HEAD)"; done;
 ```
 
-Then to run the automated end-to-end tests, run the following command:
+#### Using podman with Kind
+When running kind on MacOS using podman, it is recommended to create podman machine 4 CPUs and 8GiB memory. Less resources might cause end to end tests fail because of lack of resources for cluster.
+
+```
+podman machine init --cpus=4 --memory=8192 --rootful --now
+```
+Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster:
+```
+CONTAINER_CLI=podman make image
+
+for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook"; do podman save --quiet -o images/$n.tar "quay.io/prometheus-operator/$n:$(git rev-parse --short HEAD)"; kind load image-archive images/$n.tar; done
+```
+
+### Running the automated E2E Tests
+To run the automated end-to-end tests, run the following command:
 
 ```
 make test-e2e

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,9 +65,11 @@ For manual testing, you can use the utility script [scripts/run-external.sh](scr
 ```
 ./scripts/run-external.sh -c
 ```
+
 ### Building Images and Loading them into your cluster
 
 #### Using docker with Kind
+
 Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster: 
 
 ```
@@ -77,12 +79,15 @@ for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook";
 ```
 
 #### Using podman with Kind
+
 When running kind on MacOS using podman, it is recommended to create podman machine 4 CPUs and 8 GiB memory. Less resources might cause end to end tests fail because of lack of resources for cluster.
 
 ```
 podman machine init --cpus=4 --memory=8192 --rootful --now
 ```
+
 Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster:
+
 ```
 CONTAINER_CLI=podman make image
 
@@ -90,6 +95,7 @@ for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook";
 ```
 
 ### Running the automated E2E Tests
+
 To run the automated end-to-end tests, run the following command:
 
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,15 +36,15 @@ Or even particular functions:
 go test -run ^TestPodLabelsAnnotations$ ./pkg/prometheus/server
 ```
 
-### Testing multiline string comparison - Golden files
+### Testing multi line string comparison - Golden files
 
-Golden files are plaintext documents designed to facilitate the validation of lengthy strings. They come in handy when, for instance, you need to test a Prometheus configuration that's generated using Go structures. You can marshal this configuration into YAML and then compare it against a static reference to ensure a match. Golden files offer an elegant solution to this challenge, sparing you the need to hard-code the static configuration directly into your test code.
+Golden files are plain-text documents designed to facilitate the validation of lengthy strings. They come in handy when, for instance, you need to test a Prometheus configuration that's generated using Go structures. You can marshal this configuration into YAML and then compare it against a static reference to ensure a match. Golden files offer an elegant solution to this challenge, sparing you the need to hard-code the static configuration directly into your test code.
 
 In the example below, we're generating the Prometheus configuration (which can easily have 100+ lines for each individual test) and comparing it against a golden file:
 
 https://github.com/prometheus-operator/prometheus-operator/blob/aeceb0b4fadc8307a44dc55afdceca0bea50bbb0/pkg/prometheus/promcfg_test.go#L102-L277
 
-If not for golden files, the test above, instead of ~150 lines, would easily require around ~1000 lines. The usage of golden files help us maintain test suites with several multiline strings comparison without sacrifing test readability.
+If not for golden files, the test above, instead of ~150 lines, would easily require around ~1000 lines. The usage of golden files help us maintain test suites with several multi line strings comparison without sacrificing test readability.
 
 ### Updating Golden Files
 
@@ -77,7 +77,7 @@ for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook";
 ```
 
 #### Using podman with Kind
-When running kind on MacOS using podman, it is recommended to create podman machine 4 CPUs and 8GiB memory. Less resources might cause end to end tests fail because of lack of resources for cluster.
+When running kind on MacOS using podman, it is recommended to create podman machine 4 CPUs and 8 GiB memory. Less resources might cause end to end tests fail because of lack of resources for cluster.
 
 ```
 podman machine init --cpus=4 --memory=8192 --rootful --now
@@ -104,7 +104,7 @@ When working on a contribution though, it's rare that you'll need to make a chan
 
 https://github.com/prometheus-operator/prometheus-operator/blob/272df8a2411bcf877107b3251e79ae8aa8c24761/test/e2e/main_test.go#L46-L50
 
-As shown above, particular test suites can be skipped with Environment Variables. You can also look at our [CI pipeline as example](https://github.com/prometheus-operator/prometheus-operator/blob/272df8a2411bcf877107b3251e79ae8aa8c24761/.github/workflows/e2e.yaml#L85-L94). Altough we always run all tests in CI, skipping irrelevant tests are great during development as they shorten the feedback loop.
+As shown above, particular test suites can be skipped with Environment Variables. You can also look at our [CI pipeline as example](https://github.com/prometheus-operator/prometheus-operator/blob/272df8a2411bcf877107b3251e79ae8aa8c24761/.github/workflows/e2e.yaml#L85-L94). Although we always run all tests in CI, skipping irrelevant tests are great during development as they shorten the feedback loop.
 
 The following Makefile targets can run specific end-to-end tests:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -66,7 +66,7 @@ For manual testing, you can use the utility script [scripts/run-external.sh](scr
 ./scripts/run-external.sh -c
 ```
 
-### Building Images and Loading them into your cluster
+### Building images and loading them into your cluster
 
 #### Using docker with Kind
 
@@ -80,7 +80,7 @@ for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook";
 
 #### Using podman with Kind
 
-When running kind on MacOS using podman, it is recommended to create podman machine 4 CPUs and 8 GiB memory. Less resources might cause end to end tests fail because of lack of resources for cluster.
+When running kind on MacOS using podman, it is recommended to create podman machine with `4` CPUs and `8 GiB` memory. Less resources might cause end to end tests to fail because of lack of resources in the cluster.
 
 ```
 podman machine init --cpus=4 --memory=8192 --rootful --now
@@ -91,7 +91,7 @@ Before running automated end-to-end tests, you need run the following command to
 ```
 CONTAINER_CLI=podman make image
 
-for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook"; do podman save --quiet -o images/$n.tar "quay.io/prometheus-operator/$n:$(git rev-parse --short HEAD)"; kind load image-archive images/$n.tar; done
+for n in "prometheus-operator" "prometheus-config-reloader" "admission-webhook"; do podman save --quiet -o tmp/$n.tar "quay.io/prometheus-operator/$n:$(git rev-parse --short HEAD)"; kind load image-archive tmp/$n.tar; done
 ```
 
 ### Running the automated E2E Tests

--- a/TESTING.md
+++ b/TESTING.md
@@ -70,7 +70,7 @@ For manual testing, you can use the utility script [scripts/run-external.sh](scr
 
 #### Using docker with Kind
 
-Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster: 
+Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster:
 
 ```
 make image


### PR DESCRIPTION
## Description
Updating Testing.md to add the steps for making the images with podman and adding them to kind cluster.
Closes #6488 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Tested the steps on a Mac machine with podman was able to run the alertmanger tests.

## Changelog entry



<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added Testing steps for using podman with Kind for running automated E2E tests.
```
