### PR TITLE
Fix: Image path in troubleshooting doc

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -70,7 +70,7 @@ A common problem related to `ServiceMonitor` identification by Prometheus is rel
 
 <!-- do not change this link without verifying that the image will display correctly on https://prometheus-operator.dev -->
 
-![flow diagram](/img/custom-metrics-elements.png)
+![flow diagram](img/custom-metrics-elements.png)
 
 Note: The `ServiceMonitor` references a `Service` (not a `Deployment`, or a `Pod`), by labels *and* by the port name in the `Service`. This *port name* is optional in Kubernetes, but must be specified for the `ServiceMonitor` to work. It is not the same as the port name on the `Pod` or container, although it can be.
 


### PR DESCRIPTION
## Description

Fix image link used [here](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/troubleshooting.md#overview-of-servicemonitor-tagging-and-related-elements)


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix image path in troubleshooting doc
```
