### PR TITLE
feat: add cli flag to enable Thanos http port

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -53,6 +53,8 @@ Usage of ./operator:
     	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.
   -enable-config-reloader-probes
     	Enable liveness and readiness for the config-reloader container. Default: false
+  -enable-thanos-http-port
+    	Whether to enable Thanos HTTP Port
   -feature-gates value
     	Feature gates are a set of key=value pairs that describe Prometheus-Operator features.
     	Available feature gates:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -181,6 +181,8 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.SecretListWatchFieldSelector, "secret-field-selector", "Field selector to filter Secrets to watch")
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
 
+	fs.BoolVar(&cfg.EnableThanosHTTPPort, "enable-thanos-http-port", false, "Whether to enable Thanos HTTP Port")
+
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -68,6 +68,9 @@ type Config struct {
 	// Event recorder factory.
 	EventRecorderFactory EventRecorderFactory
 
+	// Whether to Enable Thanos HTTP Port
+	EnableThanosHTTPPort bool
+
 	// Feature gates.
 	Gates *FeatureGates
 }

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -154,6 +154,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			ReloaderConfig:             c.ReloaderConfig,
 			PrometheusDefaultBaseImage: c.PrometheusDefaultBaseImage,
 			ThanosDefaultBaseImage:     c.ThanosDefaultBaseImage,
+			EnableThanosHTTPPort:       c.EnableThanosHTTPPort,
 			Annotations:                c.Annotations,
 			Labels:                     c.Labels,
 		},

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -42,6 +42,7 @@ type Config struct {
 	ReloaderConfig             operator.ContainerConfig
 	PrometheusDefaultBaseImage string
 	ThanosDefaultBaseImage     string
+	EnableThanosHTTPPort       bool
 	Annotations                operator.Map
 	Labels                     operator.Map
 }

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -821,6 +821,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 				Port:       10901,
 				TargetPort: intstr.FromString("grpc"),
 			})
+			if c.config.EnableThanosHTTPPort {
+				svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
+					Name:       "metrics",
+					Port:       10902,
+					TargetPort: intstr.FromString("metrics"),
+				})
+			}
 		}
 
 		if _, err := k8sutil.CreateOrUpdateService(ctx, c.kclient.CoreV1().Services(p.Namespace), svc); err != nil {


### PR DESCRIPTION
## Description

Add the new CLI flag to expose port 10901 (Thanos HTTP) in Kubernetes Service

Fix #7368

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
