### PR TITLE
FIX: K8S selector role regression

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2834,7 +2834,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			if len(config.Selectors) > 0 {
 				selectors := make([][]yaml.MapItem, len(config.Selectors))
 				for i, s := range config.Selectors {
-					selectors[i] = cg.AppendMapItem(selectors[i], "role", s.Role)
+					selectors[i] = cg.AppendMapItem(selectors[i], "role", strings.ToLower(string(s.Role)))
 
 					if s.Label != nil {
 						selectors[i] = cg.AppendMapItem(selectors[i], "label", *s.Label)

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -6351,9 +6351,8 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
 							{
-								Role:  "node",
-								Label: ptr.To("type=infra"),
-								Field: ptr.To("spec.unschedulable=false"),
+								Role:  "Pod",
+								Label: ptr.To("component=executor"),
 							},
 						},
 					},
@@ -6370,7 +6369,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
 							{
-								Role:  "node",
+								Role:  "Node",
 								Label: ptr.To("type=infra"),
 								Field: ptr.To("spec.unschedulable=false"),
 							},

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -6351,7 +6351,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
 							{
-								Role:  "Pod",
+								Role:  monitoringv1alpha1.KubernetesRolePod,
 								Label: ptr.To("component=executor"),
 							},
 						},
@@ -6369,7 +6369,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
 							{
-								Role:  "Node",
+								Role:  monitoringv1alpha1.KubernetesRoleNode,
 								Label: ptr.To("type=infra"),
 								Field: ptr.To("spec.unschedulable=false"),
 							},

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD_with_Selectors.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD_with_Selectors.golden
@@ -9,9 +9,8 @@ scrape_configs:
   kubernetes_sd_configs:
   - role: node
     selectors:
-    - role: node
-      label: type=infra
-      field: spec.unschedulable=false
+    - role: pod
+      label: component=executor
   relabel_configs:
   - source_labels:
     - job

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -91,6 +91,12 @@ func testScrapeConfigCreation(t *testing.T) {
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
 					{
 						Role: monitoringv1alpha1.KubernetesRoleNode,
+						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
+							{
+								Role:  "Pod",
+								Label: ptr.To("component=executor"),
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Fixes the Role field bug in the generated K8S Service discovery config.
Closes https://github.com/prometheus-operator/prometheus-operator/issues/6885



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
The following spec
```
		{
			name: "kubernetes_sd_config_with_selectors",
			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{
					{
						Role: monitoringv1alpha1.KubernetesRoleNode,
						Selectors: []monitoringv1alpha1.K8SSelectorConfig{
							{
								Role:  "Node",
								Label: ptr.To("component=executor"),
							},
						},
					},
				},
			},
			version: "2.18.0",
			golden:  "ScrapeConfigSpecConfig_K8SSD_with_Selectors.golden",
		},
```
generates the following config:

```
...
scrape_configs:
- job_name: scrapeConfig/default/testscrapeconfig1
  kubernetes_sd_configs:
  - role: node
 ...
```

## Changelog entry

Fix bug with Kubernetes service discovery Selector.Role field

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix bug with Kubernetes service discovery `Selector.Role` field
```
