### PR TITLE
doc: fix sample port name used

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -141,7 +141,7 @@ spec:
     port: 8080
 ```
 
-We would then define the service monitor using `metrics` as the port not `"8080"`. E.g.
+We would then define the service monitor using `web` as the port, not `"8080"`. E.g.
 
 **CORRECT**
 


### PR DESCRIPTION
## Description

Fixes minor documentation glitch at https://github.com/prometheus-operator/prometheus-operator/issues/6552


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Proof-reading done

## Changelog entry

```release-note
- Minor documentation fix for the troubleshooting section.
```
