### PR TITLE
chore: reduce e2e test timeouts

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2433,7 +2433,7 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 				t.Fatal(fmt.Errorf("creating Alertmanager service failed: %w", err))
 			}
 
-			err = wait.PollUntilContextTimeout(context.Background(), time.Second, 18*time.Minute, false, isAlertmanagerDiscoveryWorking(ns, svc.Name, alertmanagerName))
+			err = wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, false, isAlertmanagerDiscoveryWorking(ns, svc.Name, alertmanagerName))
 			if err != nil {
 				t.Fatal(fmt.Errorf("validating Prometheus Alertmanager discovery failed: %w", err))
 			}

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -241,7 +241,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -304,7 +304,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)
@@ -351,17 +351,6 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 	dmsName := fmt.Sprintf("prom-agent-%s", p.Name)
 	framework.KubeClient.AppsV1().DaemonSets(ns).Delete(ctx, dmsName, metav1.DeleteOptions{})
 
-	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 20*time.Minute, false, func(ctx context.Context) (bool, error) {
-		dms, _ := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
-		if dms.Status.NumberAvailable == 0 {
-			pollErr = fmt.Errorf("no Prometheus Agent DaemonSet available: %w", err)
-			return false, nil
-		}
-
-		return true, nil
-	})
-
-	require.NoError(t, pollErr)
+	err = framework.WaitForPrometheusAgentDSReady(ctx, ns, prometheusAgentDSCRD)
 	require.NoError(t, err)
 }

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -108,7 +108,7 @@ func (f *Framework) MakeCRD(source string) (*v1.CustomResourceDefinition, error)
 
 // WaitForCRDReady waits for a Custom Resource Definition to be available for use.
 func WaitForCRDReady(listFunc func(opts metav1.ListOptions) (runtime.Object, error)) error {
-	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 10*time.Minute, false, func(_ context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 2*time.Minute, false, func(_ context.Context) (bool, error) {
 		_, err := listFunc(metav1.ListOptions{})
 		if err != nil {
 			if se, ok := err.(*apierrors.StatusError); ok {


### PR DESCRIPTION
## Description

This change decreases all timeouts greater than 10 minutes.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
