### PR TITLE
cmd: Add secret label selector to filter secrets to watch

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -83,6 +83,8 @@ Usage of ./operator:
     	Label selector to filter Prometheus and PrometheusAgent Custom Resources to watch.
   -secret-field-selector value
     	Field selector to filter Secrets to watch
+  -secret-label-selector value
+    	Label selector to filter Secrets to watch
   -short-version
     	Print just the version number.
   -thanos-default-base-image string

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -172,6 +172,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.AlertmanagerSelector, "alertmanager-instance-selector", "Label selector to filter Alertmanager Custom Resources to watch.")
 	fs.Var(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	fs.Var(&cfg.SecretListWatchSelector, "secret-field-selector", "Field selector to filter Secrets to watch")
+	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -218,6 +218,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 			resyncPeriod,
 			func(options *metav1.ListOptions) {
 				options.FieldSelector = config.SecretListWatchSelector.String()
+				options.LabelSelector = config.SecretListWatchLabelSelector.String()
 			},
 		),
 		v1.SchemeGroupVersion.WithResource("secrets"),

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -57,10 +57,11 @@ type Config struct {
 	LocalHost string
 
 	// Label and field selectors for resource watchers.
-	PromSelector            LabelSelector
-	AlertmanagerSelector    LabelSelector
-	ThanosRulerSelector     LabelSelector
-	SecretListWatchSelector FieldSelector
+	PromSelector                 LabelSelector
+	AlertmanagerSelector         LabelSelector
+	ThanosRulerSelector          LabelSelector
+	SecretListWatchSelector      FieldSelector
+	SecretListWatchLabelSelector LabelSelector
 
 	// Controller id for pod ownership.
 	ControllerID string


### PR DESCRIPTION
## Description
This commit adds a flag for secret label selector so user can use label to filter secrets that prometheus-operator watches. This reduces calls to kube-apiserver.

Fixes Exclude irrelevant certs/tls secrets watch in monitoring namespace #6610



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

```release-note
cmd: Add secret label selector to filter secrets to watch
```
