### PR TITLE
replace go kit log

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	stdlog "log"
+	"log/slog"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -27,7 +28,6 @@ import (
 	"syscall"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
@@ -64,7 +64,7 @@ import (
 // that the operator has enough permissions to manage the resource.
 func checkPrerequisites(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	kclient kubernetes.Interface,
 	allowedNamespaces []string,
 	groupVersion schema.GroupVersion,
@@ -77,7 +77,7 @@ func checkPrerequisites(
 	}
 
 	if !installed {
-		level.Warn(logger).Log("msg", fmt.Sprintf("resource %q (group: %q) not installed in the cluster", resource, groupVersion))
+		logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster", resource, groupVersion))
 		return false, nil
 	}
 
@@ -88,7 +88,7 @@ func checkPrerequisites(
 
 	if !allowed {
 		for _, reason := range errs {
-			level.Warn(logger).Log("msg", fmt.Sprintf("missing permission on resource %q (group: %q)", resource, groupVersion), "reason", reason)
+			logger.Warn(fmt.Sprintf("missing permission on resource %q (group: %q)", resource, groupVersion), "reason", reason)
 		}
 		return false, nil
 	}
@@ -193,32 +193,38 @@ func run(fs *flag.FlagSet) int {
 		return 0
 	}
 
-	logger, err := logging.NewLogger(logConfig)
+	logger, err := logging.NewLoggerSlog(logConfig)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+
+	// We're currently migrating our logging library from go-kit to slog.
+	// The go-kit logger is being removed in small PRs. For now, we are creating 2 loggers to avoid breaking changes and
+	// to have a smooth transition.
+	goKitLogger, err := logging.NewLogger(logConfig)
 	if err != nil {
 		stdlog.Fatal(err)
 	}
 
 	if err := cfg.Gates.UpdateFeatureGates(*featureGates.Map); err != nil {
-		level.Error(logger).Log("error", err)
+		logger.Error("", "error", err)
 		return 1
 	}
 
-	level.Info(logger).Log("msg", "Starting Prometheus Operator", "version", version.Info())
-	level.Info(logger).Log("build_context", version.BuildContext())
-	level.Info(logger).Log("feature_gates", cfg.Gates.String())
+	logger.Info("Starting Prometheus Operator", "version", version.Info(), "build_context", version.BuildContext(), "feature_gates", cfg.Gates.String())
 	goruntime.SetMaxProcs(logger)
 	goruntime.SetMemLimit(logger, memlimitRatio)
 
 	if len(cfg.Namespaces.AllowList) > 0 && len(cfg.Namespaces.DenyList) > 0 {
-		level.Error(logger).Log(
-			"msg", "--namespaces and --deny-namespaces are mutually exclusive, only one should be provided",
+		logger.Error(
+			"--namespaces and --deny-namespaces are mutually exclusive, only one should be provided",
 			"namespaces", cfg.Namespaces.AllowList,
 			"deny_namespaces", cfg.Namespaces.DenyList,
 		)
 		return 1
 	}
 	cfg.Namespaces.Finalize()
-	level.Info(logger).Log("msg", "namespaces filtering configuration ", "config", cfg.Namespaces.String())
+	logger.Info("namespaces filtering configuration ", "config", cfg.Namespaces.String())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)
@@ -233,26 +239,26 @@ func run(fs *flag.FlagSet) int {
 	})
 
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to create Kubernetes client configuration", "err", err)
+		logger.Error("failed to create Kubernetes client configuration", "err", err)
 		cancel()
 		return 1
 	}
 
 	kclient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to create Kubernetes client", "err", err)
+		logger.Error("failed to create Kubernetes client", "err", err)
 		cancel()
 		return 1
 	}
 
 	kubernetesVersion, err := kclient.Discovery().ServerVersion()
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to request Kubernetes server version", "err", err)
+		logger.Error("failed to request Kubernetes server version", "err", err)
 		cancel()
 		return 1
 	}
 	cfg.KubernetesVersion = *kubernetesVersion
-	level.Info(logger).Log("msg", "connection established", "cluster-version", cfg.KubernetesVersion)
+	logger.Info("connection established", "cluster-version", cfg.KubernetesVersion)
 
 	promControllerOptions := make([]prometheuscontroller.ControllerOptions, 0)
 	// Check if we can read the storage classs
@@ -271,7 +277,7 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check StorageClass support", "err", err)
+		logger.Error("failed to check StorageClass support", "err", err)
 		cancel()
 		return 1
 	}
@@ -287,14 +293,14 @@ func run(fs *flag.FlagSet) int {
 			Verbs:    []string{"create", "patch"},
 		})
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check Events support", "err", err)
+		logger.Error("failed to check Events support", "err", err)
 		cancel()
 		return 1
 	}
 
 	if !canEmitEvents {
 		for _, reason := range reasons {
-			level.Warn(logger).Log("msg", "missing permission to emit events", "reason", reason)
+			logger.Warn("missing permission to emit events", "reason", reason)
 		}
 	}
 	eventRecorderFactory := operator.NewEventRecorderFactory(canEmitEvents)
@@ -314,7 +320,7 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check ScrapeConfig support", "err", err)
+		logger.Error("failed to check ScrapeConfig support", "err", err)
 		cancel()
 		return 1
 	}
@@ -343,16 +349,16 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check Prometheus support", "err", err)
+		logger.Error("failed to check Prometheus support", "err", err)
 		cancel()
 		return 1
 	}
 
 	var po *prometheuscontroller.Operator
 	if prometheusSupported {
-		po, err = prometheuscontroller.New(ctx, restConfig, cfg, logger, r, eventRecorderFactory, promControllerOptions...)
+		po, err = prometheuscontroller.New(ctx, restConfig, cfg, goKitLogger, r, eventRecorderFactory, promControllerOptions...)
 		if err != nil {
-			level.Error(logger).Log("msg", "instantiating prometheus controller failed", "err", err)
+			logger.Error("instantiating prometheus controller failed", "err", err)
 			cancel()
 			return 1
 		}
@@ -379,7 +385,7 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check PrometheusAgent support", "err", err)
+		logger.Error("failed to check PrometheusAgent support", "err", err)
 		cancel()
 		return 1
 	}
@@ -397,13 +403,13 @@ func run(fs *flag.FlagSet) int {
 				Verbs:    []string{"get", "list", "watch", "create", "update", "delete"},
 			})
 		if err != nil {
-			level.Error(logger).Log("msg", "failed to check permissions on DaemonSet resource", "err", err)
+			logger.Error("failed to check permissions on DaemonSet resource", "err", err)
 			cancel()
 			return 1
 		}
 		if !allowed {
 			for _, reason := range errs {
-				level.Error(logger).Log("msg", "missing permissions to manage Daemonset resource for Prometheus Agent", "reason", reason)
+				logger.Error("missing permissions to manage Daemonset resource for Prometheus Agent", "reason", reason)
 				cancel()
 				return 1
 			}
@@ -412,9 +418,9 @@ func run(fs *flag.FlagSet) int {
 
 	var pao *prometheusagentcontroller.Operator
 	if prometheusAgentSupported {
-		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, logger, r, scrapeConfigSupported, canReadStorageClass, eventRecorderFactory)
+		pao, err = prometheusagentcontroller.New(ctx, restConfig, cfg, goKitLogger, r, scrapeConfigSupported, canReadStorageClass, eventRecorderFactory)
 		if err != nil {
-			level.Error(logger).Log("msg", "instantiating prometheus-agent controller failed", "err", err)
+			logger.Error("instantiating prometheus-agent controller failed", "err", err)
 			cancel()
 			return 1
 		}
@@ -441,16 +447,16 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check Alertmanager support", "err", err)
+		logger.Error("failed to check Alertmanager support", "err", err)
 		cancel()
 		return 1
 	}
 
 	var ao *alertmanagercontroller.Operator
 	if alertmanagerSupported {
-		ao, err = alertmanagercontroller.New(ctx, restConfig, cfg, logger, r, canReadStorageClass, eventRecorderFactory)
+		ao, err = alertmanagercontroller.New(ctx, restConfig, cfg, goKitLogger, r, canReadStorageClass, eventRecorderFactory)
 		if err != nil {
-			level.Error(logger).Log("msg", "instantiating alertmanager controller failed", "err", err)
+			logger.Error("instantiating alertmanager controller failed", "err", err)
 			cancel()
 			return 1
 		}
@@ -477,16 +483,16 @@ func run(fs *flag.FlagSet) int {
 		},
 	)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to check ThanosRuler support", "err", err)
+		logger.Error("failed to check ThanosRuler support", "err", err)
 		cancel()
 		return 1
 	}
 
 	var to *thanoscontroller.Operator
 	if thanosRulerSupported {
-		to, err = thanoscontroller.New(ctx, restConfig, cfg, logger, r, canReadStorageClass, eventRecorderFactory)
+		to, err = thanoscontroller.New(ctx, restConfig, cfg, goKitLogger, r, canReadStorageClass, eventRecorderFactory)
 		if err != nil {
-			level.Error(logger).Log("msg", "instantiating thanos controller failed", "err", err)
+			logger.Error("instantiating thanos controller failed", "err", err)
 			cancel()
 			return 1
 		}
@@ -495,7 +501,7 @@ func run(fs *flag.FlagSet) int {
 	var kec *kubelet.Controller
 	if kubeletObject != "" {
 		if kec, err = kubelet.New(
-			log.With(logger, "component", "kubelet_endpoints"),
+			log.With(goKitLogger, "component", "kubelet_endpoints"),
 			restConfig,
 			r,
 			kubeletObject,
@@ -504,14 +510,14 @@ func run(fs *flag.FlagSet) int {
 			cfg.Labels,
 			nodeAddressPriority,
 		); err != nil {
-			level.Error(logger).Log("msg", "instantiating kubelet endpoints controller failed", "err", err)
+			logger.Error("instantiating kubelet endpoints controller failed", "err", err)
 			cancel()
 			return 1
 		}
 	}
 
 	if po == nil && pao == nil && ao == nil && to == nil && kec == nil {
-		level.Error(logger).Log("msg", "no controller can be started, check the RBAC permissions of the service account")
+		logger.Error("no controller can be started, check the RBAC permissions of the service account")
 		cancel()
 		return 1
 	}
@@ -519,7 +525,7 @@ func run(fs *flag.FlagSet) int {
 	// Setup the web server.
 	mux := http.NewServeMux()
 
-	admit := admission.New(log.With(logger, "component", "admissionwebhook"))
+	admit := admission.New(log.With(goKitLogger, "component", "admissionwebhook"))
 	admit.Register(mux)
 
 	r.MustRegister(
@@ -544,9 +550,9 @@ func run(fs *flag.FlagSet) int {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	srv, err := server.NewServer(logger, &serverConfig, mux)
+	srv, err := server.NewServer(goKitLogger, &serverConfig, mux)
 	if err != nil {
-		level.Error(logger).Log("msg", "failed to create web server", "err", err)
+		logger.Error("failed to create web server", "err", err)
 		cancel()
 		return 1
 	}
@@ -576,17 +582,17 @@ func run(fs *flag.FlagSet) int {
 
 	select {
 	case <-term:
-		level.Info(logger).Log("msg", "received SIGTERM, exiting gracefully...")
+		logger.Info("received SIGTERM, exiting gracefully...")
 	case <-ctx.Done():
 	}
 
 	if err := srv.Shutdown(ctx); err != nil {
-		level.Warn(logger).Log("msg", "server shutdown error", "err", err)
+		logger.Warn("server shutdown error", "err", err)
 	}
 
 	cancel()
 	if err := wg.Wait(); err != nil {
-		level.Warn(logger).Log("msg", "unhandled error received. Exiting...", "err", err)
+		logger.Warn("unhandled error received. Exiting...", "err", err)
 		return 1
 	}
 

--- a/internal/goruntime/cpu.go
+++ b/internal/goruntime/cpu.go
@@ -16,19 +16,18 @@ package goruntime
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
-func SetMaxProcs(logger log.Logger) {
+func SetMaxProcs(logger *slog.Logger) {
 	l := func(format string, a ...interface{}) {
-		level.Info(logger).Log("msg", fmt.Sprintf(strings.TrimPrefix(format, "maxprocs: "), a...))
+		logger.Info(fmt.Sprintf(strings.TrimPrefix(format, "maxprocs: "), a...))
 	}
 
 	if _, err := maxprocs.Set(maxprocs.Logger(l)); err != nil {
-		level.Warn(logger).Log("msg", "Failed to set GOMAXPROCS automatically", "err", err)
+		logger.Warn("Failed to set GOMAXPROCS automatically", "err", err)
 	}
 }

--- a/internal/goruntime/memory.go
+++ b/internal/goruntime/memory.go
@@ -15,14 +15,14 @@
 package goruntime
 
 import (
+	"fmt"
+	"log/slog"
 	"runtime/debug"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 )
 
-func SetMemLimit(logger log.Logger, memlimitRatio float64) {
+func SetMemLimit(logger *slog.Logger, memlimitRatio float64) {
 	if memlimitRatio >= 1.0 {
 		memlimitRatio = 1.0
 	} else if memlimitRatio <= 0.0 {
@@ -43,8 +43,8 @@ func SetMemLimit(logger log.Logger, memlimitRatio float64) {
 			),
 		),
 	); err != nil {
-		level.Warn(logger).Log("component", "automemlimit", "msg", "Failed to set GOMEMLIMIT automatically", "err", err)
+		logger.Warn("Failed to set GOMEMLIMIT automatically", "component", "automemlimit", "err", err)
 	}
 
-	level.Info(logger).Log("GOMEMLIMIT set to %d", debug.SetMemoryLimit(-1))
+	logger.Info(fmt.Sprintf("GOMEMLIMIT set to %d", debug.SetMemoryLimit(-1)))
 }


### PR DESCRIPTION
## Description

Adapting the places where we are using the `go_kit_log library`, but doing that in baby steps to avoid changing many places simultaneously.

I'm Keeping the oldLogger (go_kit_log) in places where we have more dependencies and adding the new Logger where it's easy to change

This PR follows up on the changes made here https://github.com/prometheus-operator/prometheus-operator/pull/6743

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
replace go-kit-log
```
