### PR TITLE
Feat: new logger slog

### DIFF
--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -38,7 +38,7 @@ func NewLoggerSlog(c Config) (*slog.Logger, error) {
 	return logger, nil
 }
 
-func replaceSlogAttributes(groups []string, a slog.Attr) slog.Attr {
+func replaceSlogAttributes(_ []string, a slog.Attr) slog.Attr {
 	if a.Key == "time" {
 		return slog.Attr{
 			Key:   "ts",

--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -42,6 +42,9 @@ func NewLoggerSlog(c Config) (*slog.Logger, error) {
 	return slog.New(handler), nil
 }
 
+// replaceSlogAttributes replaces fields that were added by default by slog, but had different
+// formats or key names in github.com/go-kit/log. The operator was originally implemented with go-kit/log,
+// so we use these replacements to make the migration smoother.
 func replaceSlogAttributes(_ []string, a slog.Attr) slog.Attr {
 	if a.Key == "time" {
 		return slog.Attr{
@@ -67,6 +70,7 @@ func replaceSlogAttributes(_ []string, a slog.Attr) slog.Attr {
 	return a
 }
 
+// getHandlerFromFormat returns a slog.Handler based on the provided format and slog options.
 func getHandlerFromFormat(format string, opts slog.HandlerOptions) (slog.Handler, error) {
 	var handler slog.Handler
 	switch strings.ToLower(format) {
@@ -81,6 +85,7 @@ func getHandlerFromFormat(format string, opts slog.HandlerOptions) (slog.Handler
 	}
 }
 
+// parseLevel returns the slog.Level based on the provided string.
 func parseLevel(lvl string) (slog.Level, error) {
 	switch strings.ToLower(lvl) {
 	case LevelAll:

--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func NewLoggerSlog(c Config) (*slog.Logger, error) {
+	var (
+		logger *slog.Logger
+	)
+
+	lvlOption, err := ParseLevel(c.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err = ParseFmt(lvlOption, c.Format)
+	if err != nil {
+		return nil, err
+	}
+
+	return logger, nil
+}
+
+func ParseFmt(lvlOption slog.Level, format string) (*slog.Logger, error) {
+	var logger *slog.Logger
+	switch strings.ToLower(format) {
+	case FormatLogFmt:
+		h := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: lvlOption,
+		})
+		logger = slog.New(h)
+		return logger, nil
+	case FormatJSON:
+		h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: lvlOption,
+		})
+		logger = slog.New(h)
+		return logger, nil
+	default:
+		return nil, fmt.Errorf("log format %s unknown, %v are possible values", format, AvailableLogFormats)
+	}
+}
+
+func ParseLevel(lvl string) (slog.Level, error) {
+	switch strings.ToLower(lvl) {
+	case LevelAll:
+		return slog.LevelDebug, nil
+	case LevelDebug:
+		return slog.LevelDebug, nil
+	case LevelInfo:
+		return slog.LevelInfo, nil
+	case LevelWarn:
+		return slog.LevelWarn, nil
+	case LevelError:
+		return slog.LevelError, nil
+	case LevelNone:
+		return -1, nil
+	default:
+		return -1, fmt.Errorf("log log_level %s unknown, %v are possible values", lvl, AvailableLogLevels)
+	}
+}

--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package log
 
 import (

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -55,19 +56,40 @@ func TestReplaceAttributes(t *testing.T) {
 }
 
 func TestParseFmt(t *testing.T) {
-	_, err := parseFmt(slog.LevelDebug, FormatJSON)
+	handler, err := getHandlerFromFormat(FormatJSON, slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	})
+
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, err = parseFmt(slog.LevelDebug, FormatLogFmt)
+	wantJSONHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	})
+
+	if !reflect.DeepEqual(handler, wantJSONHandler) {
+		t.Fatalf("handler not equal to wantJSONHandler")
+	}
+
+	handler, err = getHandlerFromFormat(FormatLogFmt, slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	})
+
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, err = parseFmt(slog.LevelDebug, "unknown")
-	if err == nil {
-		t.Fatalf("expected error")
+	wantTextHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     slog.LevelDebug,
+		AddSource: true,
+	})
+
+	if !reflect.DeepEqual(handler, wantTextHandler) {
+		t.Fatalf("handler not equal to wantTextHandler")
 	}
 }
 

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -1,0 +1,133 @@
+package log
+
+import (
+	"log/slog"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseFmt(t *testing.T) {
+	type args struct {
+		lvlOption slog.Level
+		format    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *slog.Logger
+		wantErr bool
+	}{
+		{
+			name: "logfmt",
+			args: args{
+				lvlOption: slog.LevelDebug,
+				format:    FormatLogFmt,
+			},
+			want:    slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+			wantErr: false,
+		},
+		{
+			name: "json",
+			args: args{
+				lvlOption: slog.LevelDebug,
+				format:    FormatJSON,
+			},
+			want:    slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFmt(tt.args.lvlOption, tt.args.format)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseFmt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseFmt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	type args struct {
+		lvl string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    slog.Level
+		wantErr bool
+	}{
+		{
+			name: "all",
+			args: args{
+				lvl: LevelAll,
+			},
+			want:    slog.LevelDebug,
+			wantErr: false,
+		},
+		{
+			name: "debug",
+			args: args{
+				lvl: LevelDebug,
+			},
+			want:    slog.LevelDebug,
+			wantErr: false,
+		},
+		{
+			name: "info",
+			args: args{
+				lvl: LevelInfo,
+			},
+			want:    slog.LevelInfo,
+			wantErr: false,
+		},
+		{
+			name: "warn",
+			args: args{
+				lvl: LevelWarn,
+			},
+			want:    slog.LevelWarn,
+			wantErr: false,
+		},
+		{
+			name: "error",
+			args: args{
+				lvl: LevelError,
+			},
+			want:    slog.LevelError,
+			wantErr: false,
+		},
+		{
+			name: "none",
+			args: args{
+				lvl: LevelNone,
+			},
+			want:    -1,
+			wantErr: false,
+		},
+		{
+			name: "unknown",
+			args: args{
+				lvl: "unknown",
+			},
+			want:    -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLevel(tt.args.lvl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseLevel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -1,3 +1,17 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package log
 
 import (

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestReplaceAttribute validates if all attributes that were replaced are present in the slog.Logger output.
@@ -39,20 +41,12 @@ func TestReplaceAttributes(t *testing.T) {
 	var m map[string]interface{}
 	err := json.Unmarshal(buf.Bytes(), &m)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		require.NoError(t, err)
 	}
 
-	if _, ok := m["level"]; !ok {
-		t.Fatalf("key level not found in the JSON")
-	}
-
-	if _, ok := m["ts"]; !ok {
-		t.Fatalf("key ts not found in the JSON")
-	}
-
-	if _, ok := m["caller"]; !ok {
-		t.Fatalf("key caller not found in the JSON")
-	}
+	require.Contains(t, m, "level")
+	require.Contains(t, m, "msg")
+	require.Contains(t, m, "caller")
 }
 
 func TestParseFmt(t *testing.T) {
@@ -62,7 +56,7 @@ func TestParseFmt(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		require.NoError(t, err)
 	}
 
 	wantJSONHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -70,9 +64,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	if !reflect.DeepEqual(handler, wantJSONHandler) {
-		t.Fatalf("handler not equal to wantJSONHandler")
-	}
+	require.Equal(t, handler, wantJSONHandler)
 
 	handler, err = getHandlerFromFormat(FormatLogFmt, slog.HandlerOptions{
 		Level:     slog.LevelDebug,
@@ -80,7 +72,7 @@ func TestParseFmt(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		require.NoError(t, err)
 	}
 
 	wantTextHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -88,9 +80,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	if !reflect.DeepEqual(handler, wantTextHandler) {
-		t.Fatalf("handler not equal to wantTextHandler")
-	}
+	require.Equal(t, handler, wantTextHandler)
 }
 
 func TestParseLevel(t *testing.T) {

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,7 +63,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	require.Equal(t, handler, wantJSONHandler)
+	require.Equal(t, wantJSONHandler, handler)
 
 	handler, err = getHandlerFromFormat(FormatLogFmt, slog.HandlerOptions{
 		Level:     slog.LevelDebug,
@@ -80,7 +79,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	require.Equal(t, handler, wantTextHandler)
+	require.Equal(t, wantTextHandler, handler)
 }
 
 func TestParseLevel(t *testing.T) {
@@ -157,9 +156,7 @@ func TestParseLevel(t *testing.T) {
 				t.Errorf("ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseLevel() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -39,9 +39,7 @@ func TestReplaceAttributes(t *testing.T) {
 
 	var m map[string]interface{}
 	err := json.Unmarshal(buf.Bytes(), &m)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	require.Contains(t, m, "level")
 	require.Contains(t, m, "msg")
@@ -54,9 +52,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	wantJSONHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,
@@ -70,9 +66,7 @@ func TestParseFmt(t *testing.T) {
 		AddSource: true,
 	})
 
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	wantTextHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     slog.LevelDebug,


### PR DESCRIPTION
## Description

Fixes #6183

Following the @ArthurSens suggestion, first I'm adapting the new slog constructor to follow the same requirements of the `k8s.io/klog/v2` and afterwards I plan to replace all the imports.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feature: add new logger for slog library
```
