### PR TITLE
Workflow for Automating PR Creation for Release Updates in Website

### DIFF
--- a/.github/workflows/website-release-update.yaml
+++ b/.github/workflows/website-release-update.yaml
@@ -1,0 +1,75 @@
+name: Check and Update Release Version in Website Repository
+
+on:
+  schedule:
+    - cron:   '0 12 * * *' #Every day 12:00
+
+jobs:
+  check-and-update-release-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Get latest release tag
+        id: get_latest_release
+        run: |
+          LATEST_RELEASE=$(curl --fail --silent "https://api.github.com/repos/prometheus-operator/prometheus-operator/releases/latest" | jq -r '.tag_name')
+          if ["$LATEST_RELEASE" == "" ]; then
+              echo "latest-release is invalid" >> "$GITHUB_OUTPUT"
+              exit 1
+          fi
+              echo "latest-release = $LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Clone target repository
+        uses: actions/checkout@v4
+        with:
+          repository: "prometheus-operator/website"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: website
+
+      - name: Check version in target repository
+        run: |
+          JSON_FILE="website/data/prometheusOperator.json"
+          CURRENT_VERSION=$(jq -r '.version' $JSON_FILE)
+          echo "Current version: $CURRENT_VERSION"
+
+          if ["$CURRENT_VERSION" == "${{ steps.get_latest_release.outputs.latest_release }}"]; then
+            echo "Latest version. No updates needed"
+            echo "update_needed=false" >> "$GITHUB_ENV"
+          else
+            echo "Versions do not match. An update is required."
+            echo "update_needed=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Update version
+        if: env.update_needed == 'true'
+        run: |
+          JSON_FILE="website/data/prometheusOperator.json"
+          NEW_VERSION="${{steps.get_latest_release.outputs.latest_release}}"
+
+          jq -i --arg version "$NEW_VERSION" '.version = $version' $JSON_FILE
+
+          cd website
+          git config --global user.name 'github-actions[bot]''
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout -b update-version
+          git add $JSON_FILE
+          git commit -m "chore: bump to $JSON_FILE"
+          git push origin update-version
+
+      - name: Create Pull Request
+        if: env.update_needed == 'true'
+        uses: rhobs/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: "prometheus-operator/website"
+          base: main
+          head: update-version
+          title: "chore: bump to ${{ steps.get_latest_release.outputs.latest_release }}"
+          body: "This PR updates the release version in prometheusOperator.json file to the latest version: ${{ steps.get_latest_release.outputs.latest_release }}"
+
+
+


### PR DESCRIPTION
## Description

Closes #6877. With this workflow, a PR inn the website repository will be automatically created when the Upstream release in this repository does not match the release version in https://github.com/prometheus-operator/website/blob/main/data/prometheusOperator.json. 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
