### PR TITLE
feat: add credentialsFile support in scrape class

### DIFF
--- a/pkg/client/applyconfiguration/monitoring/v1/scrapeclass.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/scrapeclass.go
@@ -25,6 +25,7 @@ type ScrapeClassApplyConfiguration struct {
 	Relabelings       []RelabelConfigApplyConfiguration `json:"relabelings,omitempty"`
 	MetricRelabelings []RelabelConfigApplyConfiguration `json:"metricRelabelings,omitempty"`
 	AttachMetadata    *AttachMetadataApplyConfiguration `json:"attachMetadata,omitempty"`
+	CredentialsFile   *string                           `json:"credentialsFile,omitempty"`
 }
 
 // ScrapeClassApplyConfiguration constructs a declarative configuration of the ScrapeClass type for use with
@@ -90,3 +91,12 @@ func (b *ScrapeClassApplyConfiguration) WithAttachMetadata(value *AttachMetadata
 	b.AttachMetadata = value
 	return b
 }
+
+// WithCredentialsFile sets the CredentialsFile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CredentialsFile field is set to the value of the last call.
+func (b *ScrapeClassApplyConfiguration) WithCredentialsFile(value string) *ScrapeClassApplyConfiguration {
+    b.CredentialsFile = &value
+    return b
+}
+


### PR DESCRIPTION
## Description

_This change introduces a new field, credentialsFile, to the ScrapeClass configuration. It allows users to specify a path to a file containing authentication credentials, enhancing the flexibility of scrape configurations for various use cases._

Fixes #6986
## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
