### PR TITLE
[BUGFIX] Fixing pod and service monitor selector validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* [BUGFIX] Fix pod and service monitor selector validation. #7214
+
 # 0.79.1 / 2024-12-17
 
 * [CHANGE] Rename the field `scrapeFallbackProtocol` to `fallbackScrapeProtocol` to match with naming as in Prometheus #7199

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -476,19 +476,19 @@ func BuildStatefulSetService(name string, selector map[string]string, p monitori
 	return svc
 }
 
-func ConvertLabelSelectorRequirementToRequirementSelector(requirement metav1.LabelSelectorRequirement) (*selection.Operator, error) {
-	var operator *selection.Operator
-	switch requirement.Operator {
+func ConvertRequirementOperator(selectorOperator metav1.LabelSelectorOperator) (selection.Operator, error) {
+	var operator selection.Operator
+	switch selectorOperator {
 	case metav1.LabelSelectorOpIn:
-		operator = ptr.To(selection.In)
+		operator = selection.In
 	case metav1.LabelSelectorOpNotIn:
-		operator = ptr.To(selection.NotIn)
+		operator = selection.NotIn
 	case metav1.LabelSelectorOpExists:
-		operator = ptr.To(selection.Exists)
+		operator = selection.Exists
 	case metav1.LabelSelectorOpDoesNotExist:
-		operator = ptr.To(selection.DoesNotExist)
+		operator = selection.DoesNotExist
 	default:
-		return nil, fmt.Errorf("invalid operator %q", requirement.Operator)
+		return operator, fmt.Errorf("invalid requirement %q", operator)
 	}
 	return operator, nil
 }

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -473,4 +474,21 @@ func BuildStatefulSetService(name string, selector map[string]string, p monitori
 	)
 
 	return svc
+}
+
+func ConvertLabelSelectorRequirementToRequirementSelector(requirement metav1.LabelSelectorRequirement) (*selection.Operator, error) {
+	var operator *selection.Operator
+	switch requirement.Operator {
+	case metav1.LabelSelectorOpIn:
+		operator = ptr.To(selection.In)
+	case metav1.LabelSelectorOpNotIn:
+		operator = ptr.To(selection.NotIn)
+	case metav1.LabelSelectorOpExists:
+		operator = ptr.To(selection.Exists)
+	case metav1.LabelSelectorOpDoesNotExist:
+		operator = ptr.To(selection.DoesNotExist)
+	default:
+		return nil, fmt.Errorf("invalid operator %q", requirement.Operator)
+	}
+	return operator, nil
 }

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -474,21 +473,4 @@ func BuildStatefulSetService(name string, selector map[string]string, p monitori
 	)
 
 	return svc
-}
-
-func ConvertRequirementOperator(selectorOperator metav1.LabelSelectorOperator) (selection.Operator, error) {
-	var operator selection.Operator
-	switch selectorOperator {
-	case metav1.LabelSelectorOpIn:
-		operator = selection.In
-	case metav1.LabelSelectorOpNotIn:
-		operator = selection.NotIn
-	case metav1.LabelSelectorOpExists:
-		operator = selection.Exists
-	case metav1.LabelSelectorOpDoesNotExist:
-		operator = selection.DoesNotExist
-	default:
-		return operator, fmt.Errorf("invalid requirement %q", operator)
-	}
-	return operator, nil
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2229,6 +2229,8 @@ func (cg *ConfigGenerator) generateRoleSelectorConfig(k8sSDConfig yaml.MapSlice,
 	selectors := make([]yaml.MapSlice, 0, len(roles))
 	labelSelector, err := metav1.LabelSelectorAsSelector(&selector)
 	if err != nil {
+		// The field must have been validated by the controller beforehand.
+		// If we fail here, it's a functional bug.
 		panic(fmt.Errorf("failed to convert label selector to selector: %w", err))
 	}
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2231,12 +2231,12 @@ func (cg *ConfigGenerator) generateRoleSelectorConfig(k8sSDConfig yaml.MapSlice,
 	labelSelector := labels.SelectorFromValidatedSet(labels.Set(selector.MatchLabels))
 
 	for _, exp := range selector.MatchExpressions {
-		operator, err := ConvertLabelSelectorRequirementToRequirementSelector(exp)
+		operator, err := ConvertRequirementOperator(exp.Operator)
 		if err != nil {
 			panic(fmt.Errorf("failed to convert label selector requirement to requirement selector: %w", err))
 		}
 
-		requirement, err := labels.NewRequirement(exp.Key, *operator, exp.Values)
+		requirement, err := labels.NewRequirement(exp.Key, operator, exp.Values)
 		if err != nil {
 			panic(fmt.Errorf("failed to create label requirement: %w", err))
 		}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -33,7 +33,6 @@ import (
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -2228,20 +2227,9 @@ func (cg *ConfigGenerator) generateK8SSDConfig(
 
 func (cg *ConfigGenerator) generateRoleSelectorConfig(k8sSDConfig yaml.MapSlice, roles []string, selector metav1.LabelSelector) yaml.MapSlice {
 	selectors := make([]yaml.MapSlice, 0, len(roles))
-	labelSelector := labels.SelectorFromValidatedSet(labels.Set(selector.MatchLabels))
-
-	for _, exp := range selector.MatchExpressions {
-		operator, err := ConvertRequirementOperator(exp.Operator)
-		if err != nil {
-			panic(fmt.Errorf("failed to convert label selector requirement to requirement selector: %w", err))
-		}
-
-		requirement, err := labels.NewRequirement(exp.Key, operator, exp.Values)
-		if err != nil {
-			panic(fmt.Errorf("failed to create label requirement: %w", err))
-		}
-
-		labelSelector = labelSelector.Add(*requirement)
+	labelSelector, err := metav1.LabelSelectorAsSelector(&selector)
+	if err != nil {
+		panic(fmt.Errorf("failed to convert label selector to selector: %w", err))
 	}
 
 	for _, role := range roles {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -12613,6 +12613,10 @@ func TestPodMonitorSelectors(t *testing.T) {
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"group2"},
 							},
+							{
+								Key:      "groupb",
+								Operator: metav1.LabelSelectorOpDoesNotExist,
+							},
 						},
 					},
 					PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -386,11 +386,11 @@ func validateScrapeClass(p monitoringv1.PrometheusInterface, sc *string) error {
 
 func validaMatchExpressions(matchExpressions []metav1.LabelSelectorRequirement) error {
 	for _, exp := range matchExpressions {
-		operator, err := ConvertLabelSelectorRequirementToRequirementSelector(exp)
+		operator, err := ConvertRequirementOperator(exp.Operator)
 		if err != nil {
 			return fmt.Errorf("failed to convert label selector requirement to requirement selector: %w", err)
 		}
-		_, err = labels.NewRequirement(exp.Key, *operator, exp.Values)
+		_, err = labels.NewRequirement(exp.Key, operator, exp.Values)
 		if err != nil {
 			return err
 		}

--- a/pkg/prometheus/testdata/PodMonitorObjectWithSelectorAndMatchExpressionSelector.golden
+++ b/pkg/prometheus/testdata/PodMonitorObjectWithSelectorAndMatchExpressionSelector.golden
@@ -14,7 +14,7 @@ scrape_configs:
       - default
     selectors:
     - role: pod
-      label: group=group1,group in (group2)
+      label: group=group1,group in (group2),!groupb
   scrape_interval: 30s
   relabel_configs:
   - source_labels:


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixing pod and service monitor selector validation. https://github.com/prometheus-operator/prometheus-operator/issues/7214

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixing pod and service monitor selector validation.
```
