### PR TITLE
chore: redirect klog to slog

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	k8sflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	"github.com/prometheus-operator/prometheus-operator/internal/goruntime"
@@ -198,10 +199,7 @@ func run(fs *flag.FlagSet) int {
 	if err != nil {
 		stdlog.Fatal(err)
 	}
-
-	if err != nil {
-		stdlog.Fatal(err)
-	}
+	klog.SetSlogLogger(logger)
 
 	if err := cfg.Gates.UpdateFeatureGates(*featureGates.Map); err != nil {
 		logger.Error("", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -144,5 +144,4 @@ require (
 replace (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => ./pkg/apis/monitoring
 	github.com/prometheus-operator/prometheus-operator/pkg/client => ./pkg/client
-	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/simonpasquier/klog-gokit/v3 v3.5.0 h1:ewnk+ickph0hkQFgdI4pffKIbruAxxWcg0Fe/vQmLOM=
-github.com/simonpasquier/klog-gokit/v3 v3.5.0/go.mod h1:S9flvRzzpaYLYtXI2w8jf9R/IU/Cy14NrbvDUevNP1E=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -754,6 +752,8 @@ k8s.io/client-go v0.31.0 h1:QqEJzNjbN2Yv1H79SsS+SWnXkBgVu4Pj3CJQgbx0gI8=
 k8s.io/client-go v0.31.0/go.mod h1:Y9wvC76g4fLjmU0BA+rV+h2cncoadjvjjkkIGoTLcGU=
 k8s.io/component-base v0.31.0 h1:/KIzGM5EvPNQcYgwq5NwoQBaOlVFrghoVGr8lG6vNRs=
 k8s.io/component-base v0.31.0/go.mod h1:TYVuzI1QmN4L5ItVdMSXKvH7/DtvIuas5/mm8YT3rTo=
+k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20240808142205-8e686545bdb8 h1:1Wof1cGQgA5pqgo8MxKPtf+qN6Sh/0JzznmeGPm1HnE=
 k8s.io/kube-openapi v0.0.0-20240808142205-8e686545bdb8/go.mod h1:Os6V6dZwLNii3vxFpxcNaTmH8LJJBkOTg1N0tOA0fvA=
 k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-kit/log"
 	loglevel "github.com/go-kit/log/level"
-	klogv2 "k8s.io/klog/v2"
 )
 
 const (
@@ -59,14 +58,10 @@ func NewLogger(c Config) (log.Logger, error) {
 	)
 
 	// For log levels other than debug, the klog verbosity level is 0.
-	klogv2.ClampLevel(0)
 	switch strings.ToLower(c.Level) {
 	case LevelAll:
 		lvlOption = loglevel.AllowAll()
 	case LevelDebug:
-		// When the log level is set to debug, we set the klog verbosity level to 6.
-		// Above level 6, the k8s client would log bearer tokens in clear-text.
-		klogv2.ClampLevel(6)
 		lvlOption = loglevel.AllowDebug()
 	case LevelInfo:
 		lvlOption = loglevel.AllowInfo()
@@ -92,8 +87,6 @@ func NewLogger(c Config) (log.Logger, error) {
 	logger = loglevel.NewFilter(logger, lvlOption)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
-
-	klogv2.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
 
 	return logger, nil
 }


### PR DESCRIPTION
## Description

PR #6890 removed the final bits from go-kit/log in the operator code base but forgot to redirect the klog logs to the new slog logger. `ResourceReconciler` has a dependency on klog because it uses `utilruntime.HandleError()` when it fails to sync a resource. As a consequence, the operator didn't log reconciliation failures anymore.

_I didn't qualify it as a bug because the latest operator version doesn't have the issue._

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
