### PR TITLE
fix: register k8s metrics

### DIFF
--- a/pkg/k8sutil/metrics.go
+++ b/pkg/k8sutil/metrics.go
@@ -28,9 +28,14 @@ type clientGoHTTPMetricAdapter struct {
 	duration *prometheus.SummaryVec
 }
 
+var _ = metrics.LatencyMetric(&clientGoHTTPMetricAdapter{})
+var _ = metrics.ResultMetric(&clientGoHTTPMetricAdapter{})
+
 type clientGoRateLimiterMetricAdapter struct {
 	duration *prometheus.SummaryVec
 }
+
+var _ = metrics.LatencyMetric(&clientGoRateLimiterMetricAdapter{})
 
 // MustRegisterClientGoMetrics registers k8s.io/client-go metrics.
 // It panics if it encounters an error (e.g. metrics already registered).
@@ -64,6 +69,13 @@ func MustRegisterClientGoMetrics(registerer prometheus.Registerer) {
 		),
 	}
 
+	// controller-runtime also calls metrics.Register() during init and this
+	// function can be called only once. To ensure that the k8s client metrics
+	// get updated, the global variables need to be set again here.
+	//
+	// Details:
+	// https://github.com/kubernetes-sigs/controller-runtime/blob/67b27f27e514bd9ac4cf9a2d84dec089ece95bf7/pkg/metrics/client_go_adapter.go#L42-L55
+	// https://github.com/kubernetes/client-go/blob/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53/tools/metrics/metrics.go#L129-L170
 	metrics.Register(
 		metrics.RegisterOpts{
 			RequestLatency:     httpMetrics,
@@ -71,6 +83,9 @@ func MustRegisterClientGoMetrics(registerer prometheus.Registerer) {
 			RateLimiterLatency: rateLimiterMetrics,
 		},
 	)
+	metrics.RequestLatency = httpMetrics
+	metrics.RequestResult = httpMetrics
+	metrics.RateLimiterLatency = rateLimiterMetrics
 
 	registerer.MustRegister(httpMetrics.count, httpMetrics.duration, rateLimiterMetrics.duration)
 }


### PR DESCRIPTION
## Description

controller-runtime also calls `metrics.Register()` during init and this function can be called only once. To ensure that the k8s client metrics get updated, the global variables need to be set again by the operator.

https://github.com/kubernetes-sigs/controller-runtime/blob/67b27f27e514bd9ac4cf9a2d84dec089ece95bf7/pkg/metrics/client_go_adapter.go#L42-L55 https://github.com/kubernetes/client-go/blob/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53/tools/metrics/metrics.go#L129-L170

Closes #6513 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix missing `prometheus_operator_kubernetes_client_http_requests_total` metric.
```
