### PR TITLE
promcfg: Remove web console arguments if prometheus version >= 3

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1097,14 +1097,13 @@ func initRelabelings() []yaml.MapSlice {
 func (cg *ConfigGenerator) BuildCommonPrometheusArgs() []monitoringv1.Argument {
 	cpf := cg.prom.GetCommonPrometheusFields()
 	promArgs := []monitoringv1.Argument{
-		{Name: "web.console.templates", Value: "/etc/prometheus/consoles"},
-		{Name: "web.console.libraries", Value: "/etc/prometheus/console_libraries"},
 		{Name: "config.file", Value: path.Join(ConfOutDir, ConfigEnvsubstFilename)},
 	}
 
-	if cg.version.Major >= 3 {
-		// remove web.console.templates and web.console.libraries if prometheus version is 3.0.0 or greater
-		promArgs = promArgs[len(promArgs)-1:]
+	if cg.version.Major == 2 {
+		// Add web.console.templates and web.console.libraries only if Prometheus version is v2.x.
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.console.templates", Value: "/etc/prometheus/consoles"},
+			monitoringv1.Argument{Name: "web.console.libraries", Value: "/etc/prometheus/console_libraries"})
 	}
 
 	if ptr.Deref(cpf.ReloadStrategy, monitoringv1.HTTPReloadStrategyType) == monitoringv1.HTTPReloadStrategyType {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1102,6 +1102,11 @@ func (cg *ConfigGenerator) BuildCommonPrometheusArgs() []monitoringv1.Argument {
 		{Name: "config.file", Value: path.Join(ConfOutDir, ConfigEnvsubstFilename)},
 	}
 
+	if cg.version.Major >= 3 {
+		// remove web.console.templates and web.console.libraries if prometheus version is 3.0.0 or greater
+		promArgs = promArgs[len(promArgs)-1:]
+	}
+
 	if ptr.Deref(cpf.ReloadStrategy, monitoringv1.HTTPReloadStrategyType) == monitoringv1.HTTPReloadStrategyType {
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "web.enable-lifecycle"})
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -2351,50 +2351,71 @@ func TestPrometheusAdditionalArgsNoError(t *testing.T) {
 		"--storage.tsdb.no-lockfile",
 	}
 
-	expectedPrometheusArgsV2 := append([]string{"--web.console.templates=/etc/prometheus/consoles",
-		"--web.console.libraries=/etc/prometheus/console_libraries"}, expectedPrometheusArgsV3...)
-
-	labels := map[string]string{
-		"testlabel": "testlabelvalue",
+	expectedPrometheusArgsV2 := []string{
+		"--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
+		"--web.console.templates=/etc/prometheus/consoles",
+		"--web.console.libraries=/etc/prometheus/console_libraries",
+		"--web.enable-lifecycle",
+		"--web.route-prefix=/",
+		"--storage.tsdb.retention.time=24h",
+		"--storage.tsdb.path=/prometheus",
+		"--web.config.file=/etc/prometheus/web_config/web-config.yaml",
+		"--scrape.discovery-reload-interval=30s",
+		"--storage.tsdb.no-lockfile",
 	}
-	annotations := map[string]string{
-		"testannotation": "testannotationvalue",
-	}
 
-	p := monitoringv1.Prometheus{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:      labels,
-			Annotations: annotations,
+	argTests := []struct {
+		version      string
+		expectedArgs []string
+	}{
+		{
+			version:      "v2.54.0",
+			expectedArgs: expectedPrometheusArgsV2,
 		},
-		Spec: monitoringv1.PrometheusSpec{
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				AdditionalArgs: []monitoringv1.Argument{
-					{
-						Name:  "scrape.discovery-reload-interval",
-						Value: "30s",
-					},
-					{
-						Name: "storage.tsdb.no-lockfile",
+		{
+			version:      "v3.0.0",
+			expectedArgs: expectedPrometheusArgsV3,
+		},
+	}
+
+	for _, argTest := range argTests {
+		t.Run(argTest.version, func(t *testing.T) {
+
+			labels := map[string]string{
+				"testlabel": "testlabelvalue",
+			}
+			annotations := map[string]string{
+				"testannotation": "testannotationvalue",
+			}
+
+			p := monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						AdditionalArgs: []monitoringv1.Argument{
+							{
+								Name:  "scrape.discovery-reload-interval",
+								Value: "30s",
+							},
+							{
+								Name: "storage.tsdb.no-lockfile",
+							},
+						},
+						Version: argTest.version,
 					},
 				},
-				Version: "v2.54.0",
-			},
-		},
+			}
+			sset, err := makeStatefulSetFromPrometheus(p)
+			require.NoError(t, err)
+			ssetContainerArgs := sset.Spec.Template.Spec.Containers[0].Args
+			// web.console.templates and web.console.libraries should be present in prometheus versisons < 3
+			require.Equal(t, argTest.expectedArgs, ssetContainerArgs, "expected Prometheus container args to match, want %s, got %s", argTest.expectedArgs, ssetContainerArgs)
+		})
+
 	}
-
-	sset, err := makeStatefulSetFromPrometheus(p)
-	require.NoError(t, err)
-
-	ssetContainerArgs := sset.Spec.Template.Spec.Containers[0].Args
-	// web.console.templates and web.console.libraries should be present in prometheus versisons < 3
-	require.Equal(t, expectedPrometheusArgsV2, ssetContainerArgs, "expected Prometheus container args to match, want %s, got %s", expectedPrometheusArgsV2, ssetContainerArgs)
-
-	p.Spec.CommonPrometheusFields.Version = "v3.0.0"
-	sset, err = makeStatefulSetFromPrometheus(p)
-	require.NoError(t, err)
-	ssetContainerArgs = sset.Spec.Template.Spec.Containers[0].Args
-	// web.console.templates and web.console.libraries should not be present in prometheus versions >= 3
-	require.Equal(t, expectedPrometheusArgsV3, ssetContainerArgs, "expected Prometheus container args to match, want %s, got %s", expectedPrometheusArgsV3, ssetContainerArgs)
 }
 
 func TestPrometheusAdditionalArgsDuplicate(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #7319



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

Updated the unit TestPrometheusAdditionalArgsNoError unit test that checks for these arguments with both a `v2` and `v3` prometheus config.  

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove `web.console.templates` and `web.console.libraries` symlinks in >= v3 prometheus
```
