### PR TITLE
enhancement: allow toggling custom config deprecation behaviour

### DIFF
--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -49,6 +49,8 @@ Usage of ./operator:
     	Value used by the operator to filter Alertmanager, Prometheus, PrometheusAgent and ThanosRuler objects that it should reconcile. If the value isn't empty, the operator only reconciles objects with an operator.prometheus.io/controller-id annotation of the same value. Otherwise the operator reconciles all objects without the annotation or with an empty annotation value.
   -deny-namespaces value
     	Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.
+  -disable-unmanaged-prometheus-configuration
+    	Toggle the legacy deprecation behaviour for unmanaged Prometheus configuration. Default: false.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
   -feature-gates value

--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -50,7 +50,7 @@ Usage of ./operator:
   -deny-namespaces value
     	Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.
   -disable-unmanaged-prometheus-configuration
-    	Toggle the legacy deprecation behaviour for unmanaged Prometheus configuration. Default: false.
+    	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. Default: false.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
   -feature-gates value

--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -49,8 +49,8 @@ Usage of ./operator:
     	Value used by the operator to filter Alertmanager, Prometheus, PrometheusAgent and ThanosRuler objects that it should reconcile. If the value isn't empty, the operator only reconciles objects with an operator.prometheus.io/controller-id annotation of the same value. Otherwise the operator reconciles all objects without the annotation or with an empty annotation value.
   -deny-namespaces value
     	Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.
-  -disable-unmanaged-prometheus-configuration
-    	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. Default: false.
+  -disable-unmanaged-prometheus-configuration additionalScrapeConfigs
+    	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with additionalScrapeConfigs or the ScrapeConfig CRD. Default: false.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
   -feature-gates value

--- a/Documentation/operator.md
+++ b/Documentation/operator.md
@@ -49,8 +49,8 @@ Usage of ./operator:
     	Value used by the operator to filter Alertmanager, Prometheus, PrometheusAgent and ThanosRuler objects that it should reconcile. If the value isn't empty, the operator only reconciles objects with an operator.prometheus.io/controller-id annotation of the same value. Otherwise the operator reconciles all objects without the annotation or with an empty annotation value.
   -deny-namespaces value
     	Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with --namespaces.
-  -disable-unmanaged-prometheus-configuration additionalScrapeConfigs
-    	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with additionalScrapeConfigs or the ScrapeConfig CRD. Default: false.
+  -disable-unmanaged-prometheus-configuration
+    	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
   -feature-gates value

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,7 +185,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
-	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. Default: false.")
+	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with `additionalScrapeConfigs` or the ScrapeConfig CRD. Default: false.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -278,7 +278,7 @@ func run(fs *flag.FlagSet) int {
 	)
 	if disableUnmanagedPrometheusConfiguration {
 		logger.Info("unmanaged Prometheus configuration is disabled")
-		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithUnmanagedConfigurationDisabled())
+		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithoutUnmanagedConfiguration())
 	}
 	// Check if we can read the storage classs
 	canReadStorageClass, err := checkPrerequisites(

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,7 +185,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
-	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Toggle the legacy deprecation behaviour for unmanaged Prometheus configuration. Default: false.")
+	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. Default: false.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -277,7 +277,8 @@ func run(fs *flag.FlagSet) int {
 		thanosControllerOptions       = []thanoscontroller.ControllerOption{}
 	)
 	if disableUnmanagedPrometheusConfiguration {
-		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithDisableUnmanagedPrometheusConfiguration())
+		logger.Info("unmanaged Prometheus configuration is disabled")
+		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithUnmanagedConfigurationDisabled())
 	}
 	// Check if we can read the storage classs
 	canReadStorageClass, err := checkPrerequisites(

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,7 +185,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
-	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with `additionalScrapeConfigs` or the ScrapeConfig CRD. Default: false.")
+	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -277,7 +277,7 @@ func run(fs *flag.FlagSet) int {
 		thanosControllerOptions       = []thanoscontroller.ControllerOption{}
 	)
 	if disableUnmanagedPrometheusConfiguration {
-		logger.Info("unmanaged Prometheus configuration is disabled")
+		logger.Info("Disabling support for unmanaged Prometheus configurations")
 		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithoutUnmanagedConfiguration())
 	}
 	// Check if we can read the storage classs

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -119,6 +119,8 @@ var (
 
 	serverConfig = server.DefaultConfig(":8080", false)
 
+	disableUnmanagedPrometheusConfiguration bool
+
 	// Parameters for the kubelet endpoints controller.
 	kubeletObject        string
 	kubeletSelector      operator.LabelSelector
@@ -183,7 +185,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
-
+	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Toggle the legacy deprecation behaviour for unmanaged Prometheus configuration. Default: false.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -274,6 +276,9 @@ func run(fs *flag.FlagSet) int {
 		promControllerOptions         = []prometheuscontroller.ControllerOption{}
 		thanosControllerOptions       = []thanoscontroller.ControllerOption{}
 	)
+	if disableUnmanagedPrometheusConfiguration {
+		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithDisableUnmanagedPrometheusConfiguration())
+	}
 	// Check if we can read the storage classs
 	canReadStorageClass, err := checkPrerequisites(
 		ctx,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -91,6 +91,8 @@ type Operator struct {
 	canReadStorageClass    bool
 
 	eventRecorder record.EventRecorder
+
+	disableUnmanagedPrometheusConfiguration bool
 }
 
 type ControllerOption func(*Operator)
@@ -114,6 +116,14 @@ func WithScrapeConfig() ControllerOption {
 func WithStorageClassValidation() ControllerOption {
 	return func(o *Operator) {
 		o.canReadStorageClass = true
+	}
+}
+
+// WithDisableUnmanagedPrometheusConfiguration tells that the controller should deprecate
+// the custom configuration.
+func WithDisableUnmanagedPrometheusConfiguration() ControllerOption {
+	return func(o *Operator) {
+		o.disableUnmanagedPrometheusConfiguration = true
 	}
 }
 
@@ -737,7 +747,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	logger := c.logger.With("key", key)
-	logDeprecatedFields(logger, p)
+	logDeprecatedFields(logger, p, c.disableUnmanagedPrometheusConfiguration)
 
 	// Check if the Prometheus instance is marked for deletion.
 	if c.rr.DeletionInProgress(p) {
@@ -954,7 +964,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	return nil
 }
 
-func logDeprecatedFields(logger *slog.Logger, p *monitoringv1.Prometheus) {
+func logDeprecatedFields(logger *slog.Logger, p *monitoringv1.Prometheus, disableUnmanagedPrometheusConfiguration bool) {
 	deprecationWarningf := "field %q is deprecated, field %q should be used instead"
 
 	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
@@ -989,7 +999,7 @@ func logDeprecatedFields(logger *slog.Logger, p *monitoringv1.Prometheus) {
 		}
 	}
 
-	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil && p.Spec.ProbeSelector == nil && p.Spec.ScrapeConfigSelector == nil {
+	if !disableUnmanagedPrometheusConfiguration && p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil && p.Spec.ProbeSelector == nil && p.Spec.ScrapeConfigSelector == nil {
 
 		logger.Warn("neither serviceMonitorSelector nor podMonitorSelector, nor probeSelector specified. Custom configuration is deprecated, use additionalScrapeConfigs instead")
 	}
@@ -1047,7 +1057,7 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, p *mon
 	// If no service or pod monitor selectors are configured, the user wants to
 	// manage configuration themselves. Do create an empty Secret if it doesn't
 	// exist.
-	if p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil &&
+	if !c.disableUnmanagedPrometheusConfiguration && p.Spec.ServiceMonitorSelector == nil && p.Spec.PodMonitorSelector == nil &&
 		p.Spec.ProbeSelector == nil && p.Spec.ScrapeConfigSelector == nil {
 		c.logger.Debug("neither ServiceMonitor nor PodMonitor, nor Probe selector specified, leaving configuration unmanaged", "prometheus", p.Name, "namespace", p.Namespace)
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -118,8 +118,8 @@ func WithStorageClassValidation() ControllerOption {
 	}
 }
 
-// WithoutUnmanagedConfiguration tells that the controller should deprecate
-// the custom configuration.
+// WithoutUnmanagedConfiguration tells that the controller should not support
+// unmanaged configurations.
 func WithoutUnmanagedConfiguration() ControllerOption {
 	return func(o *Operator) {
 		o.disableUnmanagedConfiguration = true

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -86,13 +86,12 @@ type Operator struct {
 	reconciliations *operator.ReconciliationTracker
 	statusReporter  prompkg.StatusReporter
 
-	endpointSliceSupported bool
-	scrapeConfigSupported  bool
-	canReadStorageClass    bool
+	endpointSliceSupported        bool
+	scrapeConfigSupported         bool
+	canReadStorageClass           bool
+	disableUnmanagedConfiguration bool
 
 	eventRecorder record.EventRecorder
-
-	disableUnmanagedConfiguration bool
 }
 
 type ControllerOption func(*Operator)
@@ -119,9 +118,9 @@ func WithStorageClassValidation() ControllerOption {
 	}
 }
 
-// WithUnmanagedConfigurationDisabled tells that the controller should deprecate
+// WithoutUnmanagedConfiguration tells that the controller should deprecate
 // the custom configuration.
-func WithUnmanagedConfigurationDisabled() ControllerOption {
+func WithoutUnmanagedConfiguration() ControllerOption {
 	return func(o *Operator) {
 		o.disableUnmanagedConfiguration = true
 	}


### PR DESCRIPTION


## Description

Allow toggling custom config deprecation behaviour; helpful in scenarios where a controller disables all service discovery methods.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Users can toggle Prometheus controller's custom configuration deprecation behavior using the "--deprecate-custom-configuration" flag.
```
