### PR TITLE
Support PodMonitor for Prometheus Agent in DaemonSet mode

### DIFF
--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -53,6 +53,8 @@ type PrometheusInterface interface {
 	GetStatus() PrometheusStatus
 }
 
+var _ = PrometheusInterface(&Prometheus{})
+
 func (l *Prometheus) GetCommonPrometheusFields() CommonPrometheusFields {
 	return l.Spec.CommonPrometheusFields
 }

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -53,8 +53,6 @@ type PrometheusInterface interface {
 	GetStatus() PrometheusStatus
 }
 
-var _ = PrometheusInterface(&Prometheus{})
-
 func (l *Prometheus) GetCommonPrometheusFields() CommonPrometheusFields {
 	return l.Spec.CommonPrometheusFields
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -661,8 +661,7 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 
 	logger.Info("sync prometheus")
 
-	opts := []prompkg.ConfigGeneratorOption{}
-	opts = append(opts, prompkg.DaemonSet())
+	opts := []prompkg.ConfigGeneratorOption{prompkg.WithDaemonSet()}
 	if c.endpointSliceSupported {
 		opts = append(opts, prompkg.WithEndpointSliceSupport())
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -662,6 +662,7 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 	logger.Info("sync prometheus")
 
 	opts := []prompkg.ConfigGeneratorOption{}
+	opts = append(opts, prompkg.DaemonSet())
 	if c.endpointSliceSupported {
 		opts = append(opts, prompkg.WithEndpointSliceSupport())
 	}
@@ -915,10 +916,6 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 }
 
 func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, store *assets.StoreBuilder) error {
-	if c.daemonSetFeatureGateEnabled {
-		cg.PromAgentDaemonSet = true
-	}
-
 	resourceSelector, err := prompkg.NewResourceSelector(c.logger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
 	if err != nil {
 		return err

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -915,6 +915,10 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 }
 
 func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, store *assets.StoreBuilder) error {
+	if c.daemonSetFeatureGateEnabled {
+		cg.PromAgentDaemonSet = true
+	}
+
 	resourceSelector, err := prompkg.NewResourceSelector(c.logger, p, store, c.nsMonInf, c.metrics, c.eventRecorder)
 	if err != nil {
 		return err

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -80,7 +80,7 @@ func WithEndpointSliceSupport() ConfigGeneratorOption {
 	}
 }
 
-func DaemonSet() ConfigGeneratorOption {
+func WithDaemonSet() ConfigGeneratorOption {
 	return func(cg *ConfigGenerator) {
 		cg.daemonSet = true
 	}
@@ -2016,10 +2016,8 @@ func (cg *ConfigGenerator) generateAdditionalScrapeConfigs(
 	}
 
 	// DaemonSet mode doesn't support sharding.
-	if !cg.daemonSet {
-		if shards == 1 {
-			return additionalScrapeConfigsYaml, nil
-		}
+	if cg.daemonSet || shards == 1 {
+		return additionalScrapeConfigsYaml, nil
 	}
 
 	var addlScrapeConfigs []yaml.MapSlice
@@ -2047,9 +2045,7 @@ func (cg *ConfigGenerator) generateAdditionalScrapeConfigs(
 		}
 		// DaemonSet mode doesn't support sharding.
 		if !cg.daemonSet {
-			if shards == 1 {
-				relabelings = cg.generateAddressShardingRelabelingRulesIfMissing(relabelings, shards)
-			}
+			relabelings = cg.generateAddressShardingRelabelingRulesIfMissing(relabelings, shards)
 		}
 
 		addlScrapeConfig = append(addlScrapeConfig, otherConfigItems...)

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -68,6 +68,7 @@ type ConfigGenerator struct {
 	useEndpointSlice       bool // Whether to use EndpointSlice for service discovery from `ServiceMonitor` objects.
 	scrapeClasses          map[string]monitoringv1.ScrapeClass
 	defaultScrapeClassName string
+	PromAgentDaemonSet     bool
 }
 
 type ConfigGeneratorOption func(*ConfigGenerator)
@@ -184,6 +185,7 @@ func (cg *ConfigGenerator) WithKeyVals(keyvals ...interface{}) *ConfigGenerator 
 		useEndpointSlice:       cg.useEndpointSlice,
 		scrapeClasses:          cg.scrapeClasses,
 		defaultScrapeClassName: cg.defaultScrapeClassName,
+		PromAgentDaemonSet:     cg.PromAgentDaemonSet,
 	}
 }
 
@@ -203,6 +205,7 @@ func (cg *ConfigGenerator) WithMinimumVersion(version string) *ConfigGenerator {
 			useEndpointSlice:       cg.useEndpointSlice,
 			scrapeClasses:          cg.scrapeClasses,
 			defaultScrapeClassName: cg.defaultScrapeClassName,
+			PromAgentDaemonSet:     cg.PromAgentDaemonSet,
 		}
 	}
 
@@ -225,6 +228,7 @@ func (cg *ConfigGenerator) WithMaximumVersion(version string) *ConfigGenerator {
 			useEndpointSlice:       cg.useEndpointSlice,
 			scrapeClasses:          cg.scrapeClasses,
 			defaultScrapeClassName: cg.defaultScrapeClassName,
+			PromAgentDaemonSet:     cg.PromAgentDaemonSet,
 		}
 	}
 
@@ -1136,7 +1140,11 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 	labeler := namespacelabeler.New(cpf.EnforcedNamespaceLabel, cpf.ExcludedFromEnforcement, false)
 	relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, ep.RelabelConfigs))...)
 
-	relabelings = generateAddressShardingRelabelingRules(relabelings, shards)
+	// Prometheus Agent in DaemonSet mode doesn't support sharding.
+	if !cg.PromAgentDaemonSet {
+		relabelings = generateAddressShardingRelabelingRules(relabelings, shards)
+	}
+
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cpf.EnforcedSampleLimit)
@@ -1875,6 +1883,28 @@ func (cg *ConfigGenerator) generateK8SSDConfig(
 			})
 	}
 
+	// Specific configuration generated for Prometheus Agent in DaemonSet mode.
+	if cg.PromAgentDaemonSet {
+		k8sSDConfig = cg.AppendMapItem(k8sSDConfig, "selectors", []yaml.MapSlice{
+			{
+				{
+					Key:   "role",
+					Value: "pod",
+				},
+				{
+					Key:   "field",
+					Value: "spec.nodeName=$(NODE_NAME)",
+				},
+			},
+		})
+		k8sSDConfig = cg.AppendMapItem(k8sSDConfig, "attach_metadata", yaml.MapSlice{
+			{
+				Key:   "node",
+				Value: true,
+			},
+		})
+	}
+
 	return yaml.MapItem{
 		Key: "kubernetes_sd_configs",
 		Value: []yaml.MapSlice{
@@ -2575,18 +2605,23 @@ func (cg *ConfigGenerator) GenerateAgentConfiguration(
 		shards          = shardsNumber(cg.prom)
 	)
 
-	scrapeConfigs = cg.appendServiceMonitorConfigs(scrapeConfigs, sMons, apiserverConfig, store, shards)
 	scrapeConfigs = cg.appendPodMonitorConfigs(scrapeConfigs, pMons, apiserverConfig, store, shards)
-	scrapeConfigs = cg.appendProbeConfigs(scrapeConfigs, probes, apiserverConfig, store, shards)
-	scrapeConfigs, err := cg.appendScrapeConfigs(scrapeConfigs, sCons, store, shards)
-	if err != nil {
-		return nil, fmt.Errorf("generate scrape configs: %w", err)
+
+	// Currently, Prometheus Agent in DaemonSet mode doesn't support these.
+	if !cg.PromAgentDaemonSet {
+		scrapeConfigs = cg.appendServiceMonitorConfigs(scrapeConfigs, sMons, apiserverConfig, store, shards)
+		scrapeConfigs = cg.appendProbeConfigs(scrapeConfigs, probes, apiserverConfig, store, shards)
+		scrapeConfigs, err := cg.appendScrapeConfigs(scrapeConfigs, sCons, store, shards)
+		if err != nil {
+			return nil, fmt.Errorf("generate scrape configs: %w", err)
+		}
+
+		scrapeConfigs, err = cg.appendAdditionalScrapeConfigs(scrapeConfigs, additionalScrapeConfigs, shards)
+		if err != nil {
+			return nil, fmt.Errorf("generate additional scrape configs: %w", err)
+		}
 	}
 
-	scrapeConfigs, err = cg.appendAdditionalScrapeConfigs(scrapeConfigs, additionalScrapeConfigs, shards)
-	if err != nil {
-		return nil, fmt.Errorf("generate additional scrape configs: %w", err)
-	}
 	cfg = append(cfg, yaml.MapItem{
 		Key:   "scrape_configs",
 		Value: scrapeConfigs,

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5485,7 +5485,7 @@ func TestTSDBConfigPrometheusAgent(t *testing.T) {
 func TestPromAgentDaemonSetPodMonitorConfig(t *testing.T) {
 	p := defaultPrometheus()
 	cg := mustNewConfigGenerator(t, p)
-	cg.PromAgentDaemonSet = true
+	cg.daemonSet = true
 	pmons := map[string]*monitoringv1.PodMonitor{
 		"pm": defaultPodMonitor(),
 	}
@@ -5499,7 +5499,7 @@ func TestPromAgentDaemonSetPodMonitorConfig(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	golden.Assert(t, string(cfg), "Empty.golden")
+	golden.Assert(t, string(cfg), "PromAgentDaemonSetPodMonitorConfig.golden")
 }
 
 func TestGenerateRelabelConfig(t *testing.T) {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -44,6 +44,11 @@ func defaultPrometheus() *monitoringv1.Prometheus {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				PodMonitorSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"group": "group1",
+					},
+				},
 				ProbeSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"group": "group1",
@@ -5475,6 +5480,26 @@ func TestTSDBConfigPrometheusAgent(t *testing.T) {
 			golden.Assert(t, string(cfg), tc.golden)
 		})
 	}
+}
+
+func TestPromAgentDaemonSetPodMonitorConfig(t *testing.T) {
+	p := defaultPrometheus()
+	cg := mustNewConfigGenerator(t, p)
+	cg.PromAgentDaemonSet = true
+	pmons := map[string]*monitoringv1.PodMonitor{
+		"pm": defaultPodMonitor(),
+	}
+	cfg, err := cg.GenerateAgentConfiguration(
+		nil,
+		pmons,
+		nil,
+		nil,
+		nil,
+		&assets.StoreBuilder{},
+		nil,
+	)
+	require.NoError(t, err)
+	golden.Assert(t, string(cfg), "Empty.golden")
 }
 
 func TestGenerateRelabelConfig(t *testing.T) {

--- a/pkg/prometheus/testdata/PromAgentDaemonSetPodMonitorConfig.golden
+++ b/pkg/prometheus/testdata/PromAgentDaemonSetPodMonitorConfig.golden
@@ -1,0 +1,47 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+scrape_configs:
+- job_name: podMonitor/default/defaultPodMonitor/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - default
+    selectors:
+    - role: pod
+      field: spec.nodeName=$(NODE_NAME)
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_label_group
+    - __meta_kubernetes_pod_labelpresent_group
+    regex: (group1);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - target_label: job
+    replacement: default/defaultPodMonitor
+  - target_label: endpoint
+    replacement: web

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -409,7 +409,7 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
+		//"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
 		/*"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,*/

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
+
+	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/fields"
 
 	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -170,7 +171,7 @@ func TestMain(m *testing.M) {
 
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
-func TestAllNS(t *testing.T) {
+/*func TestAllNS(t *testing.T) {
 	skipAllNSTests(t)
 
 	testCtx := framework.NewTestCtx(t)
@@ -212,7 +213,7 @@ func TestAllNS(t *testing.T) {
 	for _, restart := range restarts {
 		require.Equal(t, int32(0), restart, "expected Prometheus Operator to never restart during entire test execution but got %d restarts", restart)
 	}
-}
+}*/
 
 func testAllNSAlertmanager(t *testing.T) {
 	skipAlertmanagerTests(t)
@@ -295,15 +296,15 @@ func testAllNSPrometheus(t *testing.T) {
 		"RelabelConfigCRDValidation":                testRelabelConfigCRDValidation,
 		"PromReconcileStatusWhenInvalidRuleCreated": testPromReconcileStatusWhenInvalidRuleCreated,
 		"ScrapeConfigCreation":                      testScrapeConfigCreation,
-		"CreatePrometheusAgent":                     testCreatePrometheusAgent,
-		"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
-		"ScrapeConfigKubeNode":                      testScrapeConfigKubernetesNodeRole,
-		"ScrapeConfigDNSSD":                         testScrapeConfigDNSSDConfig,
-		"PrometheusWithStatefulsetCreationFailure":  testPrometheusWithStatefulsetCreationFailure,
-		"PrometheusAgentCheckStorageClass":          testAgentCheckStorageClass,
-		"PrometheusAgentStatusScale":                testPrometheusAgentStatusScale,
-		"PrometheusStatusScale":                     testPrometheusStatusScale,
-		"ScrapeConfigCRDValidations":                testScrapeConfigCRDValidations,
+		//"CreatePrometheusAgent":                     testCreatePrometheusAgent,
+		//"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
+		"ScrapeConfigKubeNode":                     testScrapeConfigKubernetesNodeRole,
+		"ScrapeConfigDNSSD":                        testScrapeConfigDNSSDConfig,
+		"PrometheusWithStatefulsetCreationFailure": testPrometheusWithStatefulsetCreationFailure,
+		//"PrometheusAgentCheckStorageClass":          testAgentCheckStorageClass,
+		//"PrometheusAgentStatusScale":                testPrometheusAgentStatusScale,
+		"PrometheusStatusScale":      testPrometheusStatusScale,
+		"ScrapeConfigCRDValidations": testScrapeConfigCRDValidations,
 	}
 
 	for name, f := range testFuncs {
@@ -408,10 +409,11 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
+		/*"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
 		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
+		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,*/
+		"PrometheusAgentDaemonSetSelectPodMonitor": testPrometheusAgentDaemonSetSelectPodMonitor,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -409,8 +409,8 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		/*"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
-		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
+		"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
+		/*"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,*/
 		"PrometheusAgentDaemonSetSelectPodMonitor": testPrometheusAgentDaemonSetSelectPodMonitor,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
-	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//"k8s.io/apimachinery/pkg/fields"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 
 	operatorFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -171,7 +171,7 @@ func TestMain(m *testing.M) {
 
 // TestAllNS tests the Prometheus Operator watching all namespaces in a
 // Kubernetes cluster.
-/*func TestAllNS(t *testing.T) {
+func TestAllNS(t *testing.T) {
 	skipAllNSTests(t)
 
 	testCtx := framework.NewTestCtx(t)
@@ -213,7 +213,7 @@ func TestMain(m *testing.M) {
 	for _, restart := range restarts {
 		require.Equal(t, int32(0), restart, "expected Prometheus Operator to never restart during entire test execution but got %d restarts", restart)
 	}
-}*/
+}
 
 func testAllNSAlertmanager(t *testing.T) {
 	skipAlertmanagerTests(t)
@@ -296,15 +296,15 @@ func testAllNSPrometheus(t *testing.T) {
 		"RelabelConfigCRDValidation":                testRelabelConfigCRDValidation,
 		"PromReconcileStatusWhenInvalidRuleCreated": testPromReconcileStatusWhenInvalidRuleCreated,
 		"ScrapeConfigCreation":                      testScrapeConfigCreation,
-		//"CreatePrometheusAgent":                     testCreatePrometheusAgent,
-		//"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
-		"ScrapeConfigKubeNode":                     testScrapeConfigKubernetesNodeRole,
-		"ScrapeConfigDNSSD":                        testScrapeConfigDNSSDConfig,
-		"PrometheusWithStatefulsetCreationFailure": testPrometheusWithStatefulsetCreationFailure,
-		//"PrometheusAgentCheckStorageClass":          testAgentCheckStorageClass,
-		//"PrometheusAgentStatusScale":                testPrometheusAgentStatusScale,
-		"PrometheusStatusScale":      testPrometheusStatusScale,
-		"ScrapeConfigCRDValidations": testScrapeConfigCRDValidations,
+		"CreatePrometheusAgent":                     testCreatePrometheusAgent,
+		"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
+		"ScrapeConfigKubeNode":                      testScrapeConfigKubernetesNodeRole,
+		"ScrapeConfigDNSSD":                         testScrapeConfigDNSSDConfig,
+		"PrometheusWithStatefulsetCreationFailure":  testPrometheusWithStatefulsetCreationFailure,
+		"PrometheusAgentCheckStorageClass":          testAgentCheckStorageClass,
+		"PrometheusAgentStatusScale":                testPrometheusAgentStatusScale,
+		"PrometheusStatusScale":                     testPrometheusStatusScale,
+		"ScrapeConfigCRDValidations":                testScrapeConfigCRDValidations,
 	}
 
 	for name, f := range testFuncs {
@@ -409,11 +409,11 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		//"CreatePrometheusAgentDaemonSet": testCreatePrometheusAgentDaemonSet,
-		/*"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
+		"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
+		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
 		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,*/
-		"PrometheusAgentDaemonSetSelectPodMonitor": testPrometheusAgentDaemonSetSelectPodMonitor,
+		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
+		"PrometheusAgentDaemonSetSelectPodMonitor":  testPrometheusAgentDaemonSetSelectPodMonitor,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -395,11 +395,16 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 
 	var pollErr error
 	var paPods *v1.PodList
+	var firstTargetIP string
+	var secondTargetIP string
+
 	appPodsNodes := make([]string, 0, 2)
 	appPodsIPs := make([]string, 0, 2)
 	paPodsNodes := make([]string, 0, 2)
+
 	cfg := framework.RestConfig
 	httpClient := http.Client{}
+
 	err = wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 15*time.Minute, false, func(_ context.Context) (bool, error) {
 		ctx := context.Background()
 
@@ -489,6 +494,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 		for _, ip := range ips {
 			if slices.Contains(appPodsIPs, ip) {
 				found = true
+				firstTargetIP = ip
 			}
 		}
 		if found == false {
@@ -556,6 +562,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 		for _, ip := range ips {
 			if slices.Contains(appPodsIPs, ip) {
 				found = true
+				secondTargetIP = ip
 			}
 		}
 		if found == false {
@@ -568,6 +575,8 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 
 	require.NoError(t, pollErr)
 	require.NoError(t, err)
+
+	require.NotEqual(t, firstTargetIP, secondTargetIP)
 }
 
 type Target struct {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-
 	"reflect"
 	"strings"
 	"testing"
@@ -30,9 +29,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
-
 	v1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -499,6 +496,9 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 			pollErr = fmt.Errorf("first target IP not found in app's list of pod IPs. Target's IP: %#+v, app's pod IPs: %#+v", ips, appPodsIPs)
 			return false, nil
 		}
+
+		ctx, cancel = context.WithTimeout(ctx, 15*time.Minute)
+		defer cancel()
 
 		closer, err = testFramework.StartPortForward(ctx, cfg, "https", paPods.Items[1].Name, ns, "9090")
 		if err != nil {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -62,7 +62,7 @@ import (
 	err = framework.DeletePrometheusAgentAndWaitUntilGone(context.Background(), ns, name)
 	require.NoError(t, err)
 
-}
+}*/
 
 func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 	t.Parallel()
@@ -92,7 +92,7 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func testAgentAndServerNameColision(t *testing.T) {
+/*func testAgentAndServerNameColision(t *testing.T) {
 	t.Parallel()
 
 	testCtx := framework.NewTestCtx(t)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -497,7 +496,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 			return false, nil
 		}
 
-		ctx, cancel = context.WithTimeout(ctx, 15*time.Minute)
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Minute)
 		defer cancel()
 
 		closer, err = testFramework.StartPortForward(ctx, cfg, "https", paPods.Items[1].Name, ns, "9090")

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -16,25 +16,35 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"reflect"
+	"io"
+	"net"
+	"net/http"
+
+	//"reflect"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	//"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	"golang.org/x/exp/slices"
+
+	//v1 "k8s.io/api/core/v1"
+
+	//"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	//"k8s.io/utils/ptr"
+
+	//monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	pa "github.com/prometheus-operator/prometheus-operator/pkg/prometheus/agent"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
-func testCreatePrometheusAgent(t *testing.T) {
+/*func testCreatePrometheusAgent(t *testing.T) {
 	t.Parallel()
 
 	testCtx := framework.NewTestCtx(t)
@@ -353,4 +363,213 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 
 	err = framework.WaitForPrometheusAgentDSReady(ctx, ns, prometheusAgentDSCRD)
 	require.NoError(t, err)
+}*/
+
+func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ctx := context.Background()
+	name := "test"
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+		},
+	)
+	require.NoError(t, err)
+
+	app, err := testFramework.MakeDeployment("../../test/framework/resources/basic-app-for-daemonset-test.yaml")
+	require.NoError(t, err)
+
+	err = framework.CreateDeployment(ctx, ns, app)
+	require.NoError(t, err)
+
+	pm := framework.MakeBasicPodMonitor(name)
+	_, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	prometheusAgentDS := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, prometheusAgentDS)
+	require.NoError(t, err)
+
+	var pollErr error
+	err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 30*time.Minute, false, func(_ context.Context) (bool, error) {
+		ctx := context.Background()
+
+		appPods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: "group=test",
+		})
+		if err != nil {
+			pollErr = fmt.Errorf("can't list app pods: %w", err)
+			return false, nil
+		}
+
+		appPodsNodes := make([]string, 0, 2)
+		appPodsIPs := make([]string, 0, 2)
+		for _, pod := range appPods.Items {
+			appPodsNodes = append(appPodsNodes, pod.Spec.NodeName)
+			appPodsIPs = append(appPodsIPs, pod.Status.PodIP)
+		}
+
+		paPods, err := framework.KubeClient.CoreV1().Pods(ns).List(ctx, pa.ListOptions(name))
+		if err != nil {
+			pollErr = fmt.Errorf("can't list prometheus agent pods: %w", err)
+			return false, nil
+		}
+
+		paPodsNodes := make([]string, 0, 2)
+		for _, pod := range paPods.Items {
+			paPodsNodes = append(paPodsNodes, pod.Spec.NodeName)
+		}
+
+		if len(appPodsNodes) != len(paPodsNodes) {
+			pollErr = fmt.Errorf("got %d application pods and %d prometheus-agent pods", len(appPodsNodes), len(paPodsNodes))
+			return false, nil
+		}
+		for _, n := range appPodsNodes {
+			if !slices.Contains(paPodsNodes, n) {
+				pollErr = fmt.Errorf("no prometheus-agent pod found on node %s", n)
+				return false, nil
+			}
+		}
+
+		cfg := framework.RestConfig
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		closer, err := testFramework.StartPortForward(ctx, cfg, "https", paPods.Items[0].Name, ns, "9090")
+		if err != nil {
+			pollErr = fmt.Errorf("can't start port forward to first prometheus agent pod: %w", err)
+			return false, nil
+		}
+		defer closer()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:9090/api/v1/targets", nil)
+		if err != nil {
+			pollErr = fmt.Errorf("can't create http request to first prometheus server: %w", err)
+			return false, nil
+		}
+
+		httpClient := http.Client{}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			pollErr = fmt.Errorf("can't send http request to first prometheus server: %w", err)
+			return false, nil
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			pollErr = fmt.Errorf("can't read http response from first prometheus server: %w", err)
+			return false, nil
+		}
+
+		var targetsResponse TargetsResponse
+		err = json.Unmarshal(body, &targetsResponse)
+		if err != nil {
+			pollErr = fmt.Errorf("can't unmarshall target's http response from first prometheus server: %w", err)
+			return false, nil
+		}
+		if len(targetsResponse.Data.ActiveTargets) != 1 {
+			pollErr = fmt.Errorf("expect 1 target from first prometheus agent. Actual http response: %s", string(body))
+			//pollErr = fmt.Errorf("expect 1 target from first prometheus agent. Actual target's response: %#+v", targetsResponse)
+			return false, nil
+		}
+
+		target := targetsResponse.Data.ActiveTargets[0]
+		instance := target.Labels.Instance
+		host := strings.Split(instance, ":")[0]
+		ips, err := net.LookupHost(host)
+		if err != nil {
+			pollErr = fmt.Errorf("can't find IPs from first target's host: %w", err)
+			return false, nil
+		}
+
+		found := false
+		for _, ip := range ips {
+			if slices.Contains(appPodsIPs, ip) {
+				found = true
+			}
+		}
+		if found == false {
+			pollErr = fmt.Errorf("first target IP not found in app's list of pod IPs. Target's IP: %#+v, app's pod IPs: %#+v", ips, appPodsIPs)
+			return false, nil
+		}
+
+		closer, err = testFramework.StartPortForward(ctx, cfg, "https", paPods.Items[1].Name, ns, "9090")
+		if err != nil {
+			pollErr = fmt.Errorf("can't start port forward to second prometheus agent pod: %w", err)
+			return false, nil
+		}
+		defer closer()
+
+		req, err = http.NewRequestWithContext(ctx, "GET", "http://localhost:9090/api/v1/targets", nil)
+		if err != nil {
+			pollErr = fmt.Errorf("can't create http request to second prometheus server: %w", err)
+			return false, nil
+		}
+
+		resp, err = httpClient.Do(req)
+		if err != nil {
+			pollErr = fmt.Errorf("can't send http request to second prometheus server: %w", err)
+			return false, nil
+		}
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			pollErr = fmt.Errorf("can't read http response from second prometheus server: %w", err)
+			return false, nil
+		}
+
+		err = json.Unmarshal(body, &targetsResponse)
+		if err != nil {
+			pollErr = fmt.Errorf("can't unmarshall target's http response from second prometheus server: %w", err)
+			return false, nil
+		}
+		if len(targetsResponse.Data.ActiveTargets) != 1 {
+			pollErr = fmt.Errorf("expect 1 target from second prometheus agent. Actual target's response: %#+v", targetsResponse)
+			return false, nil
+		}
+
+		target = targetsResponse.Data.ActiveTargets[0]
+		instance = target.Labels.Instance
+		host = strings.Split(instance, ":")[0]
+		ips, err = net.LookupHost(host)
+		if err != nil {
+			pollErr = fmt.Errorf("can't find IPs from second target's host: %w", err)
+			return false, nil
+		}
+
+		found = false
+		for _, ip := range ips {
+			if slices.Contains(appPodsIPs, ip) {
+				found = true
+			}
+		}
+		if found == false {
+			pollErr = fmt.Errorf("second target IP not found in app's list of pod IPs. Target's IP: %#+v, app's pod IPs: %#+v", ips, appPodsIPs)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	require.NoError(t, pollErr)
+	require.NoError(t, err)
+}
+
+type Target struct {
+	Labels struct {
+		Instance string `json:"instance"`
+	} `json:"labels"`
+}
+
+type TargetsResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ActiveTargets []Target `json:"activeTargets"`
+	} `json:"data"`
 }

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -84,6 +84,11 @@ func (f *Framework) MakeBasicPrometheusAgentDaemonSet(ns, name string) *monitori
 						v1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
+				PodMonitorSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"group": name,
+					},
+				},
 			},
 		},
 	}

--- a/test/framework/resources/basic-app-for-daemonset-test.yaml
+++ b/test/framework/resources/basic-app-for-daemonset-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-for-daemonset-test
+  labels:
+    group: test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      group: test
+  template:
+    metadata:
+      labels:
+        group: test
+    spec:
+      containers:
+      - name: example-app
+        image: quay.io/prometheus-operator/instrumented-sample-app:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: web
+          containerPort: 8080
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: group
+                operator: In
+                values:
+                - test
+            topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
## Description

Support PodMonitor for Prometheus Agent in DaemonSet mode. The reasons and design of this feature are described in https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202405-agent-daemonset.md#63-targets-filtering-for-pods-podmonitor-support



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
WIP: e2e for sure, unit tests maybe

## Changelog entry

Support PodMonitor for Prometheus Agent in DaemonSet mode