### PR TITLE
feat: empty string values test cases

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -85,7 +85,7 @@ For manual testing, you can use the utility script [scripts/run-external.sh](scr
 Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster:
 
 ```shell
-KIND_CONTEXT=e2e make test-e2e-image
+KIND_CONTEXT=e2e make test-e2e-images
 ```
 
 #### Using podman with Kind
@@ -99,7 +99,7 @@ podman machine init --cpus=4 --memory=8192 --rootful --now
 Before running automated end-to-end tests, you need run the following command to make images and load it in your local cluster:
 
 ```shell
-CONTAINER_CLI=podman KIND_CONTEXT=e2e make test-e2e-image
+CONTAINER_CLI=podman KIND_CONTEXT=e2e make test-e2e-images
 ```
 
 ### Running the automated E2E Tests

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -151,6 +151,26 @@ func testScrapeConfigCreation(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "invalid-scaleway-sd-config-with-empty-string-tagfilter",
+			spec: monitoringv1alpha1.ScrapeConfigSpec{
+				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
+					{
+						AccessKey: "ak",
+						SecretKey: v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "secret",
+							},
+							Key: "key.pem",
+						},
+						ProjectID:  "1",
+						Role:       monitoringv1alpha1.ScalewayRoleInstance,
+						TagsFilter: []string{""},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
 			name: "invalid-scaleway-sd-config-tagfilter-items-repeat",
 			spec: monitoringv1alpha1.ScrapeConfigSpec{
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
@@ -339,7 +359,8 @@ func testScrapeConfigLifecycleInDifferentNS(t *testing.T) {
 	// 1. Create a ScrapeConfig in scns and check that its targets appear in Prometheus
 	sc := framework.MakeBasicScrapeConfig(scns, "scrape-config")
 	sc.ObjectMeta.Labels = map[string]string{
-		"group": "sc"}
+		"group": "sc",
+	}
 
 	sc.Spec.StaticConfigs = []monitoringv1alpha1.StaticConfig{
 		{
@@ -986,6 +1007,17 @@ var DNSSDTestCases = []scrapeCRDTestCase{
 		expectedError: true,
 	},
 	{
+		name: "Empty string in Names",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
+				{
+					Names: []string{""},
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
 		name: "Valid Record Type A",
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 			DNSSDConfigs: []monitoringv1alpha1.DNSSDConfig{
@@ -1236,6 +1268,23 @@ var EC2SDTestCases = []scrapeCRDTestCase{
 						{
 							Name:   "foo",
 							Values: []string{},
+						},
+					},
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid Filters with empty string values",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
+				{
+					Region: ptr.To("us-west"),
+					Filters: []monitoringv1alpha1.Filter{
+						{
+							Name:   "foo",
+							Values: []string{""},
 						},
 					},
 				},


### PR DESCRIPTION
## Description

Closes #6976

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Adds test cases for empty string values in `[]string` types. As per the discussion in #6976, I only added tests in ScrapeConfig and where the annotation is `kubebuilder:validation:items:MinLength=1`

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add test cases for empty string values in slices
```
