### PR TITLE
Feat: Add enableHTTP2 to ScrapeConfig CRD

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -19290,6 +19290,19 @@ bool
 </tr>
 <tr>
 <td>
+<code>enableHTTP2</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>When false, Prometheus will not enable HTTP2.</p>
+<p>If unset, Prometheus uses true by default.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>basicAuth</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.BasicAuth">

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -47737,6 +47737,12 @@ spec:
 
                   If unset, Prometheus uses true by default.
                 type: boolean
+              enableHTTP2:
+                description: |-
+                  When false, Prometheus will not enable HTTP2.
+
+                  If unset, Prometheus uses true by default.
+                type: boolean
               eurekaSDConfigs:
                 description: EurekaSDConfigs defines a list of Eureka service discovery
                   configurations.

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -280,6 +280,11 @@ type ScrapeConfigSpec struct {
 	// If unset, Prometheus uses true by default.
 	// +optional
 	EnableCompression *bool `json:"enableCompression,omitempty"`
+	// When false, Prometheus will request uncompressed response from the scraped target.
+	//
+	// If unset, Prometheus uses true by default.
+	// +optional
+	EnableHTTP2 *bool `json:"enableHTTP2,omitempty"`
 	// BasicAuth information to use on every scrape request.
 	// +optional
 	BasicAuth *v1.BasicAuth `json:"basicAuth,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -2528,6 +2528,11 @@ func (in *ScrapeConfigSpec) DeepCopyInto(out *ScrapeConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableHTTP2 != nil {
+		in, out := &in.EnableHTTP2, &out.EnableHTTP2
+		*out = new(bool)
+		**out = **in
+	}
 	if in.BasicAuth != nil {
 		in, out := &in.BasicAuth, &out.BasicAuth
 		*out = new(monitoringv1.BasicAuth)

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
@@ -60,6 +60,7 @@ type ScrapeConfigSpecApplyConfiguration struct {
 	Params                           map[string][]string                      `json:"params,omitempty"`
 	Scheme                           *string                                  `json:"scheme,omitempty"`
 	EnableCompression                *bool                                    `json:"enableCompression,omitempty"`
+	EnableHTTP2                      *bool                                    `json:"enableHTTP2,omitempty"`
 	BasicAuth                        *v1.BasicAuthApplyConfiguration          `json:"basicAuth,omitempty"`
 	Authorization                    *v1.SafeAuthorizationApplyConfiguration  `json:"authorization,omitempty"`
 	OAuth2                           *v1.OAuth2ApplyConfiguration             `json:"oauth2,omitempty"`
@@ -478,6 +479,14 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithParams(entries map[string][]str
 // If called multiple times, the Scheme field is set to the value of the last call.
 func (b *ScrapeConfigSpecApplyConfiguration) WithScheme(value string) *ScrapeConfigSpecApplyConfiguration {
 	b.Scheme = &value
+	return b
+}
+
+// WithEnableCompression sets the EnableCompression field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableCompression field is set to the value of the last call.
+func (b *ScrapeConfigSpecApplyConfiguration) WithEnableCompression(value bool) *ScrapeConfigSpecApplyConfiguration {
+	b.EnableCompression = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
@@ -490,11 +490,11 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithEnableCompression(value bool) *
 	return b
 }
 
-// WithEnableCompression sets the EnableCompression field in the declarative configuration to the given value
+// WithEnableHTTP2 sets the EnableHTTP2 field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the EnableCompression field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithEnableCompression(value bool) *ScrapeConfigSpecApplyConfiguration {
-	b.EnableCompression = &value
+// If called multiple times, the EnableHTTP2 field is set to the value of the last call.
+func (b *ScrapeConfigSpecApplyConfiguration) WithEnableHTTP2(value bool) *ScrapeConfigSpecApplyConfiguration {
+	b.EnableHTTP2 = &value
 	return b
 }
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2714,6 +2714,10 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		cfg = cg.WithMinimumVersion("2.49.0").AppendMapItem(cfg, "enable_compression", *sc.Spec.EnableCompression)
 	}
 
+	if sc.Spec.EnableHTTP2 != nil {
+		cfg = cg.AppendMapItem(cfg, "enable_http2", *sc.Spec.EnableHTTP2)
+	}
+
 	if sc.Spec.ScrapeInterval != nil {
 		cfg = append(cfg, yaml.MapItem{Key: "scrape_interval", Value: *sc.Spec.ScrapeInterval})
 	}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5962,6 +5962,20 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			},
 			golden: "ScrapeConfigSpecConfig_EnableCompression_False.golden",
 		},
+		{
+			name: "enable_http2_is_set_to_true",
+			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EnableHTTP2: ptr.To(true),
+			},
+			golden: "ScrapeConfigSpecConfig_EnableHTTP2_True.golden",
+		},
+		{
+			name: "enable_http2_is_set_to_false",
+			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
+				EnableHTTP2: ptr.To(false),
+			},
+			golden: "ScrapeConfigSpecConfig_EnableHTTP2_False.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scs := map[string]*monitoringv1alpha1.ScrapeConfig{


### PR DESCRIPTION
## Description

Add the enableHTTP2 to the ScrapeConfig CRD to map with enable_http2 in Prometheus Scrape Config.

Refer to #6970.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

I have written tests under pkg/prometheus/promfg_test.go for verifying the working of enableHTTP2 config.

## Changelog entry

```release-note
Add support for enableHTTP2 in ScrapeConfig
```
