### PR TITLE
CHANGE/BugFix: Rename scrapeFallbackProtocol to fallbackScrapeProtocol

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1035,7 +1035,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -1458,7 +1458,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -3744,7 +3744,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -10786,7 +10786,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -11160,7 +11160,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -15715,7 +15715,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -20347,7 +20347,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol
@@ -29460,7 +29460,7 @@ protocols supported by Prometheus in order of preference (from most to least pre
 </tr>
 <tr>
 <td>
-<code>scrapeFallbackProtocol</code><br/>
+<code>fallbackScrapeProtocol</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.ScrapeProtocol">
 ScrapeProtocol

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -18828,6 +18828,18 @@ spec:
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   The label to use to retrieve the job name from.
@@ -19844,18 +19856,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
@@ -20131,6 +20131,18 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               interval:
                 description: |-
                   Interval at which targets are probed using the configured prober.
@@ -20640,18 +20652,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
@@ -49101,6 +49101,18 @@ spec:
                   - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
                 description: FileSDConfigs defines a list of file service discovery
                   configurations.
@@ -56285,18 +56297,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -57552,6 +57552,18 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   `jobLabel` selects the label from the associated Kubernetes `Service`
@@ -57649,18 +57661,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -76,6 +76,18 @@ spec:
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   The label to use to retrieve the job name from.
@@ -1092,18 +1104,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -172,6 +172,18 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               interval:
                 description: |-
                   Interval at which targets are probed using the configured prober.
@@ -681,18 +693,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -4073,6 +4073,18 @@ spec:
                   - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
                 description: FileSDConfigs defines a list of file service discovery
                   configurations.
@@ -11257,18 +11269,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -1009,6 +1009,18 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   `jobLabel` selects the label from the associated Kubernetes `Service`
@@ -1106,18 +1118,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -77,6 +77,18 @@ spec:
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   The label to use to retrieve the job name from.
@@ -1093,18 +1105,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -173,6 +173,18 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               interval:
                 description: |-
                   Interval at which targets are probed using the configured prober.
@@ -682,18 +694,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -4074,6 +4074,18 @@ spec:
                   - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
                 description: FileSDConfigs defines a list of file service discovery
                   configurations.
@@ -11258,18 +11270,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -1010,6 +1010,18 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   `jobLabel` selects the label from the associated Kubernetes `Service`
@@ -1107,18 +1119,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -59,6 +59,17 @@
                     "pattern": "(^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$",
                     "type": "string"
                   },
+                  "fallbackScrapeProtocol": {
+                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
+                    "enum": [
+                      "PrometheusProto",
+                      "OpenMetricsText0.0.1",
+                      "OpenMetricsText1.0.0",
+                      "PrometheusText0.0.4",
+                      "PrometheusText1.0.0"
+                    ],
+                    "type": "string"
+                  },
                   "jobLabel": {
                     "description": "The label to use to retrieve the job name from.\n`jobLabel` selects the label from the associated Kubernetes `Pod`\nobject which will be used as the `job` label for all metrics.\n\nFor example if `jobLabel` is set to `foo` and the Kubernetes `Pod`\nobject is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"`\nlabel to all ingested metrics.\n\nIf the value of this field is empty, the `job` label of the metrics\ndefaults to the namespace and name of the PodMonitor object (e.g. `<namespace>/<name>`).",
                     "type": "string"
@@ -948,17 +959,6 @@
                   "scrapeClassicHistograms": {
                     "description": "Whether to scrape a classic histogram that is also exposed as a native histogram.\nIt requires Prometheus >= v2.45.0.",
                     "type": "boolean"
-                  },
-                  "scrapeFallbackProtocol": {
-                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
-                    "enum": [
-                      "PrometheusProto",
-                      "OpenMetricsText0.0.1",
-                      "OpenMetricsText1.0.0",
-                      "PrometheusText0.0.4",
-                      "PrometheusText1.0.0"
-                    ],
-                    "type": "string"
                   },
                   "scrapeProtocols": {
                     "description": "`scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the\nprotocols supported by Prometheus in order of preference (from most to least preferred).\n\nIf unset, Prometheus uses its default value.\n\nIt requires Prometheus >= v2.49.0.",

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -152,6 +152,17 @@
                     "type": "object",
                     "x-kubernetes-map-type": "atomic"
                   },
+                  "fallbackScrapeProtocol": {
+                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
+                    "enum": [
+                      "PrometheusProto",
+                      "OpenMetricsText0.0.1",
+                      "OpenMetricsText1.0.0",
+                      "PrometheusText0.0.4",
+                      "PrometheusText1.0.0"
+                    ],
+                    "type": "string"
+                  },
                   "interval": {
                     "description": "Interval at which targets are probed using the configured prober.\nIf not specified Prometheus' global scrape interval is used.",
                     "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
@@ -625,17 +636,6 @@
                   "scrapeClassicHistograms": {
                     "description": "Whether to scrape a classic histogram that is also exposed as a native histogram.\nIt requires Prometheus >= v2.45.0.",
                     "type": "boolean"
-                  },
-                  "scrapeFallbackProtocol": {
-                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
-                    "enum": [
-                      "PrometheusProto",
-                      "OpenMetricsText0.0.1",
-                      "OpenMetricsText1.0.0",
-                      "PrometheusText0.0.4",
-                      "PrometheusText1.0.0"
-                    ],
-                    "type": "string"
                   },
                   "scrapeProtocols": {
                     "description": "`scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the\nprotocols supported by Prometheus in order of preference (from most to least preferred).\n\nIf unset, Prometheus uses its default value.\n\nIt requires Prometheus >= v2.49.0.",

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -3864,6 +3864,17 @@
                     },
                     "type": "array"
                   },
+                  "fallbackScrapeProtocol": {
+                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
+                    "enum": [
+                      "PrometheusProto",
+                      "OpenMetricsText0.0.1",
+                      "OpenMetricsText1.0.0",
+                      "PrometheusText0.0.4",
+                      "PrometheusText1.0.0"
+                    ],
+                    "type": "string"
+                  },
                   "fileSDConfigs": {
                     "description": "FileSDConfigs defines a list of file service discovery configurations.",
                     "items": {
@@ -10679,17 +10690,6 @@
                   "scrapeClassicHistograms": {
                     "description": "Whether to scrape a classic histogram that is also exposed as a native histogram.\nIt requires Prometheus >= v2.45.0.",
                     "type": "boolean"
-                  },
-                  "scrapeFallbackProtocol": {
-                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
-                    "enum": [
-                      "PrometheusProto",
-                      "OpenMetricsText0.0.1",
-                      "OpenMetricsText1.0.0",
-                      "PrometheusText0.0.4",
-                      "PrometheusText1.0.0"
-                    ],
-                    "type": "string"
                   },
                   "scrapeInterval": {
                     "description": "ScrapeInterval is the interval between consecutive scrapes.",

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -878,6 +878,17 @@
                     },
                     "type": "array"
                   },
+                  "fallbackScrapeProtocol": {
+                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
+                    "enum": [
+                      "PrometheusProto",
+                      "OpenMetricsText0.0.1",
+                      "OpenMetricsText1.0.0",
+                      "PrometheusText0.0.4",
+                      "PrometheusText1.0.0"
+                    ],
+                    "type": "string"
+                  },
                   "jobLabel": {
                     "description": "`jobLabel` selects the label from the associated Kubernetes `Service`\nobject which will be used as the `job` label for all metrics.\n\nFor example if `jobLabel` is set to `foo` and the Kubernetes `Service`\nobject is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"`\nlabel to all ingested metrics.\n\nIf the value of this field is empty or if the label doesn't exist for\nthe given Service, the `job` label of the metrics defaults to the name\nof the associated Kubernetes `Service`.",
                     "type": "string"
@@ -957,17 +968,6 @@
                   "scrapeClassicHistograms": {
                     "description": "Whether to scrape a classic histogram that is also exposed as a native histogram.\nIt requires Prometheus >= v2.45.0.",
                     "type": "boolean"
-                  },
-                  "scrapeFallbackProtocol": {
-                    "description": "The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
-                    "enum": [
-                      "PrometheusProto",
-                      "OpenMetricsText0.0.1",
-                      "OpenMetricsText1.0.0",
-                      "PrometheusText0.0.4",
-                      "PrometheusText1.0.0"
-                    ],
-                    "type": "string"
                   },
                   "scrapeProtocols": {
                     "description": "`scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the\nprotocols supported by Prometheus in order of preference (from most to least preferred).\n\nIf unset, Prometheus uses its default value.\n\nIt requires Prometheus >= v2.49.0.",

--- a/pkg/apis/monitoring/v1/podmonitor_types.go
+++ b/pkg/apis/monitoring/v1/podmonitor_types.go
@@ -120,7 +120,7 @@ type PodMonitorSpec struct {
 	//
 	// It requires Prometheus >= v3.0.0.
 	// +optional
-	ScrapeFallbackProtocol *ScrapeProtocol `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol *ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 
 	// Per-scrape limit on number of labels that will be accepted for a sample.
 	//

--- a/pkg/apis/monitoring/v1/probe_types.go
+++ b/pkg/apis/monitoring/v1/probe_types.go
@@ -104,7 +104,7 @@ type ProbeSpec struct {
 	//
 	// It requires Prometheus >= v3.0.0.
 	// +optional
-	ScrapeFallbackProtocol *ScrapeProtocol `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol *ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 	// Per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +optional

--- a/pkg/apis/monitoring/v1/servicemonitor_types.go
+++ b/pkg/apis/monitoring/v1/servicemonitor_types.go
@@ -119,7 +119,7 @@ type ServiceMonitorSpec struct {
 	//
 	// It requires Prometheus >= v3.0.0.
 	// +optional
-	ScrapeFallbackProtocol *ScrapeProtocol `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol *ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 
 	// `targetLimit` defines a limit on the number of scraped targets that will
 	// be accepted.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1833,8 +1833,8 @@ func (in *PodMonitorSpec) DeepCopyInto(out *PodMonitorSpec) {
 		*out = make([]ScrapeProtocol, len(*in))
 		copy(*out, *in)
 	}
-	if in.ScrapeFallbackProtocol != nil {
-		in, out := &in.ScrapeFallbackProtocol, &out.ScrapeFallbackProtocol
+	if in.FallbackScrapeProtocol != nil {
+		in, out := &in.FallbackScrapeProtocol, &out.FallbackScrapeProtocol
 		*out = new(ScrapeProtocol)
 		**out = **in
 	}
@@ -1980,8 +1980,8 @@ func (in *ProbeSpec) DeepCopyInto(out *ProbeSpec) {
 		*out = make([]ScrapeProtocol, len(*in))
 		copy(*out, *in)
 	}
-	if in.ScrapeFallbackProtocol != nil {
-		in, out := &in.ScrapeFallbackProtocol, &out.ScrapeFallbackProtocol
+	if in.FallbackScrapeProtocol != nil {
+		in, out := &in.FallbackScrapeProtocol, &out.FallbackScrapeProtocol
 		*out = new(ScrapeProtocol)
 		**out = **in
 	}
@@ -3117,8 +3117,8 @@ func (in *ServiceMonitorSpec) DeepCopyInto(out *ServiceMonitorSpec) {
 		*out = make([]ScrapeProtocol, len(*in))
 		copy(*out, *in)
 	}
-	if in.ScrapeFallbackProtocol != nil {
-		in, out := &in.ScrapeFallbackProtocol, &out.ScrapeFallbackProtocol
+	if in.FallbackScrapeProtocol != nil {
+		in, out := &in.FallbackScrapeProtocol, &out.FallbackScrapeProtocol
 		*out = new(ScrapeProtocol)
 		**out = **in
 	}

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -255,7 +255,7 @@ type ScrapeConfigSpec struct {
 	//
 	// It requires Prometheus >= v3.0.0.
 	// +optional
-	ScrapeFallbackProtocol *v1.ScrapeProtocol `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol *v1.ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 	// HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
 	// +optional
 	HonorTimestamps *bool `json:"honorTimestamps,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -2502,8 +2502,8 @@ func (in *ScrapeConfigSpec) DeepCopyInto(out *ScrapeConfigSpec) {
 		*out = make([]monitoringv1.ScrapeProtocol, len(*in))
 		copy(*out, *in)
 	}
-	if in.ScrapeFallbackProtocol != nil {
-		in, out := &in.ScrapeFallbackProtocol, &out.ScrapeFallbackProtocol
+	if in.FallbackScrapeProtocol != nil {
+		in, out := &in.FallbackScrapeProtocol, &out.FallbackScrapeProtocol
 		*out = new(monitoringv1.ScrapeProtocol)
 		**out = **in
 	}

--- a/pkg/client/applyconfiguration/monitoring/v1/podmonitorspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/podmonitorspec.go
@@ -34,7 +34,7 @@ type PodMonitorSpecApplyConfiguration struct {
 	SampleLimit                             *uint64                                 `json:"sampleLimit,omitempty"`
 	TargetLimit                             *uint64                                 `json:"targetLimit,omitempty"`
 	ScrapeProtocols                         []monitoringv1.ScrapeProtocol           `json:"scrapeProtocols,omitempty"`
-	ScrapeFallbackProtocol                  *monitoringv1.ScrapeProtocol            `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol                  *monitoringv1.ScrapeProtocol            `json:"fallbackScrapeProtocol,omitempty"`
 	LabelLimit                              *uint64                                 `json:"labelLimit,omitempty"`
 	LabelNameLengthLimit                    *uint64                                 `json:"labelNameLengthLimit,omitempty"`
 	LabelValueLengthLimit                   *uint64                                 `json:"labelValueLengthLimit,omitempty"`
@@ -132,11 +132,11 @@ func (b *PodMonitorSpecApplyConfiguration) WithScrapeProtocols(values ...monitor
 	return b
 }
 
-// WithScrapeFallbackProtocol sets the ScrapeFallbackProtocol field in the declarative configuration to the given value
+// WithFallbackScrapeProtocol sets the FallbackScrapeProtocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ScrapeFallbackProtocol field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithScrapeFallbackProtocol(value monitoringv1.ScrapeProtocol) *PodMonitorSpecApplyConfiguration {
-	b.ScrapeFallbackProtocol = &value
+// If called multiple times, the FallbackScrapeProtocol field is set to the value of the last call.
+func (b *PodMonitorSpecApplyConfiguration) WithFallbackScrapeProtocol(value monitoringv1.ScrapeProtocol) *PodMonitorSpecApplyConfiguration {
+	b.FallbackScrapeProtocol = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/probespec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/probespec.go
@@ -40,7 +40,7 @@ type ProbeSpecApplyConfiguration struct {
 	SampleLimit                             *uint64                              `json:"sampleLimit,omitempty"`
 	TargetLimit                             *uint64                              `json:"targetLimit,omitempty"`
 	ScrapeProtocols                         []monitoringv1.ScrapeProtocol        `json:"scrapeProtocols,omitempty"`
-	ScrapeFallbackProtocol                  *monitoringv1.ScrapeProtocol         `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol                  *monitoringv1.ScrapeProtocol         `json:"fallbackScrapeProtocol,omitempty"`
 	LabelLimit                              *uint64                              `json:"labelLimit,omitempty"`
 	LabelNameLengthLimit                    *uint64                              `json:"labelNameLengthLimit,omitempty"`
 	LabelValueLengthLimit                   *uint64                              `json:"labelValueLengthLimit,omitempty"`
@@ -182,11 +182,11 @@ func (b *ProbeSpecApplyConfiguration) WithScrapeProtocols(values ...monitoringv1
 	return b
 }
 
-// WithScrapeFallbackProtocol sets the ScrapeFallbackProtocol field in the declarative configuration to the given value
+// WithFallbackScrapeProtocol sets the FallbackScrapeProtocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ScrapeFallbackProtocol field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithScrapeFallbackProtocol(value monitoringv1.ScrapeProtocol) *ProbeSpecApplyConfiguration {
-	b.ScrapeFallbackProtocol = &value
+// If called multiple times, the FallbackScrapeProtocol field is set to the value of the last call.
+func (b *ProbeSpecApplyConfiguration) WithFallbackScrapeProtocol(value monitoringv1.ScrapeProtocol) *ProbeSpecApplyConfiguration {
+	b.FallbackScrapeProtocol = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/servicemonitorspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/servicemonitorspec.go
@@ -34,7 +34,7 @@ type ServiceMonitorSpecApplyConfiguration struct {
 	NamespaceSelector                       *NamespaceSelectorApplyConfiguration    `json:"namespaceSelector,omitempty"`
 	SampleLimit                             *uint64                                 `json:"sampleLimit,omitempty"`
 	ScrapeProtocols                         []monitoringv1.ScrapeProtocol           `json:"scrapeProtocols,omitempty"`
-	ScrapeFallbackProtocol                  *monitoringv1.ScrapeProtocol            `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol                  *monitoringv1.ScrapeProtocol            `json:"fallbackScrapeProtocol,omitempty"`
 	TargetLimit                             *uint64                                 `json:"targetLimit,omitempty"`
 	LabelLimit                              *uint64                                 `json:"labelLimit,omitempty"`
 	LabelNameLengthLimit                    *uint64                                 `json:"labelNameLengthLimit,omitempty"`
@@ -135,11 +135,11 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithScrapeProtocols(values ...mon
 	return b
 }
 
-// WithScrapeFallbackProtocol sets the ScrapeFallbackProtocol field in the declarative configuration to the given value
+// WithFallbackScrapeProtocol sets the FallbackScrapeProtocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ScrapeFallbackProtocol field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithScrapeFallbackProtocol(value monitoringv1.ScrapeProtocol) *ServiceMonitorSpecApplyConfiguration {
-	b.ScrapeFallbackProtocol = &value
+// If called multiple times, the FallbackScrapeProtocol field is set to the value of the last call.
+func (b *ServiceMonitorSpecApplyConfiguration) WithFallbackScrapeProtocol(value monitoringv1.ScrapeProtocol) *ServiceMonitorSpecApplyConfiguration {
+	b.FallbackScrapeProtocol = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
@@ -55,7 +55,7 @@ type ScrapeConfigSpecApplyConfiguration struct {
 	ScrapeInterval                             *monitoringv1.Duration                   `json:"scrapeInterval,omitempty"`
 	ScrapeTimeout                              *monitoringv1.Duration                   `json:"scrapeTimeout,omitempty"`
 	ScrapeProtocols                            []monitoringv1.ScrapeProtocol            `json:"scrapeProtocols,omitempty"`
-	ScrapeFallbackProtocol                     *monitoringv1.ScrapeProtocol             `json:"scrapeFallbackProtocol,omitempty"`
+	FallbackScrapeProtocol                     *monitoringv1.ScrapeProtocol             `json:"fallbackScrapeProtocol,omitempty"`
 	HonorTimestamps                            *bool                                    `json:"honorTimestamps,omitempty"`
 	TrackTimestampsStaleness                   *bool                                    `json:"trackTimestampsStaleness,omitempty"`
 	HonorLabels                                *bool                                    `json:"honorLabels,omitempty"`
@@ -439,11 +439,11 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithScrapeProtocols(values ...monit
 	return b
 }
 
-// WithScrapeFallbackProtocol sets the ScrapeFallbackProtocol field in the declarative configuration to the given value
+// WithFallbackScrapeProtocol sets the FallbackScrapeProtocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ScrapeFallbackProtocol field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithScrapeFallbackProtocol(value monitoringv1.ScrapeProtocol) *ScrapeConfigSpecApplyConfiguration {
-	b.ScrapeFallbackProtocol = &value
+// If called multiple times, the FallbackScrapeProtocol field is set to the value of the last call.
+func (b *ScrapeConfigSpecApplyConfiguration) WithFallbackScrapeProtocol(value monitoringv1.ScrapeProtocol) *ScrapeConfigSpecApplyConfiguration {
+	b.FallbackScrapeProtocol = &value
 	return b
 }
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -398,12 +398,12 @@ func (cg *ConfigGenerator) addScrapeProtocols(cfg yaml.MapSlice, scrapeProtocols
 }
 
 // addScrapeFallbackProtocol adds the fallback_scrape_protocol field into the configuration.
-func (cg *ConfigGenerator) addScrapeFallbackProtocol(cfg yaml.MapSlice, scrapeFallbackProtocol *monitoringv1.ScrapeProtocol) yaml.MapSlice {
-	if scrapeFallbackProtocol == nil {
+func (cg *ConfigGenerator) addScrapeFallbackProtocol(cfg yaml.MapSlice, fallbackScrapeProtocol *monitoringv1.ScrapeProtocol) yaml.MapSlice {
+	if fallbackScrapeProtocol == nil {
 		return cfg
 	}
 
-	return cg.WithMinimumVersion("3.0.0-rc.0").AppendMapItem(cfg, "fallback_scrape_protocol", scrapeFallbackProtocol)
+	return cg.WithMinimumVersion("3.0.0-rc.0").AppendMapItem(cfg, "fallback_scrape_protocol", fallbackScrapeProtocol)
 }
 
 // AddHonorLabels adds the honor_labels field into scrape configurations.
@@ -1441,7 +1441,7 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 	cfg = cg.AddLimitsToYAML(cfg, keepDroppedTargetsKey, m.Spec.KeepDroppedTargets, cpf.EnforcedKeepDroppedTargets)
 	cfg = cg.addNativeHistogramConfig(cfg, m.Spec.NativeHistogramConfig)
 	cfg = cg.addScrapeProtocols(cfg, m.Spec.ScrapeProtocols)
-	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.ScrapeFallbackProtocol)
+	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.FallbackScrapeProtocol)
 
 	if bodySizeLimit := getLowerByteSize(m.Spec.BodySizeLimit, &cpf); !isByteSizeEmpty(bodySizeLimit) {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", bodySizeLimit)
@@ -1510,7 +1510,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 	cfg = cg.AddLimitsToYAML(cfg, keepDroppedTargetsKey, m.Spec.KeepDroppedTargets, cpf.EnforcedKeepDroppedTargets)
 	cfg = cg.addNativeHistogramConfig(cfg, m.Spec.NativeHistogramConfig)
 	cfg = cg.addScrapeProtocols(cfg, m.Spec.ScrapeProtocols)
-	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.ScrapeFallbackProtocol)
+	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.FallbackScrapeProtocol)
 
 	if cpf.EnforcedBodySizeLimit != "" {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", cpf.EnforcedBodySizeLimit)
@@ -1973,7 +1973,7 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 	cfg = cg.AddLimitsToYAML(cfg, keepDroppedTargetsKey, m.Spec.KeepDroppedTargets, cpf.EnforcedKeepDroppedTargets)
 	cfg = cg.addNativeHistogramConfig(cfg, m.Spec.NativeHistogramConfig)
 	cfg = cg.addScrapeProtocols(cfg, m.Spec.ScrapeProtocols)
-	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.ScrapeFallbackProtocol)
+	cfg = cg.addScrapeFallbackProtocol(cfg, m.Spec.FallbackScrapeProtocol)
 
 	if bodySizeLimit := getLowerByteSize(m.Spec.BodySizeLimit, &cpf); !isByteSizeEmpty(bodySizeLimit) {
 		cfg = cg.WithMinimumVersion("2.28.0").AppendMapItem(cfg, "body_size_limit", bodySizeLimit)
@@ -3096,7 +3096,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 	}
 
 	cfg = cg.addScrapeProtocols(cfg, sc.Spec.ScrapeProtocols)
-	cfg = cg.addScrapeFallbackProtocol(cfg, sc.Spec.ScrapeFallbackProtocol)
+	cfg = cg.addScrapeFallbackProtocol(cfg, sc.Spec.FallbackScrapeProtocol)
 
 	if sc.Spec.Scheme != nil {
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: strings.ToLower(*sc.Spec.Scheme)})

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -2191,19 +2191,19 @@ func TestSettingScrapeFallbackProtocolInServiceMonitor(t *testing.T) {
 	for _, tc := range []struct {
 		name                   string
 		version                string
-		scrapeFallbackProtocol *monitoringv1.ScrapeProtocol
+		fallbackScrapeProtocol *monitoringv1.ScrapeProtocol
 		golden                 string
 	}{
 		{
-			name:                   "setting ScrapeFallbackProtocol in ServiceMonitor with prometheus old version",
+			name:                   "setting FallbackScrapeProtocol in ServiceMonitor with prometheus old version",
 			version:                "v2.55.0",
-			scrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
+			fallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
 			golden:                 "SettingScrapeFallbackProtocolInServiceMonitor_OldVersion.golden",
 		},
 		{
-			name:                   "setting ScrapeFallbackProtocol in ServiceMonitor with prometheus new version",
+			name:                   "setting FallbackScrapeProtocol in ServiceMonitor with prometheus new version",
 			version:                "v3.0.0",
-			scrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
+			fallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
 			golden:                 "SettingScrapeFallbackProtocolInServiceMonitor_NewVersion.golden",
 		},
 	} {
@@ -2222,7 +2222,7 @@ func TestSettingScrapeFallbackProtocolInServiceMonitor(t *testing.T) {
 						},
 						Spec: monitoringv1.ServiceMonitorSpec{
 							TargetLabels:           []string{"example", "env"},
-							ScrapeFallbackProtocol: tc.scrapeFallbackProtocol,
+							FallbackScrapeProtocol: tc.fallbackScrapeProtocol,
 							Endpoints: []monitoringv1.Endpoint{
 								{
 									HonorTimestamps: ptr.To(false),
@@ -2319,19 +2319,19 @@ func TestSettingScrapeFallbackProtocolInPodMonitor(t *testing.T) {
 	for _, tc := range []struct {
 		name                   string
 		version                string
-		scrapeFallbackProtocol *monitoringv1.ScrapeProtocol
+		fallbackScrapeProtocol *monitoringv1.ScrapeProtocol
 		golden                 string
 	}{
 		{
-			name:                   "setting ScrapeFallbackProtocol in PodMonitor with prometheus old version",
+			name:                   "setting FallbackScrapeProtocol in PodMonitor with prometheus old version",
 			version:                "v2.55.0",
-			scrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
+			fallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
 			golden:                 "SettingScrapeFallbackProtocolInPodMonitor_OldVersion.golden",
 		},
 		{
-			name:                   "setting ScrapeFallbackProtocol in PodMonitor with prometheus new version",
+			name:                   "setting FallbackScrapeProtocol in PodMonitor with prometheus new version",
 			version:                "v3.0.0",
-			scrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
+			fallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
 			golden:                 "SettingScrapeFallbackProtocolInPodMonitor_NewVersion.golden",
 		},
 	} {
@@ -2351,7 +2351,7 @@ func TestSettingScrapeFallbackProtocolInPodMonitor(t *testing.T) {
 						},
 						Spec: monitoringv1.PodMonitorSpec{
 							PodTargetLabels:        []string{"example", "env"},
-							ScrapeFallbackProtocol: tc.scrapeFallbackProtocol,
+							FallbackScrapeProtocol: tc.fallbackScrapeProtocol,
 							PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
 								{
 									TrackTimestampsStaleness: ptr.To(false),
@@ -6116,7 +6116,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			name:    "fallback_scrape_protocol",
 			version: "v3.0.0",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				ScrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
+				FallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
 			},
 			golden: "ScrapeConfigSpecConfig_ScrapeFallbackProtocol.golden",
 		},
@@ -6124,7 +6124,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			name:    "fallback_scrape_protocol_with_unsupported_version",
 			version: "v2.55.0",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				ScrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
+				FallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText1_0_0),
 			},
 			golden: "ScrapeConfigSpecConfig_ScrapeFallbackProtocol_OldVersion.golden",
 		},

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -1779,23 +1779,23 @@ var ScrapeConfigCRDTestCases = []scrapeCRDTestCase{
 		expectedError: false,
 	},
 	{
-		name: "ScrapeFallbackProtocol: Valid Value",
+		name: "FallbackScrapeProtocol: Valid Value",
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
-			ScrapeFallbackProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
+			FallbackScrapeProtocol: ptr.To(monitoringv1.OpenMetricsText0_0_1),
 		},
 		expectedError: false,
 	},
 	{
-		name: "ScrapeFallbackProtocol: Invalid Protocol",
+		name: "FallbackScrapeProtocol: Invalid Protocol",
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
-			ScrapeFallbackProtocol: ptr.To(monitoringv1.ScrapeProtocol("InvalidProtocol")),
+			FallbackScrapeProtocol: ptr.To(monitoringv1.ScrapeProtocol("InvalidProtocol")),
 		},
 		expectedError: true,
 	},
 	{
-		name: "ScrapeFallbackProtocol: Setting nil",
+		name: "FallbackScrapeProtocol: Setting nil",
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
-			ScrapeFallbackProtocol: nil,
+			FallbackScrapeProtocol: nil,
 		},
 		expectedError: false,
 	},


### PR DESCRIPTION
While reviewing #7197 noticed that Prometheus is using `fallback_scrape_protocol` for the field hence updating to match similar naming to avoid confusion among users.

This is a newly introduced field in this release v0.79 so we want to update it in patch release before users use this field.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
CHANGE/BugFix: Rename scrapeFallbackProtocol to fallbackScrapeProtocol
```
