### PR TITLE
WIP: Allow users to choose Endpoints/EndpoinSlice role in Prometheus and Prometheus Agent

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -2714,6 +2714,16 @@ in a breaking way.</p>
 </tr>
 <tr>
 <td>
+<code>serviceDiscoveryRole</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>baseImage</code><br/>
 <em>
 string
@@ -7235,6 +7245,16 @@ PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
 in a breaking way.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>serviceDiscoveryRole</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.Condition">Condition
@@ -11343,6 +11363,16 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
 <p>This is an <em>experimental feature</em>, it may change in any upcoming release
 in a breaking way.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceDiscoveryRole</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
 </td>
 </tr>
 <tr>
@@ -17270,6 +17300,16 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
 <p>This is an <em>experimental feature</em>, it may change in any upcoming release
 in a breaking way.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceDiscoveryRole</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
 </td>
 </tr>
 </table>
@@ -23328,6 +23368,16 @@ If set, the value should be greater than 60 (seconds). Otherwise it will be equa
 PodMonitors, ServiceMonitors, Probes and ScrapeConfigs.</p>
 <p>This is an <em>experimental feature</em>, it may change in any upcoming release
 in a breaking way.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceDiscoveryRole</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21616,6 +21616,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-
@@ -32227,6 +32230,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -24849,8 +24849,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-
@@ -35956,8 +35954,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21614,6 +21614,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -24843,6 +24846,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-
@@ -32220,6 +32225,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -35942,6 +35950,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -9351,8 +9351,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6116,6 +6116,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -9345,6 +9348,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6118,6 +6118,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -10957,8 +10957,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7231,6 +7231,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7229,6 +7229,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -10951,6 +10954,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6119,6 +6119,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6117,6 +6117,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -9346,6 +9349,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -9352,8 +9352,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7230,6 +7230,9 @@ spec:
                   ServiceAccountName is the name of the ServiceAccount to use to run the
                   Prometheus Pods.
                 type: string
+              serviceDiscoveryRole:
+                default: Endpoints
+                type: string
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
@@ -10952,6 +10955,8 @@ spec:
                     - keySecret
                     type: object
                 type: object
+            required:
+            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -10958,8 +10958,6 @@ spec:
                     - keySecret
                     type: object
                 type: object
-            required:
-            - serviceDiscoveryRole
             type: object
           status:
             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7232,6 +7232,9 @@ spec:
                 type: string
               serviceDiscoveryRole:
                 default: Endpoints
+                enum:
+                - Endpoints
+                - EndpointSlice
                 type: string
               serviceMonitorNamespaceSelector:
                 description: |-

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5245,6 +5245,10 @@
                     "description": "ServiceAccountName is the name of the ServiceAccount to use to run the\nPrometheus Pods.",
                     "type": "string"
                   },
+                  "serviceDiscoveryRole": {
+                    "default": "Endpoints",
+                    "type": "string"
+                  },
                   "serviceMonitorNamespaceSelector": {
                     "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
                     "properties": {
@@ -7851,6 +7855,9 @@
                     "type": "object"
                   }
                 },
+                "required": [
+                  "serviceDiscoveryRole"
+                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -7859,9 +7859,6 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "serviceDiscoveryRole"
-                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5247,6 +5247,10 @@
                   },
                   "serviceDiscoveryRole": {
                     "default": "Endpoints",
+                    "enum": [
+                      "Endpoints",
+                      "EndpointSlice"
+                    ],
                     "type": "string"
                   },
                   "serviceMonitorNamespaceSelector": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -9290,9 +9290,6 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "serviceDiscoveryRole"
-                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6255,6 +6255,10 @@
                     "description": "ServiceAccountName is the name of the ServiceAccount to use to run the\nPrometheus Pods.",
                     "type": "string"
                   },
+                  "serviceDiscoveryRole": {
+                    "default": "Endpoints",
+                    "type": "string"
+                  },
                   "serviceMonitorNamespaceSelector": {
                     "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
                     "properties": {
@@ -9282,6 +9286,9 @@
                     "type": "object"
                   }
                 },
+                "required": [
+                  "serviceDiscoveryRole"
+                ],
                 "type": "object"
               },
               "status": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6257,6 +6257,10 @@
                   },
                   "serviceDiscoveryRole": {
                     "default": "Endpoints",
+                    "enum": [
+                      "Endpoints",
+                      "EndpointSlice"
+                    ],
                     "type": "string"
                   },
                   "serviceMonitorNamespaceSelector": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -693,7 +693,8 @@ type CommonPrometheusFields struct {
 	// +listMapKey=name
 	ScrapeClasses []ScrapeClass `json:"scrapeClasses,omitempty"`
 
-	//+kubebuilder:default="Endpoints"
+	// +kubebuilder:default="Endpoints"
+	// +kubebuilder:validation:Enum=Endpoints;EndpointSlice
 	ServiceDiscoveryRole string `json:"serviceDiscoveryRole"`
 }
 

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -695,7 +695,7 @@ type CommonPrometheusFields struct {
 
 	// +kubebuilder:default="Endpoints"
 	// +kubebuilder:validation:Enum=Endpoints;EndpointSlice
-	ServiceDiscoveryRole string `json:"serviceDiscoveryRole"`
+	ServiceDiscoveryRole string `json:"serviceDiscoveryRole,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=HTTP;ProcessSignal

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -692,6 +692,9 @@ type CommonPrometheusFields struct {
 	// +listType=map
 	// +listMapKey=name
 	ScrapeClasses []ScrapeClass `json:"scrapeClasses,omitempty"`
+
+	//+kubebuilder:default="Endpoints"
+	ServiceDiscoveryRole string `json:"serviceDiscoveryRole"`
 }
 
 // +kubebuilder:validation:Enum=HTTP;ProcessSignal

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -106,6 +106,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	ReloadStrategy                       *monitoringv1.ReloadStrategyType                        `json:"reloadStrategy,omitempty"`
 	MaximumStartupDurationSeconds        *int32                                                  `json:"maximumStartupDurationSeconds,omitempty"`
 	ScrapeClasses                        []ScrapeClassApplyConfiguration                         `json:"scrapeClasses,omitempty"`
+	ServiceDiscoveryRole                 *string                                                 `json:"serviceDiscoveryRole,omitempty"`
 }
 
 // CommonPrometheusFieldsApplyConfiguration constructs an declarative configuration of the CommonPrometheusFields type for use with
@@ -815,5 +816,13 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithScrapeClasses(values ...*
 		}
 		b.ScrapeClasses = append(b.ScrapeClasses, *values[i])
 	}
+	return b
+}
+
+// WithServiceDiscoveryRole sets the ServiceDiscoveryRole field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceDiscoveryRole field is set to the value of the last call.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithServiceDiscoveryRole(value string) *CommonPrometheusFieldsApplyConfiguration {
+	b.ServiceDiscoveryRole = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -761,6 +761,14 @@ func (b *PrometheusSpecApplyConfiguration) WithScrapeClasses(values ...*ScrapeCl
 	return b
 }
 
+// WithServiceDiscoveryRole sets the ServiceDiscoveryRole field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceDiscoveryRole field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithServiceDiscoveryRole(value string) *PrometheusSpecApplyConfiguration {
+	b.ServiceDiscoveryRole = &value
+	return b
+}
+
 // WithBaseImage sets the BaseImage field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the BaseImage field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -739,3 +739,11 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithScrapeClasses(values ...*v1.
 	}
 	return b
 }
+
+// WithServiceDiscoveryRole sets the ServiceDiscoveryRole field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceDiscoveryRole field is set to the value of the last call.
+func (b *PrometheusAgentSpecApplyConfiguration) WithServiceDiscoveryRole(value string) *PrometheusAgentSpecApplyConfiguration {
+	b.ServiceDiscoveryRole = &value
+	return b
+}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -566,7 +566,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 
-	cg, err := prompkg.NewConfigGenerator(c.logger, p, c.endpointSliceSupported)
+	cg, err := prompkg.NewConfigGenerator(c.logger, p, &c.endpointSliceSupported)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -318,10 +318,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		level.Warn(o.logger).Log("msg", "failed to check if the API supports the endpointslice resources", "err ", err)
 	}
 	level.Info(o.logger).Log("msg", "Kubernetes API capabilities", "endpointslices", endpointSliceSupported)
-	// The operator doesn't yet support the endpointslices API.
-	// See https://github.com/prometheus-operator/prometheus-operator/issues/3862
-	// for details.
-	o.endpointSliceSupported = false
+	o.endpointSliceSupported = endpointSliceSupported
 
 	o.statusReporter = prompkg.StatusReporter{
 		Kclient:         o.kclient,

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -230,7 +230,7 @@ func newLogger() log.Logger {
 
 func makeStatefulSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.StatefulSet, error) {
 	logger := newLogger()
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -68,7 +68,7 @@ type ConfigGenerator struct {
 }
 
 // NewConfigGenerator creates a ConfigGenerator for the provided Prometheus resource.
-func NewConfigGenerator(logger log.Logger, p monitoringv1.PrometheusInterface, endpointSliceSupported bool) (*ConfigGenerator, error) {
+func NewConfigGenerator(logger log.Logger, p monitoringv1.PrometheusInterface, endpointSliceSupported *bool) (*ConfigGenerator, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -92,11 +92,15 @@ func NewConfigGenerator(logger log.Logger, p monitoringv1.PrometheusInterface, e
 		return nil, fmt.Errorf("failed to parse scrape classes: %w", err)
 	}
 
+	if cpf.ServiceDiscoveryRole == "Endpoints" {
+		*endpointSliceSupported = false
+	}
+
 	return &ConfigGenerator{
 		logger:                 logger,
 		version:                version,
 		prom:                   p,
-		endpointSliceSupported: endpointSliceSupported,
+		endpointSliceSupported: *endpointSliceSupported,
 		scrapeClasses:          scrapeClasses,
 		defaultScrapeClassName: defaultScrapeClassName,
 	}, nil

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -68,7 +68,7 @@ func mustNewConfigGenerator(t *testing.T, p *monitoringv1.Prometheus) *ConfigGen
 	}
 	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 
-	cg, err := NewConfigGenerator(log.With(logger, "test", t.Name()), p, false)
+	cg, err := NewConfigGenerator(log.With(logger, "test", t.Name()), p, ptr.To(false))
 	require.NoError(t, err)
 
 	return cg
@@ -7972,7 +7972,7 @@ func TestNewConfigGeneratorWithMultipleDefaultScrapeClass(t *testing.T) {
 			},
 		},
 	}
-	_, err := NewConfigGenerator(log.With(logger, "test", "NewConfigGeneratorWithMultipleDefaultScrapeClass"), p, false)
+	_, err := NewConfigGenerator(log.With(logger, "test", "NewConfigGeneratorWithMultipleDefaultScrapeClass"), p, ptr.To(false))
 	require.Error(t, err)
 	require.Equal(t, "failed to parse scrape classes: multiple default scrape classes defined", err.Error())
 }

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -333,10 +333,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		level.Warn(o.logger).Log("msg", "failed to check if the API supports the endpointslice resources", "err ", err)
 	}
 	level.Info(o.logger).Log("msg", "Kubernetes API capabilities", "endpointslices", endpointSliceSupported)
-	// The operator doesn't yet support the endpointslices API.
-	// See https://github.com/prometheus-operator/prometheus-operator/issues/3862
-	// for details.
-	o.endpointSliceSupported = false
+	o.endpointSliceSupported = endpointSliceSupported
 
 	o.statusReporter = prompkg.StatusReporter{
 		Kclient:         o.kclient,
@@ -770,7 +767,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	assetStore := assets.NewStore(c.kclient.CoreV1(), c.kclient.CoreV1())
-	cg, err := prompkg.NewConfigGenerator(c.logger, p, c.endpointSliceSupported)
+	cg, err := prompkg.NewConfigGenerator(c.logger, p, &c.endpointSliceSupported)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -56,7 +56,7 @@ func newLogger() log.Logger {
 func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulSet, error) {
 	logger := newLogger()
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +442,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 
 	logger := newLogger()
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	shardedSecret, err := operator.ReconcileShardedSecretForTLSAssets(
@@ -915,7 +915,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 		},
 	}
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(
@@ -971,7 +971,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 		},
 	}
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(
@@ -1575,7 +1575,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 		},
 	}
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(
@@ -1632,7 +1632,7 @@ func TestSidecarResources(t *testing.T) {
 			Spec: monitoringv1.PrometheusSpec{},
 		}
 
-		cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+		cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 		require.NoError(t, err)
 
 		sset, err := makeStatefulSet(
@@ -2037,7 +2037,7 @@ func TestConfigReloader(t *testing.T) {
 	logger := newLogger()
 	p := monitoringv1.Prometheus{}
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(
@@ -2115,7 +2115,7 @@ func TestConfigReloaderWithSignal(t *testing.T) {
 		},
 	}
 
-	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	cg, err := prompkg.NewConfigGenerator(logger, &p, ptr.To(false))
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(


### PR DESCRIPTION
## Description

First task of the remaining tasks to support EndpointSlice, as discussed in https://github.com/prometheus-operator/prometheus-operator/issues/3862#issuecomment-2047886633


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


## Changelog entry

Allow users to choose Endpoints/EndpoinSlice role in Prometheus and Prometheus Agent