### PR TITLE
fix: deref nil pointer on WebexConfig

### DIFF
--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -321,7 +321,7 @@ func validateTelegramConfigs(configs []monitoringv1alpha1.TelegramConfig) error 
 
 func validateWebexConfigs(configs []monitoringv1alpha1.WebexConfig) error {
 	for _, config := range configs {
-		if *config.APIURL != "" {
+		if config.APIURL != nil && *config.APIURL != "" {
 			if _, err := validation.ValidateURL(string(*config.APIURL)); err != nil {
 				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -312,7 +312,7 @@ func validateTelegramConfigs(configs []monitoringv1beta1.TelegramConfig) error {
 
 func validateWebexConfigs(configs []monitoringv1beta1.WebexConfig) error {
 	for _, config := range configs {
-		if *config.APIURL != "" {
+		if config.APIURL != nil && *config.APIURL != "" {
 			if _, err := validation.ValidateURL(string(*config.APIURL)); err != nil {
 				return fmt.Errorf("invalid 'apiURL': %w", err)
 			}


### PR DESCRIPTION
## Description

Sending an allegedly mis-configured alertmanagerConfig causes the operator to panic and CrashLoopBackoff.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix panic when ApiURL is nil in WebexConfig.
```
