### PR TITLE
add listType:=set to Prometheus secrets field

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -23527,6 +23527,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.
@@ -35343,6 +35344,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6598,6 +6598,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8069,6 +8069,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6599,6 +6599,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8070,6 +8070,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               securityContext:
                 description: |-
                   SecurityContext holds pod-level security attributes and common container settings.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5434,7 +5434,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
                   },
                   "securityContext": {
                     "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6641,7 +6641,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
                   },
                   "securityContext": {
                     "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -368,6 +368,7 @@ type CommonPrometheusFields struct {
 	// object, which shall be mounted into the Prometheus Pods.
 	// Each Secret is added to the StatefulSet definition as a volume named `secret-<secret-name>`.
 	// The Secrets are mounted into /etc/prometheus/secrets/<secret-name> in the 'prometheus' container.
+	// +listType:=set
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the Prometheus
 	// object, which shall be mounted into the Prometheus Pods.


### PR DESCRIPTION
This adds the listType:=set kubebuilder marker to the secrets field in the Prometheus CRD. This allows the field to be managed by multiple managers.

## Type of change

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
I have this Prometheus instance:
```
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  creationTimestamp: "2024-07-18T18:10:17Z"
  generation: 4
  name: sample-monitoring-stack
  namespace: operators
  resourceVersion: "47399"
  uid: e1d2eb3d-ca6c-4e9d-8032-854109bb539a
spec:
  evaluationInterval: 30s
  portName: web
  scrapeInterval: 30s
```
And 2 files:
_add\_secret.yaml_
```
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  name: sample-monitoring-stack
  namespace: operators
spec:
  secrets:
  - prometheus-sample-monitoring-stack
```
_add\_secret2.yaml_
```
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  name: sample-monitoring-stack
  namespace: operators
spec:
  secrets:
  - cert-prometheus-svc
```
I'd like to be able to add both secrets at once, each with a different manager.
**Without the PR**
```
$ kubectl apply -f add_secret.yaml --server-side --field-manager="manager1"
$ kubectl apply -f add_secret2.yaml --server-side --field-manager="manager2"
error: Apply failed with 1 conflict: conflict with "manager1": .spec.secrets
Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:
* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.
* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.
* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).
See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts

# If I use --force-conflicts, the secret from the first apply is overwritten
$ kubectl apply -f add_secret2.yaml --server-side --field-manager="manager2" --force-conflicts

$ kubectl get prometheuses sample-monitoring-stack -oyaml --show-managed-fields
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  creationTimestamp: "2024-07-18T18:22:34Z"
  generation: 4
  managedFields:
  - apiVersion: monitoring.coreos.com/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        f:availableReplicas: {}
        f:conditions:
          k:{"type":"Available"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Reconciled"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
        f:paused: {}
        f:replicas: {}
        f:selector: {}
        f:shardStatuses:
          k:{"shardID":"0"}:
            .: {}
            f:availableReplicas: {}
            f:replicas: {}
            f:shardID: {}
            f:unavailableReplicas: {}
            f:updatedReplicas: {}
        f:shards: {}
        f:unavailableReplicas: {}
        f:updatedReplicas: {}
    manager: PrometheusOperator
    operation: Apply
    subresource: status
    time: "2024-07-18T18:23:25Z"
  - apiVersion: monitoring.coreos.com/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        f:secrets: {}
    manager: manager2
    operation: Apply
    time: "2024-07-18T18:23:25Z"
  name: sample-monitoring-stack
  namespace: operators
  resourceVersion: "48267"
  uid: 3e410e86-c9f9-463a-96db-29857ddbad63
spec:
  evaluationInterval: 30s
  portName: web
  scrapeInterval: 30s
  secrets:
  - cert-prometheus-svc
```

**With the PR**
```
$ kubectl apply -f add_secret.yaml --server-side --field-manager="manager1"
$ kubectl apply -f add_secret2.yaml --server-side --field-manager="manager2"

$ kubectl get prometheuses sample-monitoring-stack -oyaml --show-managed-fields
apiVersion: monitoring.coreos.com/v1
kind: Prometheus
metadata:
  creationTimestamp: "2024-07-18T18:10:17Z"
  generation: 4
  managedFields:
  - apiVersion: monitoring.coreos.com/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        f:secrets:
          v:"prometheus-sample-monitoring-stack": {}
    manager: manager1
    operation: Apply
    time: "2024-07-18T18:12:52Z"
  - apiVersion: monitoring.coreos.com/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        f:secrets:
          v:"cert-prometheus-svc": {}
    manager: manager2
    operation: Apply
    time: "2024-07-18T18:13:01Z"
  - apiVersion: monitoring.coreos.com/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        f:availableReplicas: {}
        f:conditions:
          k:{"type":"Available"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Reconciled"}:
            .: {}
            f:lastTransitionTime: {}
            f:message: {}
            f:observedGeneration: {}
            f:reason: {}
            f:status: {}
            f:type: {}
        f:paused: {}
        f:replicas: {}
        f:selector: {}
        f:shardStatuses:
          k:{"shardID":"0"}:
            .: {}
            f:availableReplicas: {}
            f:replicas: {}
            f:shardID: {}
            f:unavailableReplicas: {}
            f:updatedReplicas: {}
        f:shards: {}
        f:unavailableReplicas: {}
        f:updatedReplicas: {}
    manager: PrometheusOperator
    operation: Apply
    subresource: status
    time: "2024-07-18T18:13:34Z"
  name: sample-monitoring-stack
  namespace: operators
  resourceVersion: "47399"
  uid: e1d2eb3d-ca6c-4e9d-8032-854109bb539a
spec:
  evaluationInterval: 30s
  portName: web
  scrapeInterval: 30s
  secrets:
  - prometheus-sample-monitoring-stack
  - cert-prometheus-svc
```

## Changelog entry
```release-note
Add listType:=set to Prometheus secrets field. This allows for having a different manager for each secret.
```
