### PR TITLE
chore: add concurrency for workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,6 +8,10 @@ on:
       - 'main'
     tags:
       - 'v*'
+# To cancel running workflow when new commits pushed in a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   generate:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/e2e-feature-gated.yaml
+++ b/.github/workflows/e2e-feature-gated.yaml
@@ -12,6 +12,10 @@ on:
       - 'v*'
     paths-ignore:
       - '**/*.md'
+# To cancel running workflow when new commits pushed in a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   e2e-tests:
     name: E2E tests for feature gates

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,10 @@ on:
       - 'v*'
     paths-ignore:
       - '**/*.md'
+# To cancel running workflow when new commits pushed in a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   e2e-tests:
     name: E2E tests

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -12,6 +12,10 @@ on:
       - 'v*'
     paths-ignore:
       - '**/*.md'
+# To cancel running workflow when new commits pushed in a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To cancel the workflow running when new
commits are pushed to pull request branch

This could help us save the action time instead of running the test unnecessarily

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

To cancel the workflow run when new commits are pushed to pull request branches

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
