### PR TITLE
Reload alert manager when notification templates change

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -16,11 +16,11 @@ package alertmanager
 
 import (
 	"fmt"
-	"github.com/blang/semver/v4"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -16,11 +16,11 @@ package alertmanager
 
 import (
 	"fmt"
+	"github.com/blang/semver/v4"
 	"net/url"
 	"path"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	appsv1 "k8s.io/api/apps/v1"
@@ -511,6 +511,20 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 		},
 	}
 
+	var configReloaderWebConfigFile string
+	watchedDirectories := []string{alertmanagerConfigDir}
+	configReloaderVolumeMounts := []v1.VolumeMount{
+		{
+			Name:      alertmanagerConfigVolumeName,
+			MountPath: alertmanagerConfigDir,
+			ReadOnly:  true,
+		},
+		{
+			Name:      alertmanagerConfigOutVolumeName,
+			MountPath: alertmanagerConfigOutDir,
+		},
+	}
+
 	amCfg := a.Spec.AlertmanagerConfiguration
 	if amCfg != nil && len(amCfg.Templates) > 0 {
 		sources := []v1.VolumeProjection{}
@@ -566,20 +580,12 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 			ReadOnly:  true,
 			MountPath: alertmanagerTemplatesDir,
 		})
-	}
-
-	var configReloaderWebConfigFile string
-	watchedDirectories := []string{alertmanagerConfigDir}
-	configReloaderVolumeMounts := []v1.VolumeMount{
-		{
-			Name:      alertmanagerConfigVolumeName,
-			MountPath: alertmanagerConfigDir,
+		configReloaderVolumeMounts = append(configReloaderVolumeMounts, v1.VolumeMount{
+			Name:      alertmanagerTemplatesVolumeName,
 			ReadOnly:  true,
-		},
-		{
-			Name:      alertmanagerConfigOutVolumeName,
-			MountPath: alertmanagerConfigOutDir,
-		},
+			MountPath: alertmanagerTemplatesDir,
+		})
+		watchedDirectories = append(watchedDirectories, alertmanagerTemplatesDir)
 	}
 
 	rn := k8sutil.NewResourceNamerWithPrefix("secret")


### PR DESCRIPTION
## Description

add etc/alertmanager/templates to watched-dir to support config reload when notification template files are modified.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Add etc/alertmanager/templates to watched-dir to support config reload when notification template files are modified

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Reload alert manager when notification templates are changed
```
