### PR TITLE
chore: avoid rate-limiting from GitHub

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -31,3 +31,6 @@ validators:
   # Ignore anchor links pointing to the API documentation which are HTML <a> tags and not supported by mdox.
   - regex: 'api\.md#monitoring\.coreos\.com/v1\.(BasicAuth|PrometheusSpec|StorageSpec)$'
     type: ignore
+  # Use the githubPullsIssues validator to avoid rate-limiting.
+  - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)prometheus-operator\/prometheus-operator(\/pull\/|\/issues\/)'
+    type: githubPullsIssues


### PR DESCRIPTION
## Description

GitHub seems to have tighter rate limits nowadays.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
