### PR TITLE
feat: add `prometheus_operator_feature_gate_info` metric

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -52,7 +52,9 @@ Usage of ./operator:
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
   -feature-gates value
-    	Feature gates are a set of key=value pairs that describe Prometheus-Operator features. Available features: ["PrometheusAgentDaemonSet"].
+    	Feature gates are a set of key=value pairs that describe Prometheus-Operator features.
+    	Available feature gates:
+    	  PrometheusAgentDaemonSet: Enables the DaemonSet mode for PrometheusAgent (enabled: false)
   -key-file string
     	- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.
   -kubelet-node-address-priority value

--- a/pkg/operator/feature_gates.go
+++ b/pkg/operator/feature_gates.go
@@ -19,47 +19,113 @@ import (
 	"slices"
 	"strings"
 
-	k8sflag "k8s.io/component-base/cli/flag"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-// At the moment, the are no feature gates available.
-var defaultFeatureGates = map[string]bool{
-	"PrometheusAgentDaemonSet": false,
+const (
+	// PrometheusAgentDaemonSetFeature enables the DaemonSet mode for PrometheusAgent.
+	PrometheusAgentDaemonSetFeature FeatureGateName = "PrometheusAgentDaemonSet"
+)
+
+type FeatureGateName string
+
+type FeatureGates map[FeatureGateName]FeatureGate
+
+type FeatureGate struct {
+	description string
+	enabled     bool
 }
 
-// ValidateFeatureGates merges the feature gate default values with
+func (fg FeatureGates) Enabled(name FeatureGateName) bool {
+	return fg[name].enabled
+}
+
+// UpdateFeatureGates merges the current feature gate values with
 // the values provided by the user.
-func ValidateFeatureGates(flags *k8sflag.MapStringBool) (string, error) {
-	gates := defaultFeatureGates
-	if flags.Empty() {
-		return mapToString(gates), nil
-	}
-
-	imgs := *flags.Map
-	for k, v := range imgs {
-		if _, ok := gates[k]; !ok {
-			return "", fmt.Errorf("feature gate %v is unknown", k)
+func (fg *FeatureGates) UpdateFeatureGates(flags map[string]bool) error {
+	for k := range flags {
+		f, found := (*fg)[FeatureGateName(k)]
+		if !found {
+			return fmt.Errorf("feature gate %q is unknown (supported feature gates: %s)", k, fg.String())
 		}
-		gates[k] = v
+		f.enabled = flags[k]
+		(*fg)[FeatureGateName(k)] = f
 	}
-	return mapToString(gates), nil
+
+	return nil
 }
 
-func AvailableFeatureGates() []string {
-	i := 0
-	gates := make([]string, len(defaultFeatureGates))
-	for k := range defaultFeatureGates {
-		gates[i] = k
-		i++
+func (fg *FeatureGates) keyValuePairs() ([]FeatureGateName, []FeatureGate) {
+	if fg == nil {
+		return nil, nil
 	}
-	slices.Sort(gates)
-	return gates
+
+	var (
+		names = make([]FeatureGateName, 0, len(*fg))
+		gates = make([]FeatureGate, 0, len(*fg))
+	)
+	for k := range *fg {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+
+	for _, v := range names {
+		gates = append(gates, (*fg)[v])
+	}
+
+	return names, gates
 }
 
-func mapToString(m map[string]bool) string {
-	var s []string
-	for k, v := range m {
-		s = append(s, fmt.Sprintf("%s=%t", k, v))
+func (fg *FeatureGates) Descriptions() []string {
+	var (
+		names, gates = fg.keyValuePairs()
+		desc         = make([]string, 0, len(names))
+	)
+
+	for i := range names {
+		desc = append(desc, fmt.Sprintf("%s: %s (enabled: %t)", names[i], gates[i].description, gates[i].enabled))
 	}
+
+	return desc
+}
+
+func (fg *FeatureGates) String() string {
+	names, gates := fg.keyValuePairs()
+
+	s := make([]string, len(names))
+	for i := range names {
+		s[i] = fmt.Sprintf("%s=%t", names[i], gates[i].enabled)
+	}
+
 	return strings.Join(s, ",")
+}
+
+var featureGateInfoDesc = prometheus.NewDesc(
+	"prometheus_operator_feature_gate",
+	"Reports about the Prometheus operator feature gates. A value of 1 means that the feature gate is enabled. Otherwise the value is 0.",
+	[]string{"name"},
+	nil,
+)
+
+// Describe implements the prometheus.Collector interface.
+func (fg *FeatureGates) Describe(ch chan<- *prometheus.Desc) {
+	ch <- featureGateInfoDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (fg *FeatureGates) Collect(ch chan<- prometheus.Metric) {
+	names, gates := fg.keyValuePairs()
+
+	for i, v := range names {
+		var val float64
+		if gates[i].enabled {
+			val = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			featureGateInfoDesc,
+			prometheus.GaugeValue,
+			val,
+			string(v),
+		)
+	}
 }


### PR DESCRIPTION
## Description

This change also moves the feature gates to the operator config struct. It means that after a feature gate is enabled/disabled, the operator will reconcile the managed Prometheus resources which should be the right thing to do.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
