### PR TITLE
fix: Correct typo in comment

### DIFF
--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -170,7 +170,7 @@ func (w *ForResource) ListAllByNamespace(namespace string, selector labels.Selec
 }
 
 // Get invokes all wrapped informers and returns the first found runtime object.
-// It returns the first ocured error.
+// It returns the first occurred error.
 func (w *ForResource) Get(name string) (runtime.Object, error) {
 	var err error
 


### PR DESCRIPTION
Replace `ocured` with `occurred` in the comment of the Get function.

## Description

This PR fixes a typo in the comment of the Get function by replacing `ocured` with `occurred`.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)


## Changelog entry

```release-note
Fixed a typo in the comment of the Get function by replacing "ocured" with "occurred".
```
