### PR TITLE
feat: add timeout field in Webhook receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] Add `keepIdentifyingResourceAttributes` field in OTLPConfig for `Prometheus` and `PrometheusAgent` CRDs. #7240
 * [FEATURE] Add `fallbackScrapeProtocol` field to ScrapeClass for `Prometheus` and `PrometheusAgent` CRDs. #7288
 * [FEATURE] Support `MSTeamsV2Config` receiver in Alertmanager configuration Secret. #7296
+* [FEATURE] Add `Timeout` field in Webhook receiver in Alertmanager configuration Secret. #7312
 * [FEATURE] Add `scrapeFailureLogFile` field to the Prometheus and PrometheusAgent CRDs. #7038 #7311
 * [BUGFIX] Validate respective api URL field in PagerDutyConfigs, DiscordConfigs, SlackConfigs and WebhookConfigs in AlertManagerConfig CRD. #6585
 

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2240,6 +2240,12 @@ func (whc *webhookConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 		whc.URLFile = ""
 	}
 
+	if whc.Timeout != nil && amVersion.LT(semver.MustParse("0.28.0")) {
+		msg := "'timeout' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		whc.Timeout = nil
+	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -3649,6 +3649,38 @@ func TestSanitizeWebhookConfig(t *testing.T) {
 			},
 			golden: "test_url_takes_precedence_in_webhook_config.golden",
 		},
+		{
+			name:           "Test timeout is dropped in webhook config for unsupported versions",
+			againstVersion: semver.Version{Major: 0, Minor: 26},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						WebhookConfigs: []*webhookConfig{
+							{
+								Timeout: ptr.To(model.Duration(time.Minute)),
+							},
+						},
+					},
+				},
+			},
+			golden: "test_webhook_timeout_is_dropped_in_webhook_config_for_unsupported_versions.golden",
+		},
+		{
+			name:           "Test timeout is added in webhook config for supported versions",
+			againstVersion: semver.Version{Major: 0, Minor: 28},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						WebhookConfigs: []*webhookConfig{
+							{
+								Timeout: ptr.To(model.Duration(time.Minute)),
+							},
+						},
+					},
+				},
+			},
+			golden: "test_webhook_timeout_is_added_in_webhook_config_for_supported_versions.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)

--- a/pkg/alertmanager/testdata/test_webhook_timeout_is_added_in_webhook_config_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_webhook_timeout_is_added_in_webhook_config_for_supported_versions.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  webhook_configs:
+  - timeout: 1m
+templates: []

--- a/pkg/alertmanager/testdata/test_webhook_timeout_is_dropped_in_webhook_config_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_webhook_timeout_is_dropped_in_webhook_config_for_unsupported_versions.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  webhook_configs:
+  - {}
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -120,6 +120,7 @@ type webhookConfig struct {
 	URLFile       string            `yaml:"url_file,omitempty" json:"url_file,omitempty"`
 	HTTPConfig    *httpClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	MaxAlerts     int32             `yaml:"max_alerts,omitempty" json:"max_alerts,omitempty"`
+	Timeout       *model.Duration   `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 type pagerdutyConfig struct {


### PR DESCRIPTION
Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>
Co-Authored-by Nutmos <nutmos@users.noreply.github.com>

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
