### PR TITLE
fix: avoid invalid alerting config with TLS

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1318,6 +1318,10 @@ func addAlertmanagerEndpointsToStore(ctx context.Context, store *assets.StoreBui
 		if err := store.AddSigV4(ctx, namespace, am.Sigv4); err != nil {
 			return fmt.Errorf("alertmanager %d: %w", i, err)
 		}
+
+		if err := store.AddTLSConfig(ctx, namespace, am.TLSConfig); err != nil {
+			return fmt.Errorf("alertmanager %d: %w", i, err)
+		}
 	}
 
 	return nil

--- a/pkg/prometheus/store.go
+++ b/pkg/prometheus/store.go
@@ -99,6 +99,10 @@ func AddAPIServerConfigToStore(ctx context.Context, store *assets.StoreBuilder, 
 		return fmt.Errorf("apiserver config: %w", err)
 	}
 
+	if err := store.AddTLSConfig(ctx, namespace, config.TLSConfig); err != nil {
+		return fmt.Errorf("apiserver config: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/prometheus/testdata/AlertmanagerConfigEmpty.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigEmpty.golden
@@ -1,0 +1,7 @@
+global:
+  evaluation_interval: ""
+  scrape_interval: ""
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []

--- a/pkg/prometheus/testdata/AlertmanagerConfigOtherNamespace.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigOtherNamespace.golden
@@ -1,0 +1,24 @@
+global:
+  evaluation_interval: ""
+  scrape_interval: ""
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - other
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: foo

--- a/pkg/prometheus/testdata/AlertmanagerConfigTLSconfig.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigTLSconfig.golden
@@ -1,0 +1,28 @@
+global:
+  evaluation_interval: ""
+  scrape_interval: ""
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    tls_config:
+      ca_file: /etc/prometheus/certs/0_default_tls_ca
+      cert_file: /etc/prometheus/certs/0_default_tls_cert
+      key_file: /etc/prometheus/certs/0_default_tls_private-key
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - default
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: foo

--- a/pkg/prometheus/testdata/AlertmanagerConfigTLSconfigOtherNamespace.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigTLSconfigOtherNamespace.golden
@@ -1,0 +1,28 @@
+global:
+  evaluation_interval: ""
+  scrape_interval: ""
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs: []
+alerting:
+  alert_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica
+  alertmanagers:
+  - path_prefix: /
+    scheme: http
+    tls_config:
+      ca_file: /etc/prometheus/certs/0_default_tls_ca
+      cert_file: /etc/prometheus/certs/0_default_tls_cert
+      key_file: /etc/prometheus/certs/0_default_tls_private-key
+    kubernetes_sd_configs:
+    - role: endpoints
+      namespaces:
+        names:
+        - other
+    relabel_configs:
+    - action: keep
+      source_labels:
+      - __meta_kubernetes_service_name
+      regex: foo

--- a/pkg/prometheus/testdata/K8SSDConfigGenerationTLSConfig.golden
+++ b/pkg/prometheus/testdata/K8SSDConfigGenerationTLSConfig.golden
@@ -1,0 +1,10 @@
+kubernetes_sd_configs:
+- role: endpoints
+  namespaces:
+    names:
+    - test
+  api_server: example.com
+  tls_config:
+    ca_file: /etc/prometheus/certs/0_default_tls_ca
+    cert_file: /etc/prometheus/certs/0_default_tls_cert
+    key_file: /etc/prometheus/certs/0_default_tls_private-key


### PR DESCRIPTION
## Description

Fixes #6670

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
