### PR TITLE
feat: sync proxy settings in Alertmanager configuration

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1505,7 +1505,9 @@ func (cb *configBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1
 	}
 
 	out := &httpClientConfig{
-		ProxyURL:        in.ProxyURL,
+		proxyConfig: proxyConfig{
+			ProxyURL: in.ProxyURL,
+		},
 		FollowRedirects: in.FollowRedirects,
 	}
 

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -207,10 +207,18 @@ type httpClientConfig struct {
 	OAuth2          *oauth2        `yaml:"oauth2,omitempty"`
 	BearerToken     string         `yaml:"bearer_token,omitempty"`
 	BearerTokenFile string         `yaml:"bearer_token_file,omitempty"`
-	ProxyURL        string         `yaml:"proxy_url,omitempty"`
 	TLSConfig       *tlsConfig     `yaml:"tls_config,omitempty"`
 	FollowRedirects *bool          `yaml:"follow_redirects,omitempty"`
 	EnableHTTP2     *bool          `yaml:"enable_http2,omitempty"`
+
+	proxyConfig `yaml:",inline"`
+}
+
+type proxyConfig struct {
+	ProxyURL             string              `yaml:"proxy_url,omitempty"`
+	NoProxy              string              `yaml:"no_proxy,omitempty"`
+	ProxyFromEnvironment bool                `yaml:"proxy_from_environment,omitempty"`
+	ProxyConnectHeader   map[string][]string `yaml:"proxy_connect_header,omitempty"`
 }
 
 type tlsConfig struct {


### PR DESCRIPTION
## Description

This change doesn't implement the corresponding fields in the AlertmanagerConfig CRD but only in the configuration generated by the operator.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support all proxy settings in the Alertmanager configuration.
```
