### PR TITLE
.github/workflow: make execution of e2e and unit tests conditional

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,6 @@
 name: e2e
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
   push:
     branches:
       - 'release-*'
@@ -10,11 +8,10 @@ on:
       - 'main'
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
 jobs:
   e2e-tests:
     name: E2E tests
+    if: ${{ !contains(github.event.pull_request.files.*.filename, '.md') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,8 +1,6 @@
 name: unit
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
   push:
     branches:
       - 'release-*'
@@ -10,10 +8,9 @@ on:
       - 'main'
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
 jobs:
   unit-tests:
+    if: ${{ !contains(github.event.pull_request.files.*.filename, '.md') }}
     runs-on: ubuntu-latest
     name: Unit tests
     steps:
@@ -26,6 +23,7 @@ jobs:
         check-latest: true
     - run: make test-unit
   extended-tests:
+    if: ${{ !contains(github.event.pull_request.files.*.filename, '.md') }}
     runs-on: ubuntu-latest
     name: Extended tests
     steps:


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

This will help to avoid blocking the merge on conditional execution

Trying another approach for https://github.com/prometheus-operator/prometheus-operator/pull/6395

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
