### PR TITLE
chore: add e2e tests on operator metrics

### DIFF
--- a/pkg/k8sutil/metrics.go
+++ b/pkg/k8sutil/metrics.go
@@ -37,7 +37,7 @@ type clientGoRateLimiterMetricAdapter struct {
 
 var _ = metrics.LatencyMetric(&clientGoRateLimiterMetricAdapter{})
 
-// MustRegisterClientGoMetrics registers k8s.io/client-go metrics.
+// MustRegisterClientGoMetrics registers the k8s.io/client-go metrics.
 // It panics if it encounters an error (e.g. metrics already registered).
 func MustRegisterClientGoMetrics(registerer prometheus.Registerer) {
 	httpMetrics := &clientGoHTTPMetricAdapter{
@@ -73,7 +73,8 @@ func MustRegisterClientGoMetrics(registerer prometheus.Registerer) {
 	// function can be called only once. To ensure that the k8s client metrics
 	// get updated, the global variables need to be set again here.
 	//
-	// Details:
+	// Details in:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/3054
 	// https://github.com/kubernetes-sigs/controller-runtime/blob/67b27f27e514bd9ac4cf9a2d84dec089ece95bf7/pkg/metrics/client_go_adapter.go#L42-L55
 	// https://github.com/kubernetes/client-go/blob/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53/tools/metrics/metrics.go#L129-L170
 	metrics.Register(

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2177,7 +2177,7 @@ func testAMWeb(t *testing.T) {
 			}
 		}
 
-		reloadSuccessTimestamp, err := framework.GetMetricVal(context.Background(), "https", ns, podName, "8080", "reloader_last_reload_success_timestamp_seconds")
+		reloadSuccessTimestamp, err := framework.GetMetricValueFromPod(context.Background(), "https", ns, podName, "8080", "reloader_last_reload_success_timestamp_seconds")
 		if err != nil {
 			pollErr = err
 			return false, nil

--- a/test/e2e/prometheus_operator_test.go
+++ b/test/e2e/prometheus_operator_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testServerTLS verifies that the Prometheus operator web server is working
+// with HTTPS.
+func testServerTLS(t *testing.T, namespace string) {
+	skipPrometheusTests(t)
+
+	ctx := context.Background()
+	err := framework.WaitForServiceReady(ctx, namespace, prometheusOperatorServiceName)
+	require.NoError(t, err)
+
+	operatorService := framework.KubeClient.CoreV1().Services(namespace)
+	request := operatorService.ProxyGet("https", prometheusOperatorServiceName, "https", "/healthz", nil)
+	_, err = request.DoRaw(ctx)
+	require.NoError(t, err)
+}
+
+// testPrometheusOperatorMetrics verifies that the Prometheus operator exposes
+// the expected metrics.
+func testPrometheusOperatorMetrics(t *testing.T, namespace string) {
+	skipPrometheusTests(t)
+
+	ctx := context.Background()
+	err := framework.WaitForServiceReady(ctx, namespace, prometheusOperatorServiceName)
+	require.NoError(t, err)
+
+	// Explicitly check the client-go metrics to validate the registration
+	// workaround we have in place due to
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/3054
+	err = framework.EnsureMetricsFromService(
+		ctx,
+		"https",
+		namespace,
+		prometheusOperatorServiceName,
+		"https",
+		"prometheus_operator_kubernetes_client_http_requests_total",
+		"prometheus_operator_kubernetes_client_http_request_duration_seconds_count",
+		"prometheus_operator_kubernetes_client_http_request_duration_seconds_sum",
+		"prometheus_operator_kubernetes_client_rate_limiter_duration_seconds_count",
+		"prometheus_operator_kubernetes_client_rate_limiter_duration_seconds_sum",
+	)
+	require.NoError(t, err)
+}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -3893,7 +3893,7 @@ func testPromWebWithThanosSidecar(t *testing.T) {
 			}
 		}
 
-		reloadSuccessTimestamp, err := framework.GetMetricVal(context.Background(), "https", ns, podName, "8080", "reloader_last_reload_success_timestamp_seconds")
+		reloadSuccessTimestamp, err := framework.GetMetricValueFromPod(context.Background(), "https", ns, podName, "8080", "reloader_last_reload_success_timestamp_seconds")
 		if err != nil {
 			pollErr = err
 			return false, nil
@@ -3904,7 +3904,7 @@ func testPromWebWithThanosSidecar(t *testing.T) {
 			return false, nil
 		}
 
-		thanosSidecarPrometheusUp, err := framework.GetMetricVal(context.Background(), "http", ns, podName, "10902", "thanos_sidecar_prometheus_up")
+		thanosSidecarPrometheusUp, err := framework.GetMetricValueFromPod(context.Background(), "http", ns, podName, "10902", "thanos_sidecar_prometheus_up")
 		if err != nil {
 			pollErr = err
 			return false, nil

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -161,22 +161,19 @@ func podRunsImage(p v1.Pod, image string) bool {
 	return false
 }
 
-// ProxyGetPod expects resourceName as "[protocol:]podName[:portNameOrNumber]".
-// protocol is optional and the valid values are "http" and "https".
-// Without specifying protocol, "http" will be used.
-// podName is mandatory.
-// portNameOrNumber is optional.
-// Without specifying portNameOrNumber, default port will be used.
-func (f *Framework) ProxyGetPod(namespace, resourceName, path string) *rest.Request {
-	return f.KubeClient.
+// ProxyGetPod executes an HTTP(S) request against the default port of the pod
+// using the Proxy API.
+func (f *Framework) ProxyGetPod(ctx context.Context, scheme, namespace, pod, path string) ([]byte, error) {
+	b, err := f.KubeClient.
 		CoreV1().
-		RESTClient().
-		Get().
-		Namespace(namespace).
-		Resource("pods").
-		SubResource("proxy").
-		Name(resourceName).
-		Suffix(path)
+		Pods(namespace).
+		ProxyGet(scheme, pod, "", path, nil).
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
 // ProxyPostPod expects resourceName as "[protocol:]podName[:portNameOrNumber]".
@@ -199,32 +196,66 @@ func (f *Framework) ProxyPostPod(namespace, resourceName, path, body string) *re
 		SetHeader("Content-Type", "application/json")
 }
 
-// GetMetricVal get a particular metric value from a pod.
-// When portNumberOfName is "", default port will be used to access metrics endpoint.
-func (f *Framework) GetMetricVal(ctx context.Context, protocol, ns, podName, portNumberOrName, metricName string) (float64, error) {
-	resourceName := podName
-	if protocol == "" {
-		protocol = "http"
-	}
-	if portNumberOrName != "" {
-		resourceName = fmt.Sprintf("%s:%s:%s", protocol, podName, portNumberOrName)
-	}
-
-	request := f.ProxyGetPod(ns, resourceName, "/metrics")
-	resp, err := request.DoRaw(ctx)
+// GetMetricValueFromPod sends an HTTP(S) request to the /metrics endpoint of the pod
+// using the Proxy API, parses the response and returns the flot64 value of the
+// first series matching the metric name.
+// If protocol is empty, HTTP is used.
+// If portNumberOfName is empty, the default pod's port is used.
+func (f *Framework) GetMetricValueFromPod(ctx context.Context, protocol, ns, podName, portNumberOrName, metricName string) (float64, error) {
+	b, err := f.KubeClient.
+		CoreV1().
+		Pods(ns).
+		ProxyGet(protocol, podName, portNumberOrName, "/metrics", nil).
+		DoRaw(ctx)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("error reading /metrics: %w", err)
 	}
 
-	parser := textparse.NewPromParser(resp, labels.NewSymbolTable())
+	return getMetricValue(b, metricName)
+}
+
+// GetMetricValueFromService sends an HTTP(S) request to the /metrics endpoint
+// of the service using the Proxy API, parses the response and returns the
+// flot64 value of the first series matching the metric name.
+// If protocol is empty, HTTP is used.
+// If portNumberOfName is empty, the default pod's port is used.
+func (f *Framework) EnsureMetricsFromService(ctx context.Context, protocol, ns, service, portNumberOrName string, metrics ...string) error {
+	if len(metrics) == 0 {
+		return fmt.Errorf("need to provide at least 1 metric to check")
+	}
+
+	b, err := f.KubeClient.
+		CoreV1().
+		Services(ns).
+		ProxyGet(protocol, service, portNumberOrName, "/metrics", nil).
+		DoRaw(ctx)
+	if err != nil {
+		return fmt.Errorf("error reading /metrics: %w", err)
+	}
+
+	for _, m := range metrics {
+		_, err = getMetricValue(b, m)
+		if err != nil {
+			return fmt.Errorf("metric %s: %w", m, err)
+		}
+	}
+
+	return nil
+}
+
+func getMetricValue(b []byte, metricName string) (float64, error) {
+	parser := textparse.NewPromParser(b, labels.NewSymbolTable())
+
 	for {
 		entry, err := parser.Next()
 		if err != nil {
 			return 0, err
 		}
+
 		if entry == textparse.EntryInvalid {
 			return 0, fmt.Errorf("invalid prometheus metric entry")
 		}
+
 		if entry != textparse.EntrySeries {
 			continue
 		}


### PR DESCRIPTION
## Description

Given that we have to "patch" the registration of client-go metrics, it's quite important that we prevent regressions.

See also #6525.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
