### PR TITLE
fix: enable remote-write for Ruler only when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [BUGFIX] Fix ThanosRuler when no remote-write configuration is defined. #7498
+
 ## 0.82.0 / 2025-04-17
 
 * [CHANGE] Add more API validations to the ScrapeConfig CRD. #7413

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -220,7 +220,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		},
 		"remote-write-config",
 	)
-	if version.GTE(minRemoteWriteVersion) {
+	if version.GTE(minRemoteWriteVersion) && len(tr.Spec.RemoteWrite) > 0 {
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "remote-write.config-file", Value: fullPath})
 	}
 

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -417,7 +417,7 @@ func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
-					Name:       "http-query",
+					Name:       "web",
 					Port:       10902,
 					TargetPort: intstr.FromString("http"),
 				},

--- a/test/framework/thanos_querier.go
+++ b/test/framework/thanos_querier.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+)
+
+func MakeThanosQuerier(endpoints ...string) (*appsv1.Deployment, error) {
+	d, err := MakeDeployment("../../example/thanos/query-deployment.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	d.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("quay.io/thanos/thanos:%s", operator.DefaultThanosVersion)
+
+	var args []string
+	for _, arg := range d.Spec.Template.Spec.Containers[0].Args {
+		if strings.HasPrefix(arg, "--endpoint=") {
+			continue
+		}
+		args = append(args, arg)
+	}
+	for _, endpoint := range endpoints {
+		args = append(args, fmt.Sprintf("--endpoint=%s", endpoint))
+	}
+	d.Spec.Template.Spec.Containers[0].Args = args
+
+	return d, nil
+}


### PR DESCRIPTION
## Description

Closes #7492

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
