### PR TITLE
fix: ScrapeClass TLSConfig nil pointer exception (#6507)

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -395,23 +395,24 @@ func (cg *ConfigGenerator) MergeTLSConfigWithScrapeClass(tlsConfig *monitoringv1
 		scrapeClassName = scrapeClass.Name
 	}
 
-	scrapeClass, found := cg.scrapeClasses[scrapeClassName]
-
-	if !found {
-		return tlsConfig
+	scrapeClass = cg.scrapeClasses[scrapeClassName]
+	if scrapeClass == nil {
+		return tlsConfig // could be nil.
 	}
 
-	if tlsConfig == nil && !found {
+	// scrapeClass exists.
+
+	if tlsConfig == nil {
+		return scrapeClass.TLSConfig // could be nil.
+	}
+
+	// tlsConfig exists.
+
+	if scrapeClass.TLSConfig == nil {
 		return nil
 	}
 
-	if tlsConfig != nil && !found {
-		return tlsConfig
-	}
-
-	if tlsConfig == nil && found {
-		return scrapeClass.TLSConfig
-	}
+	// scrapeClass.TLSConfig exists.
 
 	if tlsConfig.CAFile == "" && tlsConfig.SafeTLSConfig.CA == (monitoringv1.SecretOrConfigMap{}) {
 		tlsConfig.CAFile = scrapeClass.TLSConfig.CAFile

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -8056,6 +8056,31 @@ func TestMergeTLSConfigWithScrapeClass(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "nil TLSConfig, non-nil ScrapeClass with nil TLSConfig",
+			tlsConfig: nil,
+			scrapeClass: &monitoringv1.ScrapeClass{
+				Name:      "default",
+				TLSConfig: nil,
+			},
+			expectedConfig: &monitoringv1.TLSConfig{
+				CAFile:   "defaultCAFile",
+				CertFile: "defaultCertFile",
+				KeyFile:  "defaultKeyFile",
+			},
+			cg: &ConfigGenerator{
+				defaultScrapeClassName: "default",
+				scrapeClasses: map[string]*monitoringv1.ScrapeClass{
+					"default": {
+						TLSConfig: &monitoringv1.TLSConfig{
+							CAFile:   "defaultCAFile",
+							CertFile: "defaultCertFile",
+							KeyFile:  "defaultKeyFile",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Cherry-pick of #6507

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
[BUGFIX] Fix ScrapeClass TLSConfig nil pointer panic when only relabeling is configured.
```
