### PR TITLE
Corrected Documentation for xxxMonitorNamespaceSelector 

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1507,7 +1507,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -1544,7 +1544,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6121,7 +6121,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6158,7 +6158,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10245,7 +10245,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10282,7 +10282,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16194,7 +16194,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16231,7 +16231,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22510,7 +22510,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22547,7 +22547,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector (default value) matches the current
 namespace only.</p>
 </td>
 </tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1507,7 +1507,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -1544,7 +1544,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6121,7 +6121,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6158,7 +6158,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10245,7 +10245,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10282,7 +10282,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16194,7 +16194,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16231,7 +16231,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22510,7 +22510,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22547,7 +22547,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector matches the current
+matches all namespaces. A null label selector <b>(default value)</b> matches the current
 namespace only.</p>
 </td>
 </tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1507,7 +1507,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -1544,7 +1544,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6121,7 +6121,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -6158,7 +6158,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10245,7 +10245,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -10282,7 +10282,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16194,7 +16194,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -16231,7 +16231,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22510,7 +22510,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for ServicedMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>
@@ -22547,7 +22547,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Namespaces to match for PodMonitors discovery. An empty label selector
-matches all namespaces. A null label selector <b>(default value)</b> matches the current
+matches all namespaces. A null label selector matches the current
 namespace only.</p>
 </td>
 </tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -19958,7 +19958,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -21643,7 +21643,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -30167,7 +30167,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -32472,7 +32472,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4466,7 +4466,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -6151,7 +6151,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5150,7 +5150,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -7455,7 +7455,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4467,7 +4467,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -6152,7 +6152,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5151,7 +5151,7 @@ spec:
               podMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for PodMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:
@@ -7456,7 +7456,7 @@ spec:
               serviceMonitorNamespaceSelector:
                 description: |-
                   Namespaces to match for ServicedMonitors discovery. An empty label selector
-                  matches all namespaces. A null label selector matches the current
+                  matches all namespaces. A null label selector (default value) matches the current
                   namespace only.
                 properties:
                   matchExpressions:

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3827,7 +3827,7 @@
                     "type": "object"
                   },
                   "podMonitorNamespaceSelector": {
-                    "description": "Namespaces to match for PodMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
+                    "description": "Namespaces to match for PodMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector (default value) matches the current\nnamespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5261,7 +5261,7 @@
                     "type": "string"
                   },
                   "serviceMonitorNamespaceSelector": {
-                    "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
+                    "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector (default value) matches the current\nnamespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4403,7 +4403,7 @@
                     "type": "object"
                   },
                   "podMonitorNamespaceSelector": {
-                    "description": "Namespaces to match for PodMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
+                    "description": "Namespaces to match for PodMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector (default value) matches the current\nnamespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -6409,7 +6409,7 @@
                     "type": "string"
                   },
                   "serviceMonitorNamespaceSelector": {
-                    "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector matches the current\nnamespace only.",
+                    "description": "Namespaces to match for ServicedMonitors discovery. An empty label selector\nmatches all namespaces. A null label selector (default value) matches the current\nnamespace only.",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -120,7 +120,7 @@ type CommonPrometheusFields struct {
 	// `spec.additionalScrapeConfigs` instead.
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 	// Namespaces to match for ServicedMonitors discovery. An empty label selector
-	// matches all namespaces. A null label selector matches the current
+	// matches all namespaces. A null label selector (default value) matches the current
 	// namespace only.
 	ServiceMonitorNamespaceSelector *metav1.LabelSelector `json:"serviceMonitorNamespaceSelector,omitempty"`
 
@@ -137,7 +137,7 @@ type CommonPrometheusFields struct {
 	// `spec.additionalScrapeConfigs` instead.
 	PodMonitorSelector *metav1.LabelSelector `json:"podMonitorSelector,omitempty"`
 	// Namespaces to match for PodMonitors discovery. An empty label selector
-	// matches all namespaces. A null label selector matches the current
+	// matches all namespaces. A null label selector (default value) matches the current
 	// namespace only.
 	PodMonitorNamespaceSelector *metav1.LabelSelector `json:"podMonitorNamespaceSelector,omitempty"`
 


### PR DESCRIPTION
## Description

This PR solves the issue #6550 . Added **default value** in the xxxMonitorNamespaceSelector field description.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ `x`] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Not required(docs change)

## Changelog entry

```release-note
- Documentation change foe xxxMonitorNamespaceSelector fields.
```
