### PR TITLE
fix: unblock feature-gates CI

### DIFF
--- a/pkg/operator/feature_gates.go
+++ b/pkg/operator/feature_gates.go
@@ -26,8 +26,10 @@ const (
 	// PrometheusAgentDaemonSetFeature enables the DaemonSet mode for PrometheusAgent.
 	PrometheusAgentDaemonSetFeature FeatureGateName = "PrometheusAgentDaemonSet"
 
-	// PrometheusTopologySharding enables the zone aware sharding for Prometheus.
-	PrometheusTopologyShardingFeature     FeatureGateName = "PrometheusTopologySharding"
+	// PrometheusTopologySharding enables the zone-aware sharding for Prometheus.
+	PrometheusTopologyShardingFeature FeatureGateName = "PrometheusTopologySharding"
+
+	// PrometheusShardRetentionPolicyFeature enables the shard retention policy for Prometheus.
 	PrometheusShardRetentionPolicyFeature FeatureGateName = "PrometheusShardRetentionPolicy"
 )
 

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -94,7 +94,7 @@ func testDenyServiceMonitor(t *testing.T) {
 	for _, denied := range deniedNamespaces {
 		echo := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "ehoserver",
+				Name: "echoserver",
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: proto.Int32(1),

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -38,7 +38,10 @@ var (
 	opImage                  *string
 )
 
-const testControllerID = "--controller-id=42"
+const (
+	testControllerID            = "--controller-id=42"
+	gitHubContentReleaseBaseURL = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-%d.%d"
+)
 
 func skipPrometheusAllNSTests(t *testing.T) {
 	if os.Getenv("EXCLUDE_PROMETHEUS_ALL_NS_TESTS") != "" {
@@ -113,7 +116,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	prevStableVersionURL := fmt.Sprintf("https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-%d.%d/VERSION", currentSemVer.Major, currentSemVer.Minor-1)
+	prevStableVersionURL := fmt.Sprintf(gitHubContentReleaseBaseURL, currentSemVer.Major, currentSemVer.Minor-1) + "/VERSION"
 	reader, err := operatorFramework.URLToIOReader(prevStableVersionURL)
 	if err != nil {
 		logger.Printf("failed to get previous version file content: %v\n", err)
@@ -126,16 +129,14 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	prometheusOperatorGithubBranchURL := "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator"
-
 	prevSemVer, err := semver.ParseTolerant(string(prevStableVersion))
 	if err != nil {
 		logger.Printf("failed to parse previous stable version: %v\n", err)
 		os.Exit(1)
 	}
-	prevStableOpImage := fmt.Sprintf("%s:v%s", "quay.io/prometheus-operator/prometheus-operator", strings.TrimSpace(string(prevStableVersion)))
-	prevExampleDir := fmt.Sprintf("%s/release-%d.%d/example", prometheusOperatorGithubBranchURL, prevSemVer.Major, prevSemVer.Minor)
-	prevResourcesDir := fmt.Sprintf("%s/release-%d.%d/test/framework/resources", prometheusOperatorGithubBranchURL, prevSemVer.Major, prevSemVer.Minor)
+	prevStableOpImage := fmt.Sprintf("quay.io/prometheus-operator/prometheus-operator:v%s", strings.TrimSpace(string(prevStableVersion)))
+	prevExampleDir := fmt.Sprintf(gitHubContentReleaseBaseURL, prevSemVer.Major, prevSemVer.Minor) + "/example"
+	prevResourcesDir := fmt.Sprintf(gitHubContentReleaseBaseURL, prevSemVer.Major, prevSemVer.Minor) + "/test/framework/resources"
 
 	if previousVersionFramework, err = operatorFramework.New(*kubeconfig, prevStableOpImage, prevExampleDir, prevResourcesDir, prevSemVer); err != nil {
 		logger.Printf("failed to setup previous version framework: %v\n", err)

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -5366,7 +5366,7 @@ func testPrometheusRetentionPolicies(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusShardRetentionPolicy"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusShardRetentionPolicyFeature},
 		},
 	)
 	require.NoError(t, err)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -37,6 +37,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	pa "github.com/prometheus-operator/prometheus-operator/pkg/prometheus/agent"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -74,7 +75,7 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
 		},
 	)
 	require.NoError(t, err)
@@ -204,7 +205,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
 		},
 	)
 	require.NoError(t, err)
@@ -276,7 +277,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
 		},
 	)
 	require.NoError(t, err)
@@ -341,7 +342,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
 		},
 	)
 	require.NoError(t, err)
@@ -371,7 +372,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []string{"PrometheusAgentDaemonSet"},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
 		},
 	)
 	require.NoError(t, err)

--- a/test/e2e/upgradepath_test.go
+++ b/test/e2e/upgradepath_test.go
@@ -125,7 +125,8 @@ func testOperatorUpgrade(t *testing.T) {
 	_, err = previousVersionFramework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, &alertmanagerService)
 	require.NoError(t, err)
 
-	previousVersionFramework.SetupPrometheusRBAC(context.Background(), t, nil, ns)
+	// Setup RBAC rules for the Prometheus service account.
+	previousVersionFramework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 	prometheus := previousVersionFramework.MakeBasicPrometheus(ns, name, name, 1)
 
 	_, err = previousVersionFramework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, previousVersionFramework.MakeBasicPrometheus(ns, name, name, 1))
@@ -140,8 +141,10 @@ func testOperatorUpgrade(t *testing.T) {
 	_, err = previousVersionFramework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, &thanosRulerService)
 	require.NoError(t, err)
 
+	// Update the Prometheus Operator to the current version:
+	// 1. Update the RBAC rules for the Prometheus service account.
+	// 2. Upgrade the operator deployment.
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
-	// Update Prometheus Operator to current version
 	finalizers, err := framework.CreateOrUpdatePrometheusOperator(context.Background(), ns, nil, nil, nil, nil, true, true, true)
 	require.NoError(t, err)
 	for _, f := range finalizers {

--- a/test/framework/context.go
+++ b/test/framework/context.go
@@ -271,6 +271,7 @@ func (ctx *TestCtx) ID() string {
 }
 
 func (ctx *TestCtx) Cleanup(t *testing.T) {
+	t.Helper()
 	var eg errgroup.Group
 
 	for i := len(ctx.cleanUpFns) - 1; i >= 0; i-- {


### PR DESCRIPTION
## Description

This PR updates the e2e framework to create dedicated cluster roles for each operator, otherwise tests running in parallel might change the cluster role definition concurrently.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
