### PR TITLE
[Enhancement] Replacing t.Fatal with testify/require package 

### DIFF
--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -48,9 +48,7 @@ func TestIdenticalNamespaces(t *testing.T) {
 		tc := tc
 		t.Run("", func(t *testing.T) {
 			ret := IdenticalNamespaces(tc.a, tc.b)
-			if ret != tc.ret {
-				t.Fatalf("expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
-			}
+			require.Equal(t, ret, tc.ret, "expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
 		})
 	}
 }

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -48,7 +48,9 @@ func TestIdenticalNamespaces(t *testing.T) {
 		tc := tc
 		t.Run("", func(t *testing.T) {
 			ret := IdenticalNamespaces(tc.a, tc.b)
-			require.Equal(t, ret, tc.ret, "expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
+			if ret != tc.ret {
+				t.Fatalf("expecting IdenticalNamespaces() to return %v, got %v", tc.ret, ret)
+			}
 		})
 	}
 }

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -16,8 +16,9 @@ package operator
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"golang.org/x/exp/slices"
 

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
+
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 func TestBuildArgs(t *testing.T) {

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"golang.org/x/exp/slices"
@@ -43,15 +44,11 @@ func TestBuildArgs(t *testing.T) {
 
 	for _, arg := range args {
 		argString := fmt.Sprintf("--%s=%s", arg.Name, arg.Value)
-		if !slices.Contains(containerArgs, argString) {
-			t.Fatalf("expected containerArgs to contain arg %v, got %v", argString, containerArgs)
-		}
+		require.True(t, slices.Contains(containerArgs, argString), "expected containerArgs to contain arg %v, got %v", argString, containerArgs)
 	}
 
 	for _, arg := range additionalArgs {
 		argString := fmt.Sprintf("--%s=%s", arg.Name, arg.Value)
-		if !slices.Contains(containerArgs, argString) {
-			t.Fatalf("expected containerArgs to contain additionalArg %v, got %v", argString, containerArgs)
-		}
+		require.True(t, slices.Contains(containerArgs, argString), "expected containerArgs to contain additionalArg %v, got %v", argString, containerArgs)
 	}
 }

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -18,11 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"golang.org/x/exp/slices"
-
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 func TestBuildArgs(t *testing.T) {

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -44,11 +43,11 @@ func TestBuildArgs(t *testing.T) {
 
 	for _, arg := range args {
 		argString := fmt.Sprintf("--%s=%s", arg.Name, arg.Value)
-		require.True(t, slices.Contains(containerArgs, argString), "expected containerArgs to contain arg %v, got %v", argString, containerArgs)
+		require.Contains(t, containerArgs, argString, "expected containerArgs to contain arg %v, got %v", argString, containerArgs)
 	}
 
 	for _, arg := range additionalArgs {
 		argString := fmt.Sprintf("--%s=%s", arg.Name, arg.Value)
-		require.True(t, slices.Contains(containerArgs, argString), "expected containerArgs to contain additionalArg %v, got %v", argString, containerArgs)
+		require.Contains(t, containerArgs, argString, "expected containerArgs to contain additionalArg %v, got %v", argString, containerArgs)
 	}
 }

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -15,7 +15,6 @@
 package operator
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -211,7 +210,7 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 			for _, c := range sset.Spec.Template.Spec.Containers {
 				if strings.HasSuffix(c.Name, "config-reloader") {
 					foundContainer = true
-					require.True(t, reflect.DeepEqual(c.Resources, tc.expectedResources), "Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", tc.expectedResources.String(), c.Resources.String())
+					require.Equal(t, tc.expectedResources, c.Resources, "Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", tc.expectedResources.String(), c.Resources.String())
 				}
 			}
 

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -15,10 +15,11 @@
 package operator
 
 import (
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
 	"testing"
@@ -210,15 +211,11 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 			for _, c := range sset.Spec.Template.Spec.Containers {
 				if strings.HasSuffix(c.Name, "config-reloader") {
 					foundContainer = true
-				}
-				if strings.HasSuffix(c.Name, "config-reloader") && !reflect.DeepEqual(c.Resources, tc.expectedResources) {
-					t.Fatalf("Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", tc.expectedResources.String(), c.Resources.String())
+					require.True(t, reflect.DeepEqual(c.Resources, tc.expectedResources), "Expected resource requests/limits:\n\n%s\n\nGot:\n\n%s", tc.expectedResources.String(), c.Resources.String())
 				}
 			}
 
-			if !foundContainer {
-				t.Fatalf("Expected to find a config-reloader container but it did")
-			}
+			require.True(t, foundContainer, "Expected to find a config-reloader container but it did")
 		})
 	}
 }

--- a/pkg/operator/prober_test.go
+++ b/pkg/operator/prober_test.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -66,15 +67,15 @@ func TestProbers(t *testing.T) {
 				if tc.err {
 					if err == nil {
 						t.Logf("%s: %s", strings.Join(args, " "), string(b))
-						t.Fatal("expecting error but got nil")
 					}
+					require.Error(t, err, "expecting error but got nil")
 					return
 				}
 
 				if err != nil {
 					t.Logf("%s: %s", strings.Join(args, " "), string(b))
-					t.Fatalf("expecting no error but got %v", err)
 				}
+				require.NoError(t, err, "expecting no error but got %v", err)
 			})
 		}
 

--- a/pkg/operator/prober_test.go
+++ b/pkg/operator/prober_test.go
@@ -16,12 +16,13 @@ package operator
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestProbers(t *testing.T) {

--- a/pkg/operator/prober_test.go
+++ b/pkg/operator/prober_test.go
@@ -69,14 +69,14 @@ func TestProbers(t *testing.T) {
 					if err == nil {
 						t.Logf("%s: %s", strings.Join(args, " "), string(b))
 					}
-					require.Error(t, err, "expecting error but got nil")
+					require.Error(t, err)
 					return
 				}
 
 				if err != nil {
 					t.Logf("%s: %s", strings.Join(args, " "), string(b))
 				}
-				require.NoError(t, err, "expecting no error but got %v", err)
+				require.NoError(t, err)
 			})
 		}
 

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 func TestMakeRulesConfigMaps(t *testing.T) {

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -16,7 +16,6 @@ package operator
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -71,7 +70,7 @@ func shouldAcceptRuleWithValidPartialResponseStrategyValue(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.True(t, strings.Contains(content, "partial_response_strategy: warn"), "expected `partial_response_strategy` to be set in PrometheusRule as `warn`")
+	require.Contains(t, content, "partial_response_strategy: warn", "expected `partial_response_strategy` to be set in PrometheusRule as `warn`")
 }
 
 func shouldAcceptValidRule(t *testing.T) {
@@ -94,7 +93,7 @@ func shouldAcceptValidRule(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	require.NoError(t, err, "expected no errors when parsing valid rule")
+	require.NoError(t, err)
 }
 
 func shouldAcceptRulesWithEmptyDurations(t *testing.T) {
@@ -124,7 +123,7 @@ func shouldAcceptRulesWithEmptyDurations(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	require.NoError(t, err, "expected no errors when parsing valid rule")
+	require.NoError(t, err)
 }
 
 func shouldRejectRuleWithInvalidLabels(t *testing.T) {
@@ -147,7 +146,7 @@ func shouldRejectRuleWithInvalidLabels(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	require.Error(t, err, "expected errors when parsing rule with invalid labels")
+	require.Error(t, err)
 }
 
 func shouldRejectRuleWithInvalidExpression(t *testing.T) {
@@ -168,7 +167,7 @@ func shouldRejectRuleWithInvalidExpression(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	require.Error(t, err, "expected errors when parsing rule with invalid expression")
+	require.Error(t, err)
 }
 
 func shouldResetRuleWithPartialResponseStrategySet(t *testing.T) {
@@ -189,7 +188,7 @@ func shouldResetRuleWithPartialResponseStrategySet(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.False(t, strings.Contains(content, "partial_response_strategy"), "expected `partial_response_strategy` removed from PrometheusRule")
+	require.NotContains(t, content, "partial_response_strategy", "expected `partial_response_strategy` removed from PrometheusRule")
 }
 
 func shouldAcceptRuleWithKeepFiringForPrometheus(t *testing.T) {
@@ -212,7 +211,7 @@ func shouldAcceptRuleWithKeepFiringForPrometheus(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.True(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` to be present in PrometheusRule")
+	require.Contains(t, content, "keep_firing_for", "expected `keep_firing_for` to be present in PrometheusRule")
 }
 
 func shouldDropRuleFiringForThanos(t *testing.T) {
@@ -235,7 +234,7 @@ func shouldDropRuleFiringForThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant("v0.33.0")
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.False(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` not to be present in PrometheusRule")
+	require.NotContains(t, content, "keep_firing_for", "expected `keep_firing_for` not to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleFiringForThanos(t *testing.T) {
@@ -258,7 +257,7 @@ func shouldAcceptRuleFiringForThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.True(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` to be present in PrometheusRule")
+	require.Contains(t, content, "keep_firing_for", "expected `keep_firing_for` to be present in PrometheusRule")
 }
 
 func shouldDropKeepFiringForFieldForUnsupportedPrometheusVersion(t *testing.T) {
@@ -281,7 +280,7 @@ func shouldDropKeepFiringForFieldForUnsupportedPrometheusVersion(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant("v2.30.0")
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.False(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` not to be present in PrometheusRule")
+	require.NotContains(t, content, "keep_firing_for", "expected `keep_firing_for` not to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleWithLimitPrometheus(t *testing.T) {
@@ -304,7 +303,7 @@ func shouldAcceptRuleWithLimitPrometheus(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.True(t, strings.Contains(content, "limit"), "expected `limit` to be present in PrometheusRule")
+	require.Contains(t, content, "limit", "expected `limit` to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleWithLimitThanos(t *testing.T) {
@@ -327,7 +326,7 @@ func shouldAcceptRuleWithLimitThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.True(t, strings.Contains(content, "limit"), "expected `limit` to be present in PrometheusRule")
+	require.Contains(t, content, "limit", "expected `limit` to be present in PrometheusRule")
 }
 
 func shouldDropLimitFieldForUnsupportedPrometheusVersion(t *testing.T) {
@@ -350,7 +349,7 @@ func shouldDropLimitFieldForUnsupportedPrometheusVersion(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant("v2.30.0")
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.False(t, strings.Contains(content, "limit"), "expected `limit` not to be present in PrometheusRule")
+	require.NotContains(t, content, "limit", "expected `limit` not to be present in PrometheusRule")
 }
 
 func shouldDropLimitFieldForUnsupportedThanosVersion(t *testing.T) {
@@ -373,5 +372,5 @@ func shouldDropLimitFieldForUnsupportedThanosVersion(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant("v0.23.0")
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	require.False(t, strings.Contains(content, "limit"), "expected `limit` not to be present in PrometheusRule")
+	require.NotContains(t, content, "limit", "expected `limit` not to be present in PrometheusRule")
 }

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -15,10 +15,11 @@
 package operator
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
@@ -70,9 +71,7 @@ func shouldAcceptRuleWithValidPartialResponseStrategyValue(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if !strings.Contains(content, "partial_response_strategy: warn") {
-		t.Fatalf("expected `partial_response_strategy` to be set in PrometheusRule as `warn`")
-	}
+	require.True(t, strings.Contains(content, "partial_response_strategy: warn"), "expected `partial_response_strategy` to be set in PrometheusRule as `warn`")
 }
 
 func shouldAcceptValidRule(t *testing.T) {
@@ -95,9 +94,7 @@ func shouldAcceptValidRule(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	if err != nil {
-		t.Fatalf("expected no errors when parsing valid rule")
-	}
+	require.NoError(t, err, "expected no errors when parsing valid rule")
 }
 
 func shouldAcceptRulesWithEmptyDurations(t *testing.T) {
@@ -127,9 +124,7 @@ func shouldAcceptRulesWithEmptyDurations(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	if err != nil {
-		t.Fatalf("expected no errors when parsing valid rule")
-	}
+	require.NoError(t, err, "expected no errors when parsing valid rule")
 }
 
 func shouldRejectRuleWithInvalidLabels(t *testing.T) {
@@ -152,9 +147,7 @@ func shouldRejectRuleWithInvalidLabels(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	if err == nil {
-		t.Fatalf("expected errors when parsing rule with invalid labels")
-	}
+	require.Error(t, err, "expected errors when parsing rule with invalid labels")
 }
 
 func shouldRejectRuleWithInvalidExpression(t *testing.T) {
@@ -175,9 +168,7 @@ func shouldRejectRuleWithInvalidExpression(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	_, err := pr.generateRulesConfiguration(rules)
-	if err == nil {
-		t.Fatalf("expected errors when parsing rule with invalid expression")
-	}
+	require.Error(t, err, "expected errors when parsing rule with invalid expression")
 }
 
 func shouldResetRuleWithPartialResponseStrategySet(t *testing.T) {
@@ -198,9 +189,7 @@ func shouldResetRuleWithPartialResponseStrategySet(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if strings.Contains(content, "partial_response_strategy") {
-		t.Fatalf("expected `partial_response_strategy` removed from PrometheusRule")
-	}
+	require.False(t, strings.Contains(content, "partial_response_strategy"), "expected `partial_response_strategy` removed from PrometheusRule")
 }
 
 func shouldAcceptRuleWithKeepFiringForPrometheus(t *testing.T) {
@@ -223,9 +212,7 @@ func shouldAcceptRuleWithKeepFiringForPrometheus(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if !strings.Contains(content, "keep_firing_for") {
-		t.Fatalf("expected `keep_firing_for` to be present in PrometheusRule")
-	}
+	require.True(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` to be present in PrometheusRule")
 }
 
 func shouldDropRuleFiringForThanos(t *testing.T) {
@@ -248,9 +235,7 @@ func shouldDropRuleFiringForThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant("v0.33.0")
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if strings.Contains(content, "keep_firing_for") {
-		t.Fatalf("expected `keep_firing_for` not to be present in PrometheusRule")
-	}
+	require.False(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` not to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleFiringForThanos(t *testing.T) {
@@ -273,9 +258,7 @@ func shouldAcceptRuleFiringForThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if !strings.Contains(content, "keep_firing_for") {
-		t.Fatalf("expected `keep_firing_for` to be present in PrometheusRule")
-	}
+	require.True(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` to be present in PrometheusRule")
 }
 
 func shouldDropKeepFiringForFieldForUnsupportedPrometheusVersion(t *testing.T) {
@@ -298,9 +281,7 @@ func shouldDropKeepFiringForFieldForUnsupportedPrometheusVersion(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant("v2.30.0")
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if strings.Contains(content, "keep_firing_for") {
-		t.Fatalf("expected `keep_firing_for` not to be present in PrometheusRule")
-	}
+	require.False(t, strings.Contains(content, "keep_firing_for"), "expected `keep_firing_for` not to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleWithLimitPrometheus(t *testing.T) {
@@ -323,9 +304,7 @@ func shouldAcceptRuleWithLimitPrometheus(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant(DefaultPrometheusVersion)
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if !strings.Contains(content, "limit") {
-		t.Fatalf("expected `limit` to be present in PrometheusRule")
-	}
+	require.True(t, strings.Contains(content, "limit"), "expected `limit` to be present in PrometheusRule")
 }
 
 func shouldAcceptRuleWithLimitThanos(t *testing.T) {
@@ -348,9 +327,7 @@ func shouldAcceptRuleWithLimitThanos(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant(DefaultThanosVersion)
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if !strings.Contains(content, "limit") {
-		t.Fatalf("expected `limit` to be present in PrometheusRule")
-	}
+	require.True(t, strings.Contains(content, "limit"), "expected `limit` to be present in PrometheusRule")
 }
 
 func shouldDropLimitFieldForUnsupportedPrometheusVersion(t *testing.T) {
@@ -373,9 +350,7 @@ func shouldDropLimitFieldForUnsupportedPrometheusVersion(t *testing.T) {
 	promVersion, _ := semver.ParseTolerant("v2.30.0")
 	pr := newRuleSelectorForConfigGeneration(PrometheusFormat, promVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if strings.Contains(content, "limit") {
-		t.Fatalf("expected `limit` not to be present in PrometheusRule")
-	}
+	require.False(t, strings.Contains(content, "limit"), "expected `limit` not to be present in PrometheusRule")
 }
 
 func shouldDropLimitFieldForUnsupportedThanosVersion(t *testing.T) {
@@ -398,7 +373,5 @@ func shouldDropLimitFieldForUnsupportedThanosVersion(t *testing.T) {
 	thanosVersion, _ := semver.ParseTolerant("v0.23.0")
 	pr := newRuleSelectorForConfigGeneration(ThanosFormat, thanosVersion)
 	content, _ := pr.generateRulesConfiguration(rules)
-	if strings.Contains(content, "limit") {
-		t.Fatalf("expected `limit` not to be present in PrometheusRule")
-	}
+	require.False(t, strings.Contains(content, "limit"), "expected `limit` not to be present in PrometheusRule")
 }

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -19,13 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestMakeRulesConfigMaps(t *testing.T) {


### PR DESCRIPTION
## Description

Currently, there is an excessive usage of [t.Fatal ](https://github.com/search?q=repo%3Aprometheus-operator%2Fprometheus-operator+t.Fatal&type=code&p=3)in this repository. To make the code more readable, and to remove repetitive manual checks, I have replaced t.Fatal with functions of **testify/require package**. Currently, this PR only consists of changes applied in **pkg/operator**. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Since I made changes only in **pkg/operator**, I ran a test for this package using ```go test ./pkg/operator``` and received the following output -  ```ok      github.com/prometheus-operator/prometheus-operator/pkg/operator 0.065s```