### PR TITLE
Add Duration type helper

### DIFF
--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -49,6 +49,12 @@ func (bs *ByteSize) IsEmpty() bool {
 // +kubebuilder:validation:Pattern:="^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"
 type Duration string
 
+// DurationPointer is a helper function to parse a Duration string into a *Duration.
+func DurationPointer(s string) *Duration {
+	d := Duration(s)
+	return &d
+}
+
 // NonEmptyDuration is a valid time duration that can be parsed by Prometheus model.ParseDuration() function.
 // Compared to Duration,  NonEmptyDuration enforces a minimum length of 1.
 // Supported units: y, w, d, h, m, s, ms

--- a/pkg/apis/monitoring/v1/types_test.go
+++ b/pkg/apis/monitoring/v1/types_test.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -506,5 +507,13 @@ func TestValidateOAuth2(t *testing.T) {
 				t.Fatalf("expected no error but got: %s", err)
 			}
 		})
+	}
+}
+
+func TestDurationPointer(t *testing.T) {
+	oneMinuteDuration := Duration("1m")
+	got := DurationPointer("1m")
+	if !reflect.DeepEqual(got, &oneMinuteDuration) {
+		t.Fatalf("wanted %v, but got %v", &oneMinuteDuration, got)
 	}
 }


### PR DESCRIPTION

## Description

In order to make it easier for users to creation Duration pointers used by other struct fields like `Rule.For`, add a helper function that takes a duration string and returns a Duration pointer.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
* [ENHANCEMENT] Add a v1.DurationPointer api package helper #7493
```
