### PR TITLE
Fix proxyConnectHeader type in ScrapeConfig

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -585,13 +585,13 @@ func (cg *ConfigGenerator) addProxyConfigtoYaml(
 	}
 
 	if proxyConfig.ProxyConnectHeader != nil {
-		proxyConnectHeader := make(map[string]string, len(proxyConfig.ProxyConnectHeader))
+		proxyConnectHeader := make(map[string][]string, len(proxyConfig.ProxyConnectHeader))
 
 		for k, v := range proxyConfig.ProxyConnectHeader {
 			value, _ := store.GetKey(ctx, namespace, monitoringv1.SecretOrConfigMap{
 				Secret: &v,
 			})
-			proxyConnectHeader[k] = value
+			proxyConnectHeader[k] = []string{value}
 		}
 
 		cfg = cgProxyConfig.AppendMapItem(cfg, "proxy_connect_header", stringMapToMapSlice(proxyConnectHeader))

--- a/pkg/prometheus/testdata/ConsulScrapeConfig.golden
+++ b/pkg/prometheus/testdata/ConsulScrapeConfig.golden
@@ -28,7 +28,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     follow_redirects: true
     enable_http2: true
   relabel_configs:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DigitalOceanSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DigitalOceanSD.golden
@@ -13,7 +13,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     follow_redirects: true
     enable_http2: true
     port: 9100

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSDConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSDConfig.golden
@@ -13,7 +13,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     host: hostAddress
     tls_config:
       insecure_skip_verify: false

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EurekaSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EurekaSD.golden
@@ -13,7 +13,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     follow_redirects: true
     enable_http2: true
     refresh_interval: 30s

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HTTPSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HTTPSD.golden
@@ -13,7 +13,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: false
     proxy_connect_header:
-      header: value
+      header:
+      - value
   relabel_configs:
   - source_labels:
     - job

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSD.golden
@@ -11,7 +11,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     role: hcloud
     follow_redirects: true
     enable_http2: true

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD.golden
@@ -12,7 +12,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     follow_redirects: true
     enable_http2: true
   relabel_configs:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_KumaSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_KumaSD.golden
@@ -13,7 +13,8 @@ scrape_configs:
     no_proxy: 0.0.0.0
     proxy_from_environment: true
     proxy_connect_header:
-      header: value
+      header:
+      - value
     server: 127.0.0.1
     follow_redirects: true
     enable_http2: true

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ProxySettings.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ProxySettings.golden
@@ -10,7 +10,8 @@ scrape_configs:
   no_proxy: 0.0.0.0
   proxy_from_environment: false
   proxy_connect_header:
-    header: value
+    header:
+    - value
   relabel_configs:
   - source_labels:
     - job


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fix proxyConnectHeader type in ScrapeConfig

fixes: #6523 

link: #6527 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix proxyConnectHeader type in ScrapeConfig
```
