### PR TITLE
Corrected Documentation for xxxMonitorNamespaxceSelector 

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1507,7 +1507,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -1544,7 +1544,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6121,7 +6121,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6158,7 +6158,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10245,7 +10245,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10282,7 +10282,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16194,7 +16194,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16231,7 +16231,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22510,7 +22510,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22547,7 +22547,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Description

This PR solves the issue #6550 . Added the **"default value"** description for all xxxMonitorNamespaceSelectors

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ `x`] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
N/A

## Changelog entry

```release-note
- Documentation change for xxxMonitorNamespaceSelector field
```
