### PR TITLE
replace gokitlog in the resource reconciler

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -382,7 +382,7 @@ func run(fs *flag.FlagSet) int {
 
 	var po *prometheuscontroller.Operator
 	if prometheusSupported {
-		po, err = prometheuscontroller.New(ctx, restConfig, cfg, logger, goKitLogger, r, promControllerOptions...)
+		po, err = prometheuscontroller.New(ctx, restConfig, cfg, goKitLogger, logger, r, promControllerOptions...)
 		if err != nil {
 			logger.Error("instantiating prometheus controller failed", "err", err)
 			cancel()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -480,7 +480,7 @@ func run(fs *flag.FlagSet) int {
 
 	var ao *alertmanagercontroller.Operator
 	if alertmanagerSupported {
-		ao, err = alertmanagercontroller.New(ctx, restConfig, cfg, goKitLogger, r, alertmanagerControllerOptions...)
+		ao, err = alertmanagercontroller.New(ctx, restConfig, cfg, goKitLogger, logger, r, alertmanagerControllerOptions...)
 		if err != nil {
 			logger.Error("instantiating alertmanager controller failed", "err", err)
 			cancel()
@@ -516,7 +516,7 @@ func run(fs *flag.FlagSet) int {
 
 	var to *thanoscontroller.Operator
 	if thanosRulerSupported {
-		to, err = thanoscontroller.New(ctx, restConfig, cfg, goKitLogger, r, thanosControllerOptions...)
+		to, err = thanoscontroller.New(ctx, restConfig, cfg, goKitLogger, logger, r, thanosControllerOptions...)
 		if err != nil {
 			logger.Error("instantiating thanos controller failed", "err", err)
 			cancel()

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1215,11 +1215,11 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.objects...)
 
 			o := &Operator{
-				kclient:    c,
-				mclient:    monitoringfake.NewSimpleClientset(),
-				ssarClient: &alwaysAllowed{},
-				logger:     level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowInfo()),
-				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
+				kclient:     c,
+				mclient:     monitoringfake.NewSimpleClientset(),
+				ssarClient:  &alwaysAllowed{},
+				goKitLogger: level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowInfo()),
+				metrics:     operator.NewMetrics(prometheus.NewRegistry()),
 			}
 
 			err := o.bootstrap(

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -17,12 +17,11 @@ package operator
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
@@ -65,7 +64,7 @@ type ReconcilerMetrics interface {
 // ResourceReconciler will trigger object and status reconciliations based on
 // the events received from the informer.
 type ResourceReconciler struct {
-	logger log.Logger
+	logger *slog.Logger
 
 	resourceKind string
 
@@ -99,7 +98,7 @@ const (
 
 // NewResourceReconciler returns a reconciler for the "kind" resource.
 func NewResourceReconciler(
-	l log.Logger,
+	l *slog.Logger,
 	syncer Syncer,
 	metrics ReconcilerMetrics,
 	kind string,
@@ -163,8 +162,7 @@ func NewResourceReconciler(
 // DeletionInProgress returns true if the object deletion has been requested.
 func (rr *ResourceReconciler) DeletionInProgress(o metav1.Object) bool {
 	if o.GetDeletionTimestamp() != nil {
-		level.Debug(rr.logger).Log(
-			"msg", "object deletion in progress",
+		rr.logger.Debug("object deletion in progress",
 			"object", fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName()),
 		)
 		return true
@@ -175,8 +173,7 @@ func (rr *ResourceReconciler) DeletionInProgress(o metav1.Object) bool {
 // hasObjectChanged returns true if the objects have different resource revisions.
 func (rr *ResourceReconciler) hasObjectChanged(old, cur metav1.Object) bool {
 	if old.GetResourceVersion() != cur.GetResourceVersion() {
-		level.Debug(rr.logger).Log(
-			"msg", "different resource versions",
+		rr.logger.Debug("different resource versions",
 			"current", cur.GetResourceVersion(),
 			"old", old.GetResourceVersion(),
 			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
@@ -193,8 +190,7 @@ func (rr *ResourceReconciler) hasObjectChanged(old, cur metav1.Object) bool {
 // subresource for instance.
 func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 	if old.GetGeneration() != cur.GetGeneration() {
-		level.Debug(rr.logger).Log(
-			"msg", "different generations",
+		rr.logger.Debug("different generations",
 			"current", cur.GetGeneration(),
 			"old", old.GetGeneration(),
 			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
@@ -203,8 +199,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 	}
 
 	if !reflect.DeepEqual(old.GetLabels(), cur.GetLabels()) {
-		level.Debug(rr.logger).Log(
-			"msg", "different labels",
+		rr.logger.Debug("different labels",
 			"current", fmt.Sprintf("%v", cur.GetLabels()),
 			"old", fmt.Sprintf("%v", old.GetLabels()),
 			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
@@ -213,8 +208,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 
 	}
 	if !reflect.DeepEqual(old.GetAnnotations(), cur.GetAnnotations()) {
-		level.Debug(rr.logger).Log(
-			"msg", "different annotations",
+		rr.logger.Debug("different annotations",
 			"current", fmt.Sprintf("%v", cur.GetAnnotations()),
 			"old", fmt.Sprintf("%v", old.GetAnnotations()),
 			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
@@ -230,7 +224,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 func (rr *ResourceReconciler) objectKey(obj interface{}) (string, bool) {
 	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		level.Error(rr.logger).Log("msg", "creating key failed", "err", err)
+		rr.logger.Error("creating key failed", "err", err)
 		return "", false
 	}
 
@@ -259,7 +253,7 @@ func (rr *ResourceReconciler) OnAdd(obj interface{}, _ bool) {
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s added", rr.resourceKind), "key", key)
+	rr.logger.Debug(fmt.Sprintf("%s added", rr.resourceKind), "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, AddEvent).Inc()
 
 	rr.reconcileQ.Add(key)
@@ -279,12 +273,12 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 
 	mOld, err := meta.Accessor(old)
 	if err != nil {
-		level.Error(rr.logger).Log("err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
+		rr.logger.Error("", "err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
 	}
 
 	mCur, err := meta.Accessor(cur)
 	if err != nil {
-		level.Error(rr.logger).Log("err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
+		rr.logger.Error("", "err", fmt.Sprintf("failed to get object meta: %s", err), "key", key)
 	}
 
 	if !rr.isManagedByController(mCur) {
@@ -299,7 +293,7 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s updated", rr.resourceKind), "key", key)
+	rr.logger.Debug(fmt.Sprintf("%s updated", rr.resourceKind), "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, UpdateEvent).Inc()
 
 	rr.reconcileQ.Add(key)
@@ -326,7 +320,7 @@ func (rr *ResourceReconciler) OnDelete(obj interface{}) {
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", fmt.Sprintf("%s deleted", rr.resourceKind), "key", key)
+	rr.logger.Debug(fmt.Sprintf("%s deleted", rr.resourceKind), "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, DeleteEvent).Inc()
 
 	rr.reconcileQ.Add(key)
@@ -338,14 +332,14 @@ func (rr *ResourceReconciler) onStatefulSetAdd(ss *appsv1.StatefulSet) {
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", "StatefulSet added")
+	rr.logger.Debug("StatefulSet added")
 	rr.metrics.TriggerByCounter("StatefulSet", AddEvent).Inc()
 
 	rr.EnqueueForReconciliation(obj)
 }
 
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
-	level.Debug(rr.logger).Log("msg", "update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+	rr.logger.Debug("update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
 	if rr.DeletionInProgress(cur) {
 		return
@@ -360,7 +354,7 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", "StatefulSet updated")
+	rr.logger.Debug("StatefulSet updated")
 	rr.metrics.TriggerByCounter("StatefulSet", UpdateEvent).Inc()
 
 	if !rr.hasStateChanged(old, cur) {
@@ -380,7 +374,7 @@ func (rr *ResourceReconciler) onStatefulSetDelete(ss *appsv1.StatefulSet) {
 		return
 	}
 
-	level.Debug(rr.logger).Log("msg", "StatefulSet delete")
+	rr.logger.Debug("StatefulSet delete")
 	rr.metrics.TriggerByCounter("StatefulSet", DeleteEvent).Inc()
 
 	rr.EnqueueForReconciliation(obj)
@@ -508,7 +502,7 @@ func (rr *ResourceReconciler) isManagedByController(obj metav1.Object) bool {
 	}
 
 	if controllerID != rr.controllerID {
-		level.Debug(rr.logger).Log("msg", "skipping object not managed by the controller", "object", fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()), "object_id", controllerID, "controller_id", rr.controllerID)
+		rr.logger.Debug("skipping object not managed by the controller", "object", fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()), "object_id", controllerID, "controller_id", rr.controllerID)
 		return false
 	}
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -178,7 +178,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 	}
 
 	o.rr = operator.NewResourceReconciler(
-		o.goKitLogger,
+		o.logger,
 		o,
 		o.metrics,
 		monitoringv1alpha1.PrometheusAgentsKind,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -178,7 +178,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 	o.metrics.MustRegister(o.reconciliations)
 
 	o.rr = operator.NewResourceReconciler(
-		o.goKitLogger,
+		o.logger,
 		o,
 		o.metrics,
 		monitoringv1.PrometheusesKind,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -127,7 +127,7 @@ func WithStorageClassValidation() ControllerOption {
 }
 
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger *slog.Logger, goKitLogger log.Logger, r prometheus.Registerer, opts ...ControllerOption) (*Operator, error) {
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitLogger log.Logger, logger *slog.Logger, r prometheus.Registerer, opts ...ControllerOption) (*Operator, error) {
 	goKitLogger = log.With(goKitLogger, "component", controllerName)
 	logger = logger.With("component", controllerName)
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -136,6 +136,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 		mdClient:        mdClient,
 		mclient:         mclient,
 		goKitLogger:     goKitLogger,
+		logger:          logger,
 		accessor:        operator.NewAccessor(goKitLogger),
 		metrics:         operator.NewMetrics(r),
 		eventRecorder:   c.EventRecorderFactory(client, controllerName),

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -17,6 +17,7 @@ package thanos
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -59,8 +60,12 @@ type Operator struct {
 	kclient  kubernetes.Interface
 	mdClient metadata.Interface
 	mclient  monitoringclient.Interface
-	logger   log.Logger
-	accessor *operator.Accessor
+	// We're currently migrating our logging library from go-kit to slog.
+	// The go-kit logger is being removed in small PRs. For now, we are creating 2 loggers to avoid breaking changes and
+	// to have a smooth transition.
+	goKitLogger log.Logger
+	logger      *slog.Logger
+	accessor    *operator.Accessor
 
 	controllerID string
 
@@ -105,8 +110,8 @@ func WithStorageClassValidation() ControllerOption {
 }
 
 // New creates a new controller.
-func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger log.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
-	logger = log.With(logger, "component", controllerName)
+func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitLogger log.Logger, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
+	goKitLogger = log.With(goKitLogger, "component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -130,8 +135,8 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		kclient:         client,
 		mdClient:        mdClient,
 		mclient:         mclient,
-		logger:          logger,
-		accessor:        operator.NewAccessor(logger),
+		goKitLogger:     goKitLogger,
+		accessor:        operator.NewAccessor(goKitLogger),
 		metrics:         operator.NewMetrics(r),
 		eventRecorder:   c.EventRecorderFactory(client, controllerName),
 		reconciliations: &operator.ReconciliationTracker{},
@@ -226,7 +231,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 	newNamespaceInformer := func(o *Operator, allowList map[string]struct{}) (cache.SharedIndexInformer, error) {
 		lw, privileged, err := listwatch.NewNamespaceListWatchFromClient(
 			ctx,
-			o.logger,
+			o.goKitLogger,
 			c.KubernetesVersion,
 			o.kclient.CoreV1(),
 			o.kclient.AuthorizationV1().SelfSubjectAccessReviews(),
@@ -236,7 +241,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			return nil, err
 		}
 
-		level.Debug(o.logger).Log("msg", "creating namespace informer", "privileged", privileged)
+		level.Debug(o.goKitLogger).Log("msg", "creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
 			&v1.Namespace{},
@@ -274,7 +279,7 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 		{"StatefulSet", o.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
-			if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.logger, "informer", infs.name), inf.Informer()) {
+			if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.goKitLogger, "informer", infs.name), inf.Informer()) {
 				return fmt.Errorf("failed to sync cache for %s informer", infs.name)
 			}
 		}
@@ -287,12 +292,12 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 		{"ThanosRulerNamespace", o.nsThanosRulerInf},
 		{"RuleNamespace", o.nsRuleInf},
 	} {
-		if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.logger, "informer", inf.name), inf.informer) {
+		if !operator.WaitForNamedCacheSync(ctx, "thanos", log.With(o.goKitLogger, "informer", inf.name), inf.informer) {
 			return fmt.Errorf("failed to sync cache for %s informer", inf.name)
 		}
 	}
 
-	level.Info(o.logger).Log("msg", "successfully synced all caches")
+	level.Info(o.goKitLogger).Log("msg", "successfully synced all caches")
 	return nil
 }
 
@@ -302,7 +307,7 @@ func (o *Operator) addHandlers() {
 	o.ssetInfs.AddEventHandler(o.rr)
 
 	o.cmapInfs.AddEventHandler(operator.NewEventHandler(
-		o.logger,
+		o.goKitLogger,
 		o.accessor,
 		o.metrics,
 		"ConfigMap",
@@ -310,7 +315,7 @@ func (o *Operator) addHandlers() {
 	))
 
 	o.ruleInfs.AddEventHandler(operator.NewEventHandler(
-		o.logger,
+		o.goKitLogger,
 		o.accessor,
 		o.metrics,
 		monitoringv1.PrometheusRuleKind,
@@ -365,7 +370,7 @@ func (o *Operator) Iterate(processFn func(metav1.Object, []monitoringv1.Conditio
 		a := o.(*monitoringv1.ThanosRuler)
 		processFn(a, a.Status.Conditions)
 	}); err != nil {
-		level.Error(o.logger).Log("msg", "failed to list ThanosRuler objects", "err", err)
+		level.Error(o.goKitLogger).Log("msg", "failed to list ThanosRuler objects", "err", err)
 	}
 }
 
@@ -388,7 +393,7 @@ func (o *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
 	}
 
 	if err != nil {
-		level.Error(o.logger).Log("msg", "ThanosRuler lookup failed", "err", err)
+		level.Error(o.goKitLogger).Log("msg", "ThanosRuler lookup failed", "err", err)
 		return nil
 	}
 
@@ -409,14 +414,14 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 	old := oldo.(*v1.Namespace)
 	cur := curo.(*v1.Namespace)
 
-	level.Debug(o.logger).Log("msg", "update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+	level.Debug(o.goKitLogger).Log("msg", "update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
 	// Periodic resync may resend the Namespace without changes in-between.
 	if old.ResourceVersion == cur.ResourceVersion {
 		return
 	}
 
-	level.Debug(o.logger).Log("msg", "Namespace updated", "namespace", cur.GetName())
+	level.Debug(o.goKitLogger).Log("msg", "Namespace updated", "namespace", cur.GetName())
 	o.metrics.TriggerByCounter("Namespace", operator.UpdateEvent).Inc()
 
 	// Check for ThanosRuler instances selecting PrometheusRules in the namespace.
@@ -425,7 +430,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 
 		sync, err := k8sutil.LabelSelectionHasChanged(old.Labels, cur.Labels, tr.Spec.RuleNamespaceSelector)
 		if err != nil {
-			level.Error(o.logger).Log(
+			level.Error(o.goKitLogger).Log(
 				"err", err,
 				"name", tr.Name,
 				"namespace", tr.Namespace,
@@ -438,7 +443,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 		}
 	})
 	if err != nil {
-		level.Error(o.logger).Log(
+		level.Error(o.goKitLogger).Log(
 			"msg", "listing all ThanosRuler instances from cache failed",
 			"err", err,
 		)
@@ -479,7 +484,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger := log.With(o.logger, "key", key)
+	logger := log.With(o.goKitLogger, "key", key)
 	level.Info(logger).Log("msg", "sync thanos-ruler")
 
 	if err := operator.CheckStorageClass(ctx, o.canReadStorageClass, o.kclient, tr.Spec.Storage); err != nil {
@@ -584,7 +589,7 @@ func (o *Operator) getThanosRulerFromKey(key string) (*monitoringv1.ThanosRuler,
 	obj, err := o.thanosRulerInfs.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			level.Info(o.logger).Log("msg", "ThanosRuler not found", "key", key)
+			level.Info(o.goKitLogger).Log("msg", "ThanosRuler not found", "key", key)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to retrieve ThanosRuler from informer: %w", err)
@@ -602,7 +607,7 @@ func (o *Operator) getStatefulSetFromThanosRulerKey(key string) (*appsv1.Statefu
 	obj, err := o.ssetInfs.Get(ssetName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			level.Info(o.logger).Log("msg", "StatefulSet not found", "key", ssetName)
+			level.Info(o.goKitLogger).Log("msg", "StatefulSet not found", "key", ssetName)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to retrieve StatefulSet from informer: %w", err)
@@ -703,14 +708,14 @@ func (o *Operator) enqueueForRulesNamespace(nsName string) {
 func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	nsObject, exists, err := store.GetByKey(nsName)
 	if err != nil {
-		level.Error(o.logger).Log(
+		level.Error(o.goKitLogger).Log(
 			"msg", "get namespace to enqueue ThanosRuler instances failed",
 			"err", err,
 		)
 		return
 	}
 	if !exists {
-		level.Error(o.logger).Log(
+		level.Error(o.goKitLogger).Log(
 			"msg", "get namespace to enqueue ThanosRuler instances failed: namespace does not exist",
 			"namespace", nsName,
 		)
@@ -730,7 +735,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		// the namespace.
 		ruleNSSelector, err := metav1.LabelSelectorAsSelector(tr.Spec.RuleNamespaceSelector)
 		if err != nil {
-			level.Error(o.logger).Log(
+			level.Error(o.goKitLogger).Log(
 				"err", fmt.Errorf("failed to convert RuleNamespaceSelector: %w", err),
 				"name", tr.Name,
 				"namespace", tr.Namespace,
@@ -745,7 +750,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		}
 	})
 	if err != nil {
-		level.Error(o.logger).Log(
+		level.Error(o.goKitLogger).Log(
 			"msg", "listing all ThanosRuler instances from cache failed",
 			"err", err,
 		)

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -65,7 +65,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		false,
 	)
 
-	logger := log.With(o.logger, "thanos", t.Name, "namespace", t.Namespace)
+	logger := log.With(o.goKitLogger, "thanos", t.Name, "namespace", t.Namespace)
 	thanosVersion := operator.StringValOrDefault(t.Spec.Version, operator.DefaultThanosVersion)
 
 	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, o.eventRecorder, logger)
@@ -98,7 +98,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 
 	equal := reflect.DeepEqual(newRules, currentRules)
 	if equal && len(currentConfigMaps) != 0 {
-		level.Debug(o.logger).Log(
+		level.Debug(o.goKitLogger).Log(
 			"msg", "no PrometheusRule changes",
 			"namespace", t.Namespace,
 			"thanos", t.Name,
@@ -126,7 +126,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 	}
 
 	if len(currentConfigMaps) == 0 {
-		level.Debug(o.logger).Log(
+		level.Debug(o.goKitLogger).Log(
 			"msg", "no PrometheusRule configmap found, creating new one",
 			"namespace", t.Namespace,
 			"thanos", t.Name,
@@ -149,7 +149,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		}
 	}
 
-	level.Debug(o.logger).Log(
+	level.Debug(o.goKitLogger).Log(
 		"msg", "updating PrometheusRule",
 		"namespace", t.Namespace,
 		"thanos", t.Name,
@@ -186,7 +186,7 @@ func (o *Operator) selectRuleNamespaces(p *monitoringv1.ThanosRuler) ([]string, 
 		}
 	}
 
-	level.Debug(o.logger).Log(
+	level.Debug(o.goKitLogger).Log(
 		"msg", "selected RuleNamespaces",
 		"namespaces", strings.Join(namespaces, ","),
 		"namespace", p.Namespace,


### PR DESCRIPTION
## Description

The `ResourceReconciler` structure is used across all operators. I duplicated the logger and replace their names to a meaningful one (`goKitLogger`), like i'm doing the in the past PRs.

But in the end, this PR just aim to change the log library in the following file: `pgk/operator/resource_reconciler.go`



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
