### PR TITLE
Use the AlertmanagerConfig builder outside of the operator repo

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -202,6 +202,8 @@ func (ne *namespaceEnforcer) processRoute(crKey types.NamespacedName, r *route) 
 
 // ConfigBuilder knows how to build an Alertmanager configuration from a raw
 // configuration and/or AlertmanagerConfig objects.
+// The API is public because it's used by Grafana Alloy (https://github.com/grafana/alloy).
+// Note that the project makes no API stability guarantees.
 type ConfigBuilder struct {
 	cfg       *alertmanagerConfig
 	logger    *slog.Logger

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -790,7 +790,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				},
 			},
 		)
-		cb := newConfigBuilder(
+		cb := NewConfigBuilder(
 			newNopLogger(t),
 			*tt.amVersion,
 			assets.NewStoreBuilder(kclient.CoreV1(), kclient.CoreV1()),
@@ -2564,16 +2564,16 @@ func TestGenerateConfig(t *testing.T) {
 				tc.amVersion = &version
 			}
 
-			cb := newConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
+			cb := NewConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
 			cb.cfg = &tc.baseConfig
 
 			if tc.expectedError {
-				require.Error(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
+				require.Error(t, cb.AddAlertmanagerConfigs(context.Background(), tc.amConfigs))
 				return
 			}
-			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
+			require.NoError(t, cb.AddAlertmanagerConfigs(context.Background(), tc.amConfigs))
 
-			cfgBytes, err := cb.marshalJSON()
+			cfgBytes, err := cb.MarshalJSON()
 			require.NoError(t, err)
 
 			// Verify the generated yaml is as expected
@@ -4890,7 +4890,7 @@ func TestConvertHTTPConfig(t *testing.T) {
 			v, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 			require.NoError(t, err)
 
-			cb := newConfigBuilder(
+			cb := NewConfigBuilder(
 				newNopLogger(t),
 				v,
 				nil,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -861,7 +861,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 	var (
 		additionalData map[string][]byte
-		cfgBuilder     = newConfigBuilder(namespacedLogger, version, store, am.Spec.AlertmanagerConfigMatcherStrategy)
+		cfgBuilder     = NewConfigBuilder(namespacedLogger, version, store, am.Spec.AlertmanagerConfigMatcherStrategy)
 	)
 
 	if am.Spec.AlertmanagerConfiguration != nil {
@@ -897,17 +897,17 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
-		err = cfgBuilder.initializeFromRawConfiguration(amRawConfiguration)
+		err = cfgBuilder.InitializeFromRawConfiguration(amRawConfiguration)
 		if err != nil {
 			return fmt.Errorf("failed to initialize from secret: %w", err)
 		}
 	}
 
-	if err := cfgBuilder.addAlertmanagerConfigs(ctx, amConfigs); err != nil {
+	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigs); err != nil {
 		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 
-	generatedConfig, err := cfgBuilder.marshalJSON()
+	generatedConfig, err := cfgBuilder.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}


### PR DESCRIPTION
## Description

Fixes #7418

I have been working on a new Grafana Alloy [feature](https://github.com/grafana/alloy/pull/3448) which gathers AlertmanagerConfig CRD resources, merges them, and sends them to an Alertmanager embedded into Grafana Mimir. It would be very helpful if there is a way to use the config builder. I suppose this change could be useful for other projects too, at some point. 

In this PR I only exported the functions which are useful for the Alloy feature. I still haven't finished working on it, but I'm pretty sure that at the very least I would need the functionality from this PR. I'm happy to change the PR if you think it makes sense to export the functionality differently 😊 

I'm not sure if there should be a changelog entry? There is no change from the point of view of Operator users.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
