### PR TITLE
fix: fix the ProxyURL regex. Again

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -545,7 +545,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -784,7 +784,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -1542,7 +1542,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -1781,7 +1781,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -2352,7 +2352,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -2591,7 +2591,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3144,7 +3144,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -3383,7 +3383,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3970,7 +3970,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -4209,7 +4209,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -4890,7 +4890,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5129,7 +5129,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -5635,7 +5635,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5874,7 +5874,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -6483,7 +6483,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -6722,7 +6722,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7260,7 +7260,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -7499,7 +7499,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7992,7 +7992,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8231,7 +8231,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -8711,7 +8711,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8950,7 +8950,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -9502,7 +9502,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -9741,7 +9741,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -11481,7 +11481,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               scopes:
                                 description: '`scopes` defines the OAuth2 scopes used
@@ -11713,7 +11713,7 @@ spec:
                           proxyUrl:
                             description: '`proxyURL` defines the HTTP proxy server
                               to use.'
-                            pattern: ^(http|https|socks5)?://.+$
+                            pattern: ^(http|https|socks5)://.+$
                             type: string
                           tlsConfig:
                             description: TLS configuration for the client.
@@ -19786,7 +19786,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -20897,7 +20897,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the
@@ -27150,7 +27150,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -27377,7 +27377,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue
@@ -33888,7 +33888,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         relabelings:
                           description: Relabel configuration applied to the discovered
@@ -38708,7 +38708,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -38935,7 +38935,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     readRecent:
                       description: |-
@@ -39572,7 +39572,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -39799,7 +39799,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue
@@ -46134,7 +46134,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -46369,7 +46369,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -46912,7 +46912,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -47150,7 +47150,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -47593,7 +47593,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -47826,7 +47826,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -48347,7 +48347,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -48577,7 +48577,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the container is refreshed.
@@ -49044,7 +49044,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -49279,7 +49279,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the service discovery data
@@ -49596,7 +49596,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -50072,7 +50072,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -50299,7 +50299,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -50839,7 +50839,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -51069,7 +51069,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the servers are refreshed.
@@ -51521,7 +51521,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -51748,7 +51748,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -52133,7 +52133,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -52366,7 +52366,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of resources.
@@ -52860,7 +52860,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -53087,7 +53087,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     role:
                       description: |-
@@ -53574,7 +53574,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -53801,7 +53801,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time to wait between polling update requests.
@@ -54286,7 +54286,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -54521,7 +54521,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.
@@ -54925,7 +54925,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -55158,7 +55158,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the linode instances are refreshed.
@@ -55720,7 +55720,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -55947,7 +55947,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -56268,7 +56268,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the
@@ -56905,7 +56905,7 @@ spec:
                 type: boolean
               proxyUrl:
                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                pattern: ^(http|https|socks5)?://.+$
+                pattern: ^(http|https|socks5)://.+$
                 type: string
               puppetDBSDConfigs:
                 description: PuppetDBSDConfigs defines a list of PuppetDB service
@@ -57176,7 +57176,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -57409,7 +57409,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     query:
                       description: |-
@@ -57777,7 +57777,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.
@@ -58760,7 +58760,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -64472,7 +64472,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -64699,7 +64699,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -544,7 +544,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -783,7 +783,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -1541,7 +1541,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -1780,7 +1780,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -2351,7 +2351,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -2590,7 +2590,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3143,7 +3143,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -3382,7 +3382,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3969,7 +3969,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -4208,7 +4208,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -4889,7 +4889,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5128,7 +5128,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -5634,7 +5634,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5873,7 +5873,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -6482,7 +6482,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -6721,7 +6721,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7259,7 +7259,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -7498,7 +7498,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7991,7 +7991,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8230,7 +8230,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -8710,7 +8710,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8949,7 +8949,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -9501,7 +9501,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -9740,7 +9740,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -10469,7 +10469,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -10708,7 +10708,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -11445,7 +11445,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -11684,7 +11684,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -12241,7 +12241,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -12480,7 +12480,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -13027,7 +13027,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -13266,7 +13266,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -13832,7 +13832,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -14071,7 +14071,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -14724,7 +14724,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -14963,7 +14963,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -15462,7 +15462,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -15701,7 +15701,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -16296,7 +16296,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -16535,7 +16535,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -17059,7 +17059,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -17298,7 +17298,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -17782,7 +17782,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -18021,7 +18021,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -18494,7 +18494,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -18733,7 +18733,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -19264,7 +19264,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -19503,7 +19503,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1435,7 +1435,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               scopes:
                                 description: '`scopes` defines the OAuth2 scopes used
@@ -1667,7 +1667,7 @@ spec:
                           proxyUrl:
                             description: '`proxyURL` defines the HTTP proxy server
                               to use.'
-                            pattern: ^(http|https|socks5)?://.+$
+                            pattern: ^(http|https|socks5)://.+$
                             type: string
                           tlsConfig:
                             description: TLS configuration for the client.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -575,7 +575,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -473,7 +473,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5546,7 +5546,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5773,7 +5773,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1428,7 +1428,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         relabelings:
                           description: Relabel configuration applied to the discovered
@@ -6248,7 +6248,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6475,7 +6475,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     readRecent:
                       description: |-
@@ -7112,7 +7112,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -7339,7 +7339,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -392,7 +392,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -627,7 +627,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -1170,7 +1170,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -1408,7 +1408,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -1851,7 +1851,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -2084,7 +2084,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -2605,7 +2605,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -2835,7 +2835,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the container is refreshed.
@@ -3302,7 +3302,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -3537,7 +3537,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the service discovery data
@@ -3854,7 +3854,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -4330,7 +4330,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -4557,7 +4557,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -5097,7 +5097,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5327,7 +5327,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the servers are refreshed.
@@ -5779,7 +5779,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6006,7 +6006,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -6391,7 +6391,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6624,7 +6624,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of resources.
@@ -7118,7 +7118,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -7345,7 +7345,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     role:
                       description: |-
@@ -7832,7 +7832,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -8059,7 +8059,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time to wait between polling update requests.
@@ -8544,7 +8544,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -8779,7 +8779,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.
@@ -9183,7 +9183,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -9416,7 +9416,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the linode instances are refreshed.
@@ -9978,7 +9978,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -10205,7 +10205,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -10526,7 +10526,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the
@@ -11163,7 +11163,7 @@ spec:
                 type: boolean
               proxyUrl:
                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                pattern: ^(http|https|socks5)?://.+$
+                pattern: ^(http|https|socks5)://.+$
                 type: string
               puppetDBSDConfigs:
                 description: PuppetDBSDConfigs defines a list of PuppetDB service
@@ -11434,7 +11434,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -11667,7 +11667,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     query:
                       description: |-
@@ -12035,7 +12035,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -498,7 +498,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4975,7 +4975,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5202,7 +5202,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -545,7 +545,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -784,7 +784,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -1542,7 +1542,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -1781,7 +1781,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -2352,7 +2352,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -2591,7 +2591,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3144,7 +3144,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -3383,7 +3383,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -3970,7 +3970,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -4209,7 +4209,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -4890,7 +4890,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5129,7 +5129,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -5635,7 +5635,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -5874,7 +5874,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -6483,7 +6483,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -6722,7 +6722,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7260,7 +7260,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -7499,7 +7499,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -7992,7 +7992,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8231,7 +8231,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -8711,7 +8711,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -8950,7 +8950,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.
@@ -9502,7 +9502,7 @@ spec:
                                   proxyUrl:
                                     description: '`proxyURL` defines the HTTP proxy
                                       server to use.'
-                                    pattern: ^(http|https|socks5)?://.+$
+                                    pattern: ^(http|https|socks5)://.+$
                                     type: string
                                   scopes:
                                     description: '`scopes` defines the OAuth2 scopes
@@ -9741,7 +9741,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               tlsConfig:
                                 description: TLS configuration for the client.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1436,7 +1436,7 @@ spec:
                               proxyUrl:
                                 description: '`proxyURL` defines the HTTP proxy server
                                   to use.'
-                                pattern: ^(http|https|socks5)?://.+$
+                                pattern: ^(http|https|socks5)://.+$
                                 type: string
                               scopes:
                                 description: '`scopes` defines the OAuth2 scopes used
@@ -1668,7 +1668,7 @@ spec:
                           proxyUrl:
                             description: '`proxyURL` defines the HTTP proxy server
                               to use.'
-                            pattern: ^(http|https|socks5)?://.+$
+                            pattern: ^(http|https|socks5)://.+$
                             type: string
                           tlsConfig:
                             description: TLS configuration for the client.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -576,7 +576,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -474,7 +474,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5547,7 +5547,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5774,7 +5774,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1429,7 +1429,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         relabelings:
                           description: Relabel configuration applied to the discovered
@@ -6249,7 +6249,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6476,7 +6476,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     readRecent:
                       description: |-
@@ -7113,7 +7113,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -7340,7 +7340,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -393,7 +393,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -628,7 +628,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -1171,7 +1171,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -1409,7 +1409,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -1852,7 +1852,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -2085,7 +2085,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -2606,7 +2606,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -2836,7 +2836,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the container is refreshed.
@@ -3303,7 +3303,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -3538,7 +3538,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the service discovery data
@@ -3855,7 +3855,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
@@ -4331,7 +4331,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -4558,7 +4558,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the instance list.
@@ -5098,7 +5098,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5328,7 +5328,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time after which the servers are refreshed.
@@ -5780,7 +5780,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6007,7 +6007,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -6392,7 +6392,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -6625,7 +6625,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of resources.
@@ -7119,7 +7119,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -7346,7 +7346,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     role:
                       description: |-
@@ -7833,7 +7833,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -8060,7 +8060,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: The time to wait between polling update requests.
@@ -8545,7 +8545,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -8780,7 +8780,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.
@@ -9184,7 +9184,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -9417,7 +9417,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Time after which the linode instances are refreshed.
@@ -9979,7 +9979,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -10206,7 +10206,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: |-
@@ -10527,7 +10527,7 @@ spec:
                     type: boolean
                   proxyUrl:
                     description: '`proxyURL` defines the HTTP proxy server to use.'
-                    pattern: ^(http|https|socks5)?://.+$
+                    pattern: ^(http|https|socks5)://.+$
                     type: string
                   scopes:
                     description: '`scopes` defines the OAuth2 scopes used for the
@@ -11164,7 +11164,7 @@ spec:
                 type: boolean
               proxyUrl:
                 description: '`proxyURL` defines the HTTP proxy server to use.'
-                pattern: ^(http|https|socks5)?://.+$
+                pattern: ^(http|https|socks5)://.+$
                 type: string
               puppetDBSDConfigs:
                 description: PuppetDBSDConfigs defines a list of PuppetDB service
@@ -11435,7 +11435,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -11668,7 +11668,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     query:
                       description: |-
@@ -12036,7 +12036,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     refreshInterval:
                       description: Refresh interval to re-read the list of instances.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -499,7 +499,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4976,7 +4976,7 @@ spec:
                         proxyUrl:
                           description: '`proxyURL` defines the HTTP proxy server to
                             use.'
-                          pattern: ^(http|https|socks5)?://.+$
+                          pattern: ^(http|https|socks5)://.+$
                           type: string
                         scopes:
                           description: '`scopes` defines the OAuth2 scopes used for
@@ -5203,7 +5203,7 @@ spec:
                       type: boolean
                     proxyUrl:
                       description: '`proxyURL` defines the HTTP proxy server to use.'
-                      pattern: ^(http|https|socks5)?://.+$
+                      pattern: ^(http|https|socks5)://.+$
                       type: string
                     queueConfig:
                       description: QueueConfig allows tuning of the remote write queue

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -507,7 +507,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -732,7 +732,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -1449,7 +1449,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -1674,7 +1674,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -2205,7 +2205,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -2430,7 +2430,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -2957,7 +2957,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -3182,7 +3182,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -3719,7 +3719,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -3944,7 +3944,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -4578,7 +4578,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -4803,7 +4803,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -5279,7 +5279,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -5504,7 +5504,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -6054,7 +6054,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -6279,7 +6279,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -6780,7 +6780,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -7005,7 +7005,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -7452,7 +7452,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -7677,7 +7677,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -8115,7 +8115,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -8340,7 +8340,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {
@@ -8838,7 +8838,7 @@
                                       },
                                       "proxyUrl": {
                                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                        "pattern": "^(http|https|socks5)?://.+$",
+                                        "pattern": "^(http|https|socks5)://.+$",
                                         "type": "string"
                                       },
                                       "scopes": {
@@ -9063,7 +9063,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "tlsConfig": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -376,7 +376,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -601,7 +601,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -1309,7 +1309,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -1534,7 +1534,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -2059,7 +2059,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -2284,7 +2284,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -2811,7 +2811,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -3036,7 +3036,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -3564,7 +3564,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -3789,7 +3789,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -4411,7 +4411,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -4636,7 +4636,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -5109,7 +5109,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -5334,7 +5334,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -5878,7 +5878,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -6103,7 +6103,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -6598,7 +6598,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -6823,7 +6823,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -7267,7 +7267,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -7492,7 +7492,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -7927,7 +7927,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -8152,7 +8152,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {
@@ -8641,7 +8641,7 @@
                                   },
                                   proxyUrl: {
                                     description: '`proxyURL` defines the HTTP proxy server to use.',
-                                    pattern: '^(http|https|socks5)?://.+$',
+                                    pattern: '^(http|https|socks5)://.+$',
                                     type: 'string',
                                   },
                                   scopes: {
@@ -8866,7 +8866,7 @@
                               },
                               proxyUrl: {
                                 description: '`proxyURL` defines the HTTP proxy server to use.',
-                                pattern: '^(http|https|socks5)?://.+$',
+                                pattern: '^(http|https|socks5)://.+$',
                                 type: 'string',
                               },
                               tlsConfig: {

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1226,7 +1226,7 @@
                                   },
                                   "proxyUrl": {
                                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                    "pattern": "^(http|https|socks5)?://.+$",
+                                    "pattern": "^(http|https|socks5)://.+$",
                                     "type": "string"
                                   },
                                   "scopes": {
@@ -1447,7 +1447,7 @@
                               },
                               "proxyUrl": {
                                 "description": "`proxyURL` defines the HTTP proxy server to use.",
-                                "pattern": "^(http|https|socks5)?://.+$",
+                                "pattern": "^(http|https|socks5)://.+$",
                                 "type": "string"
                               },
                               "tlsConfig": {

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -466,7 +466,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -413,7 +413,7 @@
                       },
                       "proxyUrl": {
                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                        "pattern": "^(http|https|socks5)?://.+$",
+                        "pattern": "^(http|https|socks5)://.+$",
                         "type": "string"
                       },
                       "scopes": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4692,7 +4692,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -4913,7 +4913,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "queueConfig": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -1179,7 +1179,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "relabelings": {
@@ -5282,7 +5282,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -5503,7 +5503,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "readRecent": {
@@ -6071,7 +6071,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -6292,7 +6292,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "queueConfig": {

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -347,7 +347,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -575,7 +575,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -1074,7 +1074,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -1305,7 +1305,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -1719,7 +1719,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -1947,7 +1947,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -2439,7 +2439,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -2664,7 +2664,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -3106,7 +3106,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -3334,7 +3334,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -3637,7 +3637,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -4080,7 +4080,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -4301,7 +4301,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -4797,7 +4797,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -5022,7 +5022,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -5445,7 +5445,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -5666,7 +5666,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -6030,7 +6030,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -6258,7 +6258,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -6707,7 +6707,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -6928,7 +6928,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "role": {
@@ -7388,7 +7388,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -7609,7 +7609,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -8062,7 +8062,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -8290,7 +8290,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -8672,7 +8672,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -8900,7 +8900,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -9416,7 +9416,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -9637,7 +9637,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {
@@ -9950,7 +9950,7 @@
                       },
                       "proxyUrl": {
                         "description": "`proxyURL` defines the HTTP proxy server to use.",
-                        "pattern": "^(http|https|socks5)?://.+$",
+                        "pattern": "^(http|https|socks5)://.+$",
                         "type": "string"
                       },
                       "scopes": {
@@ -10584,7 +10584,7 @@
                   },
                   "proxyUrl": {
                     "description": "`proxyURL` defines the HTTP proxy server to use.",
-                    "pattern": "^(http|https|socks5)?://.+$",
+                    "pattern": "^(http|https|socks5)://.+$",
                     "type": "string"
                   },
                   "puppetDBSDConfigs": {
@@ -10819,7 +10819,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -11047,7 +11047,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "query": {
@@ -11392,7 +11392,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "refreshInterval": {

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -400,7 +400,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4336,7 +4336,7 @@
                             },
                             "proxyUrl": {
                               "description": "`proxyURL` defines the HTTP proxy server to use.",
-                              "pattern": "^(http|https|socks5)?://.+$",
+                              "pattern": "^(http|https|socks5)://.+$",
                               "type": "string"
                             },
                             "scopes": {
@@ -4557,7 +4557,7 @@
                         },
                         "proxyUrl": {
                           "description": "`proxyURL` defines the HTTP proxy server to use.",
-                          "pattern": "^(http|https|socks5)?://.+$",
+                          "pattern": "^(http|https|socks5)://.+$",
                           "type": "string"
                         },
                         "queueConfig": {

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -83,7 +83,7 @@ type PrometheusRuleExcludeConfig struct {
 type ProxyConfig struct {
 	// `proxyURL` defines the HTTP proxy server to use.
 	//
-	// +kubebuilder:validation:Pattern:="^(http|https|socks5)?://.+$"
+	// +kubebuilder:validation:Pattern:="^(http|https|socks5)://.+$"
 	// +optional
 	ProxyURL *string `json:"proxyUrl,omitempty"`
 	// `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names


### PR DESCRIPTION
## Description

In 38352b2 I left a questionable question mark, which will allow some incorrect URLs.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

I confess I only tested this in an online regex validator.

## Changelog entry

```release-note
- Fix ProxyURL regex
```
