### PR TITLE
Refactor EC2 Service discovery

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -9145,7 +9145,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -12456,7 +12455,7 @@ A zero value means that Prometheus doesn&rsquo;t accept any incoming connection.
 <h3 id="monitoring.coreos.com/v1.ProxyConfig">ProxyConfig
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.OAuth2">OAuth2</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.ConsulSDConfig">ConsulSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DigitalOceanSDConfig">DigitalOceanSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSDConfig">DockerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSwarmSDConfig">DockerSwarmSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EurekaSDConfig">EurekaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPSDConfig">HTTPSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HetznerSDConfig">HetznerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KumaSDConfig">KumaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LightSailSDConfig">LightSailSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LinodeSDConfig">LinodeSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.NomadSDConfig">NomadSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.PuppetDBSDConfig">PuppetDBSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScalewaySDConfig">ScalewaySDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.OAuth2">OAuth2</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1alpha1.ConsulSDConfig">ConsulSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DigitalOceanSDConfig">DigitalOceanSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSDConfig">DockerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSwarmSDConfig">DockerSwarmSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EC2SDConfig">EC2SDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EurekaSDConfig">EurekaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPSDConfig">HTTPSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HetznerSDConfig">HetznerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KumaSDConfig">KumaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LightSailSDConfig">LightSailSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LinodeSDConfig">LinodeSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.NomadSDConfig">NomadSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.PuppetDBSDConfig">PuppetDBSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScalewaySDConfig">ScalewaySDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>)
 </p>
 <div>
 </div>
@@ -12478,7 +12477,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -13067,7 +13065,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -13382,7 +13379,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -13810,7 +13806,7 @@ Kubernetes core/v1.SecretKeySelector
 <h3 id="monitoring.coreos.com/v1.SafeTLSConfig">SafeTLSConfig
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1.OAuth2">OAuth2</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.TLSConfig">TLSConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ConsulSDConfig">ConsulSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DigitalOceanSDConfig">DigitalOceanSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSDConfig">DockerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSwarmSDConfig">DockerSwarmSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EmailConfig">EmailConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EurekaSDConfig">EurekaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPSDConfig">HTTPSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HetznerSDConfig">HetznerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KumaSDConfig">KumaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LightSailSDConfig">LightSailSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LinodeSDConfig">LinodeSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.NomadSDConfig">NomadSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.OpenStackSDConfig">OpenStackSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.PuppetDBSDConfig">PuppetDBSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScalewaySDConfig">ScalewaySDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>, <a href="#monitoring.coreos.com/v1beta1.EmailConfig">EmailConfig</a>, <a href="#monitoring.coreos.com/v1beta1.HTTPConfig">HTTPConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1.OAuth2">OAuth2</a>, <a href="#monitoring.coreos.com/v1.PodMetricsEndpoint">PodMetricsEndpoint</a>, <a href="#monitoring.coreos.com/v1.ProbeSpec">ProbeSpec</a>, <a href="#monitoring.coreos.com/v1.TLSConfig">TLSConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ConsulSDConfig">ConsulSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DigitalOceanSDConfig">DigitalOceanSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSDConfig">DockerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.DockerSwarmSDConfig">DockerSwarmSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EC2SDConfig">EC2SDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EmailConfig">EmailConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.EurekaSDConfig">EurekaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPConfig">HTTPConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HTTPSDConfig">HTTPSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.HetznerSDConfig">HetznerSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KubernetesSDConfig">KubernetesSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.KumaSDConfig">KumaSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LightSailSDConfig">LightSailSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.LinodeSDConfig">LinodeSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.NomadSDConfig">NomadSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.OpenStackSDConfig">OpenStackSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.PuppetDBSDConfig">PuppetDBSDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScalewaySDConfig">ScalewaySDConfig</a>, <a href="#monitoring.coreos.com/v1alpha1.ScrapeConfigSpec">ScrapeConfigSpec</a>, <a href="#monitoring.coreos.com/v1beta1.EmailConfig">EmailConfig</a>, <a href="#monitoring.coreos.com/v1beta1.HTTPConfig">HTTPConfig</a>)
 </p>
 <div>
 <p>SafeTLSConfig specifies safe TLS configuration parameters.</p>
@@ -18768,7 +18764,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -19302,7 +19297,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -19592,7 +19586,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -19830,7 +19823,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -20152,7 +20144,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -20250,6 +20241,8 @@ bool
 The private IP address is used by default, but may be changed to the public IP address with relabeling.
 The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
 See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config">https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config</a></p>
+<p>The EC2 service discovery requires AWS API keys or role ARN for authentication.
+BasicAuth, Authorization and OAuth2 fields are not present on purpose.</p>
 </div>
 <table>
 <thead>
@@ -20268,7 +20261,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>The AWS region</p>
+<p>The AWS region.</p>
 </td>
 </tr>
 <tr>
@@ -20313,6 +20306,19 @@ string
 </tr>
 <tr>
 <td>
+<code>port</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The port to scrape metrics from. If using the public IP address, this must
+instead be specified in the relabeling rule.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>refreshInterval</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.Duration">
@@ -20323,19 +20329,6 @@ Duration
 <td>
 <em>(Optional)</em>
 <p>RefreshInterval configures the refresh interval at which Prometheus will re-read the instance list.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>port</code><br/>
-<em>
-int
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The port to scrape metrics from. If using the public IP address, this must
-instead be specified in the relabeling rule.</p>
 </td>
 </tr>
 <tr>
@@ -20352,7 +20345,106 @@ Filters
 <p>Filters can be used optionally to filter the instance list by other criteria.
 Available filter criteria can be found here:
 <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html">https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html</a>
-Filter API documentation: <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html">https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html</a></p>
+Filter API documentation: <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html">https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html</a>
+It requires Prometheus &gt;= v2.3.0</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>proxyUrl</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>noProxy</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>noProxy</code> is a comma-separated string that can contain IPs, CIDR notation, domain names
+that should be excluded from proxying. IP and domain names can
+contain port numbers.</p>
+<p>It requires Prometheus &gt;= v2.43.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>proxyFromEnvironment</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+If unset, Prometheus uses its default value.</p>
+<p>It requires Prometheus &gt;= v2.43.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>proxyConnectHeader</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core">
+map[string][]k8s.io/api/core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ProxyConnectHeader optionally specifies headers to send to
+proxies during CONNECT requests.</p>
+<p>It requires Prometheus &gt;= v2.43.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tlsConfig</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.SafeTLSConfig">
+SafeTLSConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TLS configuration to connect to the AWS EC2 API.
+It requires Prometheus &gt;= v2.41.0</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>followRedirects</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Configure whether HTTP requests follow HTTP 3xx redirects.
+It requires Prometheus &gt;= v2.41.0</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableHTTP2</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether to enable HTTP2.
+It requires Prometheus &gt;= v2.41.0</p>
 </td>
 </tr>
 </tbody>
@@ -20650,7 +20742,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -21148,7 +21239,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -21282,7 +21372,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -21730,7 +21819,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -21896,7 +21984,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -22190,7 +22277,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -22384,7 +22470,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -22947,7 +23032,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -25539,7 +25623,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -26558,7 +26641,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>
@@ -27294,7 +27376,6 @@ string
 <td>
 <em>(Optional)</em>
 <p><code>proxyURL</code> defines the HTTP proxy server to use.</p>
-<p>It requires Prometheus &gt;= v2.43.0.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -557,11 +557,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -1562,11 +1559,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -2368,11 +2362,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3152,11 +3143,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3974,11 +3962,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -4892,11 +4877,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -5629,11 +5611,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -6477,11 +6456,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7240,11 +7216,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7964,11 +7937,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -8675,11 +8645,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -9455,11 +9422,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -11409,11 +11373,8 @@ spec:
                                   It requires Prometheus >= v2.43.0.
                                 type: boolean
                               proxyUrl:
-                                description: |-
-                                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                                  It requires Prometheus >= v2.43.0.
+                                description: '`proxyURL` defines the HTTP proxy server
+                                  to use.'
                                 pattern: ^http(s)?://.+$
                                 type: string
                               scopes:
@@ -19171,11 +19132,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -20301,11 +20259,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:
@@ -26581,11 +26535,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -26829,11 +26780,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:
@@ -38017,11 +37964,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -38265,11 +38209,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     readRecent:
@@ -38928,11 +38868,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -39176,11 +39113,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:
@@ -45298,11 +45231,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -45546,11 +45476,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -46226,11 +46152,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -46477,11 +46400,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -46947,11 +46866,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -47198,11 +47114,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -47747,11 +47659,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -47998,11 +47907,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -48499,11 +48404,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -48755,11 +48657,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -48963,6 +48861,10 @@ spec:
                     The private IP address is used by default, but may be changed to the public IP address with relabeling.
                     The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
+
+
+                    The EC2 service discovery requires AWS API keys or role ARN for authentication.
+                    BasicAuth, Authorization and OAuth2 fields are not present on purpose.
                   properties:
                     accessKey:
                       description: AccessKey is the AWS API key.
@@ -48990,12 +48892,18 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    enableHTTP2:
+                      description: |-
+                        Whether to enable HTTP2.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
                     filters:
                       description: |-
                         Filters can be used optionally to filter the instance list by other criteria.
                         Available filter criteria can be found here:
                         https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
                         Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+                        It requires Prometheus >= v2.3.0
                       items:
                         description: Filter name and value pairs to limit the discovery
                           process to a subset of available resources.
@@ -49017,21 +48925,89 @@ spec:
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
+                    followRedirects:
+                      description: |-
+                        Configure whether HTTP requests follow HTTP 3xx redirects.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: string
                     port:
                       description: |-
                         The port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        ProxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: boolean
+                    proxyUrl:
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
+                      pattern: ^http(s)?://.+$
+                      type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
                         at which Prometheus will re-read the instance list.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     region:
-                      description: The AWS region
+                      description: The AWS region.
+                      minLength: 1
                       type: string
                     roleARN:
                       description: AWS Role ARN, an alternative to using AWS API keys.
+                      minLength: 1
                       type: string
                     secretKey:
                       description: SecretKey is the AWS API secret.
@@ -49059,6 +49035,182 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    tlsConfig:
+                      description: |-
+                        TLS configuration to connect to the AWS EC2 API.
+                        It requires Prometheus >= v2.41.0
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            Maximum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.41.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            Minimum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.35.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
                   type: object
                 type: array
               enableCompression:
@@ -49350,11 +49502,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -49598,11 +49747,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -50158,11 +50303,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -50409,11 +50551,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -50781,11 +50919,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -51318,11 +51452,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -51566,11 +51697,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     role:
@@ -52089,11 +52216,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -52337,11 +52461,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -52861,11 +52981,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -53117,11 +53234,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -53555,11 +53668,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -53809,11 +53919,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -54262,11 +54368,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:
@@ -54927,11 +55029,7 @@ spec:
                   It requires Prometheus >= v2.43.0.
                 type: boolean
               proxyUrl:
-                description: |-
-                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                  It requires Prometheus >= v2.43.0.
+                description: '`proxyURL` defines the HTTP proxy server to use.'
                 pattern: ^http(s)?://.+$
                 type: string
               puppetDBSDConfigs:
@@ -55222,11 +55320,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -55476,11 +55571,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     query:
@@ -55873,11 +55964,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -56908,11 +56995,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -556,11 +556,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -1561,11 +1558,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -2367,11 +2361,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3151,11 +3142,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3973,11 +3961,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -4891,11 +4876,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -5628,11 +5610,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -6476,11 +6455,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7239,11 +7215,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7963,11 +7936,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -8674,11 +8644,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -9454,11 +9421,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -10415,11 +10379,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -11391,11 +11352,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -12179,11 +12137,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -12955,11 +12910,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -13750,11 +13702,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -14632,11 +14581,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -15360,11 +15306,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -16190,11 +16133,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -16935,11 +16875,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -17648,11 +17585,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -18350,11 +18284,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -19103,11 +19034,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1430,11 +1430,8 @@ spec:
                                   It requires Prometheus >= v2.43.0.
                                 type: boolean
                               proxyUrl:
-                                description: |-
-                                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                                  It requires Prometheus >= v2.43.0.
+                                description: '`proxyURL` defines the HTTP proxy server
+                                  to use.'
                                 pattern: ^http(s)?://.+$
                                 type: string
                               scopes:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -586,11 +586,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -470,11 +470,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5536,11 +5536,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -5784,11 +5781,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6257,11 +6257,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -6505,11 +6502,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     readRecent:
@@ -7168,11 +7161,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -7416,11 +7406,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -331,11 +331,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -579,11 +576,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -1259,11 +1252,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -1510,11 +1500,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -1980,11 +1966,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -2231,11 +2214,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -2780,11 +2759,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -3031,11 +3007,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -3532,11 +3504,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -3788,11 +3757,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -3996,6 +3961,10 @@ spec:
                     The private IP address is used by default, but may be changed to the public IP address with relabeling.
                     The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
+
+
+                    The EC2 service discovery requires AWS API keys or role ARN for authentication.
+                    BasicAuth, Authorization and OAuth2 fields are not present on purpose.
                   properties:
                     accessKey:
                       description: AccessKey is the AWS API key.
@@ -4023,12 +3992,18 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    enableHTTP2:
+                      description: |-
+                        Whether to enable HTTP2.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
                     filters:
                       description: |-
                         Filters can be used optionally to filter the instance list by other criteria.
                         Available filter criteria can be found here:
                         https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
                         Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+                        It requires Prometheus >= v2.3.0
                       items:
                         description: Filter name and value pairs to limit the discovery
                           process to a subset of available resources.
@@ -4050,21 +4025,89 @@ spec:
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
+                    followRedirects:
+                      description: |-
+                        Configure whether HTTP requests follow HTTP 3xx redirects.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: string
                     port:
                       description: |-
                         The port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        ProxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: boolean
+                    proxyUrl:
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
+                      pattern: ^http(s)?://.+$
+                      type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
                         at which Prometheus will re-read the instance list.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     region:
-                      description: The AWS region
+                      description: The AWS region.
+                      minLength: 1
                       type: string
                     roleARN:
                       description: AWS Role ARN, an alternative to using AWS API keys.
+                      minLength: 1
                       type: string
                     secretKey:
                       description: SecretKey is the AWS API secret.
@@ -4092,6 +4135,182 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    tlsConfig:
+                      description: |-
+                        TLS configuration to connect to the AWS EC2 API.
+                        It requires Prometheus >= v2.41.0
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            Maximum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.41.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            Minimum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.35.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
                   type: object
                 type: array
               enableCompression:
@@ -4383,11 +4602,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -4631,11 +4847,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -5191,11 +5403,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -5442,11 +5651,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -5814,11 +6019,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -6351,11 +6552,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -6599,11 +6797,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     role:
@@ -7122,11 +7316,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -7370,11 +7561,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -7894,11 +8081,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -8150,11 +8334,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -8588,11 +8768,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -8842,11 +9019,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -9295,11 +9468,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:
@@ -9960,11 +10129,7 @@ spec:
                   It requires Prometheus >= v2.43.0.
                 type: boolean
               proxyUrl:
-                description: |-
-                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                  It requires Prometheus >= v2.43.0.
+                description: '`proxyURL` defines the HTTP proxy server to use.'
                 pattern: ^http(s)?://.+$
                 type: string
               puppetDBSDConfigs:
@@ -10255,11 +10420,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -10509,11 +10671,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     query:
@@ -10906,11 +11064,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -533,11 +533,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -557,11 +557,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -1562,11 +1559,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -2368,11 +2362,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3152,11 +3143,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -3974,11 +3962,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -4892,11 +4877,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -5629,11 +5611,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -6477,11 +6456,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7240,11 +7216,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -7964,11 +7937,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -8675,11 +8645,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:
@@ -9455,11 +9422,8 @@ spec:
                                       It requires Prometheus >= v2.43.0.
                                     type: boolean
                                   proxyUrl:
-                                    description: |-
-                                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                                      It requires Prometheus >= v2.43.0.
+                                    description: '`proxyURL` defines the HTTP proxy
+                                      server to use.'
                                     pattern: ^http(s)?://.+$
                                     type: string
                                   scopes:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1431,11 +1431,8 @@ spec:
                                   It requires Prometheus >= v2.43.0.
                                 type: boolean
                               proxyUrl:
-                                description: |-
-                                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                                  It requires Prometheus >= v2.43.0.
+                                description: '`proxyURL` defines the HTTP proxy server
+                                  to use.'
                                 pattern: ^http(s)?://.+$
                                 type: string
                               scopes:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -587,11 +587,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -471,11 +471,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5537,11 +5537,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -5785,11 +5782,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6258,11 +6258,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -6506,11 +6503,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     readRecent:
@@ -7169,11 +7162,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -7417,11 +7407,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     queueConfig:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -332,11 +332,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -580,11 +577,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -1260,11 +1253,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -1511,11 +1501,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -1981,11 +1967,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -2232,11 +2215,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -2781,11 +2760,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -3032,11 +3008,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -3533,11 +3505,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -3789,11 +3758,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -3997,6 +3962,10 @@ spec:
                     The private IP address is used by default, but may be changed to the public IP address with relabeling.
                     The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
+
+
+                    The EC2 service discovery requires AWS API keys or role ARN for authentication.
+                    BasicAuth, Authorization and OAuth2 fields are not present on purpose.
                   properties:
                     accessKey:
                       description: AccessKey is the AWS API key.
@@ -4024,12 +3993,18 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    enableHTTP2:
+                      description: |-
+                        Whether to enable HTTP2.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
                     filters:
                       description: |-
                         Filters can be used optionally to filter the instance list by other criteria.
                         Available filter criteria can be found here:
                         https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
                         Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+                        It requires Prometheus >= v2.3.0
                       items:
                         description: Filter name and value pairs to limit the discovery
                           process to a subset of available resources.
@@ -4051,21 +4026,89 @@ spec:
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
+                    followRedirects:
+                      description: |-
+                        Configure whether HTTP requests follow HTTP 3xx redirects.
+                        It requires Prometheus >= v2.41.0
+                      type: boolean
+                    noProxy:
+                      description: |-
+                        `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                        that should be excluded from proxying. IP and domain names can
+                        contain port numbers.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: string
                     port:
                       description: |-
                         The port to scrape metrics from. If using the public IP address, this must
                         instead be specified in the relabeling rule.
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
                       type: integer
+                    proxyConnectHeader:
+                      additionalProperties:
+                        items:
+                          description: SecretKeySelector selects a key of a Secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      description: |-
+                        ProxyConnectHeader optionally specifies headers to send to
+                        proxies during CONNECT requests.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: |-
+                        Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value.
+
+
+                        It requires Prometheus >= v2.43.0.
+                      type: boolean
+                    proxyUrl:
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
+                      pattern: ^http(s)?://.+$
+                      type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
                         at which Prometheus will re-read the instance list.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     region:
-                      description: The AWS region
+                      description: The AWS region.
+                      minLength: 1
                       type: string
                     roleARN:
                       description: AWS Role ARN, an alternative to using AWS API keys.
+                      minLength: 1
                       type: string
                     secretKey:
                       description: SecretKey is the AWS API secret.
@@ -4093,6 +4136,182 @@ spec:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
+                    tlsConfig:
+                      description: |-
+                        TLS configuration to connect to the AWS EC2 API.
+                        It requires Prometheus >= v2.41.0
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            Maximum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.41.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            Minimum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.35.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
                   type: object
                 type: array
               enableCompression:
@@ -4384,11 +4603,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -4632,11 +4848,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -5192,11 +5404,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -5443,11 +5652,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -5815,11 +6020,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -6352,11 +6553,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -6600,11 +6798,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     role:
@@ -7123,11 +7317,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -7371,11 +7562,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -7895,11 +8082,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -8151,11 +8335,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -8589,11 +8769,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -8843,11 +9020,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:
@@ -9296,11 +9469,7 @@ spec:
                       It requires Prometheus >= v2.43.0.
                     type: boolean
                   proxyUrl:
-                    description: |-
-                      `proxyURL` defines the HTTP proxy server to use.
-
-
-                      It requires Prometheus >= v2.43.0.
+                    description: '`proxyURL` defines the HTTP proxy server to use.'
                     pattern: ^http(s)?://.+$
                     type: string
                   scopes:
@@ -9961,11 +10130,7 @@ spec:
                   It requires Prometheus >= v2.43.0.
                 type: boolean
               proxyUrl:
-                description: |-
-                  `proxyURL` defines the HTTP proxy server to use.
-
-
-                  It requires Prometheus >= v2.43.0.
+                description: '`proxyURL` defines the HTTP proxy server to use.'
                 pattern: ^http(s)?://.+$
                 type: string
               puppetDBSDConfigs:
@@ -10256,11 +10421,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:
@@ -10510,11 +10672,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     query:
@@ -10907,11 +11065,7 @@ spec:
                         It requires Prometheus >= v2.43.0.
                       type: boolean
                     proxyUrl:
-                      description: |-
-                        `proxyURL` defines the HTTP proxy server to use.
-
-
-                        It requires Prometheus >= v2.43.0.
+                      description: '`proxyURL` defines the HTTP proxy server to use.'
                       pattern: ^http(s)?://.+$
                       type: string
                     refreshInterval:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -534,11 +534,8 @@ spec:
                             It requires Prometheus >= v2.43.0.
                           type: boolean
                         proxyUrl:
-                          description: |-
-                            `proxyURL` defines the HTTP proxy server to use.
-
-
-                            It requires Prometheus >= v2.43.0.
+                          description: '`proxyURL` defines the HTTP proxy server to
+                            use.'
                           pattern: ^http(s)?://.+$
                           type: string
                         scopes:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -499,7 +499,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -1397,7 +1397,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -2109,7 +2109,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -2817,7 +2817,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -3535,7 +3535,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -4350,7 +4350,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -5007,7 +5007,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -5738,7 +5738,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -6412,7 +6412,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -7040,7 +7040,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -7659,7 +7659,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },
@@ -8333,7 +8333,7 @@
                                         "type": "boolean"
                                       },
                                       "proxyUrl": {
-                                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                                         "pattern": "^http(s)?://.+$",
                                         "type": "string"
                                       },

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -371,7 +371,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -1257,7 +1257,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -1963,7 +1963,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -2671,7 +2671,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -3380,7 +3380,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -4183,7 +4183,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -4837,7 +4837,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -5562,7 +5562,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -6230,7 +6230,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -6855,7 +6855,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -7471,7 +7471,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },
@@ -8136,7 +8136,7 @@
                                     type: 'boolean',
                                   },
                                   proxyUrl: {
-                                    description: '`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.',
+                                    description: '`proxyURL` defines the HTTP proxy server to use.',
                                     pattern: '^http(s)?://.+$',
                                     type: 'string',
                                   },

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1199,7 +1199,7 @@
                                     "type": "boolean"
                                   },
                                   "proxyUrl": {
-                                    "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                                    "description": "`proxyURL` defines the HTTP proxy server to use.",
                                     "pattern": "^http(s)?://.+$",
                                     "type": "string"
                                   },

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -432,7 +432,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -379,7 +379,7 @@
                         "type": "boolean"
                       },
                       "proxyUrl": {
-                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                         "pattern": "^http(s)?://.+$",
                         "type": "string"
                       },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4559,7 +4559,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -4780,7 +4780,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5113,7 +5113,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -5334,7 +5334,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -5888,7 +5888,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -6109,7 +6109,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -278,7 +278,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -499,7 +499,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -1094,7 +1094,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -1319,7 +1319,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -1728,7 +1728,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -1953,7 +1953,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -2438,7 +2438,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -2663,7 +2663,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -3103,7 +3103,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -3331,7 +3331,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -3522,7 +3522,7 @@
                   "ec2SDConfigs": {
                     "description": "EC2SDConfigs defines a list of EC2 service discovery configurations.",
                     "items": {
-                      "description": "EC2SDConfig allow retrieving scrape targets from AWS EC2 instances.\nThe private IP address is used by default, but may be changed to the public IP address with relabeling.\nThe IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets\nSee https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config",
+                      "description": "EC2SDConfig allow retrieving scrape targets from AWS EC2 instances.\nThe private IP address is used by default, but may be changed to the public IP address with relabeling.\nThe IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets\nSee https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config\n\n\nThe EC2 service discovery requires AWS API keys or role ARN for authentication.\nBasicAuth, Authorization and OAuth2 fields are not present on purpose.",
                       "properties": {
                         "accessKey": {
                           "description": "AccessKey is the AWS API key.",
@@ -3547,8 +3547,12 @@
                           "type": "object",
                           "x-kubernetes-map-type": "atomic"
                         },
+                        "enableHTTP2": {
+                          "description": "Whether to enable HTTP2.\nIt requires Prometheus >= v2.41.0",
+                          "type": "boolean"
+                        },
                         "filters": {
-                          "description": "Filters can be used optionally to filter the instance list by other criteria.\nAvailable filter criteria can be found here:\nhttps://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html\nFilter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html",
+                          "description": "Filters can be used optionally to filter the instance list by other criteria.\nAvailable filter criteria can be found here:\nhttps://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html\nFilter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html\nIt requires Prometheus >= v2.3.0",
                           "items": {
                             "description": "Filter name and value pairs to limit the discovery process to a subset of available resources.",
                             "properties": {
@@ -3577,9 +3581,60 @@
                           ],
                           "x-kubernetes-list-type": "map"
                         },
+                        "followRedirects": {
+                          "description": "Configure whether HTTP requests follow HTTP 3xx redirects.\nIt requires Prometheus >= v2.41.0",
+                          "type": "boolean"
+                        },
+                        "noProxy": {
+                          "description": "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names\nthat should be excluded from proxying. IP and domain names can\ncontain port numbers.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "type": "string"
+                        },
                         "port": {
                           "description": "The port to scrape metrics from. If using the public IP address, this must\ninstead be specified in the relabeling rule.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 0,
                           "type": "integer"
+                        },
+                        "proxyConnectHeader": {
+                          "additionalProperties": {
+                            "items": {
+                              "description": "SecretKeySelector selects a key of a Secret.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "type": "array"
+                          },
+                          "description": "ProxyConnectHeader optionally specifies headers to send to\nproxies during CONNECT requests.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "proxyFromEnvironment": {
+                          "description": "Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).\nIf unset, Prometheus uses its default value.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "type": "boolean"
+                        },
+                        "proxyUrl": {
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
+                          "pattern": "^http(s)?://.+$",
+                          "type": "string"
                         },
                         "refreshInterval": {
                           "description": "RefreshInterval configures the refresh interval at which Prometheus will re-read the instance list.",
@@ -3587,11 +3642,13 @@
                           "type": "string"
                         },
                         "region": {
-                          "description": "The AWS region",
+                          "description": "The AWS region.",
+                          "minLength": 1,
                           "type": "string"
                         },
                         "roleARN": {
                           "description": "AWS Role ARN, an alternative to using AWS API keys.",
+                          "minLength": 1,
                           "type": "string"
                         },
                         "secretKey": {
@@ -3616,6 +3673,167 @@
                           ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic"
+                        },
+                        "tlsConfig": {
+                          "description": "TLS configuration to connect to the AWS EC2 API.\nIt requires Prometheus >= v2.41.0",
+                          "properties": {
+                            "ca": {
+                              "description": "Certificate authority used when verifying server certificates.",
+                              "properties": {
+                                "configMap": {
+                                  "description": "ConfigMap containing data to use for the targets.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "secret": {
+                                  "description": "Secret containing data to use for the targets.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "cert": {
+                              "description": "Client certificate to present when doing client-authentication.",
+                              "properties": {
+                                "configMap": {
+                                  "description": "ConfigMap containing data to use for the targets.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "secret": {
+                                  "description": "Secret containing data to use for the targets.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "Disable target certificate validation.",
+                              "type": "boolean"
+                            },
+                            "keySecret": {
+                              "description": "Secret containing the client key file for the targets.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "maxVersion": {
+                              "description": "Maximum acceptable TLS version.\n\n\nIt requires Prometheus >= v2.41.0.",
+                              "enum": [
+                                "TLS10",
+                                "TLS11",
+                                "TLS12",
+                                "TLS13"
+                              ],
+                              "type": "string"
+                            },
+                            "minVersion": {
+                              "description": "Minimum acceptable TLS version.\n\n\nIt requires Prometheus >= v2.35.0.",
+                              "enum": [
+                                "TLS10",
+                                "TLS11",
+                                "TLS12",
+                                "TLS13"
+                              ],
+                              "type": "string"
+                            },
+                            "serverName": {
+                              "description": "Used to verify the hostname for the targets.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -3853,7 +4071,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -4074,7 +4292,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -4553,7 +4771,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -4778,7 +4996,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -5104,7 +5322,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -5558,7 +5776,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -5779,7 +5997,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -6239,7 +6457,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -6460,7 +6678,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -6913,7 +7131,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -7141,7 +7359,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -7523,7 +7741,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -7751,7 +7969,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -8138,7 +8356,7 @@
                         "type": "boolean"
                       },
                       "proxyUrl": {
-                        "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                        "description": "`proxyURL` defines the HTTP proxy server to use.",
                         "pattern": "^http(s)?://.+$",
                         "type": "string"
                       },
@@ -8762,7 +8980,7 @@
                     "type": "boolean"
                   },
                   "proxyUrl": {
-                    "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                    "description": "`proxyURL` defines the HTTP proxy server to use.",
                     "pattern": "^http(s)?://.+$",
                     "type": "string"
                   },
@@ -8997,7 +9215,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },
@@ -9225,7 +9443,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },
@@ -9569,7 +9787,7 @@
                           "type": "boolean"
                         },
                         "proxyUrl": {
-                          "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                          "description": "`proxyURL` defines the HTTP proxy server to use.",
                           "pattern": "^http(s)?://.+$",
                           "type": "string"
                         },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -395,7 +395,7 @@
                               "type": "boolean"
                             },
                             "proxyUrl": {
-                              "description": "`proxyURL` defines the HTTP proxy server to use.\n\n\nIt requires Prometheus >= v2.43.0.",
+                              "description": "`proxyURL` defines the HTTP proxy server to use.",
                               "pattern": "^http(s)?://.+$",
                               "type": "string"
                             },

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -80,7 +80,6 @@ type PrometheusRuleExcludeConfig struct {
 type ProxyConfig struct {
 	// `proxyURL` defines the HTTP proxy server to use.
 	//
-	// It requires Prometheus >= v2.43.0.
 	// +kubebuilder:validation:Pattern:="^http(s)?://.+$"
 	// +optional
 	ProxyURL *string `json:"proxyUrl,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -548,11 +548,16 @@ type DNSSDConfig struct {
 // The private IP address is used by default, but may be changed to the public IP address with relabeling.
 // The IAM credentials used must have the ec2:DescribeInstances permission to discover scrape targets
 // See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config
+//
+// The EC2 service discovery requires AWS API keys or role ARN for authentication.
+// BasicAuth, Authorization and OAuth2 fields are not present on purpose.
+//
 // +k8s:openapi-gen=true
 type EC2SDConfig struct {
-	// The AWS region
+	// The AWS region.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	Region *string `json:"region"`
+	Region *string `json:"region,omitempty"`
 	// AccessKey is the AWS API key.
 	// +optional
 	AccessKey *corev1.SecretKeySelector `json:"accessKey,omitempty"`
@@ -560,21 +565,38 @@ type EC2SDConfig struct {
 	// +optional
 	SecretKey *corev1.SecretKeySelector `json:"secretKey,omitempty"`
 	// AWS Role ARN, an alternative to using AWS API keys.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	RoleARN *string `json:"roleARN,omitempty"`
+	// The port to scrape metrics from. If using the public IP address, this must
+	// instead be specified in the relabeling rule.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port *int32 `json:"port,omitempty"`
 	// RefreshInterval configures the refresh interval at which Prometheus will re-read the instance list.
 	// +optional
 	RefreshInterval *v1.Duration `json:"refreshInterval,omitempty"`
-	// The port to scrape metrics from. If using the public IP address, this must
-	// instead be specified in the relabeling rule.
-	// +optional
-	Port *int `json:"port"`
 	// Filters can be used optionally to filter the instance list by other criteria.
 	// Available filter criteria can be found here:
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
 	// Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+	// It requires Prometheus >= v2.3.0
 	// +optional
-	Filters Filters `json:"filters,omitempty"`
+	Filters        Filters `json:"filters,omitempty"`
+	v1.ProxyConfig `json:",inline"`
+	// TLS configuration to connect to the AWS EC2 API.
+	// It requires Prometheus >= v2.41.0
+	// +optional
+	TLSConfig *v1.SafeTLSConfig `json:"tlsConfig,omitempty"`
+	// Configure whether HTTP requests follow HTTP 3xx redirects.
+	// It requires Prometheus >= v2.41.0
+	// +optional
+	FollowRedirects *bool `json:"followRedirects,omitempty"`
+	// Whether to enable HTTP2.
+	// It requires Prometheus >= v2.41.0
+	// +optional
+	EnableHTTP2 *bool `json:"enableHTTP2,omitempty"`
 }
 
 // AzureSDConfig allow retrieving scrape targets from Azure VMs.

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -580,14 +580,14 @@ func (in *EC2SDConfig) DeepCopyInto(out *EC2SDConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Port != nil {
+		in, out := &in.Port, &out.Port
+		*out = new(int32)
+		**out = **in
+	}
 	if in.RefreshInterval != nil {
 		in, out := &in.RefreshInterval, &out.RefreshInterval
 		*out = new(monitoringv1.Duration)
-		**out = **in
-	}
-	if in.Port != nil {
-		in, out := &in.Port, &out.Port
-		*out = new(int)
 		**out = **in
 	}
 	if in.Filters != nil {
@@ -596,6 +596,22 @@ func (in *EC2SDConfig) DeepCopyInto(out *EC2SDConfig) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	in.ProxyConfig.DeepCopyInto(&out.ProxyConfig)
+	if in.TLSConfig != nil {
+		in, out := &in.TLSConfig, &out.TLSConfig
+		*out = new(monitoringv1.SafeTLSConfig)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.FollowRedirects != nil {
+		in, out := &in.FollowRedirects, &out.FollowRedirects
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableHTTP2 != nil {
+		in, out := &in.EnableHTTP2, &out.EnableHTTP2
+		*out = new(bool)
+		**out = **in
 	}
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/ec2sdconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/ec2sdconfig.go
@@ -19,19 +19,24 @@ package v1alpha1
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	applyconfigurationmonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/client/applyconfiguration/monitoring/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
 // EC2SDConfigApplyConfiguration represents an declarative configuration of the EC2SDConfig type for use
 // with apply.
 type EC2SDConfigApplyConfiguration struct {
-	Region          *string                `json:"region,omitempty"`
-	AccessKey       *v1.SecretKeySelector  `json:"accessKey,omitempty"`
-	SecretKey       *v1.SecretKeySelector  `json:"secretKey,omitempty"`
-	RoleARN         *string                `json:"roleARN,omitempty"`
-	RefreshInterval *monitoringv1.Duration `json:"refreshInterval,omitempty"`
-	Port            *int                   `json:"port,omitempty"`
-	Filters         *v1alpha1.Filters      `json:"filters,omitempty"`
+	Region                                                       *string                `json:"region,omitempty"`
+	AccessKey                                                    *v1.SecretKeySelector  `json:"accessKey,omitempty"`
+	SecretKey                                                    *v1.SecretKeySelector  `json:"secretKey,omitempty"`
+	RoleARN                                                      *string                `json:"roleARN,omitempty"`
+	Port                                                         *int32                 `json:"port,omitempty"`
+	RefreshInterval                                              *monitoringv1.Duration `json:"refreshInterval,omitempty"`
+	Filters                                                      *v1alpha1.Filters      `json:"filters,omitempty"`
+	applyconfigurationmonitoringv1.ProxyConfigApplyConfiguration `json:",inline"`
+	TLSConfig                                                    *applyconfigurationmonitoringv1.SafeTLSConfigApplyConfiguration `json:"tlsConfig,omitempty"`
+	FollowRedirects                                              *bool                                                           `json:"followRedirects,omitempty"`
+	EnableHTTP2                                                  *bool                                                           `json:"enableHTTP2,omitempty"`
 }
 
 // EC2SDConfigApplyConfiguration constructs an declarative configuration of the EC2SDConfig type for use with
@@ -72,6 +77,14 @@ func (b *EC2SDConfigApplyConfiguration) WithRoleARN(value string) *EC2SDConfigAp
 	return b
 }
 
+// WithPort sets the Port field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Port field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithPort(value int32) *EC2SDConfigApplyConfiguration {
+	b.Port = &value
+	return b
+}
+
 // WithRefreshInterval sets the RefreshInterval field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RefreshInterval field is set to the value of the last call.
@@ -80,18 +93,72 @@ func (b *EC2SDConfigApplyConfiguration) WithRefreshInterval(value monitoringv1.D
 	return b
 }
 
-// WithPort sets the Port field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Port field is set to the value of the last call.
-func (b *EC2SDConfigApplyConfiguration) WithPort(value int) *EC2SDConfigApplyConfiguration {
-	b.Port = &value
-	return b
-}
-
 // WithFilters sets the Filters field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Filters field is set to the value of the last call.
 func (b *EC2SDConfigApplyConfiguration) WithFilters(value v1alpha1.Filters) *EC2SDConfigApplyConfiguration {
 	b.Filters = &value
+	return b
+}
+
+// WithProxyURL sets the ProxyURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ProxyURL field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithProxyURL(value string) *EC2SDConfigApplyConfiguration {
+	b.ProxyURL = &value
+	return b
+}
+
+// WithNoProxy sets the NoProxy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NoProxy field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithNoProxy(value string) *EC2SDConfigApplyConfiguration {
+	b.NoProxy = &value
+	return b
+}
+
+// WithProxyFromEnvironment sets the ProxyFromEnvironment field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ProxyFromEnvironment field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithProxyFromEnvironment(value bool) *EC2SDConfigApplyConfiguration {
+	b.ProxyFromEnvironment = &value
+	return b
+}
+
+// WithProxyConnectHeader puts the entries into the ProxyConnectHeader field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the ProxyConnectHeader field,
+// overwriting an existing map entries in ProxyConnectHeader field with the same key.
+func (b *EC2SDConfigApplyConfiguration) WithProxyConnectHeader(entries map[string][]v1.SecretKeySelector) *EC2SDConfigApplyConfiguration {
+	if b.ProxyConnectHeader == nil && len(entries) > 0 {
+		b.ProxyConnectHeader = make(map[string][]v1.SecretKeySelector, len(entries))
+	}
+	for k, v := range entries {
+		b.ProxyConnectHeader[k] = v
+	}
+	return b
+}
+
+// WithTLSConfig sets the TLSConfig field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TLSConfig field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithTLSConfig(value *applyconfigurationmonitoringv1.SafeTLSConfigApplyConfiguration) *EC2SDConfigApplyConfiguration {
+	b.TLSConfig = value
+	return b
+}
+
+// WithFollowRedirects sets the FollowRedirects field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the FollowRedirects field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithFollowRedirects(value bool) *EC2SDConfigApplyConfiguration {
+	b.FollowRedirects = &value
+	return b
+}
+
+// WithEnableHTTP2 sets the EnableHTTP2 field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableHTTP2 field is set to the value of the last call.
+func (b *EC2SDConfigApplyConfiguration) WithEnableHTTP2(value bool) *EC2SDConfigApplyConfiguration {
+	b.EnableHTTP2 = &value
 	return b
 }

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -1088,6 +1088,14 @@ func (rs *ResourceSelector) validateEC2SDConfigs(ctx context.Context, sc *monito
 				return fmt.Errorf("[%d]: %w", i, err)
 			}
 		}
+
+		if err := rs.store.AddSafeTLSConfig(ctx, sc.GetNamespace(), config.TLSConfig); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
+		}
+
+		if err := validateProxyConfig(ctx, config.ProxyConfig, rs.store, sc.GetNamespace()); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
+		}
 	}
 
 	return nil

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -2194,29 +2194,6 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			selected: true,
 		},
 		{
-			scenario: "EC2 SD config with invalid secret ref for accessKey",
-			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
-				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
-					{
-						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: "wrong",
-							},
-							Key: "key1",
-						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: "secret",
-							},
-							Key: "key2",
-						},
-					},
-				}
-			},
-			selected: false,
-		},
-		{
 			scenario: "EC2 SD config with invalid secret ref for secretKey",
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
@@ -2238,6 +2215,127 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				}
 			},
 			selected: false,
+		},
+		{
+			scenario: "EC2 SD config with valid TLS Config",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To("us-east-1"),
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									Key: "ca",
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "secret",
+									},
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									Key: "cert",
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "secret",
+									},
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								Key: "key",
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "secret",
+								},
+							},
+						},
+					},
+				}
+			},
+			selected: true,
+		},
+		{
+			scenario: "EC2 SD config with valid HTTPS Config",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To("us-east-1"),
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									Key: "ca",
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "secret",
+									},
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									Key: "cert",
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "secret",
+									},
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								Key: "key",
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "secret",
+								},
+							},
+						},
+						RefreshInterval: ptr.To(monitoringv1.Duration("30s")),
+						EnableHTTP2:     ptr.To(true),
+					},
+				}
+			},
+			promVersion: "2.52.0",
+			selected:    true,
+		},
+		{
+			scenario: "EC2 SD config with invalid TLS config with invalid CA data",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To("us-east-1"),
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									Key: "invalid_ca",
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "secret",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			selected: false,
+		},
+		{
+			scenario: "EC2 SD config with valid proxy settings",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To("us-east-1"),
+						ProxyConfig: monitoringv1.ProxyConfig{
+							ProxyURL:             ptr.To("http://no-proxy.com"),
+							NoProxy:              ptr.To("0.0.0.0"),
+							ProxyFromEnvironment: ptr.To(false),
+							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+								"header": {
+									{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "secret",
+										},
+										Key: "key1",
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			promVersion: "2.52.0",
+			selected:    true,
 		},
 		{
 			scenario: "Azure SD config with valid options for OAuth authentication method",

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SDConfigFilters_Unsupported_Version.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SDConfigFilters_Unsupported_Version.golden
@@ -1,0 +1,17 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - region: us-east-1
+    role_arn: arn:aws:iam::123456789:role/prometheus-role
+    refresh_interval: 30s
+    port: 9100
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withBasicAuth.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withBasicAuth.golden
@@ -1,0 +1,23 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - proxy_url: http://no-proxy.com
+    no_proxy: 0.0.0.0
+    proxy_from_environment: true
+    proxy_connect_header:
+      header:
+      - ""
+    region: us-east-1
+    refresh_interval: 30s
+    follow_redirects: true
+    enable_http2: true
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withProxyConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withProxyConfig.golden
@@ -1,0 +1,23 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - proxy_url: http://no-proxy.com
+    no_proxy: 0.0.0.0
+    proxy_from_environment: true
+    proxy_connect_header:
+      header:
+      - ""
+    region: us-east-1
+    refresh_interval: 30s
+    follow_redirects: true
+    enable_http2: true
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_OAuth.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_OAuth.golden
@@ -1,0 +1,14 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - region: us-east-1
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_TLSConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_TLSConfig.golden
@@ -1,0 +1,20 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - region: us-east-1
+    follow_redirects: true
+    enable_http2: true
+    tls_config:
+      ca_file: /etc/prometheus/certs/0_default_tls_ca
+      cert_file: /etc/prometheus/certs/0_default_tls_cert
+      key_file: /etc/prometheus/certs/0_default_tls_private-key
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_TLSConfig_Unsupported_Version.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_with_TLSConfig_Unsupported_Version.golden
@@ -1,0 +1,14 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  ec2_sd_configs:
+  - region: us-east-1
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -501,7 +501,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 		expectedError    bool
 	}{
 		{
-			name: "APIServer with empty value",
+			name: "KubernetesSDConfigs: APIServer with empty value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -513,7 +513,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Missing required Role",
+			name: "KubernetesSDConfigs: Missing required Role",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -524,7 +524,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Invalid Role",
+			name: "KubernetesSDConfigs: Invalid Role",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -535,7 +535,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Valid Role with empty APIServer",
+			name: "KubernetesSDConfigs: Valid Role with empty APIServer",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -547,7 +547,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Namespace discovery with valid namespace",
+			name: "KubernetesSDConfigs: Namespace discovery with valid namespace",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -559,7 +559,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Selector Role missing",
+			name: "KubernetesSDConfigs: Selector Role missing",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -575,7 +575,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Selector Role valid",
+			name: "KubernetesSDConfigs: Selector Role valid",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -591,7 +591,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Selector Label with empty value",
+			name: "KubernetesSDConfigs: Selector Label with empty value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -608,7 +608,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Selector Label with valid value",
+			name: "KubernetesSDConfigs: Selector Label with valid value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -625,7 +625,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Selector Field with empty value",
+			name: "KubernetesSDConfigs: Selector Field with empty value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -642,7 +642,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Selector Field with valid value",
+			name: "KubernetesSDConfigs: Selector Field with valid value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -659,7 +659,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Selector Field with valid value",
+			name: "KubernetesSDConfigs: Selector Field with valid value",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -676,7 +676,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Selector Label and Field with duplicate values",
+			name: "KubernetesSDConfigs: Selector Label and Field with duplicate values",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -699,7 +699,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "IncludeOwnNamespace set to true",
+			name: "KubernetesSDConfigs: IncludeOwnNamespace set to true",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -713,7 +713,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "IncludeOwnNamespace set to false with empty Names",
+			name: "KubernetesSDConfigs: IncludeOwnNamespace set to false with empty Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -728,7 +728,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "IncludeOwnNamespace unset with empty Names",
+			name: "KubernetesSDConfigs: IncludeOwnNamespace unset with empty Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -742,7 +742,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Names with valid namespaces",
+			name: "KubernetesSDConfigs: Names with valid namespaces",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -756,7 +756,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "IncludeOwnNamespace set to true with valid Names",
+			name: "KubernetesSDConfigs: IncludeOwnNamespace set to true with valid Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -771,7 +771,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "IncludeOwnNamespace set to true with repeated Names",
+			name: "KubernetesSDConfigs: IncludeOwnNamespace set to true with repeated Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
@@ -786,7 +786,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Valid Names",
+			name: "DNSSDConfigs: Valid Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -797,7 +797,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Missing Names",
+			name: "DNSSDConfigs: Missing Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{},
@@ -806,7 +806,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Empty Names",
+			name: "DNSSDConfigs: Empty Names",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -817,7 +817,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Valid Record Type A",
+			name: "DNSSDConfigs: Valid Record Type A",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -829,7 +829,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Valid Record Type AAAA",
+			name: "DNSSDConfigs: Valid Record Type AAAA",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -841,7 +841,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Valid Record Type MX",
+			name: "DNSSDConfigs: Valid Record Type MX",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -853,7 +853,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Valid Record Type NS",
+			name: "DNSSDConfigs: Valid Record Type NS",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -865,7 +865,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Valid Record Type SRV",
+			name: "DNSSDConfigs: Valid Record Type SRV",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -877,7 +877,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Invalid Record Type",
+			name: "DNSSDConfigs: Invalid Record Type",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -889,7 +889,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Valid Port Number",
+			name: "DNSSDConfigs: Valid Port Number",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -901,7 +901,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Invalid Port Number",
+			name: "DNSSDConfigs: Invalid Port Number",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -913,7 +913,7 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Valid RefreshInterval",
+			name: "DNSSDConfigs: Valid RefreshInterval",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
@@ -925,12 +925,96 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Invalid RefreshInterval",
+			name: "DNSSDConfigs: Invalid RefreshInterval",
 			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
 					{
 						Names:           []string{"test1"},
 						RefreshInterval: ptr.To(monitoringv1.Duration("30g")),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "EC2SDConfigs: Valid AWS Region",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To("us-west"),
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "EC2SDConfigs: Valid Absent AWS Region",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "EC2SDConfigs: Invalid AWS Region",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						Region: ptr.To(""),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "EC2SDConfigs: Valid AWS RoleARN",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						RoleARN: ptr.To("valid-role"),
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "EC2SDConfigs: Valid Absent AWS RoleARN",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "EC2SDConfigs: Invalid AWS RoleARN",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						RoleARN: ptr.To(""),
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "EC2SDConfigs: Valid Port Number",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						Port: ptr.To(int32(8080)),
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "EC2SDConfigs: Invalid Port Number",
+			scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+					{
+						Port: ptr.To(int32(80809)),
 					},
 				},
 			},


### PR DESCRIPTION
## Description

This PR refactors any inconsistencies in the EC2 service discovery. This PR also adds HTTP client configuration (`Auth`, `OAuth2`, `BasicAuth`, `EnableHTTP`, `AllowRedirects`) fields that have been part of EC2 SD since Prometheus `v2.41.0`.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add HTTP client configuration support to EC2 Service Discovery
```
