### PR TITLE
feat: add `nodeName` to  kubelet endpoints 

### DIFF
--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -267,6 +267,8 @@ type nodeAddress struct {
 	apiVersion string
 	ipAddress  string
 	name       string
+	namespace  string
+	nodeName   string
 	uid        types.UID
 	ipv4       bool
 	ready      bool
@@ -278,9 +280,11 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 		Conditions: discoveryv1.EndpointConditions{
 			Ready: ptr.To(true),
 		},
+		NodeName: ptr.To(na.nodeName),
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
+			Namespace:  na.namespace,
 			UID:        na.uid,
 			APIVersion: na.apiVersion,
 		},
@@ -289,10 +293,12 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 
 func (na *nodeAddress) v1EndpointAddress() v1.EndpointAddress {
 	return v1.EndpointAddress{
-		IP: na.ipAddress,
+		IP:       na.ipAddress,
+		NodeName: ptr.To(na.nodeName),
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
+			Namespace:  na.namespace,
 			UID:        na.uid,
 			APIVersion: na.apiVersion,
 		},
@@ -325,6 +331,8 @@ func (c *Controller) getNodeAddresses(nodes []v1.Node) ([]nodeAddress, []error) 
 			ipAddress:  address,
 			name:       n.Name,
 			uid:        n.UID,
+			namespace:  n.Namespace,
+			nodeName:   n.Name,
 			apiVersion: n.APIVersion,
 			ipv4:       ip.To4() != nil,
 			ready:      nodeReadyConditionKnown(n),

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -268,7 +268,6 @@ type nodeAddress struct {
 	ipAddress  string
 	name       string
 	namespace  string
-	nodeName   string
 	uid        types.UID
 	ipv4       bool
 	ready      bool
@@ -280,7 +279,7 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 		Conditions: discoveryv1.EndpointConditions{
 			Ready: ptr.To(true),
 		},
-		NodeName: ptr.To(na.nodeName),
+		NodeName: ptr.To(na.name),
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
@@ -294,7 +293,7 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 func (na *nodeAddress) v1EndpointAddress() v1.EndpointAddress {
 	return v1.EndpointAddress{
 		IP:       na.ipAddress,
-		NodeName: ptr.To(na.nodeName),
+		NodeName: ptr.To(na.name),
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
@@ -332,7 +331,6 @@ func (c *Controller) getNodeAddresses(nodes []v1.Node) ([]nodeAddress, []error) 
 			name:       n.Name,
 			uid:        n.UID,
 			namespace:  n.Namespace,
-			nodeName:   n.Name,
 			apiVersion: n.APIVersion,
 			ipv4:       ip.To4() != nil,
 			ready:      nodeReadyConditionKnown(n),

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -267,7 +267,6 @@ type nodeAddress struct {
 	apiVersion string
 	ipAddress  string
 	name       string
-	namespace  string
 	uid        types.UID
 	ipv4       bool
 	ready      bool
@@ -283,7 +282,6 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
-			Namespace:  na.namespace,
 			UID:        na.uid,
 			APIVersion: na.apiVersion,
 		},
@@ -297,7 +295,6 @@ func (na *nodeAddress) v1EndpointAddress() v1.EndpointAddress {
 		TargetRef: &v1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
-			Namespace:  na.namespace,
 			UID:        na.uid,
 			APIVersion: na.apiVersion,
 		},
@@ -330,7 +327,6 @@ func (c *Controller) getNodeAddresses(nodes []v1.Node) ([]nodeAddress, []error) 
 			ipAddress:  address,
 			name:       n.Name,
 			uid:        n.UID,
-			namespace:  n.Namespace,
 			apiVersion: n.APIVersion,
 			ipv4:       ip.To4() != nil,
 			ready:      nodeReadyConditionKnown(n),

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -284,7 +284,8 @@ func TestNodeAddressPriority(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node-1",
+				Name:      "node-1",
+				Namespace: "abc",
 			},
 			Status: v1.NodeStatus{
 				Addresses: []v1.NodeAddress{
@@ -315,6 +316,8 @@ func TestNodeAddressPriority(t *testing.T) {
 	require.Empty(t, errs)
 	expectedAddresses := []string{"192.168.0.100", "192.168.1.100"}
 	checkNodeAddresses(t, actualAddresses, expectedAddresses)
+	checkNodeNames(t, actualAddresses, []string{"node-0", "node-1"})
+	checkNameSpaces(t, actualAddresses, []string{"", "abc"})
 
 	externalC := Controller{
 		nodeAddressPriority: "external",
@@ -324,6 +327,24 @@ func TestNodeAddressPriority(t *testing.T) {
 	require.Empty(t, errs)
 	expectedAddresses = []string{"203.0.113.100", "104.27.131.189"}
 	checkNodeAddresses(t, actualAddresses, expectedAddresses)
+	checkNodeNames(t, actualAddresses, []string{"node-0", "node-1"})
+	checkNameSpaces(t, actualAddresses, []string{"", "abc"})
+
+}
+
+func checkNodeNames(t *testing.T, actualAddresses []nodeAddress, expectedNodeNames []string) {
+	names := make([]string, 0, len(actualAddresses))
+	for _, addr := range actualAddresses {
+		names = append(names, addr.nodeName)
+	}
+	require.Equal(t, expectedNodeNames, names)
+}
+func checkNameSpaces(t *testing.T, actualAddresses []nodeAddress, expectedNameSpaces []string) {
+	namespaces := make([]string, 0, len(actualAddresses))
+	for _, addr := range actualAddresses {
+		namespaces = append(namespaces, addr.namespace)
+	}
+	require.Equal(t, expectedNameSpaces, namespaces)
 }
 
 func checkNodeAddresses(t *testing.T, actualAddresses []nodeAddress, expectedAddresses []string) {

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -335,7 +335,7 @@ func TestNodeAddressPriority(t *testing.T) {
 func checkNodeNames(t *testing.T, actualAddresses []nodeAddress, expectedNodeNames []string) {
 	names := make([]string, 0, len(actualAddresses))
 	for _, addr := range actualAddresses {
-		names = append(names, addr.nodeName)
+		names = append(names, addr.name)
 	}
 	require.Equal(t, expectedNodeNames, names)
 }

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -317,7 +317,6 @@ func TestNodeAddressPriority(t *testing.T) {
 	expectedAddresses := []string{"192.168.0.100", "192.168.1.100"}
 	checkNodeAddresses(t, actualAddresses, expectedAddresses)
 	checkNodeNames(t, actualAddresses, []string{"node-0", "node-1"})
-	checkNameSpaces(t, actualAddresses, []string{"", "abc"})
 
 	externalC := Controller{
 		nodeAddressPriority: "external",
@@ -328,8 +327,6 @@ func TestNodeAddressPriority(t *testing.T) {
 	expectedAddresses = []string{"203.0.113.100", "104.27.131.189"}
 	checkNodeAddresses(t, actualAddresses, expectedAddresses)
 	checkNodeNames(t, actualAddresses, []string{"node-0", "node-1"})
-	checkNameSpaces(t, actualAddresses, []string{"", "abc"})
-
 }
 
 func checkNodeNames(t *testing.T, actualAddresses []nodeAddress, expectedNodeNames []string) {
@@ -338,13 +335,6 @@ func checkNodeNames(t *testing.T, actualAddresses []nodeAddress, expectedNodeNam
 		names = append(names, addr.name)
 	}
 	require.Equal(t, expectedNodeNames, names)
-}
-func checkNameSpaces(t *testing.T, actualAddresses []nodeAddress, expectedNameSpaces []string) {
-	namespaces := make([]string, 0, len(actualAddresses))
-	for _, addr := range actualAddresses {
-		namespaces = append(namespaces, addr.namespace)
-	}
-	require.Equal(t, expectedNameSpaces, namespaces)
 }
 
 func checkNodeAddresses(t *testing.T, actualAddresses []nodeAddress, expectedAddresses []string) {


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

 add `nodeName` to kubelet endpoints 

Close #6794 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add `nodeName` to  kubelet endpoints 
```
