### PR TITLE
Fix: `MatchFirstNetwork` dependency on prometheus version v2.54.1

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -20041,7 +20041,7 @@ bool
 <em>(Optional)</em>
 <p>Configure whether to match the first network if the container has multiple networks defined.
 If unset, Prometheus uses true by default.
-It requires Prometheus &gt;= v2.54.0.</p>
+It requires Prometheus &gt;= v2.54.1.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45255,7 +45255,7 @@ spec:
                       description: |-
                         Configure whether to match the first network if the container has multiple networks defined.
                         If unset, Prometheus uses true by default.
-                        It requires Prometheus >= v2.54.0.
+                        It requires Prometheus >= v2.54.1.
                       type: boolean
                     noProxy:
                       description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -1763,7 +1763,7 @@ spec:
                       description: |-
                         Configure whether to match the first network if the container has multiple networks defined.
                         If unset, Prometheus uses true by default.
-                        It requires Prometheus >= v2.54.0.
+                        It requires Prometheus >= v2.54.1.
                       type: boolean
                     noProxy:
                       description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -1764,7 +1764,7 @@ spec:
                       description: |-
                         Configure whether to match the first network if the container has multiple networks defined.
                         If unset, Prometheus uses true by default.
-                        It requires Prometheus >= v2.54.0.
+                        It requires Prometheus >= v2.54.1.
                       type: boolean
                     noProxy:
                       description: |-

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -1667,7 +1667,7 @@
                           "type": "string"
                         },
                         "matchFirstNetwork": {
-                          "description": "Configure whether to match the first network if the container has multiple networks defined.\nIf unset, Prometheus uses true by default.\nIt requires Prometheus >= v2.54.0.",
+                          "description": "Configure whether to match the first network if the container has multiple networks defined.\nIf unset, Prometheus uses true by default.\nIt requires Prometheus >= v2.54.1.",
                           "type": "boolean"
                         },
                         "noProxy": {

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -906,7 +906,7 @@ type DockerSDConfig struct {
 	HostNetworkingHost *string `json:"hostNetworkingHost,omitempty"`
 	// Configure whether to match the first network if the container has multiple networks defined.
 	// If unset, Prometheus uses true by default.
-	// It requires Prometheus >= v2.54.0.
+	// It requires Prometheus >= v2.54.1.
 	//
 	// +optional
 	MatchFirstNetwork *bool `json:"matchFirstNetwork,omitempty"`

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -3603,7 +3603,8 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			}
 
 			if config.MatchFirstNetwork != nil {
-				configs[i] = cg.WithMinimumVersion("2.54.0").AppendMapItem(configs[i],
+				// ref: https://github.com/prometheus/prometheus/pull/14654
+				configs[i] = cg.WithMinimumVersion("2.54.1").AppendMapItem(configs[i],
 					"match_first_network",
 					config.MatchFirstNetwork)
 			}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -8032,7 +8032,7 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 		},
 		{
 			name:    "docker_sd_config_match_first_network",
-			version: "v2.54.0",
+			version: "v2.54.1",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				DockerSDConfigs: []monitoringv1alpha1.DockerSDConfig{
 					{


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

ref: https://github.com/prometheus/prometheus/pull/14654

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix `MatchFirstNetwork` dependency on prometheus version v2.54.1
```
