### PR TITLE
fix: alertmanager: Add TLS-assets for email and webhook receivers to assets secret when using alertmanagerConfiguration

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1055,6 +1055,9 @@ func (cb *configBuilder) convertEmailConfig(ctx context.Context, in monitoringv1
 	}
 
 	if in.TLSConfig != nil {
+		if err := cb.store.AddSafeTLSConfig(ctx, crKey.Namespace, in.TLSConfig); err != nil {
+			return nil, err
+		}
 		out.TLSConfig = cb.convertTLSConfig(in.TLSConfig, crKey)
 	}
 
@@ -1508,6 +1511,9 @@ func (cb *configBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1
 	}
 
 	if in.TLSConfig != nil {
+		if err := cb.store.AddSafeTLSConfig(ctx, crKey.Namespace, in.TLSConfig); err != nil {
+			return nil, err
+		}
 		out.TLSConfig = cb.convertTLSConfig(in.TLSConfig, crKey)
 	}
 


### PR DESCRIPTION
## Description

When we are using alertmanagerConfiguration email and webhook receivers from this config which contain TLS setting (TLS-assets), they do not add in internal store and therese assets do not save to TLS-assets secret which will mounted to alert manager pod.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

Add TLS-assets for email and webhook receivers to assets secret when using alertmanagerConfiguration

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
