### PR TITLE
ci: Let github runner run only in the prometheus-operator main repository

### DIFF
--- a/.github/workflows/e2e-prometheus3.yaml
+++ b/.github/workflows/e2e-prometheus3.yaml
@@ -9,6 +9,7 @@ jobs:
   e2e-tests:
     name: E2E experimental version tests
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'prometheus-operator/prometheus-operator' }}
     strategy:
       # since upgrade test was failing other tests were cancelled, setting this so that other test run
       fail-fast: false
@@ -76,6 +77,7 @@ jobs:
     needs:
       - e2e-tests
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'prometheus-operator/prometheus-operator' }}
     steps:
       - name: Mark the job as a success
         if: needs.e2e-tests.result == 'success'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'prometheus-operator/prometheus-operator' }}
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/test-prom-version-upgrade.yaml
+++ b/.github/workflows/test-prom-version-upgrade.yaml
@@ -8,6 +8,7 @@ jobs:
   upgrade-prometheus:
     name: Upgrade Prometheus
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'prometheus-operator/prometheus-operator' }}
     steps:
     - name: Reclaim disk space
       run: |


### PR DESCRIPTION
## Description

I found that after forking the **prometheus-operator** code, some github runners will be run cronjob in my repository. Should we let it run only in the prometheus-operator repository?
This is the runner that runs in my repository, including `Close stale issues and PRs`, `Test Prometheus upgrades`, `e2e-prometheus3`:
https://github.com/daviderli614/prometheus-operator/actions



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
