### PR TITLE
Allow Prometheus Agent operator to create DaemonSet

### DIFF
--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -179,13 +179,13 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	}
 }
 
-// DaemonSet sets the options that only work for DaemonSet mode.
-// Currently we set SHARD env equal to 1, eventhough DaemonSet doesn't use this env.
+// DaemonSet sets the options that work for DaemonSet mode.
+// Currently we set SHARD env equal to 0, eventhough DaemonSet doesn't use this env.
 // TODO: Remove SHARD env for DaemonSet mode.
-func DaemonSet() ReloaderOption {
+func WithDaemonSetMode() ReloaderOption {
 	return func(c *ConfigReloader) {
 		c.withNodeNameEnv = true
-		c.shard = ptr.To(int32(1))
+		c.shard = ptr.To(int32(0))
 	}
 }
 

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -62,7 +62,7 @@ type ConfigReloader struct {
 	volumeMounts       []v1.VolumeMount
 	watchedDirectories []string
 	useSignal          bool
-	daemonSet          bool
+	withNodeNameEnv    bool
 }
 
 type ReloaderOption = func(*ConfigReloader)
@@ -180,9 +180,9 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 }
 
 // WithNodeNameEnv sets the withNodeNameEnv option for the config-reloader container.
-func DaemonSet() ReloaderOption {
+func WithNodeNameEnv() ReloaderOption {
 	return func(c *ConfigReloader) {
-		c.daemonSet = true
+		c.withNodeNameEnv = true
 	}
 }
 
@@ -208,14 +208,13 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		ports []v1.ContainerPort
 	)
 
-	if configReloader.daemonSet {
+	if configReloader.withNodeNameEnv {
 		envVars = append(envVars, v1.EnvVar{
 			Name: NodeNameEnvVar,
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 			},
 		})
-		configReloader.shard = nil
 	}
 
 	if configReloader.initContainer {

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -179,10 +179,13 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	}
 }
 
-// WithNodeNameEnv sets the withNodeNameEnv option for the config-reloader container.
-func WithNodeNameEnv() ReloaderOption {
+// DaemonSet sets the options that only work for DaemonSet mode.
+// Currently we set SHARD env equal to 1, eventhough DaemonSet doesn't use this env.
+// TODO: Remove SHARD env for DaemonSet mode.
+func DaemonSet() ReloaderOption {
 	return func(c *ConfigReloader) {
 		c.withNodeNameEnv = true
+		c.shard = ptr.To(int32(1))
 	}
 }
 

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -164,7 +164,15 @@ func TestCreateConfigReloader(t *testing.T) {
 		WebConfigFile(webConfigFile),
 		Shard(shard),
 		ImagePullPolicy(expectedImagePullPolicy),
+		WithNodeNameEnv(),
 	)
+
+	assert.Contains(t, container.Env, v1.EnvVar{
+		Name: NodeNameEnvVar,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	})
 
 	if container.Name != "config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", containerName, container.Name)
@@ -217,27 +225,6 @@ func TestCreateConfigReloader(t *testing.T) {
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
 	}
-}
-
-func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
-	var container = CreateConfigReloader(
-		"config-reloader",
-		Shard(int32(1)),
-		DaemonSet(),
-	)
-
-	assert.Contains(t, container.Env, v1.EnvVar{
-		Name: NodeNameEnvVar,
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-		},
-	})
-
-	// Check shard is nil in daemonset, even if Shard() is called.
-	assert.NotContains(t, container.Env, v1.EnvVar{
-		Name:  ShardEnvVar,
-		Value: strconv.Itoa(1),
-	})
 }
 
 func contains(s []string, str string) bool {

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -164,15 +164,7 @@ func TestCreateConfigReloader(t *testing.T) {
 		WebConfigFile(webConfigFile),
 		Shard(shard),
 		ImagePullPolicy(expectedImagePullPolicy),
-		WithNodeNameEnv(),
 	)
-
-	assert.Contains(t, container.Env, v1.EnvVar{
-		Name: NodeNameEnvVar,
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-		},
-	})
 
 	if container.Name != "config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", containerName, container.Name)
@@ -225,6 +217,27 @@ func TestCreateConfigReloader(t *testing.T) {
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
 	}
+}
+
+func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
+	var container = CreateConfigReloader(
+		"config-reloader",
+		Shard(int32(1)),
+		DaemonSet(),
+	)
+
+	assert.Contains(t, container.Env, v1.EnvVar{
+		Name: NodeNameEnvVar,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	})
+
+	// Check shard is nil in daemonset, even if Shard() is called.
+	assert.NotContains(t, container.Env, v1.EnvVar{
+		Name:  ShardEnvVar,
+		Value: strconv.Itoa(1),
+	})
 }
 
 func contains(s []string, str string) bool {

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -222,7 +222,7 @@ func TestCreateConfigReloader(t *testing.T) {
 func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
 	var container = CreateConfigReloader(
 		"config-reloader",
-		DaemonSet(),
+		WithDaemonSetMode(),
 	)
 
 	assert.Contains(t, container.Env, v1.EnvVar{
@@ -234,7 +234,7 @@ func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
 
 	assert.Contains(t, container.Env, v1.EnvVar{
 		Name:  ShardEnvVar,
-		Value: strconv.Itoa(1),
+		Value: strconv.Itoa(0),
 	})
 }
 

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -164,15 +164,7 @@ func TestCreateConfigReloader(t *testing.T) {
 		WebConfigFile(webConfigFile),
 		Shard(shard),
 		ImagePullPolicy(expectedImagePullPolicy),
-		WithNodeNameEnv(),
 	)
-
-	assert.Contains(t, container.Env, v1.EnvVar{
-		Name: NodeNameEnvVar,
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-		},
-	})
 
 	if container.Name != "config-reloader" {
 		t.Errorf("Expected container name %s, but found %s", containerName, container.Name)
@@ -225,6 +217,25 @@ func TestCreateConfigReloader(t *testing.T) {
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
 	}
+}
+
+func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
+	var container = CreateConfigReloader(
+		"config-reloader",
+		DaemonSet(),
+	)
+
+	assert.Contains(t, container.Env, v1.EnvVar{
+		Name: NodeNameEnvVar,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		},
+	})
+
+	assert.Contains(t, container.Env, v1.EnvVar{
+		Name:  ShardEnvVar,
+		Value: strconv.Itoa(1),
+	})
 }
 
 func contains(s []string, str string) bool {

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -154,6 +154,7 @@ func makeDaemonSetSpec(
 			true,
 			configReloaderVolumeMounts,
 			watchedDirectories,
+			operator.WithDaemonSetMode(),
 		),
 	)
 
@@ -195,7 +196,7 @@ func makeDaemonSetSpec(
 			configReloaderVolumeMounts,
 			watchedDirectories,
 			operator.WebConfigFile(configReloaderWebConfigFile),
-			operator.DaemonSet(),
+			operator.WithDaemonSetMode(),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -195,8 +195,7 @@ func makeDaemonSetSpec(
 			configReloaderVolumeMounts,
 			watchedDirectories,
 			operator.WebConfigFile(configReloaderWebConfigFile),
-			// DaemonSet needs NODE_NAME env to filter targes on the same node.
-			operator.WithNodeNameEnv(),
+			operator.DaemonSet(),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -30,7 +30,6 @@ import (
 )
 
 func makeDaemonSet(
-	name string,
 	p monitoringv1.PrometheusInterface,
 	config *prompkg.Config,
 	cg *prompkg.ConfigGenerator,
@@ -55,7 +54,7 @@ func makeDaemonSet(
 
 	operator.UpdateObject(
 		daemonSet,
-		operator.WithName(name),
+		operator.WithName("agent-daemonset"),
 		operator.WithAnnotations(objMeta.GetAnnotations()),
 		operator.WithAnnotations(config.Annotations),
 		operator.WithLabels(objMeta.GetLabels()),

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -196,7 +196,7 @@ func makeDaemonSetSpec(
 			watchedDirectories,
 			operator.WebConfigFile(configReloaderWebConfigFile),
 			// DaemonSet needs NODE_NAME env to filter targes on the same node.
-			operator.WithNodeNameEnv(),
+			operator.DaemonSet(),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -102,7 +102,7 @@ func makeDaemonSetSpec(
 
 	promArgs := buildAgentArgs(cpf, cg)
 
-	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
+	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets, false)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func makeDaemonSetSpec(
 	startupProbe, readinessProbe, livenessProbe := prompkg.MakeProbes(cpf, cg)
 
 	podAnnotations, podLabels := prompkg.BuildPodMetadata(cpf, cg)
-	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
+	// In cases where an existing selector label is modified, or a new one is added, new daemonset cannot match existing pods.
 	// We should try to avoid removing such immutable fields whenever possible since doing
 	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
 	// The requirement to make a change here should be carefully evaluated.

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -54,7 +54,7 @@ func makeDaemonSet(
 
 	operator.UpdateObject(
 		daemonSet,
-		operator.WithName("agent-daemonset"),
+		operator.WithName(prompkg.PrefixedName(p)),
 		operator.WithAnnotations(objMeta.GetAnnotations()),
 		operator.WithAnnotations(config.Annotations),
 		operator.WithLabels(objMeta.GetLabels()),

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -196,7 +196,7 @@ func makeDaemonSetSpec(
 			watchedDirectories,
 			operator.WebConfigFile(configReloaderWebConfigFile),
 			// DaemonSet needs NODE_NAME env to filter targes on the same node.
-			operator.DaemonSet(),
+			operator.WithNodeNameEnv(),
 		),
 	}, additionalContainers...)
 

--- a/pkg/prometheus/agent/daemonset_test.go
+++ b/pkg/prometheus/agent/daemonset_test.go
@@ -71,7 +71,6 @@ func makeDaemonSetFromPrometheus(p monitoringv1alpha1.PrometheusAgent) (*appsv1.
 	}
 
 	return makeDaemonSet(
-		"test",
 		&p,
 		defaultTestConfig,
 		cg,

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -603,10 +603,9 @@ func (c *Operator) Sync(ctx context.Context, key string) error {
 	p = p.DeepCopy()
 	if p.Spec.Mode != nil && *p.Spec.Mode == "DaemonSet" {
 		err = c.syncDaemonSet(ctx, key, p)
-		c.reconciliations.SetStatus(key, err)
-		return err
+	} else {
+		err = c.syncStatefulSet(ctx, key, p)
 	}
-	err = c.syncStatefulSet(ctx, key, p)
 	c.reconciliations.SetStatus(key, err)
 	return err
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -587,6 +587,7 @@ func statefulSetKeyToPrometheusAgentKey(key string) (bool, string) {
 }
 
 // Sync implements the operator.Syncer interface.
+// TODO: Consider refactoring the common code between syncDaemonSet() and syncStatefulSet().
 func (c *Operator) Sync(ctx context.Context, key string) error {
 	pobj, err := c.promInfs.Get(key)
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -659,7 +659,6 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 	}
 
 	dset, err := makeDaemonSet(
-		"daemonset",
 		p,
 		&c.config,
 		cg,
@@ -701,7 +700,6 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 
 	level.Info(logger).Log("msg", "sync prometheus")
 
-	// 1: relate
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, p.Spec.Storage); err != nil {
 		return err
 	}
@@ -725,17 +723,14 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 		return fmt.Errorf("synchronizing web config secret failed: %w", err)
 	}
 
-	// 2: relate
 	// Create governing service if it doesn't exist.
 	svcClient := c.kclient.CoreV1().Services(p.Namespace)
 	if err := k8sutil.CreateOrUpdateService(ctx, svcClient, makeStatefulSetService(p, c.config)); err != nil {
 		return fmt.Errorf("synchronizing governing service failed: %w", err)
 	}
 
-	// 3: relate
 	ssetClient := c.kclient.AppsV1().StatefulSets(p.Namespace)
 
-	// 4: relate
 	// Ensure we have a StatefulSet running Prometheus Agent deployed and that StatefulSet names are created correctly.
 	expected := prompkg.ExpectedStatefulSetShardNames(p)
 	for shard, ssetName := range expected {
@@ -827,13 +822,11 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 		}
 	}
 
-	// 5: relate
 	ssets := map[string]struct{}{}
 	for _, ssetName := range expected {
 		ssets[ssetName] = struct{}{}
 	}
 
-	// 6: relate
 	err = c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabeLName: prometheusMode}), func(obj interface{}) {
 		s := obj.(*appsv1.StatefulSet)
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -652,7 +652,7 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 
 	level.Debug(logger).Log("msg", "reconciling daemonset")
 
-	_, err = c.dsetInfs.Get(prompkg.KeyToDaemonSetKey(p, key))
+	_, err = c.dsetInfs.Get(keyToDaemonSetKey(p, key))
 	exists := !apierrors.IsNotFound(err)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("retrieving daemonset failed: %w", err)
@@ -1207,4 +1207,9 @@ func makeSelectorLabels(name string) map[string]string {
 		"app.kubernetes.io/instance":    name,
 		prompkg.PrometheusNameLabelName: name,
 	}
+}
+
+func keyToDaemonSetKey(p monitoringv1.PrometheusInterface, key string) string {
+	keyParts := strings.Split(key, "/")
+	return fmt.Sprintf("%s/%s", keyParts[0], fmt.Sprintf("%s-%s", prompkg.Prefix(p), keyParts[1]))
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -601,7 +601,7 @@ func (c *Operator) Sync(ctx context.Context, key string) error {
 
 	p := pobj.(*monitoringv1alpha1.PrometheusAgent)
 	p = p.DeepCopy()
-	if p.Spec.Mode != nil && *p.Spec.Mode == "DaemonSet" {
+	if ptr.Deref(p.Spec.Mode, "StatefulSet") == "DaemonSet" {
 		err = c.syncDaemonSet(ctx, key, p)
 	} else {
 		err = c.syncStatefulSet(ctx, key, p)

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -163,7 +163,7 @@ func makeStatefulSetSpec(
 
 	promArgs := buildAgentArgs(cpf, cg)
 
-	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
+	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -100,7 +100,7 @@ func ReplicasNumberPtr(
 }
 
 func prometheusNameByShard(p monitoringv1.PrometheusInterface, shard int32) string {
-	base := prefixedName(p)
+	base := PrefixedName(p)
 	if shard == 0 {
 		return base
 	}
@@ -140,22 +140,22 @@ func MakeConfigurationSecret(p monitoringv1.PrometheusInterface, config Config, 
 }
 
 func ConfigSecretName(p monitoringv1.PrometheusInterface) string {
-	return prefixedName(p)
+	return PrefixedName(p)
 }
 
 func TLSAssetsSecretName(p monitoringv1.PrometheusInterface) string {
-	return fmt.Sprintf("%s-tls-assets", prefixedName(p))
+	return fmt.Sprintf("%s-tls-assets", PrefixedName(p))
 }
 
 func WebConfigSecretName(p monitoringv1.PrometheusInterface) string {
-	return fmt.Sprintf("%s-web-config", prefixedName(p))
+	return fmt.Sprintf("%s-web-config", PrefixedName(p))
 }
 
 func VolumeName(p monitoringv1.PrometheusInterface) string {
-	return fmt.Sprintf("%s-db", prefixedName(p))
+	return fmt.Sprintf("%s-db", PrefixedName(p))
 }
 
-func prefixedName(p monitoringv1.PrometheusInterface) string {
+func PrefixedName(p monitoringv1.PrometheusInterface) string {
 	return fmt.Sprintf("%s-%s", Prefix(p), p.GetObjectMeta().GetName())
 }
 

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -156,10 +156,10 @@ func VolumeName(p monitoringv1.PrometheusInterface) string {
 }
 
 func prefixedName(p monitoringv1.PrometheusInterface) string {
-	return fmt.Sprintf("%s-%s", prefix(p), p.GetObjectMeta().GetName())
+	return fmt.Sprintf("%s-%s", Prefix(p), p.GetObjectMeta().GetName())
 }
 
-func prefix(p monitoringv1.PrometheusInterface) string {
+func Prefix(p monitoringv1.PrometheusInterface) string {
 	switch p.(type) {
 	case *monitoringv1.Prometheus:
 		return "prometheus"

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -53,11 +53,6 @@ type StatusReporter struct {
 	Rr              *operator.ResourceReconciler
 }
 
-func KeyToDaemonSetKey(p monitoringv1.PrometheusInterface, key string) string {
-	keyParts := strings.Split(key, "/")
-	return fmt.Sprintf("%s/%s", keyParts[0], fmt.Sprintf("%s-%s", prefix(p), keyParts[1]))
-}
-
 func KeyToStatefulSetKey(p monitoringv1.PrometheusInterface, key string, shard int) string {
 	keyParts := strings.Split(key, "/")
 	return fmt.Sprintf("%s/%s", keyParts[0], statefulSetNameFromPrometheusName(p, keyParts[1], shard))
@@ -65,9 +60,9 @@ func KeyToStatefulSetKey(p monitoringv1.PrometheusInterface, key string, shard i
 
 func statefulSetNameFromPrometheusName(p monitoringv1.PrometheusInterface, name string, shard int) string {
 	if shard == 0 {
-		return fmt.Sprintf("%s-%s", prefix(p), name)
+		return fmt.Sprintf("%s-%s", Prefix(p), name)
 	}
-	return fmt.Sprintf("%s-%s-shard-%d", prefix(p), name, shard)
+	return fmt.Sprintf("%s-%s-shard-%d", Prefix(p), name, shard)
 }
 
 func NewTLSAssetSecret(p monitoringv1.PrometheusInterface, config Config) *v1.Secret {

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -53,6 +53,11 @@ type StatusReporter struct {
 	Rr              *operator.ResourceReconciler
 }
 
+func KeyToDaemonSetKey(p monitoringv1.PrometheusInterface, key string) string {
+	keyParts := strings.Split(key, "/")
+	return fmt.Sprintf("%s/%s", keyParts[0], fmt.Sprintf("%s-%s", prefix(p), keyParts[1]))
+}
+
 func KeyToStatefulSetKey(p monitoringv1.PrometheusInterface, key string, shard int) string {
 	keyParts := strings.Split(key, "/")
 	return fmt.Sprintf("%s/%s", keyParts[0], statefulSetNameFromPrometheusName(p, keyParts[1], shard))

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -231,10 +231,11 @@ func makeStatefulSetSpec(
 	promArgs := prompkg.BuildCommonPrometheusArgs(cpf, cg)
 	promArgs = appendServerArgs(promArgs, cg, retention, retentionSize, rules, query, allowOverlappingBlocks, enableAdminAPI, cpf.WALCompression)
 
-	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets)
+	volumes, promVolumeMounts, err := prompkg.BuildCommonVolumes(p, tlsSecrets, true)
 	if err != nil {
 		return nil, err
 	}
+
 	volumes, promVolumeMounts = appendServerVolumes(volumes, promVolumeMounts, queryLogFile, ruleConfigMapNames)
 
 	configReloaderVolumeMounts := prompkg.CreateConfigReloaderVolumeMounts()

--- a/test/e2e/controllerid_test.go
+++ b/test/e2e/controllerid_test.go
@@ -51,7 +51,7 @@ func testMultipleOperatorsPrometheusAgent(t *testing.T) {
 
 	name := "test-op-1"
 	p := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
-	_, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, p)
+	_, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func testMultipleOperatorsPrometheusAgent(t *testing.T) {
 	name = "test-op-2"
 	p = framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 	p.Annotations["operator.prometheus.io/controller-id"] = testAnnotationControllerID
-	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, p)
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/controllerid_test.go
+++ b/test/e2e/controllerid_test.go
@@ -51,7 +51,7 @@ func testMultipleOperatorsPrometheusAgent(t *testing.T) {
 
 	name := "test-op-1"
 	p := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
-	_, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, p)
+	_, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func testMultipleOperatorsPrometheusAgent(t *testing.T) {
 	name = "test-op-2"
 	p = framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 	p.Annotations["operator.prometheus.io/controller-id"] = testAnnotationControllerID
-	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, p)
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -218,14 +218,14 @@ func TestAllNS(t *testing.T) {
 	if len(restarts) != 1 {
 		t.Fatalf("expected to have 1 container but got %d", len(restarts))
 	}
-	for _, restart := range restarts {
+	/*for _, restart := range restarts {
 		if restart != 0 {
 			t.Fatalf(
 				"expected Prometheus Operator to never restart during entire test execution but got %d restarts",
 				restart,
 			)
 		}
-	}
+	}*/
 }
 
 func testAllNSAlertmanager(t *testing.T) {
@@ -420,7 +420,7 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		// To be added.
+		"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -218,14 +218,14 @@ func TestAllNS(t *testing.T) {
 	if len(restarts) != 1 {
 		t.Fatalf("expected to have 1 container but got %d", len(restarts))
 	}
-	/*for _, restart := range restarts {
+	for _, restart := range restarts {
 		if restart != 0 {
 			t.Fatalf(
 				"expected Prometheus Operator to never restart during entire test execution but got %d restarts",
 				restart,
 			)
 		}
-	}*/
+	}
 }
 
 func testAllNSAlertmanager(t *testing.T) {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -76,7 +76,7 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 	name := "test"
 	prometheusAgentDSCRD := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	err = framework.CreatePrometheusAgentDS(context.Background(), ns, prometheusAgentDSCRD)
+	err = framework.CreatePrometheusAgentDSAndWaitUntilReady(context.Background(), ns, prometheusAgentDSCRD)
 	require.NoError(t, err)
 }
 

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -45,7 +45,7 @@ func testCreatePrometheusAgent(t *testing.T) {
 
 	prometheusAgentCRD := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 
-	if _, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, prometheusAgentCRD); err != nil {
+	if _, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentCRD); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,7 +76,7 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 	name := "test"
 	prometheusAgentDSCRD := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	err = framework.CreatePrometheusAgentDSAndWaitUntilReady(context.Background(), ns, prometheusAgentDSCRD)
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentDSCRD)
 	require.NoError(t, err)
 }
 
@@ -93,7 +93,7 @@ func testAgentAndServerNameColision(t *testing.T) {
 	prometheusAgentCRD := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 
-	if _, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), t, ns, prometheusAgentCRD); err != nil {
+	if _, err := framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentCRD); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prometheusCRD); err != nil {
@@ -121,7 +121,7 @@ func testAgentCheckStorageClass(t *testing.T) {
 
 	prometheusAgentCRD := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 
-	prometheusAgentCRD, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, t, ns, prometheusAgentCRD)
+	prometheusAgentCRD, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, prometheusAgentCRD)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func testPrometheusAgentStatusScale(t *testing.T) {
 	pAgent := framework.MakeBasicPrometheusAgent(ns, name, name, 1)
 	pAgent.Spec.CommonPrometheusFields.Shards = proto.Int32(1)
 
-	pAgent, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, t, ns, pAgent)
+	pAgent, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, pAgent)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -99,7 +99,8 @@ func (f *Framework) CreatePrometheusAgentDSAndWaitUntilReady(ctx context.Context
 
 	var pollErr error
 	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
-		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, p.Name, metav1.GetOptions{})
+		name := fmt.Sprintf("prom-agent-%s", p.Name)
+		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get DaemonSet: %w", err)
 			return false, nil

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -108,7 +108,7 @@ func (f *Framework) CreatePrometheusAgentDS(ctx context.Context, ns string, p *m
 			return false, nil
 		}*/
 
-		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, "daemonset", metav1.GetOptions{})
+		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, "agent-daemonset", metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get DaemonSet: %w", err)
 			return false, nil

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -108,7 +108,7 @@ func (f *Framework) CreatePrometheusAgentDS(ctx context.Context, ns string, p *m
 			return false, nil
 		}*/
 
-		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, "agent-daemonset", metav1.GetOptions{})
+		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, p.Name, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get DaemonSet: %w", err)
 			return false, nil

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -100,6 +100,7 @@ func (f *Framework) CreatePrometheusAgentDSAndWaitUntilReady(ctx context.Context
 	var pollErr error
 	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
+		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get DaemonSet: %w", err)


### PR DESCRIPTION
## Description

Allow Prometheus Agent operator to create DaemonSet if DaemonSet mode is chosen.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
WIP: Local tests and e2e tests for sure, unit tests maybe

## Changelog entry

Allow Prometheus Agent operator to create DaemonSet