### PR TITLE
chore: add test for AlertmanagerConfig with subroutes

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -41,8 +42,17 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
 )
 
+func mustMarshalRoute(r monitoringv1alpha1.Route) []byte {
+	b, err := json.Marshal(r)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
 func TestInitializeFromAlertmanagerConfig(t *testing.T) {
-	myroute := monitoringv1alpha1.Route{
+	myrouteJSON := mustMarshalRoute(monitoringv1alpha1.Route{
 		Receiver: "myreceiver",
 		Matchers: []monitoringv1alpha1.Matcher{
 			{
@@ -51,9 +61,8 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Regex: false,
 			},
 		},
-	}
+	})
 
-	myrouteJSON, _ := json.Marshal(myroute)
 	pagerdutyURL := "example.pagerduty.com"
 	invalidPagerdutyURL := "://example.pagerduty.com"
 
@@ -787,8 +796,7 @@ func TestGenerateConfig(t *testing.T) {
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_no_CRs.golden",
+			golden: "skeleton_base_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global send_revolved, no CRs",
@@ -800,8 +808,7 @@ func TestGenerateConfig(t *testing.T) {
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_global_send_revolved_no_CRs.golden",
+			golden: "skeleton_base_with_global_send_revolved_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to false, no CRs",
@@ -813,8 +820,7 @@ func TestGenerateConfig(t *testing.T) {
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_global_smtp_require_tls_set_to_false,_no_CRs.golden",
+			golden: "skeleton_base_with_global_smtp_require_tls_set_to_false,_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with global smtp_require_tls set to true, no CRs",
@@ -826,8 +832,7 @@ func TestGenerateConfig(t *testing.T) {
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_global_smtp_require_tls_set_to_true_no_CRs.golden",
+			golden: "skeleton_base_with_global_smtp_require_tls_set_to_true_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with inhibit rules, no CRs",
@@ -842,8 +847,7 @@ func TestGenerateConfig(t *testing.T) {
 				Route:     &route{Receiver: "null"},
 				Receivers: []*receiver{{Name: "null"}},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_inhibit_rules_no_CRs.golden",
+			golden: "skeleton_base_with_inhibit_rules_no_CRs.golden",
 		},
 		{
 			name:    "base with sub route and matchers, no CRs",
@@ -861,8 +865,7 @@ func TestGenerateConfig(t *testing.T) {
 					{Name: "custom"},
 				},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "base_with_sub_route_and_matchers_no_CRs.golden",
+			golden: "base_with_sub_route_and_matchers_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with mute time intervals, no CRs",
@@ -914,8 +917,7 @@ func TestGenerateConfig(t *testing.T) {
 					},
 				},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_mute_time_intervals_no_CRs.golden",
+			golden: "skeleton_base_with_mute_time_intervals_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base with sns receiver, no CRs",
@@ -944,8 +946,7 @@ func TestGenerateConfig(t *testing.T) {
 					},
 				},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_sns_receiver_no_CRs.golden",
+			golden: "skeleton_base_with_sns_receiver_no_CRs.golden",
 		},
 		{
 			name:      "skeleton base with active_time_intervals, no CRs",
@@ -977,8 +978,7 @@ func TestGenerateConfig(t *testing.T) {
 					},
 				},
 			},
-			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{},
-			golden:    "skeleton_base_with_active_time_intervals_no_CRs.golden",
+			golden: "skeleton_base_with_active_time_intervals_no_CRs.golden",
 		},
 		{
 			name:    "skeleton base, simple CR",
@@ -1003,6 +1003,53 @@ func TestGenerateConfig(t *testing.T) {
 				},
 			},
 			golden: "skeleton_base_simple_CR.golden",
+		},
+		{
+			name:    "skeleton base, CR with sub-routes",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Route:     &route{Receiver: "null"},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+							GroupBy:  []string{"job"},
+							Routes: []apiextensionsv1.JSON{
+								{
+									Raw: mustMarshalRoute(monitoringv1alpha1.Route{
+										Receiver: "test2",
+										GroupBy:  []string{"job", "instance"},
+										Continue: true,
+										Matchers: []monitoringv1alpha1.Matcher{
+											{Name: "job", Value: "foo", MatchType: "="},
+										},
+									}),
+								},
+								{
+									Raw: mustMarshalRoute(monitoringv1alpha1.Route{
+										Receiver: "test3",
+										GroupBy:  []string{"job", "instance"},
+										Matchers: []monitoringv1alpha1.Matcher{
+											{Name: "job", Value: "bar", MatchType: "="},
+										},
+									}),
+								},
+							},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{
+							{Name: "test"}, {Name: "test2"}, {Name: "test3"},
+						},
+					},
+				},
+			},
+			golden: "skeleton_base_CR_with_subroutes.golden",
 		},
 		{
 			name:    "multiple AlertmanagerConfig objects",

--- a/pkg/alertmanager/testdata/skeleton_base_CR_with_subroutes.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_CR_with_subroutes.golden
@@ -1,0 +1,29 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    group_by:
+    - job
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+    routes:
+    - receiver: mynamespace/myamc/test2
+      group_by:
+      - job
+      - instance
+      matchers:
+      - job="foo"
+      continue: true
+    - receiver: mynamespace/myamc/test3
+      group_by:
+      - job
+      - instance
+      matchers:
+      - job="bar"
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+- name: mynamespace/myamc/test2
+- name: mynamespace/myamc/test3
+templates: []


### PR DESCRIPTION
## Description

Add test coverage to ensure that sub-routes don't enforce the continue value.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
