### PR TITLE
enhancement: alertmanagerConfigMatcherStrategy None issue with routing alerts 

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -2532,6 +2532,10 @@ func TestGenerateConfig(t *testing.T) {
 			cb := newConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
 			cb.cfg = &tc.baseConfig
 
+			if tc.expectedError {
+				require.Error(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs, &monitoringv1.Alertmanager{Spec: monitoringv1.AlertmanagerSpec{AlertmanagerConfigMatcherStrategy: monitoringv1.AlertmanagerConfigMatcherStrategy{Type: monitoringv1.OnNamespaceConfigMatcherStrategyType}}}))
+				return
+			}
 			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs, &monitoringv1.Alertmanager{Spec: monitoringv1.AlertmanagerSpec{AlertmanagerConfigMatcherStrategy: monitoringv1.AlertmanagerConfigMatcherStrategy{Type: monitoringv1.OnNamespaceConfigMatcherStrategyType}}}))
 
 			cfgBytes, err := cb.marshalJSON()

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -2532,7 +2532,7 @@ func TestGenerateConfig(t *testing.T) {
 			cb := newConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
 			cb.cfg = &tc.baseConfig
 
-			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs, &monitoringv1.Alertmanager{}))
+			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs, &monitoringv1.Alertmanager{Spec: monitoringv1.AlertmanagerSpec{AlertmanagerConfigMatcherStrategy: monitoringv1.AlertmanagerConfigMatcherStrategy{Type: monitoringv1.OnNamespaceConfigMatcherStrategyType}}}))
 
 			cfgBytes, err := cb.marshalJSON()
 			require.NoError(t, err)

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -2532,11 +2532,7 @@ func TestGenerateConfig(t *testing.T) {
 			cb := newConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
 			cb.cfg = &tc.baseConfig
 
-			if tc.expectedError {
-				require.Error(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
-				return
-			}
-			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
+			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs, &monitoringv1.Alertmanager{}))
 
 			cfgBytes, err := cb.marshalJSON()
 			require.NoError(t, err)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -887,7 +887,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 		}
 	}
 
-	if err := cfgBuilder.addAlertmanagerConfigs(ctx, amConfigs); err != nil {
+	if err := cfgBuilder.addAlertmanagerConfigs(ctx, amConfigs, am); err != nil {
 		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Now prometheus-operator will generate a parent route that has continue always set to true, which is correct and has matchers set to namespace. However, if we set alertmanagerConfigMatcherStrategy to "None" the generated route for the receiver will remain and only the matchers will be removed. The problem here is that the generated route is always applied and since it has the same receiver as its child route, the alert will always come even if the child route does not meet the matchers.

I will show you an example:
Here you can try the behavior: https://prometheus.io/webtools/alerting/routing-tree-editor/

The Alertmanager config will look like this after being generated by prometheus-operator and two Alertmanagerconfigs:

```
global:
  resolve_timeout: 15m
  http_config:
    follow_redirects: true
    enable_http2: true
  smtp_hello: localhost
  smtp_require_tls: true
  pagerduty_url: https://events.pagerduty.com/v2/enqueue
  opsgenie_api_url: https://api.opsgenie.com/
  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/
  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
  telegram_api_url: https://api.telegram.org
  webex_api_url: https://webexapis.com/v1/messages
route:
  receiver: blackhole
  group_by:
  - '...'
  continue: false
  routes:
  - receiver: receiver-teamA
    group_by:
    - '...'
    continue: true
    routes:
    - receiver: receiver-teamA
      matchers:
      - app="teamA-app"
      - team="teamA"
      continue: false
  - receiver: receiver-teamB
    group_by:
    - '...'
    continue: true
    routes:
    - receiver: receiver-teamB
      matchers:
      - app="teamB-app"
      - team="teamB"
      continue: false
  - receiver: blackhole
    matchers:
    - alertname="InfoInhibitor"
    continue: false
receivers:
- name: blackhole
- name: receiver-teamA
  webhook_configs:
  - send_resolved: false
    http_config:
      follow_redirects: true
      enable_http2: true
    url: www.example.com
    url_file: ""
    max_alerts: 0
- name: receiver-teamB
  webhook_configs:
  - send_resolved: false
    http_config:
      follow_redirects: true
      enable_http2: true
    url: www.example.com
    url_file: ""
    max_alerts: 0
templates:
- /etc/alertmanager/config/*.tmpl
```

The Alert will have these labels:
```
{alertname="test-alerts",team="teamA",app="teamA-app"}
```

The result looks like this:
![obrázek](https://github.com/user-attachments/assets/1b474a4d-5f90-4ccf-aa45-f077c5625ef3)


It is clear from the image (red highlighted line) that the alert will come to both receivers generated by prometheus-operator (parent) and then to one child.

The correct behavior would be if the alert only arrived at one generated and its child. Because in this case, no matter what matchers we set, the alert will always arrive at the receiver.

Our solution is that if you set alertmanagerConfigMatcherStrategy to "None" you can tell prometheus-operator using annotations on the AlertmanagerConfig object to specify what machers you want in the generated route.
For example:
```
apiVersion: monitoring.coreos.com/v1alpha1
kind: AlertmanagerConfig
metadata:
  annotations:
    prometheus.io/generated-matcher: team=teamA
...
```

The resulting Alertmanager config will look like this:
```
global:
  resolve_timeout: 15m
  http_config:
    follow_redirects: true
    enable_http2: true
  smtp_hello: localhost
  smtp_require_tls: true
  pagerduty_url: https://events.pagerduty.com/v2/enqueue
  opsgenie_api_url: https://api.opsgenie.com/
  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/
  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
  telegram_api_url: https://api.telegram.org
  webex_api_url: https://webexapis.com/v1/messages
route:
  receiver: blackhole
  group_by:
  - '...'
  continue: false
  routes:
  - receiver: receiver-teamA-generated
    group_by:
    - '...'
    matchers:
     - team="teamA"
    continue: true
    routes:
    - receiver: receiver-teamA
      matchers:
      - app="teamA-app"
      - team="teamA"
      continue: false
...
```

This will guarantee that the alert only comes to the correct generated route with the correct receiver.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Tested by automatic tests 
- Tested in a live production environment 

## Changelog entry

- Added option to define matcher for generated reciever via annotations on alertmanager config object
- If alertmanagerConfigMatcherStrategy is set to None, the suffix generated is added to the created reciever to ensure correct routing of the alert
