### PR TITLE
Wrong link to the architecture png

### DIFF
--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture](/img/architecture.png)
+![Prometheus Operator Architecture](../img/architecture.png)
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture](../img/architecture.png)
+![Prometheus Operator Architecture]([../img/architecture.png](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/img/architecture.png))
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 

--- a/Documentation/user-guides/getting-started.md
+++ b/Documentation/user-guides/getting-started.md
@@ -59,7 +59,7 @@ describe the targets to be monitored by Prometheus.
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![Prometheus Operator Architecture]([../img/architecture.png](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/img/architecture.png))
+![Prometheus Operator Architecture](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/img/architecture.png)
 
 > Note: Check the [Alerting guide]({{< ref "alerting" >}}) for more information about the `Alertmanager` resource.
 


### PR DESCRIPTION
The link to the architecture picture was not correct.

## Description

The link was just pointing to a 404 page. This fix bring the correct path back and now the picture is display properly



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
The picture is now displayed properly

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
