### PR TITLE
Changed the description for ```overrideHonorLabels``` field

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -7,7 +7,9 @@ menu: "operator"
 weight: 211
 toc: true
 ---
+
 > This page is automatically generated with `gen-crd-api-reference-docs`.
+
 <p>Packages:</p>
 <ul>
 <li>
@@ -2292,10 +2294,8 @@ bool
 </em>
 </td>
 <td>
-<p>When true, Prometheus resolves label conflicts by renaming the labels in
-the scraped data to &ldquo;exported_<label value>&rdquo; for all targets created
-from service and pod monitors.
-Otherwise the HonorLabels field of the service or pod monitor applies.</p>
+<p>If <code>overrideHonorLabels</code> is true, then the operator sets <code>honor_labels:false</code>
+for all generated scrape configs.</p>
 </td>
 </tr>
 <tr>
@@ -6906,10 +6906,8 @@ bool
 </em>
 </td>
 <td>
-<p>When true, Prometheus resolves label conflicts by renaming the labels in
-the scraped data to &ldquo;exported_<label value>&rdquo; for all targets created
-from service and pod monitors.
-Otherwise the HonorLabels field of the service or pod monitor applies.</p>
+<p>If <code>overrideHonorLabels</code> is true, then the operator sets <code>honor_labels:false</code>
+for all generated scrape configs.</p>
 </td>
 </tr>
 <tr>
@@ -11030,10 +11028,8 @@ bool
 </em>
 </td>
 <td>
-<p>When true, Prometheus resolves label conflicts by renaming the labels in
-the scraped data to &ldquo;exported_<label value>&rdquo; for all targets created
-from service and pod monitors.
-Otherwise the HonorLabels field of the service or pod monitor applies.</p>
+<p>If <code>overrideHonorLabels</code> is true, then the operator sets <code>honor_labels:false</code>
+for all generated scrape configs.</p>
 </td>
 </tr>
 <tr>
@@ -16985,10 +16981,8 @@ bool
 </em>
 </td>
 <td>
-<p>When true, Prometheus resolves label conflicts by renaming the labels in
-the scraped data to &ldquo;exported_<label value>&rdquo; for all targets created
-from service and pod monitors.
-Otherwise the HonorLabels field of the service or pod monitor applies.</p>
+<p>If <code>overrideHonorLabels</code> is true, then the operator sets <code>honor_labels:false</code>
+for all generated scrape configs.</p>
 </td>
 </tr>
 <tr>
@@ -23826,10 +23820,8 @@ bool
 </em>
 </td>
 <td>
-<p>When true, Prometheus resolves label conflicts by renaming the labels in
-the scraped data to &ldquo;exported_<label value>&rdquo; for all targets created
-from service and pod monitors.
-Otherwise the HonorLabels field of the service or pod monitor applies.</p>
+<p>If <code>overrideHonorLabels</code> is true, then the operator sets <code>honor_labels:false</code>
+for all generated scrape configs.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21586,10 +21586,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-
@@ -32520,10 +32518,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4662,10 +4662,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5395,10 +5395,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4663,10 +4663,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5396,10 +5396,8 @@ spec:
                 type: object
               overrideHonorLabels:
                 description: |-
-                  When true, Prometheus resolves label conflicts by renaming the labels in
-                  the scraped data to "exported_<label value>" for all targets created
-                  from service and pod monitors.
-                  Otherwise the HonorLabels field of the service or pod monitor applies.
+                  If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`
+                  for all generated scrape configs.
                 type: boolean
               overrideHonorTimestamps:
                 description: |-

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -3933,7 +3933,7 @@
                     "type": "object"
                   },
                   "overrideHonorLabels": {
-                    "description": "When true, Prometheus resolves label conflicts by renaming the labels in\nthe scraped data to \"exported_<label value>\" for all targets created\nfrom service and pod monitors.\nOtherwise the HonorLabels field of the service or pod monitor applies.",
+                    "description": "If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`\nfor all generated scrape configs.",
                     "type": "boolean"
                   },
                   "overrideHonorTimestamps": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4513,7 +4513,7 @@
                     "type": "object"
                   },
                   "overrideHonorLabels": {
-                    "description": "When true, Prometheus resolves label conflicts by renaming the labels in\nthe scraped data to \"exported_<label value>\" for all targets created\nfrom service and pod monitors.\nOtherwise the HonorLabels field of the service or pod monitor applies.",
+                    "description": "If `overrideHonorLabels` is true, then the operator sets `honor_labels:false`\nfor all generated scrape configs.",
                     "type": "boolean"
                   },
                   "overrideHonorTimestamps": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -475,10 +475,8 @@ type CommonPrometheusFields struct {
 	// `spec.bearerTokenSecret` field.
 	ArbitraryFSAccessThroughSMs ArbitraryFSAccessThroughSMsConfig `json:"arbitraryFSAccessThroughSMs,omitempty"`
 
-	// When true, Prometheus resolves label conflicts by renaming the labels in
-	// the scraped data to "exported_<label value>" for all targets created
-	// from service and pod monitors.
-	// Otherwise the HonorLabels field of the service or pod monitor applies.
+	// If `overrideHonorLabels` is true, then the operator sets `honor_labels:false` 
+	// for all generated scrape configs.
 	OverrideHonorLabels bool `json:"overrideHonorLabels,omitempty"`
 	// When true, Prometheus ignores the timestamps for all the targets created
 	// from service and pod monitors.


### PR DESCRIPTION
## Description

As mentioned in #6616 , I have corrected the description of ```overrideHonorLabels``` field. Before, the description mentioned that Prometheus resolved the label conflicts by renaming the labels in the scraped data to "exported_" which was not being applied as it reverted to default value ```honorLabels:false``` 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)