### PR TITLE
bugfix: Fix bug created from race conditions during merge

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -115,7 +115,7 @@ func getScrapeClassConfig(p monitoringv1.PrometheusInterface) (map[string]monito
 		if err := ValidateRelabelConfigs(p, scrapeClass.Relabelings); err != nil {
 			return nil, "", fmt.Errorf("invalid relabelings for scrapeClass %s: %w", scrapeClass.Name, err)
 		}
-		if err := validateRelabelConfigs(p, scrapeClass.MetricRelabelings); err != nil {
+		if err := ValidateRelabelConfigs(p, scrapeClass.MetricRelabelings); err != nil {
 			return nil, "", fmt.Errorf("invalid metric relabelings for scrapeClass %s: %w", scrapeClass.Name, err)
 		}
 


### PR DESCRIPTION
## Description

It looks like we've got some sort of race conditions when merging https://github.com/prometheus-operator/prometheus-operator/pull/6492 and https://github.com/prometheus-operator/prometheus-operator/pull/6480.

We didn't have merge conflicts, and tests passed for both PRs, but [it failed to compile when they got to the `main` branch](https://github.com/prometheus-operator/prometheus-operator/actions/runs/9213422579/job/25347296248)

This PR fixes the `main` branch



## Type of change

- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry



```release-note
NONE
```
