### PR TITLE
docs: update docs for additional scrape configuration

### DIFF
--- a/Documentation/additional-scrape-config.md
+++ b/Documentation/additional-scrape-config.md
@@ -59,6 +59,19 @@ spec:
 
 NOTE: Use only one secret for ALL additional scrape configurations.
 
+## Using prometheusSpec
+
+If you're using the [prometheusSpec specification](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusSpec) then you need to modify your yaml file like this:
+```yaml
+[...]
+prometheusSpec:
+  additionalScrapeConfigsSecret:
+    enabled: true
+    name: additional-scrape-configs
+    key: prometheus-additional.yaml
+[...]
+```
+
 ## Additional References
 
 * [Prometheus Spec](api.md#monitoring.coreos.com/v1.PrometheusSpec)


### PR DESCRIPTION
## Description

In the docs there's a missing entry on `additionalScrapeConfigsSecret`. In the API of the `prometheusSpec` specification there's no entry about `additionalScrapeConfigsSecret` and the docs are misleading the user to use the `additionalScrapeConfigs` specification which doesn't work. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
I tested myself for 1h and using the secret property seems to work. 
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._



<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Update documentation for prometheusSpec and mention additionalScrapeConfigsSecret
```
