### PR TITLE
disable logs for unknow and none levels

### DIFF
--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -17,6 +17,7 @@ package log
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -99,8 +100,9 @@ func parseLevel(lvl string) (slog.Level, error) {
 	case LevelError:
 		return slog.LevelError, nil
 	case LevelNone:
-		return -1, nil
+		// Level with math.MaxInt is used to disable logging.
+		return math.MaxInt, nil
 	default:
-		return -1, fmt.Errorf("log log_level %s unknown, %v are possible values", lvl, AvailableLogLevels)
+		return math.MaxInt, fmt.Errorf("log log_level %s unknown, %v are possible values", lvl, AvailableLogLevels)
 	}
 }

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"os"
 	"testing"
 
@@ -131,7 +132,7 @@ func TestParseLevel(t *testing.T) {
 			args: args{
 				lvl: LevelNone,
 			},
-			want:    -1,
+			want:    math.MaxInt,
 			wantErr: false,
 		},
 		{
@@ -139,7 +140,7 @@ func TestParseLevel(t *testing.T) {
 			args: args{
 				lvl: "unknown",
 			},
-			want:    -1,
+			want:    math.MaxInt,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
## Description

Using the right level integer to disable logs

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
disable logs for unknow and none levels
```
