### PR TITLE
chore: predefine slice capacity to avoid extra allocations

### DIFF
--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -93,7 +93,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 			"namespace", p.Namespace,
 			"prometheus", p.Name,
 		)
-		currentConfigMapNames := []string{}
+		currentConfigMapNames := make([]string, 0, len(currentConfigMaps))
 		for _, cm := range currentConfigMaps {
 			currentConfigMapNames = append(currentConfigMapNames, cm.Name)
 		}
@@ -110,7 +110,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 		return nil, fmt.Errorf("failed to make rules ConfigMaps: %w", err)
 	}
 
-	newConfigMapNames := []string{}
+	newConfigMapNames := make([]string, 0, len(newConfigMaps))
 	for _, cm := range newConfigMaps {
 		newConfigMapNames = append(newConfigMapNames, cm.Name)
 	}
@@ -209,7 +209,7 @@ func makeRulesConfigMaps(p *monitoringv1.Prometheus, ruleFiles map[string]string
 		buckets[currBucketIndex][filename] = ruleFiles[filename]
 	}
 
-	ruleFileConfigMaps := []v1.ConfigMap{}
+	ruleFileConfigMaps := make([]v1.ConfigMap, 0, len(buckets))
 	for i, bucket := range buckets {
 		cm := v1.ConfigMap{
 			Data: bucket,

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -95,7 +95,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 			"namespace", t.Namespace,
 			"thanos", t.Name,
 		)
-		currentConfigMapNames := []string{}
+		currentConfigMapNames := make([]string, 0, len(currentConfigMaps))
 		for _, cm := range currentConfigMaps {
 			currentConfigMapNames = append(currentConfigMapNames, cm.Name)
 		}
@@ -112,7 +112,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 		return nil, fmt.Errorf("failed to make rules ConfigMaps: %w", err)
 	}
 
-	newConfigMapNames := []string{}
+	newConfigMapNames := make([]string, 0, len(newConfigMaps))
 	for _, cm := range newConfigMaps {
 		newConfigMapNames = append(newConfigMapNames, cm.Name)
 	}
@@ -211,7 +211,7 @@ func makeRulesConfigMaps(t *monitoringv1.ThanosRuler, ruleFiles map[string]strin
 		buckets[currBucketIndex][filename] = ruleFiles[filename]
 	}
 
-	ruleFileConfigMaps := []v1.ConfigMap{}
+	ruleFileConfigMaps := make([]v1.ConfigMap, 0, len(buckets))
 	for i, bucket := range buckets {
 		cm := v1.ConfigMap{Data: bucket}
 


### PR DESCRIPTION
## Description

- chore: predefine slice capacity to avoid extra allocations

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
