### PR TITLE
fix: use a separate port number for init container

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -750,7 +750,7 @@ func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config
 		operator.CreateConfigReloader(
 			"init-config-reloader",
 			operator.ReloaderConfig(config.ReloaderConfig),
-			operator.ReloaderRunOnce(),
+			operator.InitContainer(),
 			operator.LogFormat(a.Spec.LogFormat),
 			operator.LogLevel(a.Spec.LogLevel),
 			operator.WatchedDirectories(watchedDirectories),

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -73,7 +73,7 @@ func TestCreateInitConfigReloaderEnableProbes(t *testing.T) {
 			Host:   "localhost:9093",
 			Path:   "/-/reload",
 		}),
-		ReloaderRunOnce(),
+		InitContainer(),
 	)
 
 	if container.Name != "init-config-reloader" {
@@ -95,15 +95,25 @@ func TestCreateInitConfigReloader(t *testing.T) {
 	var container = CreateConfigReloader(
 		initContainerName,
 		ReloaderConfig(reloaderConfig),
-		ReloaderRunOnce(),
+		InitContainer(),
 		ImagePullPolicy(v1.PullAlways),
 	)
 	if container.Name != "init-config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", initContainerName, container.Name)
 	}
+
 	if !contains(container.Args, "--watch-interval=0") {
 		t.Errorf("Expected '--watch-interval=0' does not exist in container arguments")
 	}
+
+	if container.Ports[0].ContainerPort != initConfigReloaderPort {
+		t.Errorf("Expected port number to be %d, got %d", initConfigReloaderPort, container.Ports[0].ContainerPort)
+	}
+
+	if !contains(container.Args, "--listen-address=:8081") {
+		t.Errorf("Expected '--listen-address=:8081' not found in %s", container.Args)
+	}
+
 	if container.ImagePullPolicy != expectedImagePullPolicy {
 		t.Errorf("Expected imagePullPolicy %s, but found %s", expectedImagePullPolicy, container.ImagePullPolicy)
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -2166,7 +2166,7 @@ func TestConfigReloaderWithSignal(t *testing.T) {
 
 	expectedArgsInitConfigReloader := []string{
 		"--watch-interval=0",
-		"--listen-address=:8080",
+		"--listen-address=:8081",
 		"--config-file=/etc/prometheus/config/prometheus.yaml.gz",
 		"--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml",
 	}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -435,7 +435,7 @@ func BuildConfigReloader(
 	name := "config-reloader"
 	if initContainer {
 		name = "init-config-reloader"
-		reloaderOptions = append(reloaderOptions, operator.ReloaderRunOnce())
+		reloaderOptions = append(reloaderOptions, operator.InitContainer())
 		return operator.CreateConfigReloader(name, reloaderOptions...)
 	}
 


### PR DESCRIPTION
## Description

The Kubernetes API starting from v1.30 will return a warning when a pod template contains 2 containers exposing the same port number, even across init and regular containers.

[1] https://github.com/kubernetes/kubernetes/pull/113245

Closes #6284

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Use port 8081 instead of 8080 to expose the init config-reloader web server.
```
