### PR TITLE
Allow Prometheus Agent to update, delete, and handle changes to DaemonSet object

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -456,7 +456,9 @@ func (c *Operator) RefreshStatusFor(o metav1.Object) {
 }
 
 // Resolve implements the operator.Syncer interface.
-func (c *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
+func (c *Operator) Resolve(obj interface{}) metav1.Object {
+	ss := obj.(*appsv1.StatefulSet)
+
 	key, ok := c.accessor.MetaNamespaceKey(ss)
 	if !ok {
 		return nil

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -294,6 +294,24 @@ func UpdateStatefulSet(ctx context.Context, sstClient clientappsv1.StatefulSetIn
 	})
 }
 
+// UpdateDaemonSet merges metadata of existing DaemonSet with new one and updates it.
+func UpdateDaemonSet(ctx context.Context, dmsClient clientappsv1.DaemonSetInterface, dset *appsv1.DaemonSet) error {
+	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existingDset, err := dmsClient.Get(ctx, dset.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		mergeMetadata(&dset.ObjectMeta, existingDset.ObjectMeta)
+		// Propagate annotations set by kubectl on spec.template.annotations. e.g performing a rolling restart.
+		mergeKubectlAnnotations(&existingDset.Spec.Template.ObjectMeta, dset.Spec.Template.ObjectMeta)
+
+		_, err = dmsClient.Update(ctx, dset, metav1.UpdateOptions{})
+		return err
+	})
+}
+
 // CreateOrUpdateSecret merges metadata of existing Secret with new one and updates it.
 func CreateOrUpdateSecret(ctx context.Context, secretClient clientv1.SecretInterface, desired *v1.Secret) error {
 	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -135,7 +135,8 @@ func NewResourceReconciler(
 
 	qname := strings.ToLower(kind)
 
-	for _, t := range []string{"StatefulSet", "DaemonSet", kind} {
+	// TODO: Support reconciling metrics for DaemonSet resource
+	for _, t := range []string{"StatefulSet", kind} {
 		for _, e := range []HandlerEvent{AddEvent, DeleteEvent, UpdateEvent} {
 			metrics.TriggerByCounter(t, e)
 		}
@@ -357,7 +358,6 @@ func (rr *ResourceReconciler) onDaemonSetAdd(ds *appsv1.DaemonSet) {
 	}
 
 	rr.logger.Debug("DaemonSet added")
-	rr.metrics.TriggerByCounter("DaemonSet", AddEvent).Inc()
 
 	rr.EnqueueForReconciliation(obj)
 }
@@ -409,7 +409,6 @@ func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 	}
 
 	rr.logger.Debug("DaemonSet updated")
-	rr.metrics.TriggerByCounter("DaemonSet", UpdateEvent).Inc()
 	if !rr.hasStateChanged(old, cur) {
 		// If the daemonset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead
@@ -441,7 +440,6 @@ func (rr *ResourceReconciler) onDaemonSetDelete(ds *appsv1.DaemonSet) {
 	}
 
 	rr.logger.Debug("DaemonSet delete")
-	rr.metrics.TriggerByCounter("DaemonSet", DeleteEvent).Inc()
 
 	rr.EnqueueForReconciliation(obj)
 }

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -410,7 +410,6 @@ func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 
 	rr.logger.Debug("DaemonSet updated")
 	rr.metrics.TriggerByCounter("DaemonSet", UpdateEvent).Inc()
-	// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
 	if !rr.hasStateChanged(old, cur) {
 		// If the daemonset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -265,12 +265,12 @@ func (rr *ResourceReconciler) OnAdd(obj interface{}, _ bool) {
 
 // OnUpdate implements the cache.ResourceEventHandler interface.
 func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
-	switch cur.(type) {
+	switch v := cur.(type) {
 	case *appsv1.DaemonSet:
-		rr.onDaemonSetUpdate(old.(*appsv1.DaemonSet), cur.(*appsv1.DaemonSet))
+		rr.onDaemonSetUpdate(old.(*appsv1.DaemonSet), v)
 		return
 	case *appsv1.StatefulSet:
-		rr.onStatefulSetUpdate(old.(*appsv1.StatefulSet), cur.(*appsv1.StatefulSet))
+		rr.onStatefulSetUpdate(old.(*appsv1.StatefulSet), v)
 		return
 	}
 
@@ -411,13 +411,14 @@ func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 	rr.logger.Debug("DaemonSet updated")
 	rr.metrics.TriggerByCounter("DaemonSet", UpdateEvent).Inc()
 	// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
-	/*if !rr.hasStateChanged(old, cur) {
+	if !rr.hasStateChanged(old, cur) {
 		// If the daemonset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead
 		// of doing a full reconciliation.
-		rr.EnqueueForStatus(obj)
+		// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
+		// rr.EnqueueForStatus(obj)
 		return
-	}*/
+	}
 
 	rr.EnqueueForReconciliation(obj)
 }

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -381,14 +381,13 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 	rr.logger.Debug("StatefulSet updated")
 	rr.metrics.TriggerByCounter("StatefulSet", UpdateEvent).Inc()
 
-	// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
-	/*if !rr.hasStateChanged(old, cur) {
+	if !rr.hasStateChanged(old, cur) {
 		// If the statefulset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead
 		// of doing a full reconciliation.
 		rr.EnqueueForStatus(obj)
 		return
-	}*/
+	}
 
 	rr.EnqueueForReconciliation(obj)
 }
@@ -411,14 +410,14 @@ func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 
 	rr.logger.Debug("DaemonSet updated")
 	rr.metrics.TriggerByCounter("DaemonSet", UpdateEvent).Inc()
-
-	if !rr.hasStateChanged(old, cur) {
+	// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
+	/*if !rr.hasStateChanged(old, cur) {
 		// If the daemonset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead
 		// of doing a full reconciliation.
 		rr.EnqueueForStatus(obj)
 		return
-	}
+	}*/
 
 	rr.EnqueueForReconciliation(obj)
 }

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -34,14 +34,14 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// Syncer knows how to synchronize statefulset-based resources.
+// Syncer knows how to synchronize statefulset-based or daemonset-based resources.
 type Syncer interface {
 	// Sync the state of the object identified by its key.
 	Sync(context.Context, string) error
 	// UpdateStatus updates the status of the object identified by its key.
 	UpdateStatus(context.Context, string) error
-	// Resolve returns the resource associated to the statefulset.
-	Resolve(*appsv1.StatefulSet) metav1.Object
+	// Resolve returns the resource owning the workload object (either StatefulSet or DaemonSet).
+	Resolve(obj interface{}) metav1.Object
 }
 
 // ReconcilerMetrics tracks reconciler metrics.
@@ -135,7 +135,7 @@ func NewResourceReconciler(
 
 	qname := strings.ToLower(kind)
 
-	for _, t := range []string{"StatefulSet", kind} {
+	for _, t := range []string{"StatefulSet", "DaemonSet", kind} {
 		for _, e := range []HandlerEvent{AddEvent, DeleteEvent, UpdateEvent} {
 			metrics.TriggerByCounter(t, e)
 		}
@@ -234,8 +234,12 @@ func (rr *ResourceReconciler) objectKey(obj interface{}) (string, bool) {
 // OnAdd implements the cache.ResourceEventHandler interface.
 func (rr *ResourceReconciler) OnAdd(obj interface{}, _ bool) {
 
-	if _, ok := obj.(*appsv1.StatefulSet); ok {
-		rr.onStatefulSetAdd(obj.(*appsv1.StatefulSet))
+	switch v := obj.(type) {
+	case *appsv1.DaemonSet:
+		rr.onDaemonSetAdd(v)
+		return
+	case *appsv1.StatefulSet:
+		rr.onStatefulSetAdd(v)
 		return
 	}
 
@@ -261,7 +265,11 @@ func (rr *ResourceReconciler) OnAdd(obj interface{}, _ bool) {
 
 // OnUpdate implements the cache.ResourceEventHandler interface.
 func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
-	if _, ok := cur.(*appsv1.StatefulSet); ok {
+	switch cur.(type) {
+	case *appsv1.DaemonSet:
+		rr.onDaemonSetUpdate(old.(*appsv1.DaemonSet), cur.(*appsv1.DaemonSet))
+		return
+	case *appsv1.StatefulSet:
 		rr.onStatefulSetUpdate(old.(*appsv1.StatefulSet), cur.(*appsv1.StatefulSet))
 		return
 	}
@@ -301,8 +309,12 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 
 // OnDelete implements the cache.ResourceEventHandler interface.
 func (rr *ResourceReconciler) OnDelete(obj interface{}) {
-	if _, ok := obj.(*appsv1.StatefulSet); ok {
-		rr.onStatefulSetDelete(obj.(*appsv1.StatefulSet))
+	switch v := obj.(type) {
+	case *appsv1.DaemonSet:
+		rr.onDaemonSetDelete(v)
+		return
+	case *appsv1.StatefulSet:
+		rr.onStatefulSetDelete(v)
 		return
 	}
 
@@ -338,6 +350,18 @@ func (rr *ResourceReconciler) onStatefulSetAdd(ss *appsv1.StatefulSet) {
 	rr.EnqueueForReconciliation(obj)
 }
 
+func (rr *ResourceReconciler) onDaemonSetAdd(ds *appsv1.DaemonSet) {
+	obj := rr.syncer.Resolve(ds)
+	if obj == nil {
+		return
+	}
+
+	rr.logger.Debug("DaemonSet added")
+	rr.metrics.TriggerByCounter("DaemonSet", AddEvent).Inc()
+
+	rr.EnqueueForReconciliation(obj)
+}
+
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
 	rr.logger.Debug("update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
@@ -357,8 +381,39 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 	rr.logger.Debug("StatefulSet updated")
 	rr.metrics.TriggerByCounter("StatefulSet", UpdateEvent).Inc()
 
-	if !rr.hasStateChanged(old, cur) {
+	// TODO: Uncomment this when Prometheus Agent DaemonSet's status has been supported.
+	/*if !rr.hasStateChanged(old, cur) {
 		// If the statefulset state (spec, labels or annotations) hasn't
+		// changed, the operator can only update the status subresource instead
+		// of doing a full reconciliation.
+		rr.EnqueueForStatus(obj)
+		return
+	}*/
+
+	rr.EnqueueForReconciliation(obj)
+}
+
+func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
+	rr.logger.Debug("update handler", "resource", "daemonset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+
+	if rr.DeletionInProgress(cur) {
+		return
+	}
+
+	if !rr.hasObjectChanged(old, cur) {
+		return
+	}
+
+	obj := rr.syncer.Resolve(cur)
+	if obj == nil {
+		return
+	}
+
+	rr.logger.Debug("DaemonSet updated")
+	rr.metrics.TriggerByCounter("DaemonSet", UpdateEvent).Inc()
+
+	if !rr.hasStateChanged(old, cur) {
+		// If the daemonset state (spec, labels or annotations) hasn't
 		// changed, the operator can only update the status subresource instead
 		// of doing a full reconciliation.
 		rr.EnqueueForStatus(obj)
@@ -376,6 +431,18 @@ func (rr *ResourceReconciler) onStatefulSetDelete(ss *appsv1.StatefulSet) {
 
 	rr.logger.Debug("StatefulSet delete")
 	rr.metrics.TriggerByCounter("StatefulSet", DeleteEvent).Inc()
+
+	rr.EnqueueForReconciliation(obj)
+}
+
+func (rr *ResourceReconciler) onDaemonSetDelete(ds *appsv1.DaemonSet) {
+	obj := rr.syncer.Resolve(ds)
+	if obj == nil {
+		return
+	}
+
+	rr.logger.Debug("DaemonSet delete")
+	rr.metrics.TriggerByCounter("DaemonSet", DeleteEvent).Inc()
 
 	rr.EnqueueForReconciliation(obj)
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -557,9 +557,7 @@ func (c *Operator) Resolve(obj interface{}) metav1.Object {
 
 	switch obj.(type) {
 	case *appsv1.DaemonSet:
-		if c.daemonSetFeatureGateEnabled {
-			match, promKey = daemonSetKeyToPrometheusAgentKey(key)
-		}
+		match, promKey = daemonSetKeyToPrometheusAgentKey(key)
 	case *appsv1.StatefulSet:
 		match, promKey = statefulSetKeyToPrometheusAgentKey(key)
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -580,6 +580,8 @@ func (c *Operator) Resolve(obj interface{}) metav1.Object {
 	return p.(*monitoringv1alpha1.PrometheusAgent)
 }
 
+// statefulSetKeyToPrometheusAgentKey checks if StatefulSet key can be converted to Prometheus Agent key
+// and do the conversion if it's true. The case of Prometheus Agent key in sharding is also handled.
 func statefulSetKeyToPrometheusAgentKey(key string) (bool, string) {
 	r := prometheusAgentKey
 	if prometheusAgentKeyInShardStatefulSet.MatchString(key) {
@@ -596,6 +598,8 @@ func statefulSetKeyToPrometheusAgentKey(key string) (bool, string) {
 	return true, matches[0][1] + "/" + matches[0][2]
 }
 
+// daemonSetKeyToPrometheusAgentKey checks if DaemonSet key can be converted to Prometheus Agent key
+// and do the conversion if it's true.
 func daemonSetKeyToPrometheusAgentKey(key string) (bool, string) {
 	r := prometheusAgentKey
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -555,9 +555,12 @@ func (c *Operator) Resolve(obj interface{}) metav1.Object {
 	var match bool
 	var promKey string
 
-	if c.daemonSetFeatureGateEnabled {
-		match, promKey = daemonSetKeyToPrometheusAgentKey(key)
-	} else {
+	switch obj.(type) {
+	case *appsv1.DaemonSet:
+		if c.daemonSetFeatureGateEnabled {
+			match, promKey = daemonSetKeyToPrometheusAgentKey(key)
+		}
+	case *appsv1.StatefulSet:
 		match, promKey = statefulSetKeyToPrometheusAgentKey(key)
 	}
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -55,7 +55,7 @@ const (
 )
 
 var prometheusAgentKeyInShardStatefulSet = regexp.MustCompile("^(.+)/prom-agent-(.+)-shard-[1-9][0-9]*$")
-var prometheusAgentKeyInStatefulSet = regexp.MustCompile("^(.+)/prom-agent-(.+)$")
+var prometheusAgentKey = regexp.MustCompile("^(.+)/prom-agent-(.+)$")
 
 // Operator manages life cycle of Prometheus agent deployments and
 // monitoring configurations.
@@ -481,8 +481,9 @@ func (c *Operator) addHandlers() {
 
 	c.ssetInfs.AddEventHandler(c.rr)
 
-	// TODO: implement proper event handler for Daemonset.
-	// c.dsetInfs.AddEventHandler(c.rr)
+	if c.dsetInfs != nil {
+		c.dsetInfs.AddEventHandler(c.rr)
+	}
 
 	c.smonInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
@@ -545,13 +546,21 @@ func (c *Operator) addHandlers() {
 }
 
 // Resolve implements the operator.Syncer interface.
-func (c *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
-	key, ok := c.accessor.MetaNamespaceKey(ss)
+func (c *Operator) Resolve(obj interface{}) metav1.Object {
+	key, ok := c.accessor.MetaNamespaceKey(obj)
 	if !ok {
 		return nil
 	}
 
-	match, promKey := statefulSetKeyToPrometheusAgentKey(key)
+	var match bool
+	var promKey string
+
+	if c.daemonSetFeatureGateEnabled {
+		match, promKey = daemonSetKeyToPrometheusAgentKey(key)
+	} else {
+		match, promKey = statefulSetKeyToPrometheusAgentKey(key)
+	}
+
 	if !match {
 		c.logger.Debug("StatefulSet key did not match a Prometheus Agent key format", "key", key)
 		return nil
@@ -571,10 +580,23 @@ func (c *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
 }
 
 func statefulSetKeyToPrometheusAgentKey(key string) (bool, string) {
-	r := prometheusAgentKeyInStatefulSet
+	r := prometheusAgentKey
 	if prometheusAgentKeyInShardStatefulSet.MatchString(key) {
 		r = prometheusAgentKeyInShardStatefulSet
 	}
+
+	matches := r.FindAllStringSubmatch(key, 2)
+	if len(matches) != 1 {
+		return false, ""
+	}
+	if len(matches[0]) != 3 {
+		return false, ""
+	}
+	return true, matches[0][1] + "/" + matches[0][2]
+}
+
+func daemonSetKeyToPrometheusAgentKey(key string) (bool, string) {
+	r := prometheusAgentKey
 
 	matches := r.FindAllStringSubmatch(key, 2)
 	if len(matches) != 1 {
@@ -621,6 +643,11 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 	}
 
 	logger := c.logger.With("key", key)
+
+	// Check if the Agent instance is marked for deletion.
+	if c.rr.DeletionInProgress(p) {
+		return nil
+	}
 
 	if p.Spec.Paused {
 		logger.Info("the resource is paused, not reconciling")
@@ -676,6 +703,29 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 
 		logger.Info("daemonset successfully created")
 		return nil
+	}
+
+	err = k8sutil.UpdateDaemonSet(ctx, dsetClient, dset)
+	sErr, ok := err.(*apierrors.StatusError)
+
+	if ok && sErr.ErrStatus.Code == 422 && sErr.ErrStatus.Reason == metav1.StatusReasonInvalid {
+		// Gather only reason for failed update
+		failMsg := make([]string, len(sErr.ErrStatus.Details.Causes))
+		for i, cause := range sErr.ErrStatus.Details.Causes {
+			failMsg[i] = cause.Message
+		}
+
+		logger.Info("recreating DaemonSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
+
+		propagationPolicy := metav1.DeletePropagationForeground
+		if err := dsetClient.Delete(ctx, dset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+			return fmt.Errorf("failed to delete DaemonSet to avoid forbidden action: %w", err)
+		}
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("updating DaemonSet failed: %w", err)
 	}
 
 	return nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -661,7 +661,9 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 }
 
 // Resolve implements the operator.Syncer interface.
-func (c *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
+func (c *Operator) Resolve(obj interface{}) metav1.Object {
+	ss := obj.(*appsv1.StatefulSet)
+
 	key, ok := c.accessor.MetaNamespaceKey(ss)
 	if !ok {
 		return nil

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -375,7 +375,9 @@ func (o *Operator) RefreshStatusFor(obj metav1.Object) {
 }
 
 // Resolve implements the operator.Syncer interface.
-func (o *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
+func (o *Operator) Resolve(obj interface{}) metav1.Object {
+	ss := obj.(*appsv1.StatefulSet)
+
 	key, ok := o.accessor.MetaNamespaceKey(ss)
 	if !ok {
 		return nil

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -408,8 +408,9 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet":   testCreatePrometheusAgentDaemonSet,
-		"PromAgentDaemonSetResourceUpdate": testPromAgentDaemonSetResourceUpdate,
+		"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
+		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -408,7 +408,8 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
+		"CreatePrometheusAgentDaemonSet":   testCreatePrometheusAgentDaemonSet,
+		"PromAgentDaemonSetResourceUpdate": testPromAgentDaemonSetResourceUpdate,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -411,6 +411,7 @@ func TestGatedFeatures(t *testing.T) {
 		"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
 		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -354,9 +354,8 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	var pollErr error
 	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
-		// if dms == nil {
 		if dms.Status.NumberAvailable == 0 {
-			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
+			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)
 			return false, nil
 		}
 

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -74,7 +75,10 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 	name := "test"
 	prometheusAgentDSCRD := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, prometheusAgentDSCRD)
+	p, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, prometheusAgentDSCRD)
+	require.NoError(t, err)
+
+	err = framework.DeletePrometheusAgentDSAndWaitUntilGone(ctx, p, ns, name)
 	require.NoError(t, err)
 }
 
@@ -182,4 +186,78 @@ func testPrometheusAgentStatusScale(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int32(2), pAgent.Status.Shards)
+}
+
+func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "test"
+	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
+
+	p.Spec.Resources = v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	p, err = framework.CreatePrometheusAgentAndWaitUntilReady(context.Background(), ns, p)
+	require.NoError(t, err)
+
+	dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
+	dms, err := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	res := dms.Spec.Template.Spec.Containers[0].Resources
+	require.Equal(t, res, p.Spec.Resources)
+
+	p, err = framework.PatchPrometheusAgentAndWaitUntilReady(
+		context.Background(),
+		p.Name,
+		ns,
+		monitoringv1alpha1.PrometheusAgentSpec{
+			Mode: ptr.To("DaemonSet"),
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	var pollErr error
+	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
+		if err != nil {
+			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
+			return false, nil
+		}
+
+		res = dms.Spec.Template.Spec.Containers[0].Resources
+		if !reflect.DeepEqual(res, p.Spec.Resources) {
+			pollErr = fmt.Errorf("resources don't match. Has %#+v, want %#+v", res, p.Spec.Resources)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	require.NoError(t, pollErr)
+	require.NoError(t, err)
 }

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -353,8 +353,9 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 
 	var pollErr error
 	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
-		_, err := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
-		if err != nil {
+		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
+		// if dms == nil {
+		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
 			return false, nil
 		}

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -352,7 +352,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable == 0 {
 			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -189,7 +189,6 @@ func testPrometheusAgentStatusScale(t *testing.T) {
 }
 
 func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)
@@ -263,7 +262,6 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 }
 
 func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
 	defer testCtx.Cleanup(t)

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -199,7 +199,6 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
-		// if dms != nil {
 		if dms.Status.NumberAvailable != 0 {
 			pollErr = fmt.Errorf("Prometheus Agent DaemonSet still exists after deleting")
 			return false, nil

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 20*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -142,7 +142,7 @@ func (f *Framework) WaitForPrometheusAgentReady(ctx context.Context, p *monitori
 
 func (f *Framework) WaitForPrometheusAgentDSReady(ctx context.Context, ns string, p *monitoringv1alpha1.PrometheusAgent) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		name := fmt.Sprintf("prom-agent-%s", p.Name)
 		// TODO: Implement UpdateStatus() for DaemonSet and check status instead of using Get().
 		dms, err := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (f *Framework) DeletePrometheusAgentDSAndWaitUntilGone(ctx context.Context,
 	}
 
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 		dms, _ := f.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if dms.Status.NumberAvailable != 0 {


### PR DESCRIPTION
## Description

Allow Prometheus Agent update, delete, and handle changes to DaemonSet object



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
E2e that update/delete Prometheus Agent DaemonSet


## Changelog entry

Allow updating and deleting Prometheus Agent DaemonSet