### PR TITLE
chore: Refactor OVHCloudSDConfig and test cases

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -1534,6 +1534,21 @@ func (rs *ResourceSelector) validateOVHCloudSDConfigs(ctx context.Context, sc *m
 		if _, err := rs.store.GetSecretKey(ctx, sc.GetNamespace(), config.ConsumerKey); err != nil {
 			return fmt.Errorf("[%d]: %w", i, err)
 		}
+		if config.ApplicationKey == "" {
+			return fmt.Errorf("[%d]: applicationKey cannot be empty", i)
+		}
+
+		if config.Service != "VPS" && config.Service != "DedicatedServer" {
+			return fmt.Errorf("[%d]: service must be either 'VPS' or 'DedicatedServer'", i)
+		}
+
+		if config.Endpoint != nil && *config.Endpoint == "" {
+			return fmt.Errorf("[%d]: endpoint cannot be empty", i)
+		}
+
+		if config.RefreshInterval != nil && rs.version.LT(semver.MustParse("2.30.0")) {
+			return fmt.Errorf("[%d]: refreshInterval is not supported for Prometheus version < 2.30.0", i)
+		}
 	}
 
 	return nil

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -610,6 +610,9 @@ func testScrapeConfigCRDValidations(t *testing.T) {
 	t.Run("IonosSD", func(t *testing.T) {
 		runScrapeConfigCRDValidation(t, IonosSDTestCases)
 	})
+	t.Run("OVHCloudSD", func(t *testing.T) { 
+		runScrapeConfigCRDValidation(t, OVHCloudSDTestCases)
+	})
 }
 
 func runScrapeConfigCRDValidation(t *testing.T, testCases []scrapeCRDTestCase) {
@@ -2034,4 +2037,150 @@ var IonosSDTestCases = []scrapeCRDTestCase{
 		},
 		expectedError: true,
 	},
+}
+
+var OVHCloudSDTestCases = []scrapeCRDTestCase{
+    {
+        name: "Valid OVHCloudSDConfig",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "valid-app-key",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "VPS",
+                },
+            },
+        },
+        expectedError: false,
+    },
+    {
+        name: "Invalid ApplicationKey with empty value",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "VPS",
+                },
+            },
+        },
+        expectedError: true,
+    },
+    {
+        name: "Invalid Service type",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "valid-app-key",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "InvalidService",
+                },
+            },
+        },
+        expectedError: true,
+    },
+    {
+        name: "Empty Endpoint",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "valid-app-key",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "VPS",
+                    Endpoint:          ptr.To(""),
+                },
+            },
+        },
+        expectedError: true,
+    },
+    {
+        name: "Valid with RefreshInterval for supported version",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "valid-app-key",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "VPS",
+                    RefreshInterval:   ptr.To(monitoringv1.Duration("30s")),
+                },
+            },
+        },
+        expectedError: false,
+    },
+    {
+		// Following should technically show error when the refreshInterval has invalid value for the supported version
+        name: "Invalid RefreshInterval for unsupported version",
+        scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+            OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+                {
+                    ApplicationKey:    "valid-app-key",
+                    ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+                    ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+                    Service:           "VPS",
+                    RefreshInterval:   ptr.To(monitoringv1.Duration("30s")),
+                },
+            },
+        },
+        expectedError: true,
+    },
+	{
+		name: "Missing ConsumerKey",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+				{
+					ApplicationKey:    "valid-app-key",
+					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+					Service:           "VPS",
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid ConsumerKey with empty value",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+				{
+					ApplicationKey:    "valid-app-key",
+					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       v1.SecretKeySelector{Key: ""},
+					Service:           "VPS",
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Invalid Service type (Another Invalid Service)",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+				{
+					ApplicationKey:    "valid-app-key",
+					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					Service:           "SomeOtherInvalidService",
+				},
+			},
+		},
+		expectedError: true,
+	},
+	{
+		name: "Missing Service field",
+		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
+			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
+				{
+					ApplicationKey:    "valid-app-key",
+					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+				},
+			},
+		},
+		expectedError: true,
+	},
+			
 }


### PR DESCRIPTION
## Description

This pull request refactors the validation logic for the OVHCloudSDConfig struct in the Prometheus Operator. The changes include improving the handling of configuration fields such as ApplicationKey, Service, Endpoint, and RefreshInterval. Additionally, test cases have been updated or added to ensure that all fields are correctly validated, and edge cases like empty values or unsupported RefreshInterval formats are properly handled.

Fixes #7206 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Refactor validation and enhance test coverage for OVHCloudSDConfig in Prometheus Operator.

```
