### PR TITLE
Support makeDaemonSet() for Prometheus Agent's DaemonSet deployment

### DIFF
--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -14,3 +14,303 @@
 
 package prometheusagent
 
+import (
+	"fmt"
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func makeDaemonSet(
+	name string,
+	p monitoringv1.PrometheusInterface,
+	config *prompkg.Config,
+	cg *prompkg.ConfigGenerator,
+	tlsSecrets *operator.ShardedSecret,
+) (*appsv1.DaemonSet, error) {
+	cpf := p.GetCommonPrometheusFields()
+	objMeta := p.GetObjectMeta()
+
+	if cpf.PortName == "" {
+		cpf.PortName = prompkg.DefaultPortName
+	}
+
+	// We need to re-set the common fields because cpf is only a copy of the original object.
+	// We set some defaults if some fields are not present, and we want those fields set in the original Prometheus object before building the StatefulSetSpec.
+	p.SetCommonPrometheusFields(cpf)
+	spec, err := makeDaemonSetSpec(p, config, cg, tlsSecrets)
+	if err != nil {
+		return nil, fmt.Errorf("make DaemonSet spec: %w", err)
+	}
+
+	// do not transfer kubectl annotations to the statefulset so it is not
+	// pruned by kubectl
+	annotations := make(map[string]string, 0)
+	for key, value := range objMeta.GetAnnotations() {
+		if !strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+			annotations[key] = value
+		}
+	}
+	daemonSet := &appsv1.DaemonSet{Spec: *spec}
+
+	operator.UpdateObject(
+		daemonSet,
+		operator.WithName(name),
+		operator.WithAnnotations(annotations),
+		operator.WithAnnotations(config.Annotations),
+		operator.WithLabels(objMeta.GetLabels()),
+		operator.WithLabels(map[string]string{
+			prompkg.PrometheusNameLabelName: objMeta.GetName(),
+			prompkg.PrometheusModeLabeLName: prometheusMode,
+		}),
+		operator.WithLabels(config.Labels),
+		operator.WithManagingOwner(p),
+	)
+
+	if cpf.ImagePullSecrets != nil && len(cpf.ImagePullSecrets) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = cpf.ImagePullSecrets
+	}
+
+	if cpf.HostNetwork {
+		daemonSet.Spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	}
+
+	return daemonSet, nil
+}
+
+func makeDaemonSetSpec(
+	p monitoringv1.PrometheusInterface,
+	c *prompkg.Config,
+	cg *prompkg.ConfigGenerator,
+	tlsSecrets *operator.ShardedSecret,
+) (*appsv1.DaemonSetSpec, error) {
+	cpf := p.GetCommonPrometheusFields()
+
+	pImagePath, err := operator.BuildImagePath(
+		operator.StringPtrValOrDefault(cpf.Image, ""),
+		operator.StringValOrDefault("", c.PrometheusDefaultBaseImage),
+		operator.StringValOrDefault(cpf.Version, operator.DefaultPrometheusVersion),
+		"",
+		"",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cpf.EnableFeatures = append(cpf.EnableFeatures, "agent")
+	promArgs := prompkg.BuildCommonPrometheusArgs(cpf, cg)
+	promArgs = appendAgentArgs(promArgs, cg, cpf.WALCompression)
+
+	var ports []v1.ContainerPort
+	if !cpf.ListenLocal {
+		ports = []v1.ContainerPort{
+			{
+				Name:          cpf.PortName,
+				ContainerPort: 9090,
+				Protocol:      v1.ProtocolTCP,
+			},
+		}
+	}
+
+	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
+	if err != nil {
+		return nil, err
+	}
+
+	configReloaderVolumeMounts := []v1.VolumeMount{
+		{
+			Name:      "config",
+			MountPath: prompkg.ConfDir,
+		},
+		{
+			Name:      "config-out",
+			MountPath: prompkg.ConfOutDir,
+		},
+	}
+
+	var configReloaderWebConfigFile string
+
+	// Mount web config and web TLS credentials as volumes.
+	// We always mount the web config file for versions greater than 2.24.0.
+	// With this we avoid redeploying prometheus when reconfiguring between
+	// HTTP and HTTPS and vice-versa.
+	webConfigGenerator := cg.WithMinimumVersion("2.24.0")
+	if webConfigGenerator.IsCompatible() {
+		var fields monitoringv1.WebConfigFileFields
+		if cpf.Web != nil {
+			fields = cpf.Web.WebConfigFileFields
+		}
+
+		webConfig, err := webconfig.New(prompkg.WebConfigDir, prompkg.WebConfigSecretName(p), fields)
+		if err != nil {
+			return nil, err
+		}
+
+		confArg, configVol, configMount, err := webConfig.GetMountParameters()
+		if err != nil {
+			return nil, err
+		}
+		promArgs = append(promArgs, confArg)
+		volumes = append(volumes, configVol...)
+		promVolumeMounts = append(promVolumeMounts, configMount...)
+
+		// To avoid breaking users deploying an old version of the config-reloader image.
+		// TODO: remove the if condition after v0.72.0.
+		if cpf.Web != nil {
+			configReloaderWebConfigFile = confArg.Value
+			configReloaderVolumeMounts = append(configReloaderVolumeMounts, configMount...)
+		}
+	} else if cpf.Web != nil {
+		webConfigGenerator.Warn("web.config.file")
+	}
+
+	// The /-/ready handler returns OK only after the TSDB initialization has
+	// completed. The WAL replay can take a significant time for large setups
+	// hence we enable the startup probe with a generous failure threshold (15
+	// minutes) to ensure that the readiness probe only comes into effect once
+	// Prometheus is effectively ready.
+	// We don't want to use the /-/healthy handler here because it returns OK as
+	// soon as the web server is started (irrespective of the WAL replay).
+	readyProbeHandler := prompkg.ProbeHandler("/-/ready", cpf, webConfigGenerator)
+	startupPeriodSeconds, startupFailureThreshold := prompkg.GetStatupProbePeriodSecondsAndFailureThreshold(cpf)
+	startupProbe := &v1.Probe{
+		ProbeHandler:     readyProbeHandler,
+		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
+		PeriodSeconds:    startupPeriodSeconds,
+		FailureThreshold: startupFailureThreshold,
+	}
+
+	readinessProbe := &v1.Probe{
+		ProbeHandler:     readyProbeHandler,
+		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+
+	livenessProbe := &v1.Probe{
+		ProbeHandler:     prompkg.ProbeHandler("/-/healthy", cpf, webConfigGenerator),
+		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+
+	podAnnotations, podLabels := prompkg.BuildPodMetadata(cpf, cg)
+	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
+	// We should try to avoid removing such immutable fields whenever possible since doing
+	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
+	// The requirement to make a change here should be carefully evaluated.
+	podSelectorLabels := makeSelectorLabels(p.GetObjectMeta().GetName())
+
+	for k, v := range podSelectorLabels {
+		podLabels[k] = v
+	}
+
+	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
+	finalLabels := c.Labels.Merge(podLabels)
+
+	var additionalContainers, operatorInitContainers []v1.Container
+
+	var watchedDirectories []string
+
+	var minReadySeconds int32
+	if cpf.MinReadySeconds != nil {
+		minReadySeconds = int32(*cpf.MinReadySeconds)
+	}
+
+	operatorInitContainers = append(operatorInitContainers,
+		prompkg.BuildConfigReloader(
+			p,
+			c,
+			true,
+			configReloaderVolumeMounts,
+			watchedDirectories,
+		),
+	)
+
+	initContainers, err := k8sutil.MergePatchContainers(operatorInitContainers, cpf.InitContainers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge init containers spec: %w", err)
+	}
+
+	containerArgs, err := operator.BuildArgs(promArgs, cpf.AdditionalArgs)
+
+	if err != nil {
+		return nil, err
+	}
+
+	operatorContainers := append([]v1.Container{
+		{
+			Name:                     "prometheus",
+			Image:                    pImagePath,
+			ImagePullPolicy:          cpf.ImagePullPolicy,
+			Ports:                    ports,
+			Args:                     containerArgs,
+			VolumeMounts:             promVolumeMounts,
+			StartupProbe:             startupProbe,
+			LivenessProbe:            livenessProbe,
+			ReadinessProbe:           readinessProbe,
+			Resources:                cpf.Resources,
+			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &v1.SecurityContext{
+				ReadOnlyRootFilesystem:   ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
+			},
+		},
+		prompkg.BuildConfigReloader(
+			p,
+			c,
+			false,
+			configReloaderVolumeMounts,
+			watchedDirectories,
+			operator.WebConfigFile(configReloaderWebConfigFile),
+		),
+	}, additionalContainers...)
+
+	containers, err := k8sutil.MergePatchContainers(operatorContainers, cpf.Containers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
+	}
+
+	return &appsv1.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: finalSelectorLabels,
+		},
+		MinReadySeconds: minReadySeconds,
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      finalLabels,
+				Annotations: podAnnotations,
+			},
+			Spec: v1.PodSpec{
+				ShareProcessNamespace:        prompkg.ShareProcessNamespace(p),
+				Containers:                   containers,
+				InitContainers:               initContainers,
+				SecurityContext:              cpf.SecurityContext,
+				ServiceAccountName:           cpf.ServiceAccountName,
+				AutomountServiceAccountToken: ptr.To(ptr.Deref(cpf.AutomountServiceAccountToken, true)),
+				NodeSelector:                 cpf.NodeSelector,
+				PriorityClassName:            cpf.PriorityClassName,
+				// Prometheus may take quite long to shut down to checkpoint existing data.
+				// Allow up to 10 minutes for clean termination.
+				TerminationGracePeriodSeconds: ptr.To(int64(600)),
+				Volumes:                       volumes,
+				Tolerations:                   cpf.Tolerations,
+				Affinity:                      cpf.Affinity,
+				TopologySpreadConstraints:     prompkg.MakeK8sTopologySpreadConstraint(finalSelectorLabels, cpf.TopologySpreadConstraints),
+				HostAliases:                   operator.MakeHostAliases(cpf.HostAliases),
+				HostNetwork:                   cpf.HostNetwork,
+			},
+		},
+	}, nil
+}

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusagent
+

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -44,14 +44,14 @@ func makeDaemonSet(
 	}
 
 	// We need to re-set the common fields because cpf is only a copy of the original object.
-	// We set some defaults if some fields are not present, and we want those fields set in the original Prometheus object before building the StatefulSetSpec.
+	// We set some defaults if some fields are not present, and we want those fields set in the original Prometheus object before building the DaemonSetSpec.
 	p.SetCommonPrometheusFields(cpf)
 	spec, err := makeDaemonSetSpec(p, config, cg, tlsSecrets)
 	if err != nil {
 		return nil, fmt.Errorf("make DaemonSet spec: %w", err)
 	}
 
-	// do not transfer kubectl annotations to the statefulset so it is not
+	// do not transfer kubectl annotations to the daemonset so it is not
 	// pruned by kubectl
 	annotations := make(map[string]string, 0)
 	for key, value := range objMeta.GetAnnotations() {

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +28,6 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
-	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
 )
 
 func makeDaemonSet(
@@ -95,47 +95,27 @@ func makeDaemonSetSpec(
 ) (*appsv1.DaemonSetSpec, error) {
 	cpf := p.GetCommonPrometheusFields()
 
-	pImagePath, err := operator.BuildImagePath(
-		operator.StringPtrValOrDefault(cpf.Image, ""),
-		operator.StringValOrDefault("", c.PrometheusDefaultBaseImage),
+	pImagePath, err := operator.BuildImagePathForAgent(
+		ptr.Deref(cpf.Image, ""),
+		c.PrometheusDefaultBaseImage,
 		operator.StringValOrDefault(cpf.Version, operator.DefaultPrometheusVersion),
-		"",
-		"",
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	cpf.EnableFeatures = append(cpf.EnableFeatures, "agent")
-	promArgs := prompkg.BuildCommonPrometheusArgs(cpf, cg)
-	promArgs = appendAgentArgs(promArgs, cg, cpf.WALCompression)
-
-	var ports []v1.ContainerPort
-	if !cpf.ListenLocal {
-		ports = []v1.ContainerPort{
-			{
-				Name:          cpf.PortName,
-				ContainerPort: 9090,
-				Protocol:      v1.ProtocolTCP,
-			},
-		}
+	if !slices.Contains(cpf.EnableFeatures, "agent") {
+		cpf.EnableFeatures = append(cpf.EnableFeatures, "agent")
 	}
+
+	promArgs := buildAgentArgs(cpf, cg)
 
 	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
 	if err != nil {
 		return nil, err
 	}
 
-	configReloaderVolumeMounts := []v1.VolumeMount{
-		{
-			Name:      "config",
-			MountPath: prompkg.ConfDir,
-		},
-		{
-			Name:      "config-out",
-			MountPath: prompkg.ConfOutDir,
-		},
-	}
+	configReloaderVolumeMounts := prompkg.CreateConfigReloaderVolumeMounts()
 
 	var configReloaderWebConfigFile string
 
@@ -145,20 +125,11 @@ func makeDaemonSetSpec(
 	// HTTP and HTTPS and vice-versa.
 	webConfigGenerator := cg.WithMinimumVersion("2.24.0")
 	if webConfigGenerator.IsCompatible() {
-		var fields monitoringv1.WebConfigFileFields
-		if cpf.Web != nil {
-			fields = cpf.Web.WebConfigFileFields
-		}
-
-		webConfig, err := webconfig.New(prompkg.WebConfigDir, prompkg.WebConfigSecretName(p), fields)
+		confArg, configVol, configMount, err := prompkg.BuildWebconfig(cpf, p)
 		if err != nil {
 			return nil, err
 		}
 
-		confArg, configVol, configMount, err := webConfig.GetMountParameters()
-		if err != nil {
-			return nil, err
-		}
 		promArgs = append(promArgs, confArg)
 		volumes = append(volumes, configVol...)
 		promVolumeMounts = append(promVolumeMounts, configMount...)
@@ -173,35 +144,7 @@ func makeDaemonSetSpec(
 		webConfigGenerator.Warn("web.config.file")
 	}
 
-	// The /-/ready handler returns OK only after the TSDB initialization has
-	// completed. The WAL replay can take a significant time for large setups
-	// hence we enable the startup probe with a generous failure threshold (15
-	// minutes) to ensure that the readiness probe only comes into effect once
-	// Prometheus is effectively ready.
-	// We don't want to use the /-/healthy handler here because it returns OK as
-	// soon as the web server is started (irrespective of the WAL replay).
-	readyProbeHandler := prompkg.ProbeHandler("/-/ready", cpf, webConfigGenerator)
-	startupPeriodSeconds, startupFailureThreshold := prompkg.GetStatupProbePeriodSecondsAndFailureThreshold(cpf)
-	startupProbe := &v1.Probe{
-		ProbeHandler:     readyProbeHandler,
-		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
-		PeriodSeconds:    startupPeriodSeconds,
-		FailureThreshold: startupFailureThreshold,
-	}
-
-	readinessProbe := &v1.Probe{
-		ProbeHandler:     readyProbeHandler,
-		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
-		PeriodSeconds:    5,
-		FailureThreshold: 3,
-	}
-
-	livenessProbe := &v1.Probe{
-		ProbeHandler:     prompkg.ProbeHandler("/-/healthy", cpf, webConfigGenerator),
-		TimeoutSeconds:   prompkg.ProbeTimeoutSeconds,
-		PeriodSeconds:    5,
-		FailureThreshold: 6,
-	}
+	startupProbe, readinessProbe, livenessProbe := prompkg.MakeProbes(cpf, webConfigGenerator)
 
 	podAnnotations, podLabels := prompkg.BuildPodMetadata(cpf, cg)
 	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
@@ -242,7 +185,6 @@ func makeDaemonSetSpec(
 	}
 
 	containerArgs, err := operator.BuildArgs(promArgs, cpf.AdditionalArgs)
-
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +194,7 @@ func makeDaemonSetSpec(
 			Name:                     "prometheus",
 			Image:                    pImagePath,
 			ImagePullPolicy:          cpf.ImagePullPolicy,
-			Ports:                    ports,
+			Ports:                    prompkg.MakeContainerPorts(cpf),
 			Args:                     containerArgs,
 			VolumeMounts:             promVolumeMounts,
 			StartupProbe:             startupProbe,

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -65,6 +65,7 @@ func makeDaemonSet(
 		}),
 		operator.WithLabels(config.Labels),
 		operator.WithManagingOwner(p),
+		operator.WithoutKubectlAnnotations(),
 	)
 
 	if cpf.ImagePullSecrets != nil && len(cpf.ImagePullSecrets) > 0 {
@@ -119,12 +120,8 @@ func makeDaemonSetSpec(
 	volumes = append(volumes, configVol...)
 	promVolumeMounts = append(promVolumeMounts, configMount...)
 
-	// To avoid breaking users deploying an old version of the config-reloader image.
-	// TODO: remove the if condition after v0.72.0.
-	if cpf.Web != nil {
-		configReloaderWebConfigFile = confArg.Value
-		configReloaderVolumeMounts = append(configReloaderVolumeMounts, configMount...)
-	}
+	configReloaderWebConfigFile = confArg.Value
+	configReloaderVolumeMounts = append(configReloaderVolumeMounts, configMount...)
 
 	startupProbe, readinessProbe, livenessProbe := prompkg.MakeProbes(cpf, cg)
 

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -18,15 +18,16 @@ import (
 	"fmt"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
 	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func makeDaemonSet(

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -275,6 +275,8 @@ func makeDaemonSetSpec(
 			configReloaderVolumeMounts,
 			watchedDirectories,
 			operator.WebConfigFile(configReloaderWebConfigFile),
+			// DaemonSet needs NODE_NAME env to filter targes on the same node.
+			operator.WithNodeNameEnv(),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/agent/daemonset_test.go
+++ b/pkg/prometheus/agent/daemonset_test.go
@@ -15,11 +15,13 @@
 package prometheusagent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
@@ -102,4 +104,46 @@ func TestAutomountServiceAccountTokenForDaemonSet(t *testing.T) {
 			require.Equal(t, tc.expectedValue, *dset.Spec.Template.Spec.AutomountServiceAccountToken)
 		})
 	}
+}
+
+func TestDaemonSetLabelingAndAnnotations(t *testing.T) {
+	labels := map[string]string{
+		"testlabel": "testlabelvalue",
+	}
+	annotations := map[string]string{
+		"testannotation": "testannotationvalue",
+		"kubectl.kubernetes.io/last-applied-configuration": "something",
+		"kubectl.kubernetes.io/something":                  "something",
+	}
+	// kubectl annotations must not be on the daemonset so kubectl does
+	// not manage the generated object
+	expectedDaemonSetAnnotations := map[string]string{
+		"testannotation": "testannotationvalue",
+	}
+
+	expectedDaemonSetLabels := map[string]string{
+		"testlabel":                   "testlabelvalue",
+		"operator.prometheus.io/name": "",
+		"operator.prometheus.io/mode": "agent",
+		"managed-by":                  "prometheus-operator",
+	}
+
+	expectedPodLabels := map[string]string{
+		"app.kubernetes.io/name":       "prometheus-agent",
+		"app.kubernetes.io/version":    strings.TrimPrefix(operator.DefaultPrometheusVersion, "v"),
+		"app.kubernetes.io/managed-by": "prometheus-operator",
+		"app.kubernetes.io/instance":   "",
+		"operator.prometheus.io/name":  "",
+	}
+
+	dset, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedDaemonSetLabels, dset.Labels)
+	require.Equal(t, expectedDaemonSetAnnotations, dset.Annotations)
+	require.Equal(t, expectedPodLabels, dset.Spec.Template.ObjectMeta.Labels)
 }

--- a/pkg/prometheus/agent/daemonset_test.go
+++ b/pkg/prometheus/agent/daemonset_test.go
@@ -1,0 +1,384 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusagent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+)
+
+func TestListenTLSForDaemonSet(t *testing.T) {
+	dset, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Web: &monitoringv1.PrometheusWebSpec{
+					WebConfigFileFields: monitoringv1.WebConfigFileFields{
+						TLSConfig: &monitoringv1.WebTLSConfig{
+							KeySecret: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "some-secret",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								ConfigMap: &v1.ConfigMapKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "some-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
+		return v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   probePath,
+				Port:   intstr.FromString("web"),
+				Scheme: "HTTPS",
+			},
+		}
+	}
+
+	actualStartupProbe := dset.Spec.Template.Spec.Containers[0].StartupProbe
+	expectedStartupProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+	if !reflect.DeepEqual(actualStartupProbe, expectedStartupProbe) {
+		t.Fatalf("Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
+	}
+
+	actualLivenessProbe := dset.Spec.Template.Spec.Containers[0].LivenessProbe
+	expectedLivenessProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+	if !reflect.DeepEqual(actualLivenessProbe, expectedLivenessProbe) {
+		t.Fatalf("Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
+	}
+
+	actualReadinessProbe := dset.Spec.Template.Spec.Containers[0].ReadinessProbe
+	expectedReadinessProbe := &v1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+	if !reflect.DeepEqual(actualReadinessProbe, expectedReadinessProbe) {
+		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)
+	}
+
+	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
+	reloadURLFound := false
+	for _, arg := range dset.Spec.Template.Spec.Containers[1].Args {
+		if arg == expectedConfigReloaderReloadURL {
+			reloadURLFound = true
+		}
+	}
+	if !reloadURLFound {
+		t.Fatalf("expected to find arg %s in config reloader", expectedConfigReloaderReloadURL)
+	}
+
+	expectedArgsConfigReloader := []string{
+		"--listen-address=:8080",
+		"--web-config-file=/etc/prometheus/web_config/web-config.yaml",
+		"--reload-url=https://localhost:9090/-/reload",
+		"--config-file=/etc/prometheus/config/prometheus.yaml.gz",
+		"--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml",
+	}
+
+	for _, c := range dset.Spec.Template.Spec.Containers {
+		if c.Name == "config-reloader" {
+			if !reflect.DeepEqual(c.Args, expectedArgsConfigReloader) {
+				t.Fatalf("expected container args are %s, but found %s", expectedArgsConfigReloader, c.Args)
+			}
+		}
+	}
+}
+
+func TestWALCompressionForDaemonSet(t *testing.T) {
+	var (
+		tr = true
+		fa = false
+	)
+	tests := []struct {
+		version       string
+		enabled       *bool
+		expectedArg   string
+		shouldContain bool
+	}{
+		// Nil should not have either flag.
+		{"v2.30.0", &fa, "--storage.agent.wal-compression", false},
+		{"v2.32.0", nil, "--storage.agent.wal-compression", false},
+		{"v2.32.0", &fa, "--no-storage.agent.wal-compression", true},
+		{"v2.32.0", &tr, "--storage.agent.wal-compression", true},
+	}
+
+	for _, test := range tests {
+		dset, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+			Spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Version:        test.version,
+					WALCompression: test.enabled,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		promArgs := dset.Spec.Template.Spec.Containers[0].Args
+		found := false
+		for _, flag := range promArgs {
+			if flag == test.expectedArg {
+				found = true
+				break
+			}
+		}
+
+		if found != test.shouldContain {
+			if test.shouldContain {
+				t.Fatalf("expected Prometheus args to contain %v, but got %v", test.expectedArg, promArgs)
+			} else {
+				t.Fatalf("expected Prometheus args to NOT contain %v, but got %v", test.expectedArg, promArgs)
+			}
+		}
+	}
+}
+
+func TestStartupProbeTimeoutSecondsForDaemonSet(t *testing.T) {
+	tests := []struct {
+		maximumStartupDurationSeconds   *int32
+		expectedStartupPeriodSeconds    int32
+		expectedStartupFailureThreshold int32
+	}{
+		{
+			maximumStartupDurationSeconds:   nil,
+			expectedStartupPeriodSeconds:    15,
+			expectedStartupFailureThreshold: 60,
+		},
+		{
+			maximumStartupDurationSeconds:   ptr.To(int32(600)),
+			expectedStartupPeriodSeconds:    60,
+			expectedStartupFailureThreshold: 10,
+		},
+	}
+
+	for _, test := range tests {
+		dset, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+			Spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					MaximumStartupDurationSeconds: test.maximumStartupDurationSeconds,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, dset.Spec.Template.Spec.Containers[0].StartupProbe)
+		require.Equal(t, test.expectedStartupPeriodSeconds, dset.Spec.Template.Spec.Containers[0].StartupProbe.PeriodSeconds)
+		require.Equal(t, test.expectedStartupFailureThreshold, dset.Spec.Template.Spec.Containers[0].StartupProbe.FailureThreshold)
+	}
+}
+
+func makeDaemonSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.DaemonSet, error) {
+	logger := newLogger()
+	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return makeDaemonSet(
+		"test",
+		&p,
+		defaultTestConfig,
+		cg,
+		&operator.ShardedSecret{})
+}
+
+func TestPodTopologySpreadConstraintWithAdditionalLabelsForDaemonSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec monitoringv1alpha1.PrometheusAgentSpec
+		tsc  v1.TopologySpreadConstraint
+	}{
+		{
+			name: "without labelSelector and additionalLabels",
+			spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					TopologySpreadConstraints: []monitoringv1.TopologySpreadConstraint{
+						{
+							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
+								MaxSkew:           1,
+								TopologyKey:       "kubernetes.io/hostname",
+								WhenUnsatisfiable: v1.DoNotSchedule,
+							},
+						},
+					},
+				},
+			},
+			tsc: v1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: v1.DoNotSchedule,
+			},
+		},
+		{
+			name: "with labelSelector and without additionalLabels",
+			spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					TopologySpreadConstraints: []monitoringv1.TopologySpreadConstraint{
+						{
+							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
+								MaxSkew:           1,
+								TopologyKey:       "kubernetes.io/hostname",
+								WhenUnsatisfiable: v1.DoNotSchedule,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "prometheus",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tsc: v1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "prometheus",
+					},
+				},
+			},
+		},
+		{
+			name: "with labelSelector and additionalLabels as ResourceName",
+			spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					TopologySpreadConstraints: []monitoringv1.TopologySpreadConstraint{
+						{
+							AdditionalLabelSelectors: ptr.To(monitoringv1.ResourceNameLabelSelector),
+							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
+								MaxSkew:           1,
+								TopologyKey:       "kubernetes.io/hostname",
+								WhenUnsatisfiable: v1.DoNotSchedule,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "prometheus",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tsc: v1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":                          "prometheus",
+						"app.kubernetes.io/instance":   "test",
+						"app.kubernetes.io/managed-by": "prometheus-operator",
+						"app.kubernetes.io/name":       "prometheus-agent",
+						"operator.prometheus.io/name":  "test",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sts, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "ns-test",
+				},
+				Spec: tc.spec,
+			})
+
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, sts.Spec.Template.Spec.TopologySpreadConstraints)
+			assert.Equal(t, tc.tsc, sts.Spec.Template.Spec.TopologySpreadConstraints[0])
+		})
+	}
+}
+
+func TestAutomountServiceAccountTokenForDaemonSet(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		automountServiceAccountToken *bool
+		expectedValue                bool
+	}{
+		{
+			name:                         "automountServiceAccountToken not set",
+			automountServiceAccountToken: nil,
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to true",
+			automountServiceAccountToken: ptr.To(true),
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to false",
+			automountServiceAccountToken: ptr.To(false),
+			expectedValue:                false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dset, err := makeDaemonSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: monitoringv1alpha1.PrometheusAgentSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						AutomountServiceAccountToken: tc.automountServiceAccountToken,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			if dset.Spec.Template.Spec.AutomountServiceAccountToken == nil {
+				t.Fatalf("expected automountServiceAccountToken to be set")
+			}
+
+			if *dset.Spec.Template.Spec.AutomountServiceAccountToken != tc.expectedValue {
+				t.Fatalf("expected automountServiceAccountToken to be %v", tc.expectedValue)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -160,6 +160,7 @@ func makeStatefulSetSpec(
 	if !slices.Contains(cpf.EnableFeatures, "agent") {
 		cpf.EnableFeatures = append(cpf.EnableFeatures, "agent")
 	}
+
 	promArgs := buildAgentArgs(cpf, cg)
 
 	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
@@ -239,7 +240,6 @@ func makeStatefulSetSpec(
 	}
 
 	containerArgs, err := operator.BuildArgs(promArgs, cpf.AdditionalArgs)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Support `makeDaemonSet()` and inner function `makeDaemonSetSpec()` for Prometheus Agent's DaemonSet deployment



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit tests

## Changelog entry

Support makeDaemonSet() for Prometheus Agent's DaemonSet deployment

