### PR TITLE
docs: Document the operators ability to publish kubernetes events for rejected resources

### DIFF
--- a/Documentation/platform/troubleshooting.md
+++ b/Documentation/platform/troubleshooting.md
@@ -90,15 +90,10 @@ kubectl -n monitoring port-forward svc/prometheus-operated 9090:9090
 
 If the command runs successfully, you should be able to access the [Prometheus server UI](http://localhost:9090/) via localhost. From there you can check the live configuration and the discovered targets.
 
-### Debugging why monitoring resource spec changes are not reconciled
+#### Debugging why monitoring resource spec changes are not reconciled
 
-The Prometheus Operator will reject invalid resources and not reconcile them in the Prometheus configuration, for instance if the `ServiceMonitor` object has a references to a secret which doesn't exist in the cluster. When it happens the Operator emits a Kubernetes Event detailing the issue.
+The Prometheus Operator will reject invalid resources and not reconcile them in the Prometheus configuration. When it happens the Operator emits a Kubernetes Event detailing the issue.
 
-To check for events related to rejected resources, you can use the following command:
-
-```sh
-kubectl get events --field-selector=involvedObject.name="<name of PodMonitor resource>" -n "<namespace where resource is deployed>"
-```
 Events are supported for the following resources:
 * `AlertmanagerConfig`
 * `PrometheusRule`
@@ -107,9 +102,14 @@ Events are supported for the following resources:
 * `Probe`
 * `ScrapeConfig`
 
-If you've deployed the Prometheus Operator using kube-prometheus manifests, the `PrometheusOperatorRejectedResources` alert should fire when invalid objects are detected.
-The alert can be found in [kube-prometheus-stack repository](https://github.com/prometheus-community/helm-charts/blob/db5b859d111c2c81534c5b716aff417f13b51d2b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml#L226)
+To check for events related to rejected resources, you can use the following command:
 
+```sh
+kubectl get events --field-selector=involvedObject.name="<name of PodMonitor resource>" -n "<namespace where resource is deployed>"
+```
+
+If you've deployed the Prometheus Operator using kube-prometheus manifests, the `PrometheusOperatorRejectedResources` alert should fire when invalid objects are detected.
+The alert can be found in the [kube-prometheus-stack repository](https://github.com/prometheus-community/helm-charts/blob/db5b859d111c2c81534c5b716aff417f13b51d2b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml#L226)
 
 #### It is in the configuration but not on the Service Discovery page
 

--- a/Documentation/platform/troubleshooting.md
+++ b/Documentation/platform/troubleshooting.md
@@ -90,6 +90,27 @@ kubectl -n monitoring port-forward svc/prometheus-operated 9090:9090
 
 If the command runs successfully, you should be able to access the [Prometheus server UI](http://localhost:9090/) via localhost. From there you can check the live configuration and the discovered targets.
 
+### Debugging why monitoring resource spec changes are not reconciled
+
+The Prometheus Operator will reject invalid resources and not reconcile them in the Prometheus configuration, for instance if the `ServiceMonitor` object has a references to a secret which doesn't exist in the cluster. When it happens the Operator emits a Kubernetes Event detailing the issue.
+
+To check for events related to rejected resources, you can use the following command:
+
+```sh
+kubectl get events --field-selector=involvedObject.name="<name of PodMonitor resource>" -n "<namespace where resource is deployed>"
+```
+Events are supported for the following resources:
+* `AlertmanagerConfig`
+* `PrometheusRule`
+* `ServiceMonitor`
+* `PodMonitor`
+* `Probe`
+* `ScrapeConfig`
+
+If you've deployed the Prometheus Operator using kube-prometheus manifests, the `PrometheusOperatorRejectedResources` alert should fire when invalid objects are detected.
+The alert can be found in [kube-prometheus-stack repository](https://github.com/prometheus-community/helm-charts/blob/db5b859d111c2c81534c5b716aff417f13b51d2b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml#L226)
+
+
 #### It is in the configuration but not on the Service Discovery page
 
 ServiceMonitors pointing to Services that do not exist (e.g. nothing matching `.spec.selector`) will lead to this ServiceMonitor not being added to the Service Discovery page. Check if you can find any Service with the selector you configured.


### PR DESCRIPTION


Fixes #6219

## Description

Adds documentation how to query kubernetes



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Document the operators ability to publish kubernetes events for rejected resources
```
