### PR TITLE
Continue #6688: Refactor common test code between Prometheus modes

### DIFF
--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -52,20 +52,39 @@ func TestListenTLS(t *testing.T) {
 }
 
 func TestWALCompression(t *testing.T) {
-	testcases := createTestCasesForTestWALCompression()
+	tests := []struct {
+		version       string
+		enabled       *bool
+		expectedArg   string
+		shouldContain bool
+	}{
+		// Nil should not have either flag.
+		{"v2.30.0", ptr.To(false), "--storage.agent.wal-compression", false},
+		{"v2.32.0", nil, "--storage.agent.wal-compression", false},
+		{"v2.32.0", ptr.To(false), "--no-storage.agent.wal-compression", true},
+		{"v2.32.0", ptr.To(true), "--storage.agent.wal-compression", true},
+	}
 
-	for _, test := range testcases {
-		sset, err := makeStatefulSetFromPrometheus(
-			makePrometheusAgentForTestWALCompression(
-				test.version,
-				test.enabled))
+	for _, test := range tests {
+		sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
+			Spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Version:        test.version,
+					WALCompression: test.enabled,
+				},
+			},
+		})
 		require.NoError(t, err)
 
-		testPromArgsShouldContain(
-			t,
-			test.expectedArg,
-			sset.Spec.Template.Spec.Containers[0].Args,
-			test.shouldContain)
+		promArgs := sset.Spec.Template.Spec.Containers[0].Args
+		found := false
+		for _, flag := range promArgs {
+			if flag == test.expectedArg {
+				found = true
+				break
+			}
+		}
+		require.Equal(t, test.shouldContain, found)
 	}
 }
 

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -70,31 +70,11 @@ func TestWALCompression(t *testing.T) {
 }
 
 func TestStartupProbeTimeoutSeconds(t *testing.T) {
-	tests := []struct {
-		maximumStartupDurationSeconds   *int32
-		expectedStartupPeriodSeconds    int32
-		expectedStartupFailureThreshold int32
-	}{
-		{
-			maximumStartupDurationSeconds:   nil,
-			expectedStartupPeriodSeconds:    15,
-			expectedStartupFailureThreshold: 60,
-		},
-		{
-			maximumStartupDurationSeconds:   ptr.To(int32(600)),
-			expectedStartupPeriodSeconds:    60,
-			expectedStartupFailureThreshold: 10,
-		},
-	}
+	testcases := createTestCasesForTestStartupProbeTimeoutSeconds()
 
-	for _, test := range tests {
-		sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
-			Spec: monitoringv1alpha1.PrometheusAgentSpec{
-				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					MaximumStartupDurationSeconds: test.maximumStartupDurationSeconds,
-				},
-			},
-		})
+	for _, test := range testcases {
+		sset, err := makeStatefulSetFromPrometheus(
+			makePrometheusAgentForTestStartupProbeTimeoutSeconds(test.maximumStartupDurationSeconds))
 
 		require.NoError(t, err)
 		require.NotNil(t, sset.Spec.Template.Spec.Containers[0].StartupProbe)

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -37,15 +37,15 @@ func TestListenTLS(t *testing.T) {
 	require.NoError(t, err)
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
-	expectedStartupProbe := makeExpectedStartupProbe()
+	expectedStartupProbe := prompkg.MakeExpectedStartupProbe()
 	require.Equal(t, expectedStartupProbe, actualStartupProbe)
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
-	expectedLivenessProbe := makeExpectedLivenessProbe()
+	expectedLivenessProbe := prompkg.MakeExpectedLivenessProbe()
 	require.Equal(t, expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
-	expectedReadinessProbe := makeExpectedReadinessProbe()
+	expectedReadinessProbe := prompkg.MakeExpectedReadinessProbe()
 	require.Equal(t, expectedReadinessProbe, actualReadinessProbe)
 
 	testCorrectArgs(t, sset.Spec.Template.Spec.Containers[1].Args, sset.Spec.Template.Spec.Containers)
@@ -84,7 +84,7 @@ func TestStartupProbeTimeoutSeconds(t *testing.T) {
 }
 
 func makeStatefulSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.StatefulSet, error) {
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
 	if err != nil {
 		return nil, err

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -37,7 +37,6 @@ var (
 		LocalHost:                  "localhost",
 		ReloaderConfig:             operator.DefaultReloaderTestConfig.ReloaderConfig,
 		PrometheusDefaultBaseImage: operator.DefaultPrometheusBaseImage,
-		ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
 	}
 )
 
@@ -275,4 +274,43 @@ func makePrometheusAgentForTestAutomountServiceAccountToken(automountServiceAcco
 			},
 		},
 	}
+}
+
+type testcaseForTestWALCompression struct {
+	version       string
+	enabled       *bool
+	expectedArg   string
+	shouldContain bool
+}
+
+func createTestCasesForTestWALCompression() []testcaseForTestWALCompression {
+	return []testcaseForTestWALCompression{
+		{"v2.30.0", ptr.To(false), "--storage.agent.wal-compression", false},
+		{"v2.32.0", nil, "--storage.agent.wal-compression", false},
+		{"v2.32.0", ptr.To(false), "--no-storage.agent.wal-compression", true},
+		{"v2.32.0", ptr.To(true), "--storage.agent.wal-compression", true},
+	}
+}
+
+func makePrometheusAgentForTestWALCompression(version string, enabled *bool) monitoringv1alpha1.PrometheusAgent {
+	return monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Version:        version,
+				WALCompression: enabled,
+			},
+		},
+	}
+}
+
+func testPromArgsShouldContain(t *testing.T, expectedArg string, actualArgs []string, shouldContain bool) {
+	found := false
+	for _, flag := range actualArgs {
+		if flag == expectedArg {
+			found = true
+			break
+		}
+	}
+
+	require.Equal(t, shouldContain, found)
 }

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -314,3 +314,32 @@ func testPromArgsShouldContain(t *testing.T, expectedArg string, actualArgs []st
 
 	require.Equal(t, shouldContain, found)
 }
+
+type testcaseForTestStartupProbeTimeoutSeconds struct {
+	maximumStartupDurationSeconds   *int32
+	expectedStartupPeriodSeconds    int32
+	expectedStartupFailureThreshold int32
+}
+
+func createTestCasesForTestStartupProbeTimeoutSeconds() []testcaseForTestStartupProbeTimeoutSeconds {
+	return []testcaseForTestStartupProbeTimeoutSeconds{
+		{
+			maximumStartupDurationSeconds:   nil,
+			expectedStartupPeriodSeconds:    15,
+			expectedStartupFailureThreshold: 60,
+		},
+		{
+			maximumStartupDurationSeconds:   ptr.To(int32(600)),
+			expectedStartupPeriodSeconds:    60,
+			expectedStartupFailureThreshold: 10,
+		},
+	}
+}
+
+func makePrometheusAgentForTestStartupProbeTimeoutSeconds(maximumStartupDurationSeconds *int32) monitoringv1alpha1.PrometheusAgent {
+	return monitoringv1alpha1.PrometheusAgent{Spec: monitoringv1alpha1.PrometheusAgentSpec{
+		CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+			MaximumStartupDurationSeconds: maximumStartupDurationSeconds,
+		},
+	}}
+}

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -15,15 +15,11 @@
 package prometheusagent
 
 import (
-	"os"
 	"testing"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -65,43 +61,6 @@ func makeSpecForTestListenTLS() monitoringv1alpha1.PrometheusAgentSpec {
 	}
 }
 
-func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
-	return v1.ProbeHandler{
-		HTTPGet: &v1.HTTPGetAction{
-			Path:   probePath,
-			Port:   intstr.FromString("web"),
-			Scheme: "HTTPS",
-		},
-	}
-}
-
-func makeExpectedStartupProbe() *v1.Probe {
-	return &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    15,
-		FailureThreshold: 60,
-	}
-}
-
-func makeExpectedLivenessProbe() *v1.Probe {
-	return &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    5,
-		FailureThreshold: 6,
-	}
-}
-
-func makeExpectedReadinessProbe() *v1.Probe {
-	return &v1.Probe{
-		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
-		TimeoutSeconds:   3,
-		PeriodSeconds:    5,
-		FailureThreshold: 3,
-	}
-}
-
 func testCorrectArgs(t *testing.T, actualArgs []string, actualContainers []v1.Container) {
 	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
 	reloadURLFound := false
@@ -125,10 +84,6 @@ func testCorrectArgs(t *testing.T, actualArgs []string, actualContainers []v1.Co
 			require.Equal(t, expectedArgsConfigReloader, c.Args)
 		}
 	}
-}
-
-func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 }
 
 type testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels struct {

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -231,45 +231,6 @@ func makePrometheusAgentForTestAutomountServiceAccountToken(automountServiceAcco
 	}
 }
 
-type testcaseForTestWALCompression struct {
-	version       string
-	enabled       *bool
-	expectedArg   string
-	shouldContain bool
-}
-
-func createTestCasesForTestWALCompression() []testcaseForTestWALCompression {
-	return []testcaseForTestWALCompression{
-		{"v2.30.0", ptr.To(false), "--storage.agent.wal-compression", false},
-		{"v2.32.0", nil, "--storage.agent.wal-compression", false},
-		{"v2.32.0", ptr.To(false), "--no-storage.agent.wal-compression", true},
-		{"v2.32.0", ptr.To(true), "--storage.agent.wal-compression", true},
-	}
-}
-
-func makePrometheusAgentForTestWALCompression(version string, enabled *bool) monitoringv1alpha1.PrometheusAgent {
-	return monitoringv1alpha1.PrometheusAgent{
-		Spec: monitoringv1alpha1.PrometheusAgentSpec{
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version:        version,
-				WALCompression: enabled,
-			},
-		},
-	}
-}
-
-func testPromArgsShouldContain(t *testing.T, expectedArg string, actualArgs []string, shouldContain bool) {
-	found := false
-	for _, flag := range actualArgs {
-		if flag == expectedArg {
-			found = true
-			break
-		}
-	}
-
-	require.Equal(t, shouldContain, found)
-}
-
 type testcaseForTestStartupProbeTimeoutSeconds struct {
 	maximumStartupDurationSeconds   *int32
 	expectedStartupPeriodSeconds    int32

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -17,14 +17,11 @@ package prometheus
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,12 +46,8 @@ var defaultTestConfig = &prompkg.Config{
 	ThanosDefaultBaseImage:     operator.DefaultThanosBaseImage,
 }
 
-func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
-}
-
 func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulSet, error) {
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 
 	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
 	if err != nil {
@@ -440,7 +433,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 		},
 	}
 
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 
 	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
 	require.NoError(t, err)
@@ -907,7 +900,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	p := monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
@@ -960,7 +953,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	annotations := map[string]string{
 		"testannotation": "testannotationvalue",
 	}
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	p := monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
@@ -1565,7 +1558,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 	}
 	replicas := int32(2)
 	shards := int32(3)
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	p := monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
@@ -1627,7 +1620,7 @@ func TestSidecarResources(t *testing.T) {
 			PrometheusDefaultBaseImage: defaultTestConfig.PrometheusDefaultBaseImage,
 			ThanosDefaultBaseImage:     defaultTestConfig.ThanosDefaultBaseImage,
 		}
-		logger := newLogger()
+		logger := prompkg.NewLogger()
 		p := monitoringv1.Prometheus{
 			Spec: monitoringv1.PrometheusSpec{},
 		}
@@ -2034,7 +2027,7 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 
 func TestConfigReloader(t *testing.T) {
 	expectedShardNum := 0
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	p := monitoringv1.Prometheus{}
 
 	cg, err := prompkg.NewConfigGenerator(logger, &p, false)
@@ -2106,7 +2099,7 @@ func TestConfigReloader(t *testing.T) {
 
 func TestConfigReloaderWithSignal(t *testing.T) {
 	expectedShardNum := 0
-	logger := newLogger()
+	logger := prompkg.NewLogger()
 	p := monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{

--- a/pkg/prometheus/test_utils.go
+++ b/pkg/prometheus/test_utils.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
+	return v1.ProbeHandler{
+		HTTPGet: &v1.HTTPGetAction{
+			Path:   probePath,
+			Port:   intstr.FromString("web"),
+			Scheme: "HTTPS",
+		},
+	}
+}
+
+func MakeExpectedStartupProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+}
+
+func MakeExpectedLivenessProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+}
+
+func MakeExpectedReadinessProbe() *v1.Probe {
+	return &v1.Probe{
+		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+}
+
+func NewLogger() log.Logger {
+	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
+}


### PR DESCRIPTION
## Description

Continues #6688. Do some changes that we agreed in Slack:

- Remove Thanos image in test config: https://cloud-native.slack.com/archives/C071STDT4FP/p1718722242845739
- Refactor `TestWALCompression` for both StatefulSet and DaemonSet: https://cloud-native.slack.com/archives/C071STDT4FP/p1718703164200639
- Refactor `TestStartupProbeTimeoutSeconds`: https://github.com/prometheus-operator/prometheus-operator/pull/6686#discussion_r1645711201
- Use some appropriate refactored functions in server mode


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
CI green