### PR TITLE
fix: correctly expand OBJSTORE_CONFIG in thanos sidecar arguments

### DIFF
--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -583,7 +583,7 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 		if thanos.ObjectStorageConfigFile != nil {
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config-file", Value: *thanos.ObjectStorageConfigFile})
 		} else {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config", Value: "$(OBJSTORE_CONFIG)"})
+			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config", Value: "${OBJSTORE_CONFIG}"})
 			container.Env = append(container.Env, v1.EnvVar{
 				Name: "OBJSTORE_CONFIG",
 				ValueFrom: &v1.EnvVarSource{

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -1019,7 +1019,7 @@ func TestThanosObjectStorage(t *testing.T) {
 
 	{
 		var containsArg bool
-		const expectedArg = "--objstore.config=$(OBJSTORE_CONFIG)"
+		const expectedArg = "--objstore.config=${OBJSTORE_CONFIG}"
 		for _, arg := range sset.Spec.Template.Spec.Containers[2].Args {
 			if arg == expectedArg {
 				containsArg = true

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -407,7 +407,7 @@ func TestObjectStorageFile(t *testing.T) {
 	{
 		var containsArgConfigFile, containsArgConfig bool
 		expectedArgConfigFile := "--objstore.config-file=" + testPath
-		expectedArgConfig := "--objstore.config=$(OBJSTORE_CONFIG)"
+		expectedArgConfig := "--objstore.config=${OBJSTORE_CONFIG}"
 		for _, container := range sset.Spec.Template.Spec.Containers {
 			if container.Name == "thanos-ruler" {
 				for _, arg := range container.Args {


### PR DESCRIPTION
## Description

Using `$(OBJSTORE_CONFIG)` tried to run a command `OBJSTORE_CONFIG` using the shell which fails and sets an empty config. Instead, `${OBJSTORE_CONFIG}` is now used to use direct shell variable replacement to inject the environment variable.


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->

The issue could be reproduced by exec-ing into the thanos sidecar container
```sh
~ $ echo "$(OBJSTORE_CONFIG)"
sh: OBJSTORE_CONFIG: not found

~ $ echo "${OBJSTORE_CONFIG}"
type: S3
config: …
```

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Generate correct arguments to Thanos sidecar when providing the objstore config via the OBJSTORE_CONFIG environment variable.
```
