### PR TITLE
build: move build step to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
 ARG ARCH="amd64"
 ARG OS="linux"
+ARG GOLANG_BUILDER="1.23"
+FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
+WORKDIR /workspace
+
+# Copy source files
+COPY . .
+
+# Build
+RUN make operator
+
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 
-COPY operator /bin/operator
+COPY --from=builder workspace/operator /bin/operator
 
 # On busybox 'nobody' has uid `65534'
 USER 65534

--- a/cmd/admission-webhook/Dockerfile
+++ b/cmd/admission-webhook/Dockerfile
@@ -1,8 +1,18 @@
 ARG ARCH="amd64"
 ARG OS="linux"
+ARG GOLANG_BUILDER="1.23"
+FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
+WORKDIR /workspace
+
+# Copy source files
+COPY . .
+
+# Build
+RUN make admission-webhook
+
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 
-COPY admission-webhook /bin/admission-webhook
+COPY --from=builder workspace/admission-webhook /bin/admission-webhook
 
 USER nobody
 

--- a/cmd/prometheus-config-reloader/Dockerfile
+++ b/cmd/prometheus-config-reloader/Dockerfile
@@ -1,8 +1,18 @@
 ARG ARCH="amd64"
 ARG OS="linux"
+ARG GOLANG_BUILDER="1.23"
+FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
+WORKDIR /workspace
+
+# Copy source files
+COPY . .
+
+# Build
+RUN make prometheus-config-reloader
+
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 
-COPY prometheus-config-reloader /bin/prometheus-config-reloader
+COPY --from=builder workspace/prometheus-config-reloader /bin/prometheus-config-reloader
 
 USER nobody
 


### PR DESCRIPTION
## Description

This introduces multi-stage Dockerfiles. The go build step for images now happens in the build step in the container file definition. The prometheus golang builder image is used.

The main benefit is that external build systems can simply build the Dockerfile, no need to know how to build binaries or what dependencies to install.

In the future there could be benefits for building on non-x86 architectures and perhaps testing.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

