### PR TITLE
fix: allow proxy URL for all Prometheus versions

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -578,11 +578,11 @@ func (cg *ConfigGenerator) addProxyConfigtoYaml(
 		return cfg
 	}
 
-	var cgProxyConfig = cg.WithMinimumVersion("2.43.0")
-
 	if proxyConfig.ProxyURL != nil {
-		cfg = cgProxyConfig.AppendMapItem(cfg, "proxy_url", *proxyConfig.ProxyURL)
+		cfg = cg.AppendMapItem(cfg, "proxy_url", *proxyConfig.ProxyURL)
 	}
+
+	cgProxyConfig := cg.WithMinimumVersion("2.43.0")
 
 	if proxyConfig.NoProxy != nil {
 		cfg = cgProxyConfig.AppendMapItem(cfg, "no_proxy", *proxyConfig.NoProxy)

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ProxySettingsIncompatiblePrometheusVersion.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ProxySettingsIncompatiblePrometheusVersion.golden
@@ -6,6 +6,7 @@ global:
     prometheus_replica: $(POD_NAME)
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
+  proxy_url: http://no-proxy.com
   relabel_configs:
   - source_labels:
     - job


### PR DESCRIPTION
## Description

The `proxy_url` field is supported for all 2.x versions. I found the issue while reviewing some code. The issue doesn't impact ServiceMonitor, Probe and PodMonitor which don't call (yet) `addProxyConfigtoYaml()`. It's also not affecting deployments that use a reasonably recent version of Prometheus (e.g. >= 2.43 which is 1 year and half old)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix proxy URL support for all Prometheus versions.
```
