### PR TITLE
feat: Use protobuf encoding for core K8s APIs in prometheus-operator

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -244,7 +245,9 @@ func run(fs *flag.FlagSet) int {
 		return 1
 	}
 
-	kclient, err := kubernetes.NewForConfig(restConfig)
+	restConfigProtobuf := rest.CopyConfig(restConfig)
+	restConfigProtobuf.ContentType = runtime.ContentTypeProtobuf
+	kclient, err := kubernetes.NewForConfig(restConfigProtobuf)
 	if err != nil {
 		logger.Error("failed to create Kubernetes client", "err", err)
 		cancel()

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/metadata"
@@ -120,7 +121,9 @@ func WithStorageClassValidation() ControllerOption {
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	logger = logger.With("component", controllerName)
 
-	client, err := kubernetes.NewForConfig(restConfig)
+	restConfigProtobuf := rest.CopyConfig(restConfig)
+	restConfigProtobuf.ContentType = runtime.ContentTypeProtobuf
+	client, err := kubernetes.NewForConfig(restConfigProtobuf)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -126,7 +127,9 @@ func WithStorageClassValidation() ControllerOption {
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	logger = logger.With("component", controllerName)
 
-	client, err := kubernetes.NewForConfig(restConfig)
+	restConfigProtobuf := rest.CopyConfig(restConfig)
+	restConfigProtobuf.ContentType = runtime.ContentTypeProtobuf
+	client, err := kubernetes.NewForConfig(restConfigProtobuf)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
@@ -132,7 +133,9 @@ func WithoutUnmanagedConfiguration() ControllerOption {
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger *slog.Logger, r prometheus.Registerer, opts ...ControllerOption) (*Operator, error) {
 	logger = logger.With("component", controllerName)
 
-	client, err := kubernetes.NewForConfig(restConfig)
+	restConfigProtobuf := rest.CopyConfig(restConfig)
+	restConfigProtobuf.ContentType = runtime.ContentTypeProtobuf
+	client, err := kubernetes.NewForConfig(restConfigProtobuf)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -108,7 +109,9 @@ func WithStorageClassValidation() ControllerOption {
 func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger *slog.Logger, r prometheus.Registerer, options ...ControllerOption) (*Operator, error) {
 	logger = logger.With("component", controllerName)
 
-	client, err := kubernetes.NewForConfig(restConfig)
+	restConfigProtobuf := rest.CopyConfig(restConfig)
+	restConfigProtobuf.ContentType = runtime.ContentTypeProtobuf
+	client, err := kubernetes.NewForConfig(restConfigProtobuf)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating kubernetes client failed: %w", err)
 	}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -86,7 +86,9 @@ func New(kubeconfig, opImage, exampleDir, resourcesDir string, operatorVersion s
 		return nil, fmt.Errorf("build config from flags failed: %w", err)
 	}
 
-	cli, err := kubernetes.NewForConfig(config)
+	configProtobuf := rest.CopyConfig(config)
+	configProtobuf.ContentType = runtime.ContentTypeProtobuf
+	cli, err := kubernetes.NewForConfig(configProtobuf)
 	if err != nil {
 		return nil, fmt.Errorf("creating new kube-client failed: %w", err)
 	}


### PR DESCRIPTION
## Description
This PR makes Prometheus Operator's static K8s client use Protobuf encoding when talking to K8s API.

If not specified explicitly, JSON encoding is used by default which is less efficient than protobuf.

For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

Standard system components of K8s default their serialization method to protobuf for some time already:
- `kube-scheduler`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/scheduler/apis/config/v1/defaults.go#L143-L145)
- `kubelet`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/kubelet/apis/config/v1beta1/defaults.go#L199-L201)
- `kube-proxy`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/proxy/apis/config/v1alpha1/defaults.go#L126-L128)
- `kube-controller-manager`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/controller-manager/config/v1alpha1/defaults.go#L49) and [method's contents](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L66-L68)

Some benchmarks comparing JSON vs. protobuf showcasing how the latter data format (de)serializes faster and uses less memory:
- https://medium.com/@akresling/go-benchmark-json-v-protobuf-4ec3c62ec8d4
- https://www.codingexplorations.com/blog/performance-comparison-protobuf-marshaling-vs-json-marshaling-in-go
- https://medium.com/@david_turner/protocol-buffers-just-how-fast-are-they-9ec19ea580db

## Type of change
- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Ran unit and e2e tests.

## Changelog entry
```release-note
Use protobuf encoding for core K8s APIs in Prometheus Operator.
```
