### PR TITLE
VEX related improvements in the build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,15 +114,15 @@ build: operator prometheus-config-reloader admission-webhook k8s-gen
 
 .PHONY: operator
 operator:
-	$(GO_BUILD_RECIPE) -o $@ cmd/operator/main.go
+	$(GO_BUILD_RECIPE) -o $@ ./cmd/operator/
 
 .PHONY: prometheus-config-reloader
 prometheus-config-reloader:
-	$(GO_BUILD_RECIPE) -o $@ cmd/$@/main.go
+	$(GO_BUILD_RECIPE) -o $@ ./cmd/$@/
 
 .PHONY: admission-webhook
 admission-webhook:
-	$(GO_BUILD_RECIPE) -o $@ cmd/$@/main.go
+	$(GO_BUILD_RECIPE) -o $@ ./cmd/$@/
 
 
 DEEPCOPY_TARGETS := pkg/apis/monitoring/v1/zz_generated.deepcopy.go pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go pkg/apis/monitoring/v1beta1/zz_generated.deepcopy.go


### PR DESCRIPTION
## Description

In SUSE Rancher we have our own VEX Hub [rancher/vexhub](https://github.com/rancher/vexhub) repository to remove (VEX) known false-positive CVEs in our projects (images and binaries) and derived third-party and upstream binaries.

Note: The VEX report follows the [OpenVEX specification](https://github.com/openvex/spec). The VEX Hub repository follows Aqua Security's [VEX Repository specification](https://github.com/aquasecurity/vex-repo-spec).

In order for VEX to fully work and for security scanners (e.g., Trivy) to correctly match a VEX entry with a Go binary being scanned, the Go binary must have its full package path inside of it. Example:

```
> go version -m operator | head -n 3
operator: go1.23.3
	path	github.com/prometheus-operator/prometheus-operator/cmd/operator
	mod	github.com/prometheus-operator/prometheus-operator	(devel)
```

When a Go binary is compiled by specifying directly the file as `go build main.go` as opposed to `go build .`, the binary won't contain the package path.

```
> go version -m bin/operator | head -n 2
bin/operator: go1.23.4
	path	command-line-arguments
```

In the above case, the security scanner won't be able to match the binary with its respective VEX entry. This situation is happening with the 03 binary artifacts generated in this repo:

https://github.com/prometheus-operator/prometheus-operator/blob/ae04859fc90096b7bbbe297d4fdade73f0d1f1a6/Makefile#L112-L125
The change doesn't affect the code's behavior and features.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Change the Go build process to include the package path inside the generated binaries.
```
