### PR TITLE
[BUGFIX] Fixing pod and service monitor selector validation

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,3 +1,3 @@
 golang-version=1.23
-kind-version=v0.25.0
-kind-image=kindest/node:v1.31.2
+kind-version=v0.26.0
+kind-image=kindest/node:v1.32.0

--- a/.github/workflows/e2e-feature-gated.yaml
+++ b/.github/workflows/e2e-feature-gated.yaml
@@ -37,7 +37,7 @@ jobs:
         export SHELL=/bin/bash
         make build image
     - name: Start kind cluster
-      uses: helm/kind-action@v1.10.0
+      uses: helm/kind-action@v1.11.0
       with:
         version: ${{ env.kind-version }}
         node_image: ${{ env.kind-image }}

--- a/.github/workflows/e2e-prometheus2.yaml
+++ b/.github/workflows/e2e-prometheus2.yaml
@@ -42,7 +42,7 @@ jobs:
         export SHELL="/bin/bash"
         make build image
     - name: Start kind cluster
-      uses: helm/kind-action@v1.10.0
+      uses: helm/kind-action@v1.11.0
       with:
         version: ${{ env.kind-version }}
         node_image: ${{ env.kind-image }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,7 @@ jobs:
         export SHELL="/bin/bash"
         make build image
     - name: Start kind cluster
-      uses: helm/kind-action@v1.10.0
+      uses: helm/kind-action@v1.11.0
       with:
         version: ${{ env.kind-version }}
         node_image: ${{ env.kind-image }}

--- a/.github/workflows/test-prom-version-upgrade.yaml
+++ b/.github/workflows/test-prom-version-upgrade.yaml
@@ -26,7 +26,7 @@ jobs:
         go-version: '${{ env.golang-version }}'
         check-latest: true
     - name: Start KinD
-      uses: helm/kind-action@v1.10.0
+      uses: helm/kind-action@v1.11.0
       with:
         version: ${{ env.kind-version }}
         node_image: ${{ env.kind-image }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [BUGFIX] Fixing pod and service monitor selector validation. #7214
+
 # 0.79.1 / 2024-12-17
 
 * [CHANGE] Rename the field `scrapeFallbackProtocol` to `fallbackScrapeProtocol` to match with naming as in Prometheus #7199

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884
 	golang.org/x/net v0.32.0
 	golang.org/x/sync v0.10.0
-	google.golang.org/protobuf v1.35.2
+	google.golang.org/protobuf v1.36.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.0
 	k8s.io/apiextensions-apiserver v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
-google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.0 h1:mjIs9gYtt56AzC4ZaffQuh88TZurBGhIJMBZGSxNerQ=
+google.golang.org/protobuf v1.36.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -473,4 +474,21 @@ func BuildStatefulSetService(name string, selector map[string]string, p monitori
 	)
 
 	return svc
+}
+
+func ConvertLabelSelectorRequirementToRequirementSelector(requirement metav1.LabelSelectorRequirement) (*selection.Operator, error) {
+	var operator *selection.Operator
+	switch requirement.Operator {
+	case metav1.LabelSelectorOpIn:
+		operator = ptr.To(selection.In)
+	case metav1.LabelSelectorOpNotIn:
+		operator = ptr.To(selection.NotIn)
+	case metav1.LabelSelectorOpExists:
+		operator = ptr.To(selection.Exists)
+	case metav1.LabelSelectorOpDoesNotExist:
+		operator = ptr.To(selection.DoesNotExist)
+	default:
+		return nil, fmt.Errorf("invalid operator %q", requirement.Operator)
+	}
+	return operator, nil
 }

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -12613,6 +12613,10 @@ func TestPodMonitorSelectors(t *testing.T) {
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"group2"},
 							},
+							{
+								Key:      "groupb",
+								Operator: metav1.LabelSelectorOpDoesNotExist,
+							},
 						},
 					},
 					PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{

--- a/pkg/prometheus/testdata/PodMonitorObjectWithSelectorAndMatchExpressionSelector.golden
+++ b/pkg/prometheus/testdata/PodMonitorObjectWithSelectorAndMatchExpressionSelector.golden
@@ -14,7 +14,7 @@ scrape_configs:
       - default
     selectors:
     - role: pod
-      label: group=group1,group in (group2)
+      label: group=group1,group in (group2),!groupb
   scrape_interval: 30s
   relabel_configs:
   - source_labels:


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixing pod and service monitor selector validation. #7214

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixing pod and service monitor selector validation.
```
