### PR TITLE
bugfix: Fix merge conflict with logger

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -625,16 +625,16 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 		return fmt.Errorf("failed to set Prometheus type information: %w", err)
 	}
 
-	logger := log.With(c.logger, "key", key)
+	logger := c.logger.With("key", key)
 
 	if p.Spec.Paused {
-		level.Info(logger).Log("msg", "the resource is paused, not reconciling")
+		logger.Info("the resource is paused, not reconciling")
 		return nil
 	}
 
-	level.Info(logger).Log("msg", "sync prometheus")
+	logger.Info("sync prometheus")
 
-	cg, err := prompkg.NewConfigGenerator(c.logger, p, c.endpointSliceSupported)
+	cg, err := prompkg.NewConfigGenerator(c.goKitLogger, p, c.endpointSliceSupported)
 	if err != nil {
 		return err
 	}
@@ -655,7 +655,7 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 
 	dsetClient := c.kclient.AppsV1().DaemonSets(p.Namespace)
 
-	level.Debug(logger).Log("msg", "reconciling daemonset")
+	logger.Debug("reconciling daemonset")
 
 	_, err = c.dsetInfs.Get(keyToDaemonSetKey(p, key))
 	exists := !apierrors.IsNotFound(err)
@@ -673,13 +673,13 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 	}
 
 	if !exists {
-		level.Debug(logger).Log("msg", "no current daemonset found")
-		level.Debug(logger).Log("msg", "creating daemonset")
+		logger.Debug("no current daemonset found")
+		logger.Debug("creating daemonset")
 		if _, err := dsetClient.Create(ctx, dset, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("creating daemonset failed: %w", err)
 		}
 
-		level.Info(logger).Log("msg", "daemonset successfully created")
+		logger.Info("daemonset successfully created")
 		return nil
 	}
 


### PR DESCRIPTION
## Description

There were some unnoticeable conflicts between #6786 and #6708 that completely broke main. This PR fixes it



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
