### PR TITLE
chore: simplify controller constructors

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -61,7 +60,7 @@ const (
 func NewNamespaceListWatchFromClient(
 	ctx context.Context,
 	l log.Logger,
-	k8sVersion version.Info,
+	k8sVersion semver.Version,
 	corev1Client corev1.CoreV1Interface,
 	ssarClient authv1.SelfSubjectAccessReviewInterface,
 	allowedNamespaces, deniedNamespaces map[string]struct{},
@@ -84,13 +83,7 @@ func NewNamespaceListWatchFromClient(
 	}
 
 	// The "kubernetes.io/metadata.name" label is GA since Kubernetes 1.22.
-	var metadataNameLabelSupported bool
-	v, err := semver.ParseTolerant(k8sVersion.String())
-	if err != nil {
-		level.Warn(l).Log("msg", "failed to parse Kubernetes version", "version", k8sVersion.String(), "err", err)
-	} else {
-		metadataNameLabelSupported = v.GTE(semver.MustParse("1.22.0"))
-	}
+	metadataNameLabelSupported := k8sVersion.GTE(semver.MustParse("1.22.0"))
 
 	if IsAllNamespaces(allowedNamespaces) {
 		if !listWatchAllowed {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -21,19 +21,19 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/version"
 	k8sflag "k8s.io/component-base/cli/flag"
 )
 
 // Config defines configuration parameters for the Operator.
 type Config struct {
 	// Version reported by the Kubernetes API.
-	KubernetesVersion version.Info
+	KubernetesVersion semver.Version
 
 	// Cluster domain for Kubernetes services managed by the operator.
 	ClusterDomain string
@@ -65,6 +65,9 @@ type Config struct {
 
 	// Controller id for pod ownership.
 	ControllerID string
+
+	// Event recorder factory.
+	EventRecorderFactory EventRecorderFactory
 
 	// Feature gates.
 	Gates *FeatureGates

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -88,7 +87,8 @@ type Operator struct {
 	metrics         *operator.Metrics
 	reconciliations *operator.ReconciliationTracker
 
-	config                 prompkg.Config
+	config prompkg.Config
+
 	endpointSliceSupported bool // Whether the Kubernetes API suports the EndpointSlice kind.
 	scrapeConfigSupported  bool
 	canReadStorageClass    bool
@@ -98,8 +98,32 @@ type Operator struct {
 	statusReporter prompkg.StatusReporter
 }
 
+type ControllerOption func(*Operator)
+
+// WithEndpointSlice tells that the Kubernetes API supports the Endpointslice resource.
+func WithEndpointSlice() ControllerOption {
+	return func(o *Operator) {
+		o.endpointSliceSupported = true
+	}
+}
+
+// WithScrapeConfig tells that the controller manages ScrapeConfig objects.
+func WithScrapeConfig() ControllerOption {
+	return func(o *Operator) {
+		o.scrapeConfigSupported = true
+	}
+}
+
+// WithStorageClassValidation tells that the controller should verify that the
+// Prometheus spec references a valid StorageClass name.
+func WithStorageClassValidation() ControllerOption {
+	return func(o *Operator) {
+		o.canReadStorageClass = true
+	}
+}
+
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, scrapeConfigSupported, canReadStorageClass bool, erf operator.EventRecorderFactory) (*Operator, error) {
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	logger = log.With(logger, "component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
@@ -133,16 +157,17 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Annotations:                c.Annotations,
 			Labels:                     c.Labels,
 		},
-		metrics:               operator.NewMetrics(r),
-		reconciliations:       &operator.ReconciliationTracker{},
-		controllerID:          c.ControllerID,
-		scrapeConfigSupported: scrapeConfigSupported,
-		canReadStorageClass:   canReadStorageClass,
-		eventRecorder:         erf(client, controllerName),
+		metrics:         operator.NewMetrics(r),
+		reconciliations: &operator.ReconciliationTracker{},
+		controllerID:    c.ControllerID,
+		eventRecorder:   c.EventRecorderFactory(client, controllerName),
 	}
 	o.metrics.MustRegister(
 		o.reconciliations,
 	)
+	for _, opt := range options {
+		opt(o)
+	}
 
 	o.rr = operator.NewResourceReconciler(
 		o.logger,
@@ -317,12 +342,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			return nil, err
 		}
 	}
-
-	o.endpointSliceSupported, err = k8sutil.IsAPIGroupVersionResourceSupported(o.kclient.Discovery(), schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"}, "endpointslices")
-	if err != nil {
-		level.Warn(o.logger).Log("msg", "failed to check if the API supports the endpointslice resources", "err ", err)
-	}
-	level.Info(o.logger).Log("msg", "Kubernetes API capabilities", "endpointslices", o.endpointSliceSupported)
 
 	o.statusReporter = prompkg.StatusReporter{
 		Kclient:         o.kclient,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -99,28 +98,32 @@ type Operator struct {
 	eventRecorder record.EventRecorder
 }
 
-type ControllerOptions func(*Operator)
+type ControllerOption func(*Operator)
 
-func WithEndpointSlice() ControllerOptions {
+// WithEndpointSlice tells that the Kubernetes API supports the Endpointslice resource.
+func WithEndpointSlice() ControllerOption {
 	return func(o *Operator) {
 		o.endpointSliceSupported = true
 	}
 }
 
-func WithScrapeConfig() ControllerOptions {
+// WithScrapeConfig tells that the controller manages ScrapeConfig objects.
+func WithScrapeConfig() ControllerOption {
 	return func(o *Operator) {
 		o.scrapeConfigSupported = true
 	}
 }
 
-func WithStorageClassValidation() ControllerOptions {
+// WithStorageClassValidation tells that the controller should verify that the
+// Prometheus spec references a valid StorageClass name.
+func WithStorageClassValidation() ControllerOption {
 	return func(o *Operator) {
 		o.canReadStorageClass = true
 	}
 }
 
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, erf operator.EventRecorderFactory, opts ...ControllerOptions) (*Operator, error) {
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, opts ...ControllerOption) (*Operator, error) {
 	logger = log.With(logger, "component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
@@ -160,9 +163,8 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		reconciliations: &operator.ReconciliationTracker{},
 
 		controllerID:  c.ControllerID,
-		eventRecorder: erf(client, controllerName),
+		eventRecorder: c.EventRecorderFactory(client, controllerName),
 	}
-	// Process options, enabling or disabling features.
 	for _, opt := range opts {
 		opt(o)
 	}
@@ -354,12 +356,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			return nil, err
 		}
 	}
-
-	o.endpointSliceSupported, err = k8sutil.IsAPIGroupVersionResourceSupported(o.kclient.Discovery(), schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"}, "endpointslices")
-	if err != nil {
-		level.Warn(o.logger).Log("msg", "failed to check if the API supports the endpointslice resources", "err ", err)
-	}
-	level.Info(o.logger).Log("msg", "Kubernetes API capabilities", "endpointslices", o.endpointSliceSupported)
 
 	o.statusReporter = prompkg.StatusReporter{
 		Kclient:         o.kclient,


### PR DESCRIPTION
## Description

This change introduces functional options for all 4 controllers (previously only Prometheus used them).

It also reduces code duplication regarding API version checks.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
