### PR TITLE
Recovered remove strip limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ stripped-down-crds.yaml
 minikube-linux-amd64
 go1.24.0.linux-amd64.tar.gz
 prometheus-operator
+minikube-linux-amd64
+go1.24.0.linux-amd64.tar.gz
+prometheus-operator
+bfg.jar


### PR DESCRIPTION
### CHANGE: Removed deprecated strip-limits.libsonnet addon

This PR removes the deprecated `strip-limits.libsonnet` addon as part of ongoing cleanup efforts. It also includes an update to the `.gitignore` file to avoid tracking unnecessary generated files.

### Type of change

- [x] CHANGE (breaking change or removal of deprecated feature)

### Changelog entry
Removed deprecated `strip-limits.libsonnet` addon and updated `.gitignore`.

---

Thank you @simonpasquier for pointing out the changelog issue earlier 🙏
