### PR TITLE
Disable Prometheus Agent fields that are unrelated in DaemonSet mode

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -571,6 +571,30 @@ func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv
 		return fmt.Errorf("feature gate for Prometheus Agent's DaemonSet mode is not enabled")
 	}
 
+	if p.Spec.ServiceMonitorSelector != nil || p.Spec.ServiceMonitorNamespaceSelector != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support service monitor but service monitor fields are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
+	if p.Spec.ProbeSelector != nil || p.Spec.ProbeNamespaceSelector != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support probe monitor but probe monitor fields are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
+	if p.Spec.ScrapeConfigSelector != nil || p.Spec.ScrapeConfigNamespaceSelector != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support ScrapeConfig but ScrapeConfig selector fields are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
+	if p.Spec.Replicas != nil || p.Spec.ReplicaExternalLabelName != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support replicas but replica fields are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
+	if p.Spec.Shards != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support sharding but Shards field are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
+	if p.Spec.Storage != nil || p.Spec.Volumes != nil || p.Spec.VolumeMounts != nil || p.Spec.PersistentVolumeClaimRetentionPolicy != nil {
+		return fmt.Errorf("DaemonSet mode doesn't support storage setting but storage fields are set in Prometheus Agent CRD in DaemonSet mode")
+	}
+
 	if err := k8sutil.AddTypeInformationToObject(p); err != nil {
 		return fmt.Errorf("failed to set Prometheus type information: %w", err)
 	}


### PR DESCRIPTION
## Description

Fail Prometheus Agent operator in DaemonSet mode if unrelated fields are set



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

Disable Prometheus Agent fields that are unrelated in DaemonSet mode