### PR TITLE
Fix: One Alertmanager Config failing blocks all others.

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1273,7 +1273,7 @@ func checkDiscordConfigs(
 
 		url, err := store.GetSecretKey(ctx, namespace, config.APIURL)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to retrieve API URL: %w", err)
 		}
 		if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
 			return fmt.Errorf("discord webhook 'url' secret failed validation: %w", err)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1195,7 +1195,7 @@ func checkPagerDutyConfigs(
 
 		if config.URL != "" {
 			if _, err := validation.ValidateURL(strings.TrimSpace(config.URL)); err != nil {
-				return fmt.Errorf("pagerduty 'url' %s invalid: %w", config.URL, err)
+				return fmt.Errorf("failed to validate URL: %w ", err)
 			}
 
 		}
@@ -1276,7 +1276,7 @@ func checkDiscordConfigs(
 			return fmt.Errorf("failed to retrieve API URL: %w", err)
 		}
 		if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
-			return fmt.Errorf("discord webhook 'url' secret failed validation: %w", err)
+			return fmt.Errorf("failed to validate API URL: %w", err)
 		}
 	}
 
@@ -1301,7 +1301,7 @@ func checkSlackConfigs(
 				return err
 			}
 			if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
-				return fmt.Errorf("slack api 'url' secret failed validation: %w", err)
+				return fmt.Errorf("failed to validate API URL: %w", err)
 			}
 		}
 
@@ -1331,7 +1331,7 @@ func checkWebhookConfigs(
 				return err
 			}
 			if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
-				return fmt.Errorf("webhook 'url' secret failed validation: %w", err)
+				return fmt.Errorf("failed to validate URL: %w", err)
 			}
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1193,6 +1193,13 @@ func checkPagerDutyConfigs(
 			}
 		}
 
+		if config.URL != "" {
+			if _, err := validation.ValidateURL(strings.TrimSpace(config.URL)); err != nil {
+				return fmt.Errorf("pagerduty 'url' %s invalid: %w", config.URL, err)
+			}
+
+		}
+
 		if err := configureHTTPConfigInStore(ctx, config.HTTPConfig, namespace, store); err != nil {
 			return err
 		}
@@ -1264,9 +1271,14 @@ func checkDiscordConfigs(
 			return err
 		}
 
-		if _, err := store.GetSecretKey(ctx, namespace, config.APIURL); err != nil {
-			return fmt.Errorf("failed to retrieve API URL: %w", err)
+		url, err := store.GetSecretKey(ctx, namespace, config.APIURL)
+		if err != nil {
+			return err
 		}
+		if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
+			return fmt.Errorf("discord webhook 'url' %s invalid: %w", url, err)
+		}
+
 	}
 
 	return nil
@@ -1285,9 +1297,14 @@ func checkSlackConfigs(
 		}
 
 		if config.APIURL != nil {
-			if _, err := store.GetSecretKey(ctx, namespace, *config.APIURL); err != nil {
+			url, err := store.GetSecretKey(ctx, namespace, *config.APIURL)
+			if err != nil {
 				return err
 			}
+			if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
+				return fmt.Errorf("slack api 'url' %s invalid: %w", url, err)
+			}
+
 		}
 
 		if err := configureHTTPConfigInStore(ctx, config.HTTPConfig, namespace, store); err != nil {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1275,8 +1275,8 @@ func checkDiscordConfigs(
 		if err != nil {
 			return err
 		}
-		if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
-			return fmt.Errorf("discord webhook 'url' %s invalid: %w", url, err)
+		if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
+			return fmt.Errorf("discord webhook 'url' secret failed validation: %w", err)
 		}
 	}
 
@@ -1300,8 +1300,8 @@ func checkSlackConfigs(
 			if err != nil {
 				return err
 			}
-			if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
-				return fmt.Errorf("slack api 'url' %s invalid: %w", url, err)
+			if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
+				return fmt.Errorf("slack api 'url' secret failed validation: %w", err)
 			}
 		}
 
@@ -1330,8 +1330,8 @@ func checkWebhookConfigs(
 			if err != nil {
 				return err
 			}
-			if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
-				return fmt.Errorf("webhook 'url' %s invalid: %w", url, err)
+			if err := validation.ValidateSecretURL(strings.TrimSpace(url)); err != nil {
+				return fmt.Errorf("webhook 'url' secret failed validation: %w", err)
 			}
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1278,7 +1278,6 @@ func checkDiscordConfigs(
 		if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
 			return fmt.Errorf("discord webhook 'url' %s invalid: %w", url, err)
 		}
-
 	}
 
 	return nil
@@ -1304,7 +1303,6 @@ func checkSlackConfigs(
 			if _, err := validation.ValidateURL(strings.TrimSpace(url)); err != nil {
 				return fmt.Errorf("slack api 'url' %s invalid: %w", url, err)
 			}
-
 		}
 
 		if err := configureHTTPConfigInStore(ctx, config.HTTPConfig, namespace, store); err != nil {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -205,7 +205,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 				Namespace: "ns1",
 			},
 			Data: map[string][]byte{
-				"key1": []byte("https://val1.com"),
+				"key1":        []byte("https://val1.com"),
+				"invalid-url": []byte("://foo"),
 			},
 		},
 	)
@@ -980,6 +981,24 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					}},
 				},
 			},
+					Name:      "slack-with-invalid-url-in-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						SlackConfigs: []monitoringv1alpha1.SlackConfig{
+							{
+								APIURL: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+									Key:                  "invalid-url",
+								},
+							},
+						},
+					}},
+				},
+			},
+			ok: false,
 		},
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
@@ -1071,6 +1090,24 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			ok: true,
+					Name:      "discord-with-invalid-url-in-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						DiscordConfigs: []monitoringv1alpha1.DiscordConfig{
+							{
+								APIURL: v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+									Key:                  "invalid-url",
+								},
+							},
+						},
+					}},
+				},
+			},
+			ok: false,
 		},
 	} {
 		t.Run(tc.amConfig.Name, func(t *testing.T) {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -981,6 +981,10 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					}},
 				},
 			},
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "slack-with-invalid-url-in-secret",
 					Namespace: "ns1",
 				},
@@ -1090,6 +1094,10 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			ok: true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "discord-with-invalid-url-in-secret",
 					Namespace: "ns1",
 				},

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -41,9 +41,8 @@ func ValidateSecretURL(url string) error {
 	var u config.SecretURL
 
 	err := u.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, url)))
-
 	if err != nil {
-		return fmt.Errorf("validate url from string failed with error: %s", err)
+		return fmt.Errorf("validate url from string failed with error: %w", err)
 	}
 
 	return nil

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/prometheus/alertmanager/config"
 )
 

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -17,8 +17,6 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"github.com/prometheus/alertmanager/config"
 )
 
@@ -37,22 +35,15 @@ func ValidateURL(url string) (*config.URL, error) {
 
 // ValidateSecretURL against config.URL
 // This is for URLs which are retrieved from secrets and should not
-// logged part of the err.
+// logged as part of the err.
 func ValidateSecretURL(url string) error {
-	var u config.URL
+	var u config.SecretURL
 
-	err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, url)), &u)
+	err := u.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, url)))
 
 	if err != nil {
-		var unmarshalError string
-		//Redact the url if the error message contains it.
-		if strings.Contains(err.Error(), url) {
-			unmarshalError = strings.ReplaceAll(err.Error(), url, "[REDACTED]")
-		} else {
-			unmarshalError = err.Error()
-		}
-
-		return fmt.Errorf("validate url from string failed with error: %s", unmarshalError)
+		return fmt.Errorf("validate url from string failed with error: %s", err)
 	}
+
 	return nil
 }

--- a/pkg/alertmanager/validation/validation_test.go
+++ b/pkg/alertmanager/validation/validation_test.go
@@ -63,3 +63,42 @@ func TestValidateUrl(t *testing.T) {
 		})
 	}
 }
+func TestValidateSecretUrl(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           string
+		expectErr    bool
+		expectResult func() *config.URL
+	}{
+		{
+			name:      "Test invalid url returns error",
+			in:        "https://!^invalid.com",
+			expectErr: true,
+		},
+		{
+			name:      "Test missing scheme returns error",
+			in:        "is.normally.valid",
+			expectErr: true,
+		},
+		{
+			name: "Test happy path",
+			in:   "https://u:p@is.compliant.with.upstream.unmarshal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSecretURL(tc.in)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
## Description
We need to validate the urls passed as secrets in AlertManagerConfig receivers ( Slack and Discord in particular) to ensure we discard the faulty config early and don't create a hang up at the conversion stage.
Closes #6532


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Build the image and try passing a malformed url in slack config for which the operator logs show error.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
   Fix one alertmanagerconfig failing to sync blocks all others
```