### PR TITLE
Document disableCompaction defaulting when using thanos sidecar

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -3161,7 +3161,9 @@ bool
 </em>
 </td>
 <td>
-<p>When true, the Prometheus compaction is disabled.</p>
+<p>When true, the Prometheus compaction is disabled.
+When <code>spec.thanos.objectStorageConfig</code> or <code>spec.objectStorageConfigFile</code> are defined, the operator automatically
+disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).</p>
 </td>
 </tr>
 <tr>
@@ -13032,7 +13034,9 @@ bool
 </em>
 </td>
 <td>
-<p>When true, the Prometheus compaction is disabled.</p>
+<p>When true, the Prometheus compaction is disabled.
+When <code>spec.thanos.objectStorageConfig</code> or <code>spec.objectStorageConfigFile</code> are defined, the operator automatically
+disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -35159,7 +35159,10 @@ spec:
                   type: object
                 type: array
               disableCompaction:
-                description: When true, the Prometheus compaction is disabled.
+                description: |-
+                  When true, the Prometheus compaction is disabled.
+                  When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
+                  disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
                 type: boolean
               dnsConfig:
                 description: Defines the DNS configuration for the pods.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3523,7 +3523,10 @@ spec:
                   type: object
                 type: array
               disableCompaction:
-                description: When true, the Prometheus compaction is disabled.
+                description: |-
+                  When true, the Prometheus compaction is disabled.
+                  When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
+                  disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
                 type: boolean
               dnsConfig:
                 description: Defines the DNS configuration for the pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3524,7 +3524,10 @@ spec:
                   type: object
                 type: array
               disableCompaction:
-                description: When true, the Prometheus compaction is disabled.
+                description: |-
+                  When true, the Prometheus compaction is disabled.
+                  When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
+                  disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
                 type: boolean
               dnsConfig:
                 description: Defines the DNS configuration for the pods.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3044,7 +3044,7 @@
                     "type": "array"
                   },
                   "disableCompaction": {
-                    "description": "When true, the Prometheus compaction is disabled.",
+                    "description": "When true, the Prometheus compaction is disabled.\nWhen `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically\ndisables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).",
                     "type": "boolean"
                   },
                   "dnsConfig": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -992,6 +992,7 @@ type PrometheusSpec struct {
 	RetentionSize ByteSize `json:"retentionSize,omitempty"`
 
 	// When true, the Prometheus compaction is disabled.
+	// Defaults to true if `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined.
 	DisableCompaction bool `json:"disableCompaction,omitempty"`
 
 	// Defines the configuration of the Prometheus rules' engine.

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -992,7 +992,8 @@ type PrometheusSpec struct {
 	RetentionSize ByteSize `json:"retentionSize,omitempty"`
 
 	// When true, the Prometheus compaction is disabled.
-	// Defaults to true if `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined.
+	// When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
+	// disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
 	DisableCompaction bool `json:"disableCompaction,omitempty"`
 
 	// Defines the configuration of the Prometheus rules' engine.


### PR DESCRIPTION
## Description

For the Prometheus CRD, the operator default to true for `spec.disableCompaction` when `spec.thanos.objectStorageConfig(|File)` is defined, but this is not documented anywhere but in code (and in kube-prometheus-stack helm chart values, as it turns out).

https://github.com/prometheus-operator/prometheus-operator/blob/35790cdbeec2f302516781365313e7d6fc007ac8/pkg/prometheus/server/statefulset.go#L753-L761

Document the behavior in the API reference directly.


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
N/A

## Changelog entry

```release-note
Document default behavior of `spec.disableCompaction` in Prometheus CRD in relation to Thanos sidecar object store configuration.
```
