### PR TITLE
ScrapeConfig: Refactor StaticConfig

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -28527,7 +28527,8 @@ map[github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1.La
 (<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.StaticConfig">StaticConfig</a>)
 </p>
 <div>
-<p>Target represents a target for Prometheus to scrape</p>
+<p>Target represents a target for Prometheus to scrape
+kubebuilder:validation:MinLength:=1</p>
 </div>
 <h3 id="monitoring.coreos.com/v1alpha1.TelegramConfig">TelegramConfig
 </h3>

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -28503,7 +28503,6 @@ See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configur
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>List of targets for this static configuration.</p>
 </td>
 </tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -55438,10 +55438,13 @@ spec:
                     targets:
                       description: List of targets for this static configuration.
                       items:
-                        description: Target represents a target for Prometheus to
-                          scrape
+                        description: |-
+                          Target represents a target for Prometheus to scrape
+                          kubebuilder:validation:MinLength:=1
                         type: string
+                      minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
                 type: array
               targetLimit:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -55445,6 +55445,8 @@ spec:
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: set
+                  required:
+                  - targets
                   type: object
                 type: array
               targetLimit:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -11261,6 +11261,8 @@ spec:
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: set
+                  required:
+                  - targets
                   type: object
                 type: array
               targetLimit:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -11254,10 +11254,13 @@ spec:
                     targets:
                       description: List of targets for this static configuration.
                       items:
-                        description: Target represents a target for Prometheus to
-                          scrape
+                        description: |-
+                          Target represents a target for Prometheus to scrape
+                          kubebuilder:validation:MinLength:=1
                         type: string
+                      minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
                 type: array
               targetLimit:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -11255,10 +11255,13 @@ spec:
                     targets:
                       description: List of targets for this static configuration.
                       items:
-                        description: Target represents a target for Prometheus to
-                          scrape
+                        description: |-
+                          Target represents a target for Prometheus to scrape
+                          kubebuilder:validation:MinLength:=1
                         type: string
+                      minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
                 type: array
               targetLimit:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -11262,6 +11262,8 @@ spec:
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: set
+                  required:
+                  - targets
                   type: object
                 type: array
               targetLimit:

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -10687,6 +10687,9 @@
                           "x-kubernetes-list-type": "set"
                         }
                       },
+                      "required": [
+                        "targets"
+                      ],
                       "type": "object"
                     },
                     "type": "array"

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -10679,10 +10679,12 @@
                         "targets": {
                           "description": "List of targets for this static configuration.",
                           "items": {
-                            "description": "Target represents a target for Prometheus to scrape",
+                            "description": "Target represents a target for Prometheus to scrape\nkubebuilder:validation:MinLength:=1",
                             "type": "string"
                           },
-                          "type": "array"
+                          "minItems": 1,
+                          "type": "array",
+                          "x-kubernetes-list-type": "set"
                         }
                       },
                       "type": "object"

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -337,7 +337,7 @@ type StaticConfig struct {
 	// List of targets for this static configuration.
 	// +kubebuilder:validation:MinItems:=1
 	// +listType=set
-	// +optional
+	// +required
 	Targets []Target `json:"targets,omitempty"`
 	// Labels assigned to all metrics scraped from the targets.
 	// +mapType:=atomic

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -338,7 +338,7 @@ type StaticConfig struct {
 	// +kubebuilder:validation:MinItems:=1
 	// +listType=set
 	// +required
-	Targets []Target `json:"targets,omitempty"`
+	Targets []Target `json:"targets"`
 	// Labels assigned to all metrics scraped from the targets.
 	// +mapType:=atomic
 	// +optional

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -28,6 +28,7 @@ const (
 )
 
 // Target represents a target for Prometheus to scrape
+// kubebuilder:validation:MinLength:=1
 type Target string
 
 // SDFile represents a file used for service discovery
@@ -334,6 +335,8 @@ type ScrapeConfigSpec struct {
 // +k8s:openapi-gen=true
 type StaticConfig struct {
 	// List of targets for this static configuration.
+	// +kubebuilder:validation:MinItems:=1
+	// +listType=set
 	// +optional
 	Targets []Target `json:"targets,omitempty"`
 	// Labels assigned to all metrics scraped from the targets.

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -592,6 +592,9 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 	t.Run("EC2SD", func(t *testing.T) {
 		runScrapeConfigCRDValidation(t, EC2SDTestCases)
 	})
+	t.Run("StaticConfig", func(t *testing.T) {
+		runScrapeConfigCRDValidation(t, staticConfigTestCases)
+	})
 	t.Run("FileSD", func(t *testing.T) {
 		runScrapeConfigCRDValidation(t, FileSDTestCases)
 	})
@@ -1430,6 +1433,94 @@ var ScrapeConfigCRDTestCases = []scrapeCRDTestCase{
 			},
 		},
 		expectedError: false,
+	},
+}
+
+var staticConfigTestCases = []scrapeCRDTestCase{
+	{
+		name: "Valid targets",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
+				},
+			},
+		},
+		expectedError: false,
+	},
+	{
+		name: "Invalid absent targets",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid duplicate targets",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "1.1.1.1:9090"},
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid empty targets",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{},
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Valid labels",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
+					Labels:  map[monitoringv1.LabelName]string{"owned-by": "prometheus"},
+				},
+			},
+		},
+		expectedError: false,
+	},
+	{
+		name: "Invalid empty labels",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
+					Labels:  map[monitoringv1.LabelName]string{},
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid LabelNames",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{
+				{
+					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
+					Labels:  map[monitoringv1.LabelName]string{"11owned-by": "prometheus"},
+				},
+			},
+		},
+		expectedError: true,
 	},
 }
 

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -1497,19 +1497,6 @@ var staticConfigTestCases = []scrapeCRDTestCase{
 		expectedError: false,
 	},
 	{
-		name: "Invalid empty labels",
-		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
-
-			StaticConfigs: []monitoringv1alpha1.StaticConfig{
-				{
-					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
-					Labels:  map[monitoringv1.LabelName]string{},
-				},
-			},
-		},
-		expectedError: true,
-	},
-	{
 		name: "Invalid LabelNames",
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -1496,19 +1496,6 @@ var staticConfigTestCases = []scrapeCRDTestCase{
 		},
 		expectedError: false,
 	},
-	{
-		name: "Invalid LabelNames",
-		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
-
-			StaticConfigs: []monitoringv1alpha1.StaticConfig{
-				{
-					Targets: []monitoringv1alpha1.Target{"1.1.1.1:9090", "0.0.0.0:9090"},
-					Labels:  map[monitoringv1.LabelName]string{"11owned-by": "prometheus"},
-				},
-			},
-		},
-		expectedError: true,
-	},
 }
 
 var FileSDTestCases = []scrapeCRDTestCase{


### PR DESCRIPTION
## Description

PR adds additional validation and e2e testcases for StaticConfig.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
