### PR TITLE
replace go kit log admission pkg

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -23,7 +23,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/collectors/version"
@@ -81,7 +80,7 @@ func main() {
 	wg, ctx := errgroup.WithContext(ctx)
 
 	mux := http.NewServeMux()
-	admit := admission.New(log.With(goKitLogger, "component", "admissionwebhook"))
+	admit := admission.New(logger.With("component", "admissionwebhook"))
 	admit.Register(mux)
 
 	r := prometheus.NewRegistry()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -524,8 +524,7 @@ func run(fs *flag.FlagSet) int {
 
 	// Setup the web server.
 	mux := http.NewServeMux()
-
-	admit := admission.New(log.With(goKitLogger, "component", "admissionwebhook"))
+	admit := admission.New(logger.With("component", "admissionwebhook"))
 	admit.Register(mux)
 
 	r.MustRegister(

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -18,11 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,11 +74,11 @@ var (
 // 1. PrometheusRules (validation, mutation) - ensuring created resources can be loaded by Promethues
 // 2. monitoringv1alpha1.AlertmanagerConfig (validation) - ensuring.
 type Admission struct {
-	logger log.Logger
+	logger *slog.Logger
 	wh     http.Handler
 }
 
-func New(logger log.Logger) *Admission {
+func New(logger *slog.Logger) *Admission {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(monitoringv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1beta1.AddToScheme(scheme))
@@ -143,25 +142,25 @@ func (a *Admission) serveAdmission(w http.ResponseWriter, r *http.Request, admit
 	}
 
 	if len(body) == 0 {
-		level.Warn(a.logger).Log("msg", "request has no body")
+		a.logger.Warn("request has no body")
 		http.Error(w, "request has no body", http.StatusBadRequest)
 		return
 	}
 
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		level.Warn(a.logger).Log("msg", fmt.Sprintf("invalid Content-Type %s, want `application/json`", contentType))
+		a.logger.Warn(fmt.Sprintf("invalid Content-Type %s, want `application/json`", contentType))
 		http.Error(w, "invalid Content-Type, want `application/json`", http.StatusUnsupportedMediaType)
 		return
 	}
 
-	level.Debug(a.logger).Log("msg", "Received request", "content", string(body))
+	a.logger.Debug("Received request", "content", string(body))
 
 	requestedAdmissionReview := v1.AdmissionReview{}
 	responseAdmissionReview := v1.AdmissionReview{}
 
 	if _, _, err := deserializer.Decode(body, nil, &requestedAdmissionReview); err != nil {
-		level.Warn(a.logger).Log("msg", "Unable to deserialize request", "err", err)
+		a.logger.Warn("Unable to deserialize request", "err", err)
 		responseAdmissionReview.Response = toAdmissionResponseFailure("Unable to deserialize request", "", []error{err})
 	} else {
 		responseAdmissionReview.Response = admit(requestedAdmissionReview)
@@ -173,36 +172,36 @@ func (a *Admission) serveAdmission(w http.ResponseWriter, r *http.Request, admit
 
 	respBytes, err := json.Marshal(responseAdmissionReview)
 
-	level.Debug(a.logger).Log("msg", "sending response", "content", string(respBytes))
+	a.logger.Debug("sending response", "content", string(respBytes))
 
 	if err != nil {
-		level.Error(a.logger).Log("msg", "Cannot serialize response", "err", err)
+		a.logger.Error("Cannot serialize response", "err", err)
 		http.Error(w, fmt.Sprintf("could not serialize response: %v", err), http.StatusInternalServerError)
 	}
 	if _, err := w.Write(respBytes); err != nil {
-		level.Error(a.logger).Log("msg", "Cannot write response", "err", err)
+		a.logger.Error("Cannot write response", "err", err)
 		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
 	}
 }
 
 func (a *Admission) mutatePrometheusRules(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	level.Debug(a.logger).Log("msg", "Mutating prometheusrules")
+	a.logger.Debug("Mutating prometheusrules")
 
 	if ar.Request.Resource != prometheusRuleGVR {
 		err := fmt.Errorf("expected resource to be %v, but received %v", prometheusRuleResource, ar.Request.Resource)
-		level.Warn(a.logger).Log("err", err)
+		a.logger.Warn("", "err", err)
 		return toAdmissionResponseFailure("Unexpected resource kind", prometheusRuleResource, []error{err})
 	}
 
 	rule := &PrometheusRules{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, rule); err != nil {
-		level.Info(a.logger).Log("msg", errUnmarshalAdmission, "err", err)
+		a.logger.Info(errUnmarshalAdmission, "err", err)
 		return toAdmissionResponseFailure(errUnmarshalAdmission, prometheusRuleResource, []error{err})
 	}
 
 	patches, err := generatePatchesForNonStringLabelsAnnotations(rule.Spec.Raw)
 	if err != nil {
-		level.Info(a.logger).Log("msg", errUnmarshalRules, "err", err)
+		a.logger.Info(errUnmarshalRules, "err", err)
 		return toAdmissionResponseFailure(errUnmarshalRules, prometheusRuleResource, []error{err})
 	}
 
@@ -220,26 +219,26 @@ func (a *Admission) mutatePrometheusRules(ar v1.AdmissionReview) *v1.AdmissionRe
 }
 
 func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	level.Debug(a.logger).Log("msg", "Validating prometheusrules")
+	a.logger.Debug("Validating prometheusrules")
 
 	if ar.Request.Resource != prometheusRuleGVR {
 		err := fmt.Errorf("expected resource to be %v, but received %v", prometheusRuleResource, ar.Request.Resource)
-		level.Warn(a.logger).Log("err", err)
+		a.logger.Warn("", "err", err)
 		return toAdmissionResponseFailure("Unexpected resource kind", prometheusRuleResource, []error{err})
 	}
 
 	promRule := &monitoringv1.PrometheusRule{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, promRule); err != nil {
-		level.Info(a.logger).Log("msg", errUnmarshalRules, "err", err)
+		a.logger.Info(errUnmarshalRules, "err", err)
 		return toAdmissionResponseFailure(errUnmarshalRules, prometheusRuleResource, []error{err})
 	}
 
 	errors := promoperator.ValidateRule(promRule.Spec)
 	if len(errors) != 0 {
 		const m = "Invalid rule"
-		level.Debug(a.logger).Log("msg", m, "content", promRule.Spec)
+		a.logger.Debug(m, "content", promRule.Spec)
 		for _, err := range errors {
-			level.Info(a.logger).Log("msg", m, "err", err)
+			a.logger.Info(m, "err", err)
 		}
 
 		return toAdmissionResponseFailure("Rules are not valid", prometheusRuleResource, errors)
@@ -249,12 +248,12 @@ func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.Admission
 }
 
 func (a *Admission) validateAlertmanagerConfig(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	level.Debug(a.logger).Log("msg", "Validating alertmanagerconfigs")
+	a.logger.Debug("Validating alertmanagerconfigs")
 
 	gr := metav1.GroupResource{Group: ar.Request.Resource.Group, Resource: ar.Request.Resource.Resource}
 	if gr != alertManagerConfigGR {
 		err := fmt.Errorf("expected resource to be %v, but received %v", alertManagerConfigResource, ar.Request.Resource)
-		level.Warn(a.logger).Log("err", err)
+		a.logger.Warn("", "err", err)
 		return toAdmissionResponseFailure("Unexpected resource kind", alertManagerConfigResource, []error{err})
 	}
 
@@ -270,7 +269,7 @@ func (a *Admission) validateAlertmanagerConfig(ar v1.AdmissionReview) *v1.Admiss
 	}
 
 	if err := json.Unmarshal(ar.Request.Object.Raw, amConf); err != nil {
-		level.Info(a.logger).Log("msg", errUnmarshalConfig, "err", err)
+		a.logger.Info(errUnmarshalConfig, "err", err)
 		return toAdmissionResponseFailure(errUnmarshalConfig, alertManagerConfigResource, []error{err})
 	}
 
@@ -286,8 +285,8 @@ func (a *Admission) validateAlertmanagerConfig(ar v1.AdmissionReview) *v1.Admiss
 
 	if err != nil {
 		msg := "invalid config"
-		level.Debug(a.logger).Log("msg", msg, "content", string(ar.Request.Object.Raw))
-		level.Info(a.logger).Log("msg", msg, "err", err)
+		a.logger.Debug(msg, "content", string(ar.Request.Object.Raw))
+		a.logger.Info(msg, "err", err)
 		return toAdmissionResponseFailure("AlertmanagerConfig is invalid", alertManagerConfigResource, []error{err})
 	}
 	return &v1.AdmissionResponse{Allowed: true}

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -314,7 +315,8 @@ func TestAlertmanagerConfigConversion(t *testing.T) {
 func api() *Admission {
 	a := New(
 		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
+			// slog level math.MaxInt means no logging
+			Level: slog.Level(math.MaxInt),
 		})),
 	)
 

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,8 +27,6 @@ import (
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 	v1 "k8s.io/api/admission/v1"
@@ -313,7 +312,11 @@ func TestAlertmanagerConfigConversion(t *testing.T) {
 }
 
 func api() *Admission {
-	a := New(level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)), level.AllowNone()))
+	a := New(
+		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	)
 
 	return a
 }


### PR DESCRIPTION
## Description

Adapting the places where we are using the `go_kit_log library` into the admission package

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
replace kit log with slog in package admission
```
