### PR TITLE
fix: validate child routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.76.1 / 2025-09-03
 
+* [BUGFIX] fix panic when processing an invalid `AlertmanagerConfig` object used for global configuration. #6931
 * [BUGFIX] fix bug with Kubernetes service discovery `Selector.Role` field. #6896
 
 ## 0.76.0 / 2025-08-08

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -247,6 +247,10 @@ func (cb *configBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 		Name:      amConfig.Name,
 	}
 
+	if err := checkAlertmanagerConfigResource(ctx, amConfig, cb.amVersion, cb.store); err != nil {
+		return err
+	}
+
 	global, err := cb.convertGlobalConfig(ctx, globalConfig, crKey)
 	if err != nil {
 		return err

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -145,6 +145,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 						{
 							Name: "null",
 						},
+						{
+							Name: "myreceiver",
+						},
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "null",
@@ -190,6 +193,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 					{
 						Name: "mynamespace/global-config/null",
 					},
+					{
+						Name: "mynamespace/global-config/myreceiver",
+					},
 				},
 				Route: &route{
 					Receiver: "mynamespace/global-config/null",
@@ -225,6 +231,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 						{
 							Name: "null",
 						},
+						{
+							Name: "myreceiver",
+						},
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "null",
@@ -246,6 +255,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Receivers: []*receiver{
 					{
 						Name: "mynamespace/global-config/null",
+					},
+					{
+						Name: "mynamespace/global-config/myreceiver",
 					},
 				},
 				Route: &route{
@@ -354,6 +366,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 						{
 							Name: "null",
 						},
+						{
+							Name: "myreceiver",
+						},
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "null",
@@ -375,6 +390,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Receivers: []*receiver{
 					{
 						Name: "mynamespace/global-config/null",
+					},
+					{
+						Name: "mynamespace/global-config/myreceiver",
 					},
 				},
 				Route: &route{
@@ -483,6 +501,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 						{
 							Name: "null",
 						},
+						{
+							Name: "myreceiver",
+						},
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "null",
@@ -504,6 +525,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Receivers: []*receiver{
 					{
 						Name: "mynamespace/global-config/null",
+					},
+					{
+						Name: "mynamespace/global-config/myreceiver",
 					},
 				},
 				Route: &route{
@@ -571,6 +595,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 						{
 							Name: "null",
 						},
+						{
+							Name: "myreceiver",
+						},
 					},
 					Route: &monitoringv1alpha1.Route{
 						Receiver: "null",
@@ -592,6 +619,9 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Receivers: []*receiver{
 					{
 						Name: "mynamespace/global-config/null",
+					},
+					{
+						Name: "mynamespace/global-config/myreceiver",
 					},
 				},
 				Route: &route{
@@ -863,6 +893,34 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "invalid alertmanagerConfig with invalid child routes",
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "global-config",
+					Namespace: "mynamespace",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{
+							Name: "null",
+						},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "null",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"severity":"!=critical$"}]}`),
+							},
+						},
+					},
+				},
+			},
+			matcherStrategy: monitoringingv1.AlertmanagerConfigMatcherStrategy{
+				Type: "OnNamespace",
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1062,10 +1062,14 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 // checkAlertmanagerConfigResource verifies that an AlertmanagerConfig object is valid
 // for the given Alertmanager version and has no missing references to other objects.
 func checkAlertmanagerConfigResource(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, amVersion semver.Version, store *assets.StoreBuilder) error {
+	// Perform semantic validation irrespective of the Alertmanager version.
 	if err := validationv1alpha1.ValidateAlertmanagerConfig(amc); err != nil {
 		return err
 	}
 
+	// Perform more specific validations which depend on the Alertmanager
+	// version. It also retrieves data from referenced secrets and configmaps
+	// (and fails in case of missing/invalid references).
 	if err := checkReceivers(ctx, amc, store, amVersion); err != nil {
 		return err
 	}

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -191,9 +191,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 
 // Test to exercise the function checkAlertmanagerConfigResource
 // and validate that semantic validation is in place for all the fields in the
-// AlertmanagerConfig CR. The validation is preformed by the operator
-// after selecting AlertmanagerConfig resources but before passing them to
-// addAlertmanagerConfigs.
+// AlertmanagerConfig CR. The validation is performed by the operator
+// after selecting AlertmanagerConfig resources and before generating the
+// Alertmanager configuration.
 func TestCheckAlertmanagerConfig(t *testing.T) {
 	version, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 	require.NoError(t, err)
@@ -958,15 +958,131 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 			},
 			ok: true,
 		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subroute-with-unknow-field",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"severity":"!=critical$"}]}`),
+							},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}, {
+						Name: "recv2",
+					}},
+				},
+			},
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subroute-with-invalid-matcher",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"name": "severity", "value": "critical", "matchType": "!!"}]}`),
+							},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}, {
+						Name: "recv2",
+					}},
+				},
+			},
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subroute-with-empty-matcher-name",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"name": "", "value": "critical", "matchType": "!="}]}`),
+							},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}, {
+						Name: "recv2",
+					}},
+				},
+			},
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subroute-with-missing-receiver",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"name": "severity", "value": "critical", "matchType": "!="}]}`),
+							},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}},
+				},
+			},
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-subroute-definition",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: []byte(`{"receiver": "recv2", "matchers": [{"name": "severity", "value": "critical", "matchType": "!="}]}`),
+							},
+						},
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+					}, {
+						Name: "recv2",
+					}},
+				},
+			},
+			ok: true,
+		},
 	} {
 		t.Run(tc.amConfig.Name, func(t *testing.T) {
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
+
 			err := checkAlertmanagerConfigResource(context.Background(), tc.amConfig, version, store)
 			if tc.ok {
 				require.NoError(t, err)
 				return
 			}
 
+			t.Logf("err: %s", err)
 			require.Error(t, err)
 		})
 	}

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -42,7 +42,7 @@ func ValidateAlertmanagerConfig(amc *monitoringv1beta1.AlertmanagerConfig) error
 		return err
 	}
 
-	return validateAlertManagerRoutes(amc.Spec.Route, receivers, timeIntervals, true)
+	return validateRoute(amc.Spec.Route, receivers, timeIntervals, true)
 }
 
 func validateReceivers(receivers []monitoringv1beta1.Receiver) (map[string]struct{}, error) {
@@ -346,10 +346,11 @@ func validateMSTeamsConfigs(configs []monitoringv1beta1.MSTeamsConfig) error {
 	return nil
 }
 
-// validateAlertManagerRoutes verifies that the given route and all its children are semantically valid.
-// because of the self-referential issues mentioned in https://github.com/kubernetes/kubernetes/issues/62872
-// it is not currently possible to apply OpenAPI validation to a v1beta1.Route.
-func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeIntervals map[string]struct{}, topLevelRoute bool) error {
+// validateRoute verifies that the given route and all its children are
+// semantically valid.  because of the self-referential issues mentioned in
+// https://github.com/kubernetes/kubernetes/issues/62872 it is not currently
+// possible to apply OpenAPI validation to a v1beta1.Route.
+func validateRoute(r *monitoringv1beta1.Route, receivers, timeIntervals map[string]struct{}, topLevelRoute bool) error {
 	if r == nil {
 		return nil
 	}
@@ -389,7 +390,6 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 		}
 	}
 
-	// validate that if defaults are set, they match regex
 	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
 		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
 
@@ -402,13 +402,20 @@ func validateAlertManagerRoutes(r *monitoringv1beta1.Route, receivers, timeInter
 		return fmt.Errorf("repeatInterval %s does not match required regex: %s", r.RepeatInterval, durationRe.String())
 	}
 
+	for i, v := range r.Matchers {
+		if err := v.Validate(); err != nil {
+			return fmt.Errorf("matcher[%d]: %w", i, err)
+		}
+	}
+
+	// Unmarshal the child routes and validate them recursively.
 	children, err := r.ChildRoutes()
 	if err != nil {
 		return err
 	}
 
 	for i := range children {
-		if err := validateAlertManagerRoutes(&children[i], receivers, timeIntervals, false); err != nil {
+		if err := validateRoute(&children[i], receivers, timeIntervals, false); err != nil {
 			return fmt.Errorf("route[%d]: %w", i, err)
 		}
 	}

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -146,7 +147,9 @@ func (r *Route) ChildRoutes() ([]Route, error) {
 	out := make([]Route, len(r.Routes))
 
 	for i, v := range r.Routes {
-		if err := json.Unmarshal(v.Raw, &out[i]); err != nil {
+		dec := json.NewDecoder(bytes.NewBuffer(v.Raw))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&out[i]); err != nil {
 			return nil, fmt.Errorf("route[%d]: %w", i, err)
 		}
 	}

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -15,6 +15,7 @@
 package v1beta1
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,7 +144,9 @@ func (r *Route) ChildRoutes() ([]Route, error) {
 	out := make([]Route, len(r.Routes))
 
 	for i, v := range r.Routes {
-		if err := json.Unmarshal(v.Raw, &out[i]); err != nil {
+		dec := json.NewDecoder(bytes.NewBuffer(v.Raw))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&out[i]); err != nil {
 			return nil, fmt.Errorf("route[%d]: %w", i, err)
 		}
 	}


### PR DESCRIPTION
## Description

This change rejects AlertmanagerConfig objects with invalid child routes definition to cause problems in the configuration generation.

Closes #6277

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
