### PR TITLE
WIP: Disable direct switch between Prometheus Agent modes

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -571,6 +571,12 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 		return fmt.Errorf("feature gate for Prometheus Agent's DaemonSet mode is not enabled")
 	}
 
+	name := fmt.Sprintf("prom-agent-%s", p.Name)
+	sts, _ := c.kclient.AppsV1().StatefulSets(p.Namespace).Get(ctx, name, metav1.GetOptions{})
+	if sts != nil {
+		return fmt.Errorf("a similar StatefulSet Prometheus Agent has already exists")
+	}
+
 	if err := k8sutil.AddTypeInformationToObject(p); err != nil {
 		return fmt.Errorf("failed to set Prometheus type information: %w", err)
 	}
@@ -669,6 +675,12 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 }
 
 func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitoringv1alpha1.PrometheusAgent) error {
+	name := fmt.Sprintf("prom-agent-%s", p.Name)
+	dms, _ := c.kclient.AppsV1().DaemonSets(p.Namespace).Get(ctx, name, metav1.GetOptions{})
+	if dms != nil {
+		return fmt.Errorf("a similar DaemonSet Prometheus Agent has already exists")
+	}
+
 	if err := k8sutil.AddTypeInformationToObject(p); err != nil {
 		return fmt.Errorf("failed to set Prometheus type information: %w", err)
 	}


### PR DESCRIPTION
## Description

Disable direct switch between DaemonSet and StatefulSet modes in Prometheus Agent, which is explained in https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202405-agent-daemonset.md#61-crd



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
WIP: e2e

## Changelog entry

Disable direct switch between Prometheus Agent modes