### PR TITLE
replace goKitLogger in rules

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -17,11 +17,10 @@ package operator
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,10 +50,10 @@ type PrometheusRuleSelector struct {
 
 	eventRecorder record.EventRecorder
 
-	logger log.Logger
+	logger *slog.Logger
 }
 
-func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder record.EventRecorder, logger log.Logger) (*PrometheusRuleSelector, error) {
+func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder record.EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
 	componentVersion, err := semver.ParseTolerant(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)
@@ -77,7 +76,7 @@ func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version strin
 }
 
 func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitoringv1.PrometheusRule) (string, error) {
-	logger := log.With(prs.logger, "prometheusrule", promRule.Name, "prometheusrule-namespace", promRule.Namespace)
+	logger := prs.logger.With("prometheusrule", promRule.Name, "prometheusrule-namespace", promRule.Namespace)
 	promRuleSpec := promRule.Spec
 
 	promRuleSpec = prs.sanitizePrometheusRulesSpec(promRuleSpec, logger)
@@ -90,9 +89,9 @@ func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitori
 	errs := ValidateRule(promRuleSpec)
 	if len(errs) != 0 {
 		const m = "Invalid rule"
-		level.Debug(logger).Log("msg", m, "content", content)
+		logger.Debug(m, "content", content)
 		for _, err := range errs {
-			level.Info(logger).Log("msg", m, "err", err)
+			logger.Info(m, "err", err)
 		}
 		return "", errors.New(m)
 	}
@@ -101,7 +100,7 @@ func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitori
 }
 
 // sanitizePrometheusRulesSpec sanitizes the PrometheusRules spec depending on the Prometheus/Thanos version.
-func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec monitoringv1.PrometheusRuleSpec, logger log.Logger) monitoringv1.PrometheusRuleSpec {
+func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec monitoringv1.PrometheusRuleSpec, logger *slog.Logger) monitoringv1.PrometheusRuleSpec {
 	minVersionKeepFiringFor := semver.MustParse("2.42.0")
 	minVersionLimits := semver.MustParse("2.31.0")
 	component := "Prometheus"
@@ -115,7 +114,7 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 	for i := range promRuleSpec.Groups {
 		if promRuleSpec.Groups[i].Limit != nil && prs.version.LT(minVersionLimits) {
 			promRuleSpec.Groups[i].Limit = nil
-			level.Warn(logger).Log("msg", fmt.Sprintf("ignoring `limit` not supported by %s", component), "minimum_version", minVersionLimits)
+			logger.Warn(fmt.Sprintf("ignoring `limit` not supported by %s", component), "minimum_version", minVersionLimits)
 		}
 
 		if prs.ruleFormat == PrometheusFormat {
@@ -126,7 +125,7 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 		for j := range promRuleSpec.Groups[i].Rules {
 			if promRuleSpec.Groups[i].Rules[j].KeepFiringFor != nil && prs.version.LT(minVersionKeepFiringFor) {
 				promRuleSpec.Groups[i].Rules[j].KeepFiringFor = nil
-				level.Warn(logger).Log("msg", fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
+				logger.Warn(fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
 			}
 		}
 	}
@@ -171,7 +170,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 		err := prs.ruleInformer.ListAllByNamespace(ns, prs.ruleSelector, func(obj interface{}) {
 			promRule := obj.(*monitoringv1.PrometheusRule).DeepCopy()
 			if err := k8sutil.AddTypeInformationToObject(promRule); err != nil {
-				level.Error(prs.logger).Log("msg", "failed to set rule type information", "namespace", ns, "err", err)
+				prs.logger.Error("failed to set rule type information", "namespace", ns, "err", err)
 				return
 			}
 
@@ -195,8 +194,8 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 		content, err = prs.generateRulesConfiguration(promRule)
 		if err != nil {
 			rejected++
-			level.Warn(prs.logger).Log(
-				"msg", "skipping prometheusrule",
+			prs.logger.Warn(
+				"skipping prometheusrule",
 				"error", err.Error(),
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
@@ -213,8 +212,8 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 		ruleNames = append(ruleNames, name)
 	}
 
-	level.Debug(prs.logger).Log(
-		"msg", "selected Rules",
+	prs.logger.Debug(
+		"selected Rules",
 		"rules", strings.Join(ruleNames, ","),
 	)
 

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -15,11 +15,11 @@
 package operator
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -44,10 +44,11 @@ func TestMakeRulesConfigMaps(t *testing.T) {
 }
 
 func newRuleSelectorForConfigGeneration(ruleFormat RuleConfigurationFormat, version semver.Version) PrometheusRuleSelector {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	return PrometheusRuleSelector{
 		ruleFormat: ruleFormat,
 		version:    version,
-		logger:     log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+		logger:     logger,
 	}
 }
 

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +63,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 		true,
 	)
 
-	logger := log.With(c.goKitLogger, "prometheus", p.Name, "namespace", p.Namespace)
+	logger := c.logger.With("prometheus", p.Name, "namespace", p.Namespace)
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 
 	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.PrometheusFormat, promVersion, p.Spec.RuleSelector, nsLabeler, c.ruleInfs, c.eventRecorder, logger)

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/mitchellh/hashstructure"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -243,7 +242,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, goKitL
 			return nil, err
 		}
 
-		level.Debug(o.goKitLogger).Log("msg", "creating namespace informer", "privileged", privileged)
+		o.logger.Debug("creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
 			&v1.Namespace{},
@@ -299,7 +298,7 @@ func (o *Operator) waitForCacheSync(ctx context.Context) error {
 		}
 	}
 
-	level.Info(o.goKitLogger).Log("msg", "successfully synced all caches")
+	o.logger.Info("successfully synced all caches")
 	return nil
 }
 
@@ -372,7 +371,7 @@ func (o *Operator) Iterate(processFn func(metav1.Object, []monitoringv1.Conditio
 		a := o.(*monitoringv1.ThanosRuler)
 		processFn(a, a.Status.Conditions)
 	}); err != nil {
-		level.Error(o.goKitLogger).Log("msg", "failed to list ThanosRuler objects", "err", err)
+		o.logger.Error("failed to list ThanosRuler objects", "err", err)
 	}
 }
 
@@ -395,7 +394,7 @@ func (o *Operator) Resolve(ss *appsv1.StatefulSet) metav1.Object {
 	}
 
 	if err != nil {
-		level.Error(o.goKitLogger).Log("msg", "ThanosRuler lookup failed", "err", err)
+		o.logger.Error("ThanosRuler lookup failed", "err", err)
 		return nil
 	}
 
@@ -416,14 +415,14 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 	old := oldo.(*v1.Namespace)
 	cur := curo.(*v1.Namespace)
 
-	level.Debug(o.goKitLogger).Log("msg", "update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
+	o.logger.Debug("update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
 	// Periodic resync may resend the Namespace without changes in-between.
 	if old.ResourceVersion == cur.ResourceVersion {
 		return
 	}
 
-	level.Debug(o.goKitLogger).Log("msg", "Namespace updated", "namespace", cur.GetName())
+	o.logger.Debug("Namespace updated", "namespace", cur.GetName())
 	o.metrics.TriggerByCounter("Namespace", operator.UpdateEvent).Inc()
 
 	// Check for ThanosRuler instances selecting PrometheusRules in the namespace.
@@ -432,7 +431,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 
 		sync, err := k8sutil.LabelSelectionHasChanged(old.Labels, cur.Labels, tr.Spec.RuleNamespaceSelector)
 		if err != nil {
-			level.Error(o.goKitLogger).Log(
+			o.logger.Error("",
 				"err", err,
 				"name", tr.Name,
 				"namespace", tr.Namespace,
@@ -445,8 +444,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo interface{}) {
 		}
 	})
 	if err != nil {
-		level.Error(o.goKitLogger).Log(
-			"msg", "listing all ThanosRuler instances from cache failed",
+		o.logger.Error("listing all ThanosRuler instances from cache failed",
 			"err", err,
 		)
 	}
@@ -486,8 +484,8 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger := log.With(o.goKitLogger, "key", key)
-	level.Info(logger).Log("msg", "sync thanos-ruler")
+	logger := o.logger.With("key", key)
+	logger.Info("sync thanos-ruler")
 
 	if err := operator.CheckStorageClass(ctx, o.canReadStorageClass, o.kclient, tr.Spec.Storage); err != nil {
 		return err
@@ -553,7 +551,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	operator.SanitizeSTS(sset)
 
 	if newSSetInputHash == existingStatefulSet.ObjectMeta.Annotations[operator.InputHashAnnotationName] {
-		level.Debug(logger).Log("msg", "new statefulset generation inputs match current, skipping any actions")
+		logger.Debug("new statefulset generation inputs match current, skipping any actions")
 		return nil
 	}
 
@@ -570,7 +568,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 			failMsg[i] = cause.Message
 		}
 
-		level.Info(logger).Log("msg", "recreating ThanosRuler StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
+		logger.Info("recreating ThanosRuler StatefulSet because the update operation wasn't possible", "reason", strings.Join(failMsg, ", "))
 		propagationPolicy := metav1.DeletePropagationForeground
 		if err := ssetClient.Delete(ctx, sset.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
 			return fmt.Errorf("failed to delete StatefulSet to avoid forbidden action: %w", err)
@@ -591,7 +589,7 @@ func (o *Operator) getThanosRulerFromKey(key string) (*monitoringv1.ThanosRuler,
 	obj, err := o.thanosRulerInfs.Get(key)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			level.Info(o.goKitLogger).Log("msg", "ThanosRuler not found", "key", key)
+			o.logger.Info("ThanosRuler not found", "key", key)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to retrieve ThanosRuler from informer: %w", err)
@@ -609,7 +607,7 @@ func (o *Operator) getStatefulSetFromThanosRulerKey(key string) (*appsv1.Statefu
 	obj, err := o.ssetInfs.Get(ssetName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			level.Info(o.goKitLogger).Log("msg", "StatefulSet not found", "key", ssetName)
+			o.logger.Info("StatefulSet not found", "key", ssetName)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to retrieve StatefulSet from informer: %w", err)
@@ -710,15 +708,13 @@ func (o *Operator) enqueueForRulesNamespace(nsName string) {
 func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	nsObject, exists, err := store.GetByKey(nsName)
 	if err != nil {
-		level.Error(o.goKitLogger).Log(
-			"msg", "get namespace to enqueue ThanosRuler instances failed",
+		o.logger.Error("get namespace to enqueue ThanosRuler instances failed",
 			"err", err,
 		)
 		return
 	}
 	if !exists {
-		level.Error(o.goKitLogger).Log(
-			"msg", "get namespace to enqueue ThanosRuler instances failed: namespace does not exist",
+		o.logger.Error("get namespace to enqueue ThanosRuler instances failed: namespace does not exist",
 			"namespace", nsName,
 		)
 		return
@@ -737,7 +733,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		// the namespace.
 		ruleNSSelector, err := metav1.LabelSelectorAsSelector(tr.Spec.RuleNamespaceSelector)
 		if err != nil {
-			level.Error(o.goKitLogger).Log(
+			o.logger.Error("",
 				"err", fmt.Errorf("failed to convert RuleNamespaceSelector: %w", err),
 				"name", tr.Name,
 				"namespace", tr.Namespace,
@@ -752,8 +748,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		}
 	})
 	if err != nil {
-		level.Error(o.goKitLogger).Log(
-			"msg", "listing all ThanosRuler instances from cache failed",
+		o.logger.Error("listing all ThanosRuler instances from cache failed",
 			"err", err,
 		)
 	}

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -21,8 +21,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -65,7 +63,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		false,
 	)
 
-	logger := log.With(o.goKitLogger, "thanos", t.Name, "namespace", t.Namespace)
+	logger := o.logger.With("thanos", t.Name, "namespace", t.Namespace)
 	thanosVersion := operator.StringValOrDefault(t.Spec.Version, operator.DefaultThanosVersion)
 
 	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, o.eventRecorder, logger)
@@ -98,8 +96,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 
 	equal := reflect.DeepEqual(newRules, currentRules)
 	if equal && len(currentConfigMaps) != 0 {
-		level.Debug(o.goKitLogger).Log(
-			"msg", "no PrometheusRule changes",
+		o.logger.Debug("no PrometheusRule changes",
 			"namespace", t.Namespace,
 			"thanos", t.Name,
 		)
@@ -126,8 +123,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 	}
 
 	if len(currentConfigMaps) == 0 {
-		level.Debug(o.goKitLogger).Log(
-			"msg", "no PrometheusRule configmap found, creating new one",
+		o.logger.Debug("no PrometheusRule configmap found, creating new one",
 			"namespace", t.Namespace,
 			"thanos", t.Name,
 		)
@@ -149,8 +145,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		}
 	}
 
-	level.Debug(o.goKitLogger).Log(
-		"msg", "updating PrometheusRule",
+	o.logger.Debug("updating PrometheusRule",
 		"namespace", t.Namespace,
 		"thanos", t.Name,
 	)
@@ -186,8 +181,7 @@ func (o *Operator) selectRuleNamespaces(p *monitoringv1.ThanosRuler) ([]string, 
 		}
 	}
 
-	level.Debug(o.goKitLogger).Log(
-		"msg", "selected RuleNamespaces",
+	o.logger.Debug("selected RuleNamespaces",
 		"namespaces", strings.Join(namespaces, ","),
 		"namespace", p.Namespace,
 		"thanos", p.Name,


### PR DESCRIPTION
## Description

Replace goKitLogger in the rules (operator, prometheus server and thanos)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
