### PR TITLE
fix: apply TLS scrape class to all objects

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -13398,8 +13398,9 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Default indicates that the scrape applies to all scrape objects that don&rsquo;t configure an explicit scrape class name.</p>
-<p>Only one scrape class can be set as default.</p>
+<p>Default indicates that the scrape applies to all scrape objects that
+don&rsquo;t configure an explicit scrape class name.</p>
+<p>Only one scrape class can be set as the default.</p>
 </td>
 </tr>
 <tr>
@@ -13413,7 +13414,10 @@ TLSConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>TLSConfig section for scrapes.</p>
+<p>TLSConfig defines the TLS settings to use for the scrape. When the
+scrape objects define their own CA, certificate and/or key, they take
+precedence over the corresponding scrape class fields.</p>
+<p>For now only the <code>caFile</code>, <code>certFile</code> and <code>keyFile</code> fields are supported.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21021,10 +21021,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -21135,7 +21136,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server
@@ -31636,10 +31643,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -31750,7 +31758,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5529,10 +5529,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -5643,7 +5644,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6642,10 +6642,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -6756,7 +6757,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5530,10 +5530,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -5644,7 +5645,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6643,10 +6643,11 @@ spec:
                   properties:
                     default:
                       description: |-
-                        Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+                        Default indicates that the scrape applies to all scrape objects that
+                        don't configure an explicit scrape class name.
 
 
-                        Only one scrape class can be set as default.
+                        Only one scrape class can be set as the default.
                       type: boolean
                     name:
                       description: Name of the scrape class.
@@ -6757,7 +6758,13 @@ spec:
                         type: object
                       type: array
                     tlsConfig:
-                      description: TLSConfig section for scrapes.
+                      description: |-
+                        TLSConfig defines the TLS settings to use for the scrape. When the
+                        scrape objects define their own CA, certificate and/or key, they take
+                        precedence over the corresponding scrape class fields.
+
+
+                        For now only the `caFile`, `certFile` and `keyFile` fields are supported.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4769,7 +4769,7 @@
                     "items": {
                       "properties": {
                         "default": {
-                          "description": "Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.\n\n\nOnly one scrape class can be set as default.",
+                          "description": "Default indicates that the scrape applies to all scrape objects that\ndon't configure an explicit scrape class name.\n\n\nOnly one scrape class can be set as the default.",
                           "type": "boolean"
                         },
                         "name": {
@@ -4847,7 +4847,7 @@
                           "type": "array"
                         },
                         "tlsConfig": {
-                          "description": "TLSConfig section for scrapes.",
+                          "description": "TLSConfig defines the TLS settings to use for the scrape. When the\nscrape objects define their own CA, certificate and/or key, they take\nprecedence over the corresponding scrape class fields.\n\n\nFor now only the `caFile`, `certFile` and `keyFile` fields are supported.",
                           "properties": {
                             "ca": {
                               "description": "Certificate authority used when verifying server certificates.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5779,7 +5779,7 @@
                     "items": {
                       "properties": {
                         "default": {
-                          "description": "Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.\n\n\nOnly one scrape class can be set as default.",
+                          "description": "Default indicates that the scrape applies to all scrape objects that\ndon't configure an explicit scrape class name.\n\n\nOnly one scrape class can be set as the default.",
                           "type": "boolean"
                         },
                         "name": {
@@ -5857,7 +5857,7 @@
                           "type": "array"
                         },
                         "tlsConfig": {
-                          "description": "TLSConfig section for scrapes.",
+                          "description": "TLSConfig defines the TLS settings to use for the scrape. When the\nscrape objects define their own CA, certificate and/or key, they take\nprecedence over the corresponding scrape class fields.\n\n\nFor now only the `caFile`, `certFile` and `keyFile` fields are supported.",
                           "properties": {
                             "ca": {
                               "description": "Certificate authority used when verifying server certificates.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1815,17 +1815,25 @@ func (e *AuthorizationValidationError) Error() string {
 
 type ScrapeClass struct {
 	// Name of the scrape class.
+	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Name string `json:"name"`
 
-	// Default indicates that the scrape applies to all scrape objects that don't configure an explicit scrape class name.
+	// Default indicates that the scrape applies to all scrape objects that
+	// don't configure an explicit scrape class name.
 	//
-	// Only one scrape class can be set as default.
+	// Only one scrape class can be set as the default.
+	//
 	// +optional
 	Default *bool `json:"default,omitempty"`
 
-	// TLSConfig section for scrapes.
+	// TLSConfig defines the TLS settings to use for the scrape. When the
+	// scrape objects define their own CA, certificate and/or key, they take
+	// precedence over the corresponding scrape class fields.
+	//
+	// For now only the `caFile`, `certFile` and `keyFile` fields are supported.
+	//
 	// +optional
 	TLSConfig *TLSConfig `json:"tlsConfig,omitempty"`
 

--- a/pkg/prometheus/testdata/monitorObjectWithDefaultScrapeClassAndTLSConfig.golden
+++ b/pkg/prometheus/testdata/monitorObjectWithDefaultScrapeClassAndTLSConfig.golden
@@ -84,6 +84,10 @@ scrape_configs:
       names:
       - default
   scrape_interval: 30s
+  tls_config:
+    ca_file: /etc/prometheus/secrets/default/ca.crt
+    cert_file: /etc/prometheus/secrets/default/tls.crt
+    key_file: /etc/prometheus/secrets/default/tls.key
   relabel_configs:
   - source_labels:
     - job
@@ -159,10 +163,18 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  tls_config:
+    ca_file: /etc/prometheus/secrets/default/ca.crt
+    cert_file: /etc/prometheus/secrets/default/tls.crt
+    key_file: /etc/prometheus/secrets/default/tls.key
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop
 - job_name: scrapeConfig/default/defaultScrapeConfig
+  tls_config:
+    ca_file: /etc/prometheus/secrets/default/ca.crt
+    cert_file: /etc/prometheus/secrets/default/tls.crt
+    key_file: /etc/prometheus/secrets/default/tls.key
   http_sd_configs:
   - url: http://localhost:9100/sd.json
     refresh_interval: 5m

--- a/pkg/prometheus/testdata/monitorObjectWithNonDefaultScrapeClassAndTLSConfig.golden
+++ b/pkg/prometheus/testdata/monitorObjectWithNonDefaultScrapeClassAndTLSConfig.golden
@@ -84,6 +84,10 @@ scrape_configs:
       names:
       - default
   scrape_interval: 30s
+  tls_config:
+    ca_file: /etc/prometheus/secrets/ca.crt
+    cert_file: /etc/prometheus/secrets/tls.crt
+    key_file: /etc/prometheus/secrets/tls.key
   relabel_configs:
   - source_labels:
     - job
@@ -159,10 +163,18 @@ scrape_configs:
     - __tmp_hash
     regex: $(SHARD)
     action: keep
+  tls_config:
+    ca_file: /etc/prometheus/secrets/ca.crt
+    cert_file: /etc/prometheus/secrets/tls.crt
+    key_file: /etc/prometheus/secrets/tls.key
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop
 - job_name: scrapeConfig/default/defaultScrapeConfig
+  tls_config:
+    ca_file: /etc/prometheus/secrets/ca.crt
+    cert_file: /etc/prometheus/secrets/tls.crt
+    key_file: /etc/prometheus/secrets/tls.key
   http_sd_configs:
   - url: http://localhost:9100/sd.json
     refresh_interval: 5m


### PR DESCRIPTION
## Description

Before this change, the TLS configuration from the scrape class wasn't applied to the generated configuration for PodMonitor, ScrapeConfig and Probe objects.

Closes #6556

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix TLS configuration from scrape classes not being applied to `PodMonitor`, `Probe` and `ScrapeConfig` objects.
```
