### PR TITLE
chore: fix testScrapeConfigKubernetesNodeRole()

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,9 +78,14 @@ jobs:
         cluster_name: e2e
     - name: Wait for cluster to finish bootstraping
       run: |
+        echo "Waiting for all nodes to be ready..."
+        kubectl wait --for=condition=Ready nodes --all --timeout=120s
+        kubectl get nodes
+        echo "Waiting for all pods to be ready..."
         kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-        kubectl cluster-info
         kubectl get pods -A
+        echo "Cluster information"
+        kubectl cluster-info
     - name: Load images
       run: |
         kind load docker-image -n e2e quay.io/prometheus-operator/prometheus-operator:$(git rev-parse --short HEAD)

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -433,9 +433,11 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the targets appear in Prometheus and does proper scrapping
-	if err := framework.WaitForHealthyTargets(context.Background(), ns, "prometheus-operated", 1); err != nil {
-		t.Fatal(err)
-	}
+	nodes, err := framework.Nodes(context.Background())
+	require.NoError(t, err)
+
+	err = framework.WaitForHealthyTargets(context.Background(), ns, "prometheus-operated", len(nodes))
+	require.NoError(t, err)
 
 	// Remove the ScrapeConfig
 	err = framework.DeleteScrapeConfig(context.Background(), ns, "scrape-config")

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -17,6 +17,7 @@ package framework
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -111,6 +112,15 @@ func New(kubeconfig, opImage, exampleDir, resourcesDir string, operatorVersion s
 	mClientv1beta1, err := v1beta1monitoringclient.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("creating v1beta1 monitoring client failed: %w", err)
+	}
+
+	nodes, err := cli.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(nodes.Items) < 1 {
+		return nil, errors.New("no nodes returned")
 	}
 
 	f := &Framework{
@@ -757,11 +767,17 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 		return nil, nil, err
 	}
 
-	// Deploy only 1 replica because the end-to-end environment (single node
-	// cluster) can't satisfy the anti-affinity rules.
-	deploy.Spec.Replicas = ptr.To(int32(1))
-	deploy.Spec.Template.Spec.Affinity = nil
-	deploy.Spec.Strategy = appsv1.DeploymentStrategy{}
+	// Adjust replica count in case of single-node clusters because the
+	// deployment manifest has anti-affinity rules.
+	nodes, err := f.Nodes(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(nodes) == 1 {
+		deploy.Spec.Replicas = ptr.To(int32(1))
+		deploy.Spec.Template.Spec.Affinity = nil
+		deploy.Spec.Strategy = appsv1.DeploymentStrategy{}
+	}
 
 	deploy.Spec.Template.Spec.Containers[0].Args = append(deploy.Spec.Template.Spec.Containers[0].Args, "--log-level=debug")
 

--- a/test/framework/node.go
+++ b/test/framework/node.go
@@ -1,0 +1,53 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Nodes returns the list of nodes in the cluster.
+func (f *Framework) Nodes(ctx context.Context) ([]v1.Node, error) {
+	var (
+		loopErr error
+		nodes   *v1.NodeList
+	)
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*1, true, func(_ context.Context) (bool, error) {
+		nodes, loopErr = f.KubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		if loopErr != nil {
+			return false, nil
+		}
+
+		if len(nodes.Items) < 1 {
+			loopErr = errors.New("no nodes returned")
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v: %v", err, loopErr)
+	}
+
+	return nodes.Items, nil
+}


### PR DESCRIPTION
## Description

#6624 made testScrapeConfigKubernetesNodeRole() flaky because the test expected only 1 node target.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
