### PR TITLE
replace go kit log in resource selector

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -123,6 +123,7 @@ func WithStorageClassValidation() ControllerOption {
 // New creates a new controller.
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitLogger log.Logger, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	goKitLogger = log.With(goKitLogger, "component", controllerName)
+	logger = logger.With("component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -150,7 +151,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 
 		goKitLogger: goKitLogger,
 		logger:      logger,
-		accessor:    operator.NewAccessor(goKitLogger),
+		accessor:    operator.NewAccessor(logger),
 
 		metrics:         operator.NewMetrics(r),
 		reconciliations: &operator.ReconciliationTracker{},

--- a/pkg/operator/accessor.go
+++ b/pkg/operator/accessor.go
@@ -15,8 +15,8 @@
 package operator
 
 import (
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
+	"log/slog"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -24,10 +24,10 @@ import (
 
 // Accessor can manipulate objects returned by informers and handlers.
 type Accessor struct {
-	logger log.Logger
+	logger *slog.Logger
 }
 
-func NewAccessor(l log.Logger) *Accessor {
+func NewAccessor(l *slog.Logger) *Accessor {
 	return &Accessor{
 		logger: l,
 	}
@@ -39,7 +39,7 @@ func NewAccessor(l log.Logger) *Accessor {
 func (a *Accessor) MetaNamespaceKey(obj interface{}) (string, bool) {
 	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		level.Error(a.logger).Log("msg", "failed to retrieve object's key", "err", err)
+		a.logger.Error("failed to retrieve object's key", "err", err)
 		return k, false
 	}
 
@@ -56,7 +56,7 @@ func (a *Accessor) ObjectMetadata(obj interface{}) (metav1.Object, bool) {
 
 	o, err := meta.Accessor(obj)
 	if err != nil {
-		level.Error(a.logger).Log("msg", "get object failed", "err", err)
+		a.logger.Error("get object failed", "err", err)
 		return nil, false
 	}
 	return o, true

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -857,7 +857,7 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 }
 
 func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, store *assets.StoreBuilder) error {
-	resourceSelector, err := prompkg.NewResourceSelector(c.goKitLogger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
+	resourceSelector, err := prompkg.NewResourceSelector(c.logger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -18,14 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
 	v1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ import (
 )
 
 type ResourceSelector struct {
-	l                  log.Logger
+	l                  *slog.Logger
 	p                  monitoringv1.PrometheusInterface
 	version            semver.Version
 	store              *assets.StoreBuilder
@@ -57,7 +56,7 @@ type ResourceSelector struct {
 
 type ListAllByNamespaceFn func(namespace string, selector labels.Selector, appendFn cache.AppendFunc) error
 
-func NewResourceSelector(l log.Logger, p monitoringv1.PrometheusInterface, store *assets.StoreBuilder, namespaceInformers cache.SharedIndexInformer, metrics *operator.Metrics, eventRecorder record.EventRecorder) (*ResourceSelector, error) {
+func NewResourceSelector(l *slog.Logger, p monitoringv1.PrometheusInterface, store *assets.StoreBuilder, namespaceInformers cache.SharedIndexInformer, metrics *operator.Metrics, eventRecorder record.EventRecorder) (*ResourceSelector, error) {
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 	version, err := semver.ParseTolerant(promVersion)
 	if err != nil {
@@ -106,7 +105,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 		}
 	}
 
-	level.Debug(rs.l).Log("msg", "filtering namespaces to select ServiceMonitors from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("filtering namespaces to select ServiceMonitors from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	for _, ns := range namespaces {
 		err := listFn(ns, servMonSelector, func(obj interface{}) {
@@ -114,7 +113,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 			if ok {
 				svcMon := obj.(*monitoringv1.ServiceMonitor).DeepCopy()
 				if err := k8sutil.AddTypeInformationToObject(svcMon); err != nil {
-					level.Error(rs.l).Log("msg", "failed to set ServiceMonitor type information", "namespace", ns, "err", err)
+					rs.l.Error("failed to set ServiceMonitor type information", "namespace", ns, "err", err)
 					return
 				}
 				serviceMonitors[k] = svcMon
@@ -131,8 +130,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 		var err error
 		rejectFn := func(sm *monitoringv1.ServiceMonitor, err error) {
 			rejected++
-			level.Warn(rs.l).Log(
-				"msg", "skipping servicemonitor",
+			rs.l.Warn("skipping servicemonitor",
 				"error", err.Error(),
 				"servicemonitor", namespaceAndName,
 				"namespace", objMeta.GetNamespace(),
@@ -216,7 +214,7 @@ func (rs *ResourceSelector) SelectServiceMonitors(ctx context.Context, listFn Li
 	for k := range res {
 		smKeys = append(smKeys, k)
 	}
-	level.Debug(rs.l).Log("msg", "selected ServiceMonitors", "servicemonitors", strings.Join(smKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("selected ServiceMonitors", "servicemonitors", strings.Join(smKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
 		rs.metrics.SetSelectedResources(pKey, monitoringv1.ServiceMonitorsKind, len(res))
@@ -404,7 +402,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 		}
 	}
 
-	level.Debug(rs.l).Log("msg", "filtering namespaces to select PodMonitors from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("filtering namespaces to select PodMonitors from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	for _, ns := range namespaces {
 		err := listFn(ns, podMonSelector, func(obj interface{}) {
@@ -412,7 +410,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 			if ok {
 				podMon := obj.(*monitoringv1.PodMonitor).DeepCopy()
 				if err := k8sutil.AddTypeInformationToObject(podMon); err != nil {
-					level.Error(rs.l).Log("msg", "failed to set PodMonitor type information", "namespace", ns, "err", err)
+					rs.l.Error("failed to set PodMonitor type information", "namespace", ns, "err", err)
 					return
 				}
 				podMonitors[k] = podMon
@@ -429,8 +427,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 		var err error
 		rejectFn := func(pm *monitoringv1.PodMonitor, err error) {
 			rejected++
-			level.Warn(rs.l).Log(
-				"msg", "skipping podmonitor",
+			rs.l.Warn("skipping podmonitor",
 				"error", err.Error(),
 				"podmonitor", namespaceAndName,
 				"namespace", objMeta.GetNamespace(),
@@ -507,7 +504,7 @@ func (rs *ResourceSelector) SelectPodMonitors(ctx context.Context, listFn ListAl
 	for k := range res {
 		pmKeys = append(pmKeys, k)
 	}
-	level.Debug(rs.l).Log("msg", "selected PodMonitors", "podmonitors", strings.Join(pmKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("selected PodMonitors", "podmonitors", strings.Join(pmKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
 		rs.metrics.SetSelectedResources(pKey, monitoringv1.PodMonitorsKind, len(res))
@@ -547,14 +544,14 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 		}
 	}
 
-	level.Debug(rs.l).Log("msg", "filtering namespaces to select Probes from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("filtering namespaces to select Probes from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	for _, ns := range namespaces {
 		err := listFn(ns, bMonSelector, func(obj interface{}) {
 			if k, ok := rs.accessor.MetaNamespaceKey(obj); ok {
 				probe := obj.(*monitoringv1.Probe).DeepCopy()
 				if err := k8sutil.AddTypeInformationToObject(probe); err != nil {
-					level.Error(rs.l).Log("msg", "failed to set Probe type information", "namespace", ns, "err", err)
+					rs.l.Error("failed to set Probe type information", "namespace", ns, "err", err)
 					return
 				}
 				probes[k] = probe
@@ -571,8 +568,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 	for probeName, probe := range probes {
 		rejectFn := func(probe *monitoringv1.Probe, err error) {
 			rejected++
-			level.Warn(rs.l).Log(
-				"msg", "skipping probe",
+			rs.l.Warn("skipping probe",
 				"error", err.Error(),
 				"probe", probeName,
 				"namespace", objMeta.GetNamespace(),
@@ -665,7 +661,7 @@ func (rs *ResourceSelector) SelectProbes(ctx context.Context, listFn ListAllByNa
 	for k := range res {
 		probeKeys = append(probeKeys, k)
 	}
-	level.Debug(rs.l).Log("msg", "selected Probes", "probes", strings.Join(probeKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("selected Probes", "probes", strings.Join(probeKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if pKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
 		rs.metrics.SetSelectedResources(pKey, monitoringv1.ProbesKind, len(res))
@@ -744,14 +740,14 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 		}
 	}
 
-	level.Debug(rs.l).Log("msg", "filtering namespaces to select ScrapeConfigs from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("filtering namespaces to select ScrapeConfigs from", "namespaces", strings.Join(namespaces, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	for _, ns := range namespaces {
 		err := listFn(ns, sConSelector, func(obj interface{}) {
 			if k, ok := rs.accessor.MetaNamespaceKey(obj); ok {
 				scrapeConfig := obj.(*monitoringv1alpha1.ScrapeConfig).DeepCopy()
 				if err := k8sutil.AddTypeInformationToObject(scrapeConfig); err != nil {
-					level.Error(rs.l).Log("msg", "failed to set ScrapeConfig type information", "namespace", ns, "err", err)
+					rs.l.Error("failed to set ScrapeConfig type information", "namespace", ns, "err", err)
 					return
 				}
 				scrapeConfigs[k] = scrapeConfig
@@ -768,8 +764,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 	for scName, sc := range scrapeConfigs {
 		rejectFn := func(sc *monitoringv1alpha1.ScrapeConfig, err error) {
 			rejected++
-			level.Warn(rs.l).Log(
-				"msg", "skipping scrapeconfig",
+			rs.l.Warn("skipping scrapeconfig",
 				"error", err.Error(),
 				"scrapeconfig", scName,
 				"namespace", objMeta.GetNamespace(),
@@ -934,7 +929,7 @@ func (rs *ResourceSelector) SelectScrapeConfigs(ctx context.Context, listFn List
 	for k := range res {
 		scrapeConfigKeys = append(scrapeConfigKeys, k)
 	}
-	level.Debug(rs.l).Log("msg", "selected ScrapeConfigs", "scrapeConfig", strings.Join(scrapeConfigKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
+	rs.l.Debug("selected ScrapeConfigs", "scrapeConfig", strings.Join(scrapeConfigKeys, ","), "namespace", objMeta.GetNamespace(), "prometheus", objMeta.GetName())
 
 	if sKey, ok := rs.accessor.MetaNamespaceKey(rs.p); ok {
 		rs.metrics.SetSelectedResources(sKey, monitoringv1alpha1.ScrapeConfigsKind, len(res))

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -16,11 +16,10 @@ package prometheus
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
@@ -38,8 +37,8 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
-func newLogger() log.Logger {
-	return level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
+func newLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
 }
 
 func TestValidateRelabelConfig(t *testing.T) {

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -155,7 +155,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 		mclient:     mclient,
 		goKitLogger: goKitLogger,
 		logger:      logger,
-		accessor:    operator.NewAccessor(goKitLogger),
+		accessor:    operator.NewAccessor(logger),
 
 		config: prompkg.Config{
 			LocalHost:                  c.LocalHost,
@@ -1130,7 +1130,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 		return nil
 	}
 
-	resourceSelector, err := prompkg.NewResourceSelector(c.goKitLogger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
+	resourceSelector, err := prompkg.NewResourceSelector(c.logger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
 	if err != nil {
 		return err
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -112,6 +112,7 @@ func WithStorageClassValidation() ControllerOption {
 // New creates a new controller.
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitLogger log.Logger, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	goKitLogger = log.With(goKitLogger, "component", controllerName)
+	logger = logger.With("component", controllerName)
 
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
@@ -137,7 +138,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 		mclient:         mclient,
 		goKitLogger:     goKitLogger,
 		logger:          logger,
-		accessor:        operator.NewAccessor(goKitLogger),
+		accessor:        operator.NewAccessor(logger),
 		metrics:         operator.NewMetrics(r),
 		eventRecorder:   c.EventRecorderFactory(client, controllerName),
 		reconciliations: &operator.ReconciliationTracker{},

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -97,9 +97,6 @@ func New(kubeconfig, opImage, exampleDir, resourcesDir string, operatorVersion s
 	}
 
 	httpc := cli.CoreV1().RESTClient().(*rest.RESTClient).Client
-	if err != nil {
-		return nil, fmt.Errorf("creating http-client failed: %w", err)
-	}
 
 	mClientV1, err := v1monitoringclient.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
## Description

- replace go kit log in resource_selector.go
- replace go kit log in accessor.go
- remove unused err validation



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
