### PR TITLE
feat: pass feature gates to scripts/run-external.sh

### DIFF
--- a/scripts/run-external.sh
+++ b/scripts/run-external.sh
@@ -14,6 +14,7 @@ declare SKIP_OPERATOR_RUN_CHECK=false
 declare USE_DEFAULT_CONTEXT=false
 declare API_SERVER=""
 declare IMPERSONATE_USER="${IMPERSONATE_USER:-}"
+declare FEATURE_GATES="${FEATURE_GATES:-}"
 
 # tmp operator files that needs to be cleaned up
 declare -r CA_FILE="tmp/CA_FILE"
@@ -130,6 +131,7 @@ run_operator() {
 		--apiserver="$API_SERVER" \
 		--ca-file="$CA_FILE" \
 		--cert-file="$CERT_FILE" \
+		--feature-gates="$FEATURE_GATES" \
 		--key-file="$KEY_FILE" 2>&1 | tee tmp/operator.log
 }
 


### PR DESCRIPTION
This change allows to pass feature gates to the script. For instance:

```
FEATURE_GATES="PrometheusAgentDaemonSet=true"  ./run/run-external.sh -c
```

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
