### PR TITLE
fix: address OpenAPI text inconsistency for `prometheus.spec.remoteWrite.sendExemplars`

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -13688,7 +13688,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Enables sending of exemplars over remote write. Note that
-exemplar-storage itself must be enabled using the <code>spec.enableFeature</code>
+exemplar-storage itself must be enabled using the <code>spec.enableFeatures</code>
 option for exemplars to be scraped in the first place.</p>
 <p>It requires Prometheus &gt;= v2.27.0.</p>
 </td>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -26654,7 +26654,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.
@@ -38729,7 +38729,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5767,7 +5767,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7270,7 +7270,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5768,7 +5768,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7271,7 +7271,7 @@ spec:
                     sendExemplars:
                       description: |-
                         Enables sending of exemplars over remote write. Note that
-                        exemplar-storage itself must be enabled using the `spec.enableFeature`
+                        exemplar-storage itself must be enabled using the `spec.enableFeatures`
                         option for exemplars to be scraped in the first place.
 
                         It requires Prometheus >= v2.27.0.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4930,7 +4930,7 @@
                           "type": "string"
                         },
                         "sendExemplars": {
-                          "description": "Enables sending of exemplars over remote write. Note that\nexemplar-storage itself must be enabled using the `spec.enableFeature`\noption for exemplars to be scraped in the first place.\n\nIt requires Prometheus >= v2.27.0.",
+                          "description": "Enables sending of exemplars over remote write. Note that\nexemplar-storage itself must be enabled using the `spec.enableFeatures`\noption for exemplars to be scraped in the first place.\n\nIt requires Prometheus >= v2.27.0.",
                           "type": "boolean"
                         },
                         "sendNativeHistograms": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6259,7 +6259,7 @@
                           "type": "string"
                         },
                         "sendExemplars": {
-                          "description": "Enables sending of exemplars over remote write. Note that\nexemplar-storage itself must be enabled using the `spec.enableFeature`\noption for exemplars to be scraped in the first place.\n\nIt requires Prometheus >= v2.27.0.",
+                          "description": "Enables sending of exemplars over remote write. Note that\nexemplar-storage itself must be enabled using the `spec.enableFeatures`\noption for exemplars to be scraped in the first place.\n\nIt requires Prometheus >= v2.27.0.",
                           "type": "boolean"
                         },
                         "sendNativeHistograms": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1348,7 +1348,7 @@ type RemoteWriteSpec struct {
 	Name string `json:"name,omitempty"`
 
 	// Enables sending of exemplars over remote write. Note that
-	// exemplar-storage itself must be enabled using the `spec.enableFeature`
+	// exemplar-storage itself must be enabled using the `spec.enableFeatures`
 	// option for exemplars to be scraped in the first place.
 	//
 	// It requires Prometheus >= v2.27.0.

--- a/scripts/generate/append-operator-version.sh
+++ b/scripts/generate/append-operator-version.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
 
-set -xuo pipefail
-
-# shellcheck disable=SC2209
-sed=sed
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  if ! command -v gsed &> /dev/null; then
-    echo 'gsed could not be found. Please install gsed.'
-    exit 1
-  fi
-  sed=gsed
+  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '' -e "/^    controller-gen.kubebuilder.io.version.*/a\\
+    operator.prometheus.io/version: $VERSION" {} +
+else
+  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    operator.prometheus.io/version: $VERSION" {} +
 fi
-
-find example/prometheus-operator-crd/ -name '*.yaml' -exec $sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    operator.prometheus.io/version: $VERSION" {} +

--- a/scripts/generate/append-operator-version.sh
+++ b/scripts/generate/append-operator-version.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
+set -xuo pipefail
+
+# shellcheck disable=SC2209
+sed=sed
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i '' -e "/^    controller-gen.kubebuilder.io.version.*/a\\
-    operator.prometheus.io/version: $VERSION" {} +
-else
-  find example/prometheus-operator-crd/ -name '*.yaml' -exec sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    operator.prometheus.io/version: $VERSION" {} +
+  if ! command -v gsed &> /dev/null; then
+    echo 'gsed could not be found. Please install gsed.'
+    exit 1
+  fi
+  sed=gsed
 fi
+
+find example/prometheus-operator-crd/ -name '*.yaml' -exec $sed -i "/^    controller-gen.kubebuilder.io.version.*/a\\    operator.prometheus.io/version: $VERSION" {} +


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

The description for `prometheus.spec.remoteWrite.sendExemplars` suggests using `spec.enableFeature` instead of the existing `spec.enableFeatures` field.

```
$ oc explain prometheus.spec.remoteWrite.sendExemplars
GROUP:      monitoring.coreos.com
KIND:       Prometheus
VERSION:    v1FIELD: sendExemplars <boolean>DESCRIPTION:
    Enables sending of exemplars over remote write. Note that exemplar-storage
    itself must be enabled using the `spec.enableFeature` option for exemplars
    to be scraped in the first place. 
     It requires Prometheus >= v2.27.0.
```

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
