### PR TITLE
Dockerfile: drop double quotes around ARG default values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG ARCH="amd64"
-ARG OS="linux"
-ARG GOLANG_BUILDER="1.23"
+ARG ARCH=amd64
+ARG OS=linux
+ARG GOLANG_BUILDER=1.23
 FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -176,11 +176,11 @@ k8s-gen: $(DEEPCOPY_TARGETS) k8s-client-gen
 
 image-builder-version: .github/env
 	@echo $(GO_VERSION)
-	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=\"$(GO_VERSION)\"/" \
+	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=$(GO_VERSION)/" \
 		Dockerfile && rm Dockerfile.bak
-	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=\"$(GO_VERSION)\"/" \
+	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=$(GO_VERSION)/" \
 		cmd/prometheus-config-reloader/Dockerfile && rm cmd/prometheus-config-reloader/Dockerfile.bak
-	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=\"$(GO_VERSION)\"/" \
+	sed -i.bak "s/ARG GOLANG_BUILDER=.*/ARG GOLANG_BUILDER=$(GO_VERSION)/" \
 		cmd/admission-webhook/Dockerfile && rm cmd/admission-webhook/Dockerfile.bak
 
 .PHONY: image

--- a/cmd/admission-webhook/Dockerfile
+++ b/cmd/admission-webhook/Dockerfile
@@ -1,6 +1,6 @@
-ARG ARCH="amd64"
-ARG OS="linux"
-ARG GOLANG_BUILDER="1.23"
+ARG ARCH=amd64
+ARG OS=linux
+ARG GOLANG_BUILDER=1.23
 FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
 WORKDIR /workspace
 

--- a/cmd/prometheus-config-reloader/Dockerfile
+++ b/cmd/prometheus-config-reloader/Dockerfile
@@ -1,6 +1,6 @@
-ARG ARCH="amd64"
-ARG OS="linux"
-ARG GOLANG_BUILDER="1.23"
+ARG ARCH=amd64
+ARG OS=linux
+ARG GOLANG_BUILDER=1.23
 FROM quay.io/prometheus/golang-builder:${GOLANG_BUILDER}-base as builder
 WORKDIR /workspace
 


### PR DESCRIPTION
Afaiu the spec is unclear whether to quote this or not. In this case here is certainly not requires and works fine without. Additionally, there is some tooling which does not treat quotes values correctly and generates image links like
`quay.io/prometheus/golang-builder:\"1.23\"-base`.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
