### PR TITLE
Add NODE_NAME env in config reloader

### DIFF
--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -180,9 +180,9 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 }
 
 // WithNodeNameEnv sets the withNodeNameEnv option for the config-reloader container.
-func WithNodeNameEnv(nodeNameNeeded bool) ReloaderOption {
+func WithNodeNameEnv() ReloaderOption {
 	return func(c *ConfigReloader) {
-		c.withNodeNameEnv = nodeNameNeeded
+		c.withNodeNameEnv = true
 	}
 }
 

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -36,6 +36,10 @@ const (
 	// PodNameEnvVar is the name of the environment variable injected in the
 	// config-reloader container that contains the pod name.
 	PodNameEnvVar = "POD_NAME"
+
+	// NodeNameEnvVar is the name of the environment variable injected in the
+	// config-reloader container that contains the node name.
+	NodeNameEnvVar = "NODE_NAME"
 )
 
 // ConfigReloader contains the options to configure
@@ -190,6 +194,12 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 				Name: PodNameEnvVar,
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"},
+				},
+			},
+			{
+				Name: NodeNameEnvVar,
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 				},
 			},
 		}

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -62,7 +62,7 @@ type ConfigReloader struct {
 	volumeMounts       []v1.VolumeMount
 	watchedDirectories []string
 	useSignal          bool
-	needNodeNameEnv    bool
+	withNodeNameEnv    bool
 }
 
 type ReloaderOption = func(*ConfigReloader)
@@ -179,10 +179,10 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	}
 }
 
-// NeedNodeNameEnv sets the needNodeNameEnv option for the config-reloader container.
-func NeedNodeNameEnv(need bool) ReloaderOption {
+// WithNodeNameEnv sets the withNodeNameEnv option for the config-reloader container.
+func WithNodeNameEnv(nodeNameNeeded bool) ReloaderOption {
 	return func(c *ConfigReloader) {
-		c.needNodeNameEnv = need
+		c.withNodeNameEnv = nodeNameNeeded
 	}
 }
 
@@ -208,7 +208,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		ports []v1.ContainerPort
 	)
 
-	if configReloader.needNodeNameEnv {
+	if configReloader.withNodeNameEnv {
 		envVars = append(envVars, v1.EnvVar{
 			Name: NodeNameEnvVar,
 			ValueFrom: &v1.EnvVarSource{

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -20,10 +20,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var reloaderConfig = ContainerConfig{

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -99,6 +99,14 @@ func TestCreateInitConfigReloader(t *testing.T) {
 		InitContainer(),
 		ImagePullPolicy(v1.PullAlways),
 	)
+
+	assert.NotContains(t, container.Env, v1.EnvVar{
+		Name: NodeNameEnvVar,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	})
+
 	if container.Name != "init-config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", initContainerName, container.Name)
 	}

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -22,6 +22,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var reloaderConfig = ContainerConfig{
@@ -155,7 +157,16 @@ func TestCreateConfigReloader(t *testing.T) {
 		WebConfigFile(webConfigFile),
 		Shard(shard),
 		ImagePullPolicy(expectedImagePullPolicy),
+		WithNodeNameEnv(),
 	)
+
+	assert.Contains(t, container.Env, v1.EnvVar{
+		Name: NodeNameEnvVar,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	})
+
 	if container.Name != "config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", containerName, container.Name)
 	}


### PR DESCRIPTION
## Description

Add `NODE_NAME` env in config reloader for DaemonSet deployment of Prometheus Agent. In DaemonSet deployment, Prometheus Agent is deployed per node and only scrapes targets located on the same node. That's why it needs to know its `NODE_NAME` to filter targets. Detailed reasons and how `NODE_NAME` env is used are explained in the proposal #6600.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit tests

## Changelog entry

Add NODE_NAME env in config reloader