### PR TITLE
Use functional options pattern for Prometheus Controller

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -95,8 +95,28 @@ type Operator struct {
 	eventRecorder record.EventRecorder
 }
 
+type ControllerOptions func(*Operator)
+
+func WithEndpointSlice() ControllerOptions {
+	return func(o *Operator) {
+		o.endpointSliceSupported = true
+	}
+}
+
+func WithScrapeConfig() ControllerOptions {
+	return func(o *Operator) {
+		o.scrapeConfigSupported = true
+	}
+}
+
+func WithStorageClassValidation() ControllerOptions {
+	return func(o *Operator) {
+		o.canReadStorageClass = true
+	}
+}
+
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, scrapeConfigSupported, canReadStorageClass bool, erf operator.EventRecorderFactory) (*Operator, error) {
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, erf operator.EventRecorderFactory, opts ...ControllerOptions) (*Operator, error) {
 	logger = log.With(logger, "component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
@@ -135,13 +155,14 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		metrics:         operator.NewMetrics(r),
 		reconciliations: &operator.ReconciliationTracker{},
 
-		controllerID: c.ControllerID,
-
-		scrapeConfigSupported: scrapeConfigSupported,
-		canReadStorageClass:   canReadStorageClass,
-
+		controllerID:  c.ControllerID,
 		eventRecorder: erf(client, controllerName),
 	}
+	// Process options, enabling or disabling features.
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	o.metrics.MustRegister(o.reconciliations)
 
 	o.rr = operator.NewResourceReconciler(


### PR DESCRIPTION
## Description

After #6491 got merged, I went back to #6198. While I was trying to pass the feature-gate value to the controller, I noticed how we're passing way too many booleans to the function signature. Something that will only grow as we introduce more optionality as feature flags.

Here I'm proposing that we use a functional options pattern to create Prometheus Controller, allowing us to introduce more options without much effort. (The same can be done to other controllers as well)

In #6198, the plan would be to have a `WithGracefulShutdownSupport()` function, that would enable the feature in the controller's level.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
