### PR TITLE
feat : Recreate Alertmanager StatefulSet when ClusterTLSConfig changes

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -760,6 +760,7 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *opera
 		AlertmanagerAnnotations map[string]string
 		AlertmanagerGeneration  int64
 		AlertmanagerWebHTTP2    *bool
+		AlertmanagerClusterTLS  *monitoringv1.ClusterTLSConfig
 		Config                  Config
 		StatefulSetSpec         appsv1.StatefulSetSpec
 		ShardedSecret           *operator.ShardedSecret
@@ -768,6 +769,7 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *opera
 		AlertmanagerAnnotations: a.Annotations,
 		AlertmanagerGeneration:  a.Generation,
 		AlertmanagerWebHTTP2:    http2,
+		AlertmanagerClusterTLS:  a.Spec.ClusterTLS,
 		Config:                  c,
 		StatefulSetSpec:         s,
 		ShardedSecret:           tlsAssets,

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -166,6 +166,142 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 
 			equal: false,
 		},
+		{
+			name: "different ClusterTLSConfig",
+			a: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+					ClusterTLS: &monitoringv1.ClusterTLSConfig{
+						ServerTLS: monitoringv1.WebTLSConfig{
+							ClientCA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret",
+									},
+									Key: "ca.crt",
+								},
+							},
+						},
+						ClientTLS: monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret",
+									},
+									Key: "ca.crt",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret",
+									},
+									Key: "tls.crt",
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "tls-secret",
+								},
+								Key: "tls.key",
+							},
+						},
+					},
+				},
+			},
+			b: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "different values within ClusterTLSConfig",
+			a: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+					ClusterTLS: &monitoringv1.ClusterTLSConfig{
+						ServerTLS: monitoringv1.WebTLSConfig{
+							ClientCA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-1",
+									},
+									Key: "ca.crt",
+								},
+							},
+						},
+						ClientTLS: monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-1",
+									},
+									Key: "ca.crt",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-1",
+									},
+									Key: "tls.crt",
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "tls-secret-1",
+								},
+								Key: "tls.key",
+							},
+						},
+					},
+				},
+			},
+			b: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+					ClusterTLS: &monitoringv1.ClusterTLSConfig{
+						ServerTLS: monitoringv1.WebTLSConfig{
+							ClientCA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-2",
+									},
+									Key: "ca.crt",
+								},
+							},
+						},
+						ClientTLS: monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-2",
+									},
+									Key: "ca.crt",
+								},
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "tls-secret-2",
+									},
+									Key: "tls.crt",
+								},
+							},
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "tls-secret-2",
+								},
+								Key: "tls.key",
+							},
+						},
+					},
+				},
+			},
+			equal: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			a1Hash, err := createSSetInputHash(tc.a, Config{}, &operator.ShardedSecret{}, appsv1.StatefulSetSpec{})


### PR DESCRIPTION
## Description

This PR adds support for recreating the Alertmanager StatefulSet when ClusterTLSConfig is modified. Previously, changes to the ClusterTLSConfig would not trigger a StatefulSet recreation, which meant that pod configuration wouldn't be updated with the new TLS settings.

The changes include:
- Adding ClusterTLSConfig to the hash calculation in `createSSetInputHash` function
- Ensuring volumes related to ClusterTLS are properly added/removed when config changes
- Adding unit tests to verify that StatefulSet recreation happens correctly

This addresses issue #7372.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

I've added unit tests in `pkg/alertmanager/operator_test.go` to verify that:
1. Changes to ClusterTLSConfig trigger StatefulSet recreation
2. Both adding/removing the config and modifying values within it are detected
3. The appropriate hash calculation is performed

## Changelog entry

```release-note
Ensure Alertmanager StatefulSet is recreated when ClusterTLSConfig changes
```
