### PR TITLE
feat: add MatchFirstNetwork field for DockerSD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -20007,8 +20007,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>Configure whether match the first network if the container has multiple networks defined.
-If unset, Prometheus uses its default value.
+<p>Configure whether to match the first network if the container has multiple networks defined.
+If unset, Prometheus uses true by default.
 It requires Prometheus &gt;= v2.54.0.</p>
 </td>
 </tr>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -20000,6 +20000,20 @@ string
 </tr>
 <tr>
 <td>
+<code>matchFirstNetwork</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Configure whether match the first network if the container has multiple networks defined.
+If unset, Prometheus uses its default value.
+It requires Prometheus &gt;= v2.54.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>filters</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1alpha1.Filters">

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -47529,8 +47529,8 @@ spec:
                       type: string
                     matchFirstNetwork:
                       description: |-
-                        Configure whether match the first network if the container has multiple networks defined.
-                        If unset, Prometheus uses its default value.
+                        Configure whether to match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses true by default.
                         It requires Prometheus >= v2.54.0.
                       type: boolean
                     noProxy:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -47527,6 +47527,12 @@ spec:
                       description: The host to use if the container is in host networking
                         mode.
                       type: string
+                    matchFirstNetwork:
+                      description: |-
+                        Configure whether match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses its default value.
+                        It requires Prometheus >= v2.54.0.
+                      type: boolean
                     noProxy:
                       description: |-
                         `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -2599,8 +2599,8 @@ spec:
                       type: string
                     matchFirstNetwork:
                       description: |-
-                        Configure whether match the first network if the container has multiple networks defined.
-                        If unset, Prometheus uses its default value.
+                        Configure whether to match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses true by default.
                         It requires Prometheus >= v2.54.0.
                       type: boolean
                     noProxy:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -2597,6 +2597,12 @@ spec:
                       description: The host to use if the container is in host networking
                         mode.
                       type: string
+                    matchFirstNetwork:
+                      description: |-
+                        Configure whether match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses its default value.
+                        It requires Prometheus >= v2.54.0.
+                      type: boolean
                     noProxy:
                       description: |-
                         `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -2600,8 +2600,8 @@ spec:
                       type: string
                     matchFirstNetwork:
                       description: |-
-                        Configure whether match the first network if the container has multiple networks defined.
-                        If unset, Prometheus uses its default value.
+                        Configure whether to match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses true by default.
                         It requires Prometheus >= v2.54.0.
                       type: boolean
                     noProxy:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -2598,6 +2598,12 @@ spec:
                       description: The host to use if the container is in host networking
                         mode.
                       type: string
+                    matchFirstNetwork:
+                      description: |-
+                        Configure whether match the first network if the container has multiple networks defined.
+                        If unset, Prometheus uses its default value.
+                        It requires Prometheus >= v2.54.0.
+                      type: boolean
                     noProxy:
                       description: |-
                         `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -2309,6 +2309,10 @@
                           "description": "The host to use if the container is in host networking mode.",
                           "type": "string"
                         },
+                        "matchFirstNetwork": {
+                          "description": "Configure whether match the first network if the container has multiple networks defined.\nIf unset, Prometheus uses its default value.\nIt requires Prometheus >= v2.54.0.",
+                          "type": "boolean"
+                        },
                         "noProxy": {
                           "description": "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names\nthat should be excluded from proxying. IP and domain names can\ncontain port numbers.\n\n\nIt requires Prometheus >= v2.43.0.",
                           "type": "string"

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -2310,7 +2310,7 @@
                           "type": "string"
                         },
                         "matchFirstNetwork": {
-                          "description": "Configure whether match the first network if the container has multiple networks defined.\nIf unset, Prometheus uses its default value.\nIt requires Prometheus >= v2.54.0.",
+                          "description": "Configure whether to match the first network if the container has multiple networks defined.\nIf unset, Prometheus uses true by default.\nIt requires Prometheus >= v2.54.0.",
                           "type": "boolean"
                         },
                         "noProxy": {

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -888,8 +888,8 @@ type DockerSDConfig struct {
 	// The host to use if the container is in host networking mode.
 	// +optional
 	HostNetworkingHost *string `json:"hostNetworkingHost,omitempty"`
-	// Configure whether match the first network if the container has multiple networks defined.
-	// If unset, Prometheus uses its default value.
+	// Configure whether to match the first network if the container has multiple networks defined.
+	// If unset, Prometheus uses true by default.
 	// It requires Prometheus >= v2.54.0.
 	//
 	// +optional

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -888,6 +888,12 @@ type DockerSDConfig struct {
 	// The host to use if the container is in host networking mode.
 	// +optional
 	HostNetworkingHost *string `json:"hostNetworkingHost,omitempty"`
+	// Configure whether match the first network if the container has multiple networks defined.
+	// If unset, Prometheus uses its default value.
+	// It requires Prometheus >= v2.54.0.
+	//
+	// +optional
+	MatchFirstNetwork *bool `json:"matchFirstNetwork,omitempty"`
 	// Optional filters to limit the discovery process to a subset of the available resources.
 	// +optional
 	Filters Filters `json:"filters,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -445,6 +445,11 @@ func (in *DockerSDConfig) DeepCopyInto(out *DockerSDConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MatchFirstNetwork != nil {
+		in, out := &in.MatchFirstNetwork, &out.MatchFirstNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Filters != nil {
 		in, out := &in.Filters, &out.Filters
 		*out = make(Filters, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/dockersdconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/dockersdconfig.go
@@ -31,6 +31,7 @@ type DockerSDConfigApplyConfiguration struct {
 	TLSConfig                        *v1.SafeTLSConfigApplyConfiguration     `json:"tlsConfig,omitempty"`
 	Port                             *int                                    `json:"port,omitempty"`
 	HostNetworkingHost               *string                                 `json:"hostNetworkingHost,omitempty"`
+	MatchFirstNetwork                *bool                                   `json:"matchFirstNetwork,omitempty"`
 	Filters                          *v1alpha1.Filters                       `json:"filters,omitempty"`
 	RefreshInterval                  *monitoringv1.Duration                  `json:"refreshInterval,omitempty"`
 	BasicAuth                        *v1.BasicAuthApplyConfiguration         `json:"basicAuth,omitempty"`
@@ -113,6 +114,14 @@ func (b *DockerSDConfigApplyConfiguration) WithPort(value int) *DockerSDConfigAp
 // If called multiple times, the HostNetworkingHost field is set to the value of the last call.
 func (b *DockerSDConfigApplyConfiguration) WithHostNetworkingHost(value string) *DockerSDConfigApplyConfiguration {
 	b.HostNetworkingHost = &value
+	return b
+}
+
+// WithMatchFirstNetwork sets the MatchFirstNetwork field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MatchFirstNetwork field is set to the value of the last call.
+func (b *DockerSDConfigApplyConfiguration) WithMatchFirstNetwork(value bool) *DockerSDConfigApplyConfiguration {
+	b.MatchFirstNetwork = &value
 	return b
 }
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -3573,6 +3573,12 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 					Value: config.HostNetworkingHost})
 			}
 
+			if config.MatchFirstNetwork != nil {
+				configs[i] = cg.WithMinimumVersion("2.54.0").AppendMapItem(configs[i],
+					"match_first_network",
+					config.MatchFirstNetwork)
+			}
+
 			if config.RefreshInterval != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
 					Key:   "refresh_interval",

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -7563,9 +7563,10 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 
 func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		scSpec monitoringv1alpha1.ScrapeConfigSpec
-		golden string
+		name    string
+		version string
+		scSpec  monitoringv1alpha1.ScrapeConfigSpec
+		golden  string
 	}{
 		{
 			name: "docker_sd_config_with_authorization",
@@ -7756,6 +7757,120 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 			},
 			golden: "ScrapeConfigSpecConfig_DockerSD_with_BasicAuth.golden",
 		},
+		{
+			name:    "docker_sd_config_match_first_network",
+			version: "v2.54.0",
+			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				DockerSDConfigs: []monitoringv1alpha1.DockerSDConfig{
+					{
+						Host: "hostAddress",
+						Filters: []monitoringv1alpha1.Filter{
+							{Name: "dummy_label_1",
+								Values: []string{"dummy_value_1"}},
+							{Name: "dummy_label_2",
+								Values: []string{"dummy_value_2", "dummy_value_3"}},
+						},
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls",
+									},
+									Key: "ca",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls",
+									},
+									Key: "cert",
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "tls",
+								},
+								Key: "private-key",
+							},
+						},
+						BasicAuth: &monitoringv1.BasicAuth{
+							Username: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "username",
+							},
+							Password: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "password",
+							},
+						},
+						MatchFirstNetwork: ptr.To(true),
+					},
+				},
+			},
+			golden: "ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork.golden",
+		},
+		{
+			name:    "docker_sd_config_match_first_network_with_old_verison",
+			version: "v2.53.0",
+			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				DockerSDConfigs: []monitoringv1alpha1.DockerSDConfig{
+					{
+						Host: "hostAddress",
+						Filters: []monitoringv1alpha1.Filter{
+							{Name: "dummy_label_1",
+								Values: []string{"dummy_value_1"}},
+							{Name: "dummy_label_2",
+								Values: []string{"dummy_value_2", "dummy_value_3"}},
+						},
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls",
+									},
+									Key: "ca",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls",
+									},
+									Key: "cert",
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "tls",
+								},
+								Key: "private-key",
+							},
+						},
+						BasicAuth: &monitoringv1.BasicAuth{
+							Username: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "username",
+							},
+							Password: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "foo",
+								},
+								Key: "password",
+							},
+						},
+						MatchFirstNetwork: ptr.To(true),
+					},
+				},
+			},
+			golden: "ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork_OldVersion.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
@@ -7801,6 +7916,9 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 			}
 
 			p := defaultPrometheus()
+			if tc.version != "" {
+				p.Spec.CommonPrometheusFields.Version = tc.version
+			}
 			cg := mustNewConfigGenerator(t, p)
 			cfg, err := cg.GenerateServerConfiguration(
 				p.Spec.EvaluationInterval,

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork.golden
@@ -1,0 +1,30 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  docker_sd_configs:
+  - basic_auth:
+      username: ""
+      password: ""
+    filters:
+    - name: dummy_label_1
+      values:
+      - dummy_value_1
+    - name: dummy_label_2
+      values:
+      - dummy_value_2
+      - dummy_value_3
+    host: hostAddress
+    tls_config:
+      ca_file: /etc/prometheus/certs/0_default_tls_ca
+      cert_file: /etc/prometheus/certs/0_default_tls_cert
+      key_file: /etc/prometheus/certs/0_default_tls_private-key
+    match_first_network: true
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork_OldVersion.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSD_with_MatchFirstNetwork_OldVersion.golden
@@ -1,0 +1,29 @@
+global:
+  evaluation_interval: 30s
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  docker_sd_configs:
+  - basic_auth:
+      username: ""
+      password: ""
+    filters:
+    - name: dummy_label_1
+      values:
+      - dummy_value_1
+    - name: dummy_label_2
+      values:
+      - dummy_value_2
+      - dummy_value_3
+    host: hostAddress
+    tls_config:
+      ca_file: /etc/prometheus/certs/0_default_tls_ca
+      cert_file: /etc/prometheus/certs/0_default_tls_cert
+      key_file: /etc/prometheus/certs/0_default_tls_private-key
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Closes #6839 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support MatchFirstNetwork field for DockerSD
```
