### PR TITLE
chore: Replace StringPtrValOrDefault with ptr.Deref

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -221,7 +221,7 @@ func makeStatefulSetService(a *monitoringv1.Alertmanager, config Config) *v1.Ser
 func makeStatefulSetSpec(logger log.Logger, a *monitoringv1.Alertmanager, config Config, tlsSecrets *operator.ShardedSecret) (*appsv1.StatefulSetSpec, error) {
 	amVersion := operator.StringValOrDefault(a.Spec.Version, operator.DefaultAlertmanagerVersion)
 	amImagePath, err := operator.BuildImagePath(
-		operator.StringPtrValOrDefault(a.Spec.Image, ""),
+		ptr.Deref(a.Spec.Image, ""),
 		operator.StringValOrDefault(a.Spec.BaseImage, config.AlertmanagerDefaultBaseImage),
 		amVersion,
 		operator.StringValOrDefault(a.Spec.Tag, ""),

--- a/pkg/operator/image.go
+++ b/pkg/operator/image.go
@@ -65,13 +65,3 @@ func StringValOrDefault(val, defaultVal string) string {
 	}
 	return val
 }
-
-// StringPtrValOrDefault returns the default val if the
-// given string pointer is nil points to an empty/whitespace string.
-// Otherwise returns the value of the string.
-func StringPtrValOrDefault(val *string, defaultVal string) string {
-	if val == nil {
-		return defaultVal
-	}
-	return StringValOrDefault(*val, defaultVal)
-}

--- a/pkg/operator/storageclass.go
+++ b/pkg/operator/storageclass.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -31,7 +32,7 @@ func CheckStorageClass(ctx context.Context, canReadStorageClass bool, kclient ku
 		return nil
 	}
 
-	storageClassName := StringPtrValOrDefault(storage.VolumeClaimTemplate.Spec.StorageClassName, "")
+	storageClassName := ptr.Deref(storage.VolumeClaimTemplate.Spec.StorageClassName, "")
 	if storageClassName == "" {
 		return nil
 	}

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -157,7 +157,7 @@ func makeStatefulSetSpec(
 	cpf := p.GetCommonPrometheusFields()
 
 	pImagePath, err := operator.BuildImagePath(
-		operator.StringPtrValOrDefault(cpf.Image, ""),
+		ptr.Deref(cpf.Image, ""),
 		operator.StringValOrDefault("", c.PrometheusDefaultBaseImage),
 		operator.StringValOrDefault(cpf.Version, operator.DefaultPrometheusVersion),
 		"",

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -232,7 +232,7 @@ func makeStatefulSetSpec(
 	cpf := p.GetCommonPrometheusFields()
 
 	pImagePath, err := operator.BuildImagePath(
-		operator.StringPtrValOrDefault(cpf.Image, ""),
+		ptr.Deref(cpf.Image, ""),
 		operator.StringValOrDefault(baseImage, c.PrometheusDefaultBaseImage),
 		operator.StringValOrDefault(cpf.Version, operator.DefaultPrometheusVersion),
 		operator.StringValOrDefault(tag, ""),
@@ -617,11 +617,11 @@ func createThanosContainer(
 
 	if thanos != nil {
 		thanosImage, err := operator.BuildImagePath(
-			operator.StringPtrValOrDefault(thanos.Image, ""),
-			operator.StringPtrValOrDefault(thanos.BaseImage, c.ThanosDefaultBaseImage),
-			operator.StringPtrValOrDefault(thanos.Version, operator.DefaultThanosVersion),
-			operator.StringPtrValOrDefault(thanos.Tag, ""),
-			operator.StringPtrValOrDefault(thanos.SHA, ""),
+			ptr.Deref(thanos.Image, ""),
+			ptr.Deref(thanos.BaseImage, c.ThanosDefaultBaseImage),
+			ptr.Deref(thanos.Version, operator.DefaultThanosVersion),
+			ptr.Deref(thanos.Tag, ""),
+			ptr.Deref(thanos.SHA, ""),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build image path: %w", err)
@@ -751,7 +751,7 @@ func createThanosContainer(
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "prometheus.ready_timeout", Value: string(thanos.ReadyTimeout)})
 		}
 
-		thanosVersion, err := semver.ParseTolerant(operator.StringPtrValOrDefault(thanos.Version, operator.DefaultThanosVersion))
+		thanosVersion, err := semver.ParseTolerant(ptr.Deref(thanos.Version, operator.DefaultThanosVersion))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse Thanos version: %w", err)
 		}


### PR DESCRIPTION
## Description

While reviewing a few PRs from @haanhvu, I've noticed we're using a function that does the same thing as `ptr.Deref`. The reason is because that code was written before generics were a thing.

I don't mean to create conflicts with @haanhvu's PRs, so we can merge this one after we get yours merged first :)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
