### PR TITLE
feat: Add support for configuring Alertmanager STS persistentVolumeClaimRetentionPolicy

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -354,6 +354,23 @@ that are generated as a result of StorageSpec objects.</p>
 </tr>
 <tr>
 <td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>externalUrl</code><br/>
 <em>
 string
@@ -5651,6 +5668,23 @@ StorageSpec objects.</p>
 <p>VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition.
 VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container,
 that are generated as a result of StorageSpec objects.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>persistentVolumeClaimRetentionPolicy</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">
+Kubernetes apps/v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+The default behavior is all PVCs are retained.
+This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+It requires enabling the StatefulSetAutoDeletePVC feature gate.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15178,6 +15178,29 @@ spec:
                   If set to true all actions on the underlying managed objects are not
                   goint to be performed, except for delete actions.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+                  The default behavior is all PVCs are retained.
+                  This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+                  It requires enabling the StatefulSetAutoDeletePVC feature gate.
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: |-
                   PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -5139,6 +5139,29 @@ spec:
                   If set to true all actions on the underlying managed objects are not
                   goint to be performed, except for delete actions.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+                  The default behavior is all PVCs are retained.
+                  This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+                  It requires enabling the StatefulSetAutoDeletePVC feature gate.
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: |-
                   PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -5140,6 +5140,29 @@ spec:
                   If set to true all actions on the underlying managed objects are not
                   goint to be performed, except for delete actions.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+                  The default behavior is all PVCs are retained.
+                  This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+                  It requires enabling the StatefulSetAutoDeletePVC feature gate.
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: |-
                   PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -4575,6 +4575,20 @@
                     "description": "If set to true all actions on the underlying managed objects are not\ngoint to be performed, except for delete actions.",
                     "type": "boolean"
                   },
+                  "persistentVolumeClaimRetentionPolicy": {
+                    "description": "The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.\nThe default behavior is all PVCs are retained.\nThis is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.\nIt requires enabling the StatefulSetAutoDeletePVC feature gate.",
+                    "properties": {
+                      "whenDeleted": {
+                        "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
+                        "type": "string"
+                      },
+                      "whenScaled": {
+                        "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "podMetadata": {
                     "description": "PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.\n\nThe following items are reserved and cannot be overridden:\n* \"alertmanager\" label, set to the name of the Alertmanager instance.\n* \"app.kubernetes.io/instance\" label, set to the name of the Alertmanager instance.\n* \"app.kubernetes.io/managed-by\" label, set to \"prometheus-operator\".\n* \"app.kubernetes.io/name\" label, set to \"alertmanager\".\n* \"app.kubernetes.io/version\" label, set to the Alertmanager version.\n* \"kubectl.kubernetes.io/default-container\" annotation, set to \"alertmanager\".",
                     "properties": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -156,6 +156,10 @@ func makeStatefulSet(logger *slog.Logger, am *monitoringv1.Alertmanager, config 
 
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, am.Spec.Volumes...)
 
+	if am.Spec.PersistentVolumeClaimRetentionPolicy != nil {
+		statefulset.Spec.PersistentVolumeClaimRetentionPolicy = am.Spec.PersistentVolumeClaimRetentionPolicy
+	}
+
 	return statefulset, nil
 }
 

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1315,3 +1315,24 @@ func TestStatefulSetDNSPolicyAndDNSConfig(t *testing.T) {
 			},
 		}, sset.Spec.Template.Spec.DNSConfig, "expected dns configuration to match")
 }
+
+func TestPersistentVolumeClaimRetentionPolicy(t *testing.T) {
+	sset, err := makeStatefulSet(nil, &monitoringv1.Alertmanager{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: monitoringv1.AlertmanagerSpec{
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+		},
+	}, defaultTestConfig, "", &operator.ShardedSecret{})
+	require.NoError(t, err)
+
+	if sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("expected persistentVolumeClaimDeletePolicy.WhenDeleted to be %s but got %s", appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+	}
+
+	if sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
+		t.Fatalf("expected persistentVolumeClaimDeletePolicy.WhenScaled to be %s but got %s", appsv1.DeletePersistentVolumeClaimRetentionPolicyType, sset.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+	}
+}

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -152,6 +153,13 @@ type AlertmanagerSpec struct {
 	// VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container,
 	// that are generated as a result of StorageSpec objects.
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	// The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+	// The default behavior is all PVCs are retained.
+	// This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+	// It requires enabling the StatefulSetAutoDeletePVC feature gate.
+	//
+	// +optional
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 	// The external URL the Alertmanager instances will be available under. This is
 	// necessary to generate correct URLs. This is necessary if Alertmanager is not
 	// served from root of a DNS name.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -329,6 +329,11 @@ func (in *AlertmanagerSpec) DeepCopyInto(out *AlertmanagerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
@@ -25,57 +26,58 @@ import (
 // AlertmanagerSpecApplyConfiguration represents a declarative configuration of the AlertmanagerSpec type for use
 // with apply.
 type AlertmanagerSpecApplyConfiguration struct {
-	PodMetadata                         *EmbeddedObjectMetadataApplyConfiguration            `json:"podMetadata,omitempty"`
-	Image                               *string                                              `json:"image,omitempty"`
-	ImagePullPolicy                     *corev1.PullPolicy                                   `json:"imagePullPolicy,omitempty"`
-	Version                             *string                                              `json:"version,omitempty"`
-	Tag                                 *string                                              `json:"tag,omitempty"`
-	SHA                                 *string                                              `json:"sha,omitempty"`
-	BaseImage                           *string                                              `json:"baseImage,omitempty"`
-	ImagePullSecrets                    []corev1.LocalObjectReference                        `json:"imagePullSecrets,omitempty"`
-	Secrets                             []string                                             `json:"secrets,omitempty"`
-	ConfigMaps                          []string                                             `json:"configMaps,omitempty"`
-	ConfigSecret                        *string                                              `json:"configSecret,omitempty"`
-	LogLevel                            *string                                              `json:"logLevel,omitempty"`
-	LogFormat                           *string                                              `json:"logFormat,omitempty"`
-	Replicas                            *int32                                               `json:"replicas,omitempty"`
-	Retention                           *monitoringv1.GoDuration                             `json:"retention,omitempty"`
-	Storage                             *StorageSpecApplyConfiguration                       `json:"storage,omitempty"`
-	Volumes                             []corev1.Volume                                      `json:"volumes,omitempty"`
-	VolumeMounts                        []corev1.VolumeMount                                 `json:"volumeMounts,omitempty"`
-	ExternalURL                         *string                                              `json:"externalUrl,omitempty"`
-	RoutePrefix                         *string                                              `json:"routePrefix,omitempty"`
-	Paused                              *bool                                                `json:"paused,omitempty"`
-	NodeSelector                        map[string]string                                    `json:"nodeSelector,omitempty"`
-	Resources                           *corev1.ResourceRequirements                         `json:"resources,omitempty"`
-	Affinity                            *corev1.Affinity                                     `json:"affinity,omitempty"`
-	Tolerations                         []corev1.Toleration                                  `json:"tolerations,omitempty"`
-	TopologySpreadConstraints           []corev1.TopologySpreadConstraint                    `json:"topologySpreadConstraints,omitempty"`
-	SecurityContext                     *corev1.PodSecurityContext                           `json:"securityContext,omitempty"`
-	DNSPolicy                           *monitoringv1.DNSPolicy                              `json:"dnsPolicy,omitempty"`
-	DNSConfig                           *PodDNSConfigApplyConfiguration                      `json:"dnsConfig,omitempty"`
-	ServiceAccountName                  *string                                              `json:"serviceAccountName,omitempty"`
-	ListenLocal                         *bool                                                `json:"listenLocal,omitempty"`
-	Containers                          []corev1.Container                                   `json:"containers,omitempty"`
-	InitContainers                      []corev1.Container                                   `json:"initContainers,omitempty"`
-	PriorityClassName                   *string                                              `json:"priorityClassName,omitempty"`
-	AdditionalPeers                     []string                                             `json:"additionalPeers,omitempty"`
-	ClusterAdvertiseAddress             *string                                              `json:"clusterAdvertiseAddress,omitempty"`
-	ClusterGossipInterval               *monitoringv1.GoDuration                             `json:"clusterGossipInterval,omitempty"`
-	ClusterLabel                        *string                                              `json:"clusterLabel,omitempty"`
-	ClusterPushpullInterval             *monitoringv1.GoDuration                             `json:"clusterPushpullInterval,omitempty"`
-	ClusterPeerTimeout                  *monitoringv1.GoDuration                             `json:"clusterPeerTimeout,omitempty"`
-	PortName                            *string                                              `json:"portName,omitempty"`
-	ForceEnableClusterMode              *bool                                                `json:"forceEnableClusterMode,omitempty"`
-	AlertmanagerConfigSelector          *metav1.LabelSelectorApplyConfiguration              `json:"alertmanagerConfigSelector,omitempty"`
-	AlertmanagerConfigNamespaceSelector *metav1.LabelSelectorApplyConfiguration              `json:"alertmanagerConfigNamespaceSelector,omitempty"`
-	AlertmanagerConfigMatcherStrategy   *AlertmanagerConfigMatcherStrategyApplyConfiguration `json:"alertmanagerConfigMatcherStrategy,omitempty"`
-	MinReadySeconds                     *uint32                                              `json:"minReadySeconds,omitempty"`
-	HostAliases                         []HostAliasApplyConfiguration                        `json:"hostAliases,omitempty"`
-	Web                                 *AlertmanagerWebSpecApplyConfiguration               `json:"web,omitempty"`
-	AlertmanagerConfiguration           *AlertmanagerConfigurationApplyConfiguration         `json:"alertmanagerConfiguration,omitempty"`
-	AutomountServiceAccountToken        *bool                                                `json:"automountServiceAccountToken,omitempty"`
-	EnableFeatures                      []string                                             `json:"enableFeatures,omitempty"`
+	PodMetadata                          *EmbeddedObjectMetadataApplyConfiguration               `json:"podMetadata,omitempty"`
+	Image                                *string                                                 `json:"image,omitempty"`
+	ImagePullPolicy                      *corev1.PullPolicy                                      `json:"imagePullPolicy,omitempty"`
+	Version                              *string                                                 `json:"version,omitempty"`
+	Tag                                  *string                                                 `json:"tag,omitempty"`
+	SHA                                  *string                                                 `json:"sha,omitempty"`
+	BaseImage                            *string                                                 `json:"baseImage,omitempty"`
+	ImagePullSecrets                     []corev1.LocalObjectReference                           `json:"imagePullSecrets,omitempty"`
+	Secrets                              []string                                                `json:"secrets,omitempty"`
+	ConfigMaps                           []string                                                `json:"configMaps,omitempty"`
+	ConfigSecret                         *string                                                 `json:"configSecret,omitempty"`
+	LogLevel                             *string                                                 `json:"logLevel,omitempty"`
+	LogFormat                            *string                                                 `json:"logFormat,omitempty"`
+	Replicas                             *int32                                                  `json:"replicas,omitempty"`
+	Retention                            *monitoringv1.GoDuration                                `json:"retention,omitempty"`
+	Storage                              *StorageSpecApplyConfiguration                          `json:"storage,omitempty"`
+	Volumes                              []corev1.Volume                                         `json:"volumes,omitempty"`
+	VolumeMounts                         []corev1.VolumeMount                                    `json:"volumeMounts,omitempty"`
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
+	ExternalURL                          *string                                                 `json:"externalUrl,omitempty"`
+	RoutePrefix                          *string                                                 `json:"routePrefix,omitempty"`
+	Paused                               *bool                                                   `json:"paused,omitempty"`
+	NodeSelector                         map[string]string                                       `json:"nodeSelector,omitempty"`
+	Resources                            *corev1.ResourceRequirements                            `json:"resources,omitempty"`
+	Affinity                             *corev1.Affinity                                        `json:"affinity,omitempty"`
+	Tolerations                          []corev1.Toleration                                     `json:"tolerations,omitempty"`
+	TopologySpreadConstraints            []corev1.TopologySpreadConstraint                       `json:"topologySpreadConstraints,omitempty"`
+	SecurityContext                      *corev1.PodSecurityContext                              `json:"securityContext,omitempty"`
+	DNSPolicy                            *monitoringv1.DNSPolicy                                 `json:"dnsPolicy,omitempty"`
+	DNSConfig                            *PodDNSConfigApplyConfiguration                         `json:"dnsConfig,omitempty"`
+	ServiceAccountName                   *string                                                 `json:"serviceAccountName,omitempty"`
+	ListenLocal                          *bool                                                   `json:"listenLocal,omitempty"`
+	Containers                           []corev1.Container                                      `json:"containers,omitempty"`
+	InitContainers                       []corev1.Container                                      `json:"initContainers,omitempty"`
+	PriorityClassName                    *string                                                 `json:"priorityClassName,omitempty"`
+	AdditionalPeers                      []string                                                `json:"additionalPeers,omitempty"`
+	ClusterAdvertiseAddress              *string                                                 `json:"clusterAdvertiseAddress,omitempty"`
+	ClusterGossipInterval                *monitoringv1.GoDuration                                `json:"clusterGossipInterval,omitempty"`
+	ClusterLabel                         *string                                                 `json:"clusterLabel,omitempty"`
+	ClusterPushpullInterval              *monitoringv1.GoDuration                                `json:"clusterPushpullInterval,omitempty"`
+	ClusterPeerTimeout                   *monitoringv1.GoDuration                                `json:"clusterPeerTimeout,omitempty"`
+	PortName                             *string                                                 `json:"portName,omitempty"`
+	ForceEnableClusterMode               *bool                                                   `json:"forceEnableClusterMode,omitempty"`
+	AlertmanagerConfigSelector           *metav1.LabelSelectorApplyConfiguration                 `json:"alertmanagerConfigSelector,omitempty"`
+	AlertmanagerConfigNamespaceSelector  *metav1.LabelSelectorApplyConfiguration                 `json:"alertmanagerConfigNamespaceSelector,omitempty"`
+	AlertmanagerConfigMatcherStrategy    *AlertmanagerConfigMatcherStrategyApplyConfiguration    `json:"alertmanagerConfigMatcherStrategy,omitempty"`
+	MinReadySeconds                      *uint32                                                 `json:"minReadySeconds,omitempty"`
+	HostAliases                          []HostAliasApplyConfiguration                           `json:"hostAliases,omitempty"`
+	Web                                  *AlertmanagerWebSpecApplyConfiguration                  `json:"web,omitempty"`
+	AlertmanagerConfiguration            *AlertmanagerConfigurationApplyConfiguration            `json:"alertmanagerConfiguration,omitempty"`
+	AutomountServiceAccountToken         *bool                                                   `json:"automountServiceAccountToken,omitempty"`
+	EnableFeatures                       []string                                                `json:"enableFeatures,omitempty"`
 }
 
 // AlertmanagerSpecApplyConfiguration constructs a declarative configuration of the AlertmanagerSpec type for use with
@@ -235,6 +237,14 @@ func (b *AlertmanagerSpecApplyConfiguration) WithVolumeMounts(values ...corev1.V
 	for i := range values {
 		b.VolumeMounts = append(b.VolumeMounts, values[i])
 	}
+	return b
+}
+
+// WithPersistentVolumeClaimRetentionPolicy sets the PersistentVolumeClaimRetentionPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PersistentVolumeClaimRetentionPolicy field is set to the value of the last call.
+func (b *AlertmanagerSpecApplyConfiguration) WithPersistentVolumeClaimRetentionPolicy(value appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) *AlertmanagerSpecApplyConfiguration {
+	b.PersistentVolumeClaimRetentionPolicy = &value
 	return b
 }
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Allows configuring Alertmanager Statefulsets persistentVolumeClaimRetentionPolicy which will allow for easier statefulset cleanups on deletion.

Followup https://github.com/prometheus-operator/prometheus-operator/pull/6038

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: Add `persistentVolumeClaimRetentionPolicy` field to the Alertmanager CRD.
```
