### PR TITLE
httpPortName must be named http-metrics

### DIFF
--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -47,7 +47,7 @@ const (
 	httpsPort        = int32(10250)
 	httpsPortName    = "https-metrics"
 	httpPort         = int32(10255)
-	httpPortName     = "http-metric"
+	httpPortName     = "http-metrics"
 	cAdvisorPort     = int32(4194)
 	cAdvisorPortName = "cadvisor"
 )


### PR DESCRIPTION
## Description
Fix for issue https://github.com/prometheus-operator/prometheus-operator/issues/7023


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Just revert to the correct name before merge https://github.com/prometheus-operator/prometheus-operator/pull/6882

## Changelog entry
Fix kubelet httpPortName and revert it to http-metrics

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->
