### PR TITLE
validation: fix alertManagerRoutes validation for repeatInterval and …

### DIFF
--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -26,6 +26,7 @@ import (
 )
 
 var durationRe = regexp.MustCompile(`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`)
+var nonZeroDurationRe = regexp.MustCompile(`^(([1-9][0-9]*)y)?(([1-9][0-9]*)w)?(([1-9][0-9]*)d)?(([1-9][0-9]*)h)?(([1-9][0-9]*)m)?(([1-9][0-9]*)s)?(([1-9][0-9]*)ms)?$`)
 
 // ValidateAlertmanagerConfig checks that the given resource complies with the
 // semantics of the Alertmanager configuration.
@@ -389,16 +390,16 @@ func validateAlertManagerRoutes(r *monitoringv1alpha1.Route, receivers, muteTime
 	}
 
 	// validate that if defaults are set, they match regex
-	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
-		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
+	if r.GroupInterval != "" && !nonZeroDurationRe.MatchString(r.GroupInterval) {
+		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, nonZeroDurationRe.String())
 
 	}
 	if r.GroupWait != "" && !durationRe.MatchString(r.GroupWait) {
 		return fmt.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
 	}
 
-	if r.RepeatInterval != "" && !durationRe.MatchString(r.RepeatInterval) {
-		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
+	if r.RepeatInterval != "" && !nonZeroDurationRe.MatchString(r.RepeatInterval) {
+		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, nonZeroDurationRe.String())
 	}
 
 	children, err := r.ChildRoutes()

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -26,6 +26,7 @@ import (
 )
 
 var durationRe = regexp.MustCompile(`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`)
+var nonZeroDurationRe = regexp.MustCompile(`^(([1-9][0-9]*)y)?(([1-9][0-9]*)w)?(([1-9][0-9]*)d)?(([1-9][0-9]*)h)?(([1-9][0-9]*)m)?(([1-9][0-9]*)s)?(([1-9][0-9]*)ms)?$`)
 
 // ValidateAlertmanagerConfig checks that the given resource complies with the
 // semantics of the Alertmanager configuration.
@@ -390,16 +391,16 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 	}
 
 	// validate that if defaults are set, they match regex
-	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
-		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
+	if r.GroupInterval != "" && !nonZeroDurationRe.MatchString(r.GroupInterval) {
+		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, nonZeroDurationRe.String())
 
 	}
 	if r.GroupWait != "" && !durationRe.MatchString(r.GroupWait) {
 		return fmt.Errorf("groupWait %s does not match required regex: %s", r.GroupWait, durationRe.String())
 	}
 
-	if r.RepeatInterval != "" && !durationRe.MatchString(r.RepeatInterval) {
-		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
+	if r.RepeatInterval != "" && !nonZeroDurationRe.MatchString(r.RepeatInterval) {
+		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, nonZeroDurationRe.String())
 	}
 
 	children, err := r.ChildRoutes()

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -413,6 +413,40 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "Test fail to validate routes with zero value for GroupInterval",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+					},
+					Route: &monitoringv1beta1.Route{
+						Receiver:      "same",
+						GroupInterval: "0s",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate routes with zero value for RepeatInterval",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+					},
+					Route: &monitoringv1beta1.Route{
+						Receiver:       "same",
+						RepeatInterval: "0s",
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
 			name: "Test happy path",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{


### PR DESCRIPTION
## Description

the existing pattern is correct for most duration fields except for groupInterval and repeatInterval which don't allow "zero" values. In this commit we define new pattern that rejects "zero" durations.

Fixes #6594


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
I added some tests with zero value for ‍`GroupInterval` and `RepeatInterval`. These tests must be filled.

## Changelog entry
add new pattern called `nonZeroDurationRe` that rejects "zero" durations.
