### PR TITLE
Switching the position of Platform and Developer Guide in Website

### DIFF
--- a/Documentation/high-availability.md
+++ b/Documentation/high-availability.md
@@ -1,5 +1,5 @@
 ---
-weight: 256
+weight: 206
 toc: true
 title: High Availability
 menu:

--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -1,5 +1,5 @@
 ---
-weight: 259
+weight: 209
 toc: false
 title: CLI reference
 menu:

--- a/Documentation/rbac-crd.md
+++ b/Documentation/rbac-crd.md
@@ -1,5 +1,5 @@
 ---
-weight: 255
+weight: 205
 toc: true
 title: RBAC for CRDs
 menu:

--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -1,5 +1,5 @@
 ---
-weight: 254
+weight: 204
 toc: true
 title: RBAC
 menu:

--- a/Documentation/thanos.md
+++ b/Documentation/thanos.md
@@ -1,5 +1,5 @@
 ---
-weight: 253
+weight: 203
 toc: true
 title: Thanos
 menu:

--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-weight: 260
+weight: 210
 toc: true
 title: Troubleshooting
 menu:

--- a/Documentation/user-guides/alerting.md
+++ b/Documentation/user-guides/alerting.md
@@ -1,5 +1,5 @@
 ---
-weight: 202
+weight: 252
 toc: true
 title: Alerting
 menu:

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-weight: 201
+weight: 251
 toc: true
 title: Getting Started
 menu:

--- a/Documentation/user-guides/prometheus-agent.md
+++ b/Documentation/user-guides/prometheus-agent.md
@@ -1,5 +1,5 @@
 ---
-weight: 252
+weight: 202
 toc: true
 title: Prometheus Agent
 menu:

--- a/Documentation/user-guides/scrapeconfig.md
+++ b/Documentation/user-guides/scrapeconfig.md
@@ -1,5 +1,5 @@
 ---
-weight: 203
+weight: 253
 toc: true
 title: ScrapeConfig CRD
 menu:

--- a/Documentation/user-guides/storage.md
+++ b/Documentation/user-guides/storage.md
@@ -1,5 +1,5 @@
 ---
-weight: 257
+weight: 207
 toc: true
 title: Storage
 menu:

--- a/Documentation/user-guides/strategic-merge-patch.md
+++ b/Documentation/user-guides/strategic-merge-patch.md
@@ -1,5 +1,5 @@
 ---
-weight: 258
+weight: 208
 toc: true
 title: Strategic Merge Patch
 menu:

--- a/Documentation/user-guides/webhook.md
+++ b/Documentation/user-guides/webhook.md
@@ -1,5 +1,5 @@
 ---
-weight: 251
+weight: 201
 toc: true
 title: Admission webhook
 menu:


### PR DESCRIPTION
## Description

On the [website](https://prometheus-operator.dev/), the Developer Guide comes before the Platform Guide. The Developer Guide instructs us how to configure scraping, alerting, and recording rules while the Platform Guide instructs us how to deploy a Prometheus, Alertmanager, or Thanos instance. In discussion with @nicolastakashi and @ArthurSens, we concluded moving the Platform Guide before the Developer Guide would be better to make a better user experience. It makes more sense to learn how to deploy Prometheus before moving on to learning configuration for scraping metrics.

This PR will change the order of these Guides. You can view the preview in this [PR](https://github.com/prometheus-operator/website/pull/100).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
