### PR TITLE
WIP: Refactor common test code between Prometheus Agent's StatefulSet and DaemonSet modes

### DIFF
--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -49,15 +49,8 @@ func TestListenTLS(t *testing.T) {
 	require.Equal(t, expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
-	expectedReadinessProbe := &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    5,
-		FailureThreshold: 3,
-	}
-	if !reflect.DeepEqual(actualReadinessProbe, expectedReadinessProbe) {
-		t.Fatalf("Readiness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedReadinessProbe, actualReadinessProbe)
-	}
+	expectedReadinessProbe := makeExpectedReadinessProbe()
+	require.Equal(t, expectedReadinessProbe, actualReadinessProbe)
 
 	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
 	reloadURLFound := false

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -41,15 +41,8 @@ func TestListenTLS(t *testing.T) {
 	require.NoError(t, err)
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
-	expectedStartupProbe := &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    15,
-		FailureThreshold: 60,
-	}
-	if !reflect.DeepEqual(actualStartupProbe, expectedStartupProbe) {
-		t.Fatalf("Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
-	}
+	expectedStartupProbe := makeExpectedStartupProbe()
+	require.Equal(t, expectedStartupProbe, actualStartupProbe)
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
 	expectedLivenessProbe := &v1.Probe{

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -26,7 +26,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -41,19 +40,9 @@ func TestListenTLS(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
-		return v1.ProbeHandler{
-			HTTPGet: &v1.HTTPGetAction{
-				Path:   probePath,
-				Port:   intstr.FromString("web"),
-				Scheme: "HTTPS",
-			},
-		}
-	}
-
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
 	expectedStartupProbe := &v1.Probe{
-		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
 		FailureThreshold: 60,
@@ -64,7 +53,7 @@ func TestListenTLS(t *testing.T) {
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
 	expectedLivenessProbe := &v1.Probe{
-		ProbeHandler:     expectedProbeHandler("/-/healthy"),
+		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
 		FailureThreshold: 6,
@@ -75,7 +64,7 @@ func TestListenTLS(t *testing.T) {
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
 	expectedReadinessProbe := &v1.Probe{
-		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
 		FailureThreshold: 3,

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -35,39 +35,9 @@ import (
 	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
 )
 
-var (
-	defaultTestConfig = &prompkg.Config{
-		LocalHost:                  "localhost",
-		ReloaderConfig:             operator.DefaultReloaderTestConfig.ReloaderConfig,
-		PrometheusDefaultBaseImage: operator.DefaultPrometheusBaseImage,
-		ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
-	}
-)
-
 func TestListenTLS(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
-		Spec: monitoringv1alpha1.PrometheusAgentSpec{
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Web: &monitoringv1.PrometheusWebSpec{
-					WebConfigFileFields: monitoringv1.WebConfigFileFields{
-						TLSConfig: &monitoringv1.WebTLSConfig{
-							KeySecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
-									Name: "some-secret",
-								},
-							},
-							Cert: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: "some-configmap",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+		Spec: makeSpecForTestListenTLS(),
 	})
 	require.NoError(t, err)
 

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -45,15 +45,8 @@ func TestListenTLS(t *testing.T) {
 	require.Equal(t, expectedStartupProbe, actualStartupProbe)
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
-	expectedLivenessProbe := &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    5,
-		FailureThreshold: 6,
-	}
-	if !reflect.DeepEqual(actualLivenessProbe, expectedLivenessProbe) {
-		t.Fatalf("Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
-	}
+	expectedLivenessProbe := makeExpectedLivenessProbe()
+	require.Equal(t, expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
 	expectedReadinessProbe := &v1.Probe{

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -16,7 +16,6 @@ package prometheusagent
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -52,33 +51,7 @@ func TestListenTLS(t *testing.T) {
 	expectedReadinessProbe := makeExpectedReadinessProbe()
 	require.Equal(t, expectedReadinessProbe, actualReadinessProbe)
 
-	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
-	reloadURLFound := false
-	for _, arg := range sset.Spec.Template.Spec.Containers[1].Args {
-		if arg == expectedConfigReloaderReloadURL {
-			reloadURLFound = true
-			break
-		}
-	}
-	if !reloadURLFound {
-		t.Fatalf("expected to find arg %s in config reloader", expectedConfigReloaderReloadURL)
-	}
-
-	expectedArgsConfigReloader := []string{
-		"--listen-address=:8080",
-		"--web-config-file=/etc/prometheus/web_config/web-config.yaml",
-		"--reload-url=https://localhost:9090/-/reload",
-		"--config-file=/etc/prometheus/config/prometheus.yaml.gz",
-		"--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml",
-	}
-
-	for _, c := range sset.Spec.Template.Spec.Containers {
-		if c.Name == "config-reloader" {
-			if !reflect.DeepEqual(c.Args, expectedArgsConfigReloader) {
-				t.Fatalf("expected container args are %s, but found %s", expectedArgsConfigReloader, c.Args)
-			}
-		}
-	}
+	testCorrectArgs(t, sset.Spec.Template.Spec.Containers[1].Args, sset.Spec.Template.Spec.Containers)
 }
 
 func TestWALCompression(t *testing.T) {

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -57,6 +57,7 @@ func TestListenTLS(t *testing.T) {
 	for _, arg := range sset.Spec.Template.Spec.Containers[1].Args {
 		if arg == expectedConfigReloaderReloadURL {
 			reloadURLFound = true
+			break
 		}
 	}
 	if !reloadURLFound {

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -52,10 +52,6 @@ func TestListenTLS(t *testing.T) {
 }
 
 func TestWALCompression(t *testing.T) {
-	var (
-		tr = true
-		fa = false
-	)
 	tests := []struct {
 		version       string
 		enabled       *bool
@@ -63,10 +59,10 @@ func TestWALCompression(t *testing.T) {
 		shouldContain bool
 	}{
 		// Nil should not have either flag.
-		{"v2.30.0", &fa, "--storage.agent.wal-compression", false},
+		{"v2.30.0", ptr.To(false), "--storage.agent.wal-compression", false},
 		{"v2.32.0", nil, "--storage.agent.wal-compression", false},
-		{"v2.32.0", &fa, "--no-storage.agent.wal-compression", true},
-		{"v2.32.0", &tr, "--storage.agent.wal-compression", true},
+		{"v2.32.0", ptr.To(false), "--no-storage.agent.wal-compression", true},
+		{"v2.32.0", ptr.To(true), "--storage.agent.wal-compression", true},
 	}
 
 	for _, test := range tests {

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -193,43 +193,6 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 			},
 		},
 		{
-			name: "with labelSelector and additionalLabels as ShardAndNameResource",
-			spec: monitoringv1alpha1.PrometheusAgentSpec{
-				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					TopologySpreadConstraints: []monitoringv1.TopologySpreadConstraint{
-						{
-							AdditionalLabelSelectors: ptr.To(monitoringv1.ShardAndResourceNameLabelSelector),
-							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
-								MaxSkew:           1,
-								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										"app": "prometheus",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			tsc: v1.TopologySpreadConstraint{
-				MaxSkew:           1,
-				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app":                          "prometheus",
-						"app.kubernetes.io/instance":   "test",
-						"app.kubernetes.io/managed-by": "prometheus-operator",
-						"app.kubernetes.io/name":       "prometheus-agent",
-						"operator.prometheus.io/name":  "test",
-						"operator.prometheus.io/shard": "0",
-					},
-				},
-			},
-		},
-		{
 			name: "with labelSelector and additionalLabels as ResourceName",
 			spec: monitoringv1alpha1.PrometheusAgentSpec{
 				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -67,3 +67,12 @@ func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
 		},
 	}
 }
+
+func makeExpectedStartupProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+}

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -76,3 +76,12 @@ func makeExpectedStartupProbe() *v1.Probe {
 		FailureThreshold: 60,
 	}
 }
+
+func makeExpectedLivenessProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+}

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -85,3 +85,12 @@ func makeExpectedLivenessProbe() *v1.Probe {
 		FailureThreshold: 6,
 	}
 }
+
+func makeExpectedReadinessProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+}

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -16,6 +16,7 @@ package prometheusagent
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -53,6 +54,16 @@ func makeSpecForTestListenTLS() monitoringv1alpha1.PrometheusAgentSpec {
 					},
 				},
 			},
+		},
+	}
+}
+
+func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
+	return v1.ProbeHandler{
+		HTTPGet: &v1.HTTPGetAction{
+			Path:   probePath,
+			Port:   intstr.FromString("web"),
+			Scheme: "HTTPS",
 		},
 	}
 }

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusagent
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	prompkg "github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+)
+
+var (
+	defaultTestConfig = &prompkg.Config{
+		LocalHost:                  "localhost",
+		ReloaderConfig:             operator.DefaultReloaderTestConfig.ReloaderConfig,
+		PrometheusDefaultBaseImage: operator.DefaultPrometheusBaseImage,
+		ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
+	}
+)
+
+func makeSpecForTestListenTLS() monitoringv1alpha1.PrometheusAgentSpec {
+	return monitoringv1alpha1.PrometheusAgentSpec{
+		CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+			Web: &monitoringv1.PrometheusWebSpec{
+				WebConfigFileFields: monitoringv1.WebConfigFileFields{
+					TLSConfig: &monitoringv1.WebTLSConfig{
+						KeySecret: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "some-secret",
+							},
+						},
+						Cert: monitoringv1.SecretOrConfigMap{
+							ConfigMap: &v1.ConfigMapKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "some-configmap",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -250,9 +250,8 @@ type testcaseForTestAutomountServiceAccountToken struct {
 func createTestCasesForTestAutomountServiceAccountToken() []testcaseForTestAutomountServiceAccountToken {
 	return []testcaseForTestAutomountServiceAccountToken{
 		{
-			name:                         "automountServiceAccountToken not set",
-			automountServiceAccountToken: nil,
-			expectedValue:                true,
+			name:          "automountServiceAccountToken not set",
+			expectedValue: true,
 		},
 		{
 			name:                         "automountServiceAccountToken set to true",

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -132,14 +132,14 @@ func newLogger() log.Logger {
 	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 }
 
-type testcase struct {
+type testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels struct {
 	name string
 	spec monitoringv1alpha1.PrometheusAgentSpec
 	tsc  v1.TopologySpreadConstraint
 }
 
-func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []testcase {
-	return []testcase{
+func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels {
+	return []testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels{
 		{
 			name: "without labelSelector and additionalLabels",
 			spec: monitoringv1alpha1.PrometheusAgentSpec{
@@ -275,5 +275,42 @@ func makePrometheusAgentForTestPodTopologySpreadConstraintWithAdditionalLabels(s
 			Namespace: "ns-test",
 		},
 		Spec: spec,
+	}
+}
+
+type testcaseForTestAutomountServiceAccountToken struct {
+	name                         string
+	automountServiceAccountToken *bool
+	expectedValue                bool
+}
+
+func createTestCasesForTestAutomountServiceAccountToken() []testcaseForTestAutomountServiceAccountToken {
+	return []testcaseForTestAutomountServiceAccountToken{
+		{
+			name:                         "automountServiceAccountToken not set",
+			automountServiceAccountToken: nil,
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to true",
+			automountServiceAccountToken: ptr.To(true),
+			expectedValue:                true,
+		},
+		{
+			name:                         "automountServiceAccountToken set to false",
+			automountServiceAccountToken: ptr.To(false),
+			expectedValue:                false,
+		},
+	}
+}
+
+func makePrometheusAgentForTestAutomountServiceAccountToken(automountServiceAccountToken *bool) monitoringv1alpha1.PrometheusAgent {
+	return monitoringv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				AutomountServiceAccountToken: automountServiceAccountToken,
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description

Refactor common test code between Prometheus Agent's StatefulSet and DaemonSet modes to reduce duplication and make reviewing https://github.com/prometheus-operator/prometheus-operator/pull/6652 easier.
If seeing any pieces can be refactored further into the Server mode then do it too.
If seeing anywhere `testing` package is used when `require` and `assert` is the better option, make the change too.
If seeing any minor code-related improvement chance, do it too. 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
CI green