### PR TITLE
chore: replace goKitLogger in k8sutil and event handler

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -340,7 +340,7 @@ func (c *Operator) addHandlers() {
 	c.ssetInfs.AddEventHandler(c.rr)
 
 	c.alrtCfgInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1alpha1.AlertmanagerConfigKind,
@@ -348,7 +348,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.secrInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",

--- a/pkg/k8sutil/secrets.go
+++ b/pkg/k8sutil/secrets.go
@@ -17,9 +17,8 @@ package k8sutil
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,7 @@ import (
 // LoadSecretRef returns the data from a secret key reference.
 // If the reference is set as optional and the secret or key isn't found, the
 // function returns no error.
-func LoadSecretRef(ctx context.Context, logger log.Logger, client clientv1.SecretInterface, sks *v1.SecretKeySelector) ([]byte, error) {
+func LoadSecretRef(ctx context.Context, logger *slog.Logger, client clientv1.SecretInterface, sks *v1.SecretKeySelector) ([]byte, error) {
 	if sks == nil {
 		return nil, nil
 	}
@@ -41,7 +40,7 @@ func LoadSecretRef(ctx context.Context, logger log.Logger, client clientv1.Secre
 	secret, err := client.Get(ctx, sks.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) && optional {
-			level.Debug(logger).Log("msg", fmt.Sprintf("secret %v could not be found", sks.Name))
+			logger.Debug(fmt.Sprintf("secret %v could not be found", sks.Name))
 			return nil, nil
 		}
 
@@ -51,7 +50,7 @@ func LoadSecretRef(ctx context.Context, logger log.Logger, client clientv1.Secre
 	b, found := secret.Data[sks.Key]
 	if !found {
 		if optional {
-			level.Debug(logger).Log("msg", fmt.Sprintf("secret %v could not be found", sks.Name))
+			logger.Debug(fmt.Sprintf("secret %v could not be found", sks.Name))
 			return nil, nil
 		}
 

--- a/pkg/k8sutil/secrets_test.go
+++ b/pkg/k8sutil/secrets_test.go
@@ -16,9 +16,11 @@ package k8sutil
 
 import (
 	"context"
+	"log/slog"
+	"math"
+	"os"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +41,10 @@ func TestLoadSecretRef(t *testing.T) {
 	}
 
 	sClient := fake.NewSimpleClientset(secret).CoreV1().Secrets("ns")
-	logger := log.NewNopLogger()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		// slog level math.MaxInt means no logging
+		Level: slog.Level(math.MaxInt),
+	}))
 
 	for _, tc := range []struct {
 		name     string

--- a/pkg/k8sutil/secrets_test.go
+++ b/pkg/k8sutil/secrets_test.go
@@ -43,6 +43,8 @@ func TestLoadSecretRef(t *testing.T) {
 	sClient := fake.NewSimpleClientset(secret).CoreV1().Secrets("ns")
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		// slog level math.MaxInt means no logging
+		// We would like to use the slog buil-in No-op level once it is available
+		// More: https://github.com/golang/go/issues/62005
 		Level: slog.Level(math.MaxInt),
 	}))
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -490,7 +490,7 @@ func (c *Operator) addHandlers() {
 	// c.dsetInfs.AddEventHandler(c.rr)
 
 	c.smonInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.ServiceMonitorsKind,
@@ -498,7 +498,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.pmonInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.PodMonitorsKind,
@@ -506,7 +506,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.probeInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.ProbesKind,
@@ -515,7 +515,7 @@ func (c *Operator) addHandlers() {
 
 	if c.sconInfs != nil {
 		c.sconInfs.AddEventHandler(operator.NewEventHandler(
-			c.goKitLogger,
+			c.logger,
 			c.accessor,
 			c.metrics,
 			monitoringv1alpha1.ScrapeConfigsKind,
@@ -524,7 +524,7 @@ func (c *Operator) addHandlers() {
 	}
 
 	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		"ConfigMap",
@@ -532,7 +532,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.secrInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
@@ -898,7 +898,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 
 	sClient := c.kclient.CoreV1().Secrets(p.Namespace)
-	additionalScrapeConfigs, err := k8sutil.LoadSecretRef(ctx, c.goKitLogger, sClient, p.Spec.AdditionalScrapeConfigs)
+	additionalScrapeConfigs, err := k8sutil.LoadSecretRef(ctx, c.logger, sClient, p.Spec.AdditionalScrapeConfigs)
 	if err != nil {
 		return fmt.Errorf("loading additional scrape configs from Secret failed: %w", err)
 	}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -425,7 +425,7 @@ func (c *Operator) addHandlers() {
 	c.ssetInfs.AddEventHandler(c.rr)
 
 	c.smonInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.ServiceMonitorsKind,
@@ -433,7 +433,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.pmonInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.PodMonitorsKind,
@@ -441,7 +441,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.probeInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.ProbesKind,
@@ -450,7 +450,7 @@ func (c *Operator) addHandlers() {
 
 	if c.sconInfs != nil {
 		c.sconInfs.AddEventHandler(operator.NewEventHandler(
-			c.goKitLogger,
+			c.logger,
 			c.accessor,
 			c.metrics,
 			monitoringv1alpha1.ScrapeConfigsKind,
@@ -459,7 +459,7 @@ func (c *Operator) addHandlers() {
 	}
 
 	c.ruleInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		monitoringv1.PrometheusRuleKind,
@@ -467,7 +467,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		"ConfigMap",
@@ -475,7 +475,7 @@ func (c *Operator) addHandlers() {
 	))
 
 	c.secrInfs.AddEventHandler(operator.NewEventHandler(
-		c.goKitLogger,
+		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
@@ -1189,15 +1189,15 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	}
 
 	sClient := c.kclient.CoreV1().Secrets(p.Namespace)
-	additionalScrapeConfigs, err := k8sutil.LoadSecretRef(ctx, c.goKitLogger, sClient, p.Spec.AdditionalScrapeConfigs)
+	additionalScrapeConfigs, err := k8sutil.LoadSecretRef(ctx, c.logger, sClient, p.Spec.AdditionalScrapeConfigs)
 	if err != nil {
 		return fmt.Errorf("loading additional scrape configs from Secret failed: %w", err)
 	}
-	additionalAlertRelabelConfigs, err := k8sutil.LoadSecretRef(ctx, c.goKitLogger, sClient, p.Spec.AdditionalAlertRelabelConfigs)
+	additionalAlertRelabelConfigs, err := k8sutil.LoadSecretRef(ctx, c.logger, sClient, p.Spec.AdditionalAlertRelabelConfigs)
 	if err != nil {
 		return fmt.Errorf("loading additional alert relabel configs from Secret failed: %w", err)
 	}
-	additionalAlertManagerConfigs, err := k8sutil.LoadSecretRef(ctx, c.goKitLogger, sClient, p.Spec.AdditionalAlertManagerConfigs)
+	additionalAlertManagerConfigs, err := k8sutil.LoadSecretRef(ctx, c.logger, sClient, p.Spec.AdditionalAlertManagerConfigs)
 	if err != nil {
 		return fmt.Errorf("loading additional alert manager configs from Secret failed: %w", err)
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -309,7 +309,7 @@ func (o *Operator) addHandlers() {
 	o.ssetInfs.AddEventHandler(o.rr)
 
 	o.cmapInfs.AddEventHandler(operator.NewEventHandler(
-		o.goKitLogger,
+		o.logger,
 		o.accessor,
 		o.metrics,
 		"ConfigMap",
@@ -317,7 +317,7 @@ func (o *Operator) addHandlers() {
 	))
 
 	o.ruleInfs.AddEventHandler(operator.NewEventHandler(
-		o.goKitLogger,
+		o.logger,
 		o.accessor,
 		o.metrics,
 		monitoringv1.PrometheusRuleKind,


### PR DESCRIPTION
## Description

Replace goKitLogger in k8sutil package and EventHandler struct 


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
