### PR TITLE
fix: render metric_name_validation_scheme in config

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -4824,6 +4824,17 @@ func (cg *ConfigGenerator) appendTracingConfig(cfg yaml.MapSlice, s assets.Store
 		}), nil
 }
 
+func (cg *ConfigGenerator) appendNameValidationScheme(cfg yaml.MapSlice, nameValidationScheme *monitoringv1.NameValidationSchemeOptions) yaml.MapSlice {
+	if nameValidationScheme == nil {
+		return cfg
+	}
+
+	// need to cast it to a string in order to use strings.ToLower() to render the value in the way prometheus expects it
+	nameValidationSchemeValue := string(*nameValidationScheme)
+
+	return cg.WithMinimumVersion("3.0.0").AppendMapItem(cfg, "metric_name_validation_scheme", strings.ToLower(nameValidationSchemeValue))
+}
+
 func (cg *ConfigGenerator) getScrapeClassOrDefault(name *string) monitoringv1.ScrapeClass {
 	if name != nil {
 		if scrapeClass, found := cg.scrapeClasses[*name]; found {
@@ -4897,8 +4908,7 @@ func (cg *ConfigGenerator) buildGlobalConfig() yaml.MapSlice {
 	cfg = cg.appendExternalLabels(cfg)
 	cfg = cg.appendScrapeLimits(cfg)
 	cfg = cg.appendScrapeFailureLogFile(cfg, cg.prom.GetCommonPrometheusFields().ScrapeFailureLogFile)
-	if cpf.NameValidationScheme != nil {
-		cg.WithMinimumVersion("3.0.0").AppendMapItem(cfg, "metric_name_validation_scheme", *cpf.NameValidationScheme)
-	}
+	cfg = cg.appendNameValidationScheme(cfg, cpf.NameValidationScheme)
+
 	return cfg
 }

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -9220,13 +9220,13 @@ func TestAppendNameValidationScheme(t *testing.T) {
 	}{
 		{
 			name:                 "UTF8 nameValidationScheme withPrometheus Version 3",
-			version:              "v3.0.0-beta.0",
+			version:              "v3.0.0",
 			nameValidationScheme: ptr.To(monitoringv1.UTF8NameValidationScheme),
 			expectedCfg:          "NameValidationSchemeUTF8WithPrometheusV3.golden",
 		},
 		{
 			name:                 "Legacy nameValidationScheme with Prometheus Version 3",
-			version:              "v3.0.0-beta.0",
+			version:              "v3.0.0",
 			nameValidationScheme: ptr.To(monitoringv1.LegacyNameValidationScheme),
 			expectedCfg:          "NameValidationSchemeLegacyWithPrometheusV3.golden",
 		},

--- a/pkg/prometheus/testdata/NameValidationSchemeLegacyWithPrometheusV3.golden
+++ b/pkg/prometheus/testdata/NameValidationSchemeLegacyWithPrometheusV3.golden
@@ -3,5 +3,6 @@ global:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
+  metric_name_validation_scheme: legacy
   evaluation_interval: 30s
 scrape_configs: []

--- a/pkg/prometheus/testdata/NameValidationSchemeUTF8WithPrometheusV3.golden
+++ b/pkg/prometheus/testdata/NameValidationSchemeUTF8WithPrometheusV3.golden
@@ -3,5 +3,6 @@ global:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
+  metric_name_validation_scheme: utf8
   evaluation_interval: 30s
 scrape_configs: []

--- a/pkg/prometheus/testdata/OTLPConfig_Config_translation_strategy_with_suffixes_and_name_validation_scheme.golden
+++ b/pkg/prometheus/testdata/OTLPConfig_Config_translation_strategy_with_suffixes_and_name_validation_scheme.golden
@@ -3,6 +3,7 @@ global:
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
+  metric_name_validation_scheme: legacy
   evaluation_interval: 30s
 scrape_configs: []
 otlp:


### PR DESCRIPTION
## Description

This PR adds rendering of the metric_name_validation_scheme config param if it is provided in the Custom Resource.



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Built docker image, deployed in dev k8s cluster, manually edited CR to have nameValidationScheme set to Legacy, UTF-8, and omitting it whatsoever. Checked if resulting config is rendered properly.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Render metric_name_validation_scheme in config.
```
