### PR TITLE
fix: Fix parsing `role`  field in openstackSDConfigs in ScrapeConfig CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.82.2 / 2025-05-09
 
 * [BUGFIX] Fix Alertmanager peer discovery for Alertmanager when using custom service name. #7512
+* [BUGFIX] Fix parsing `role` field in openstackSDConfigs in ScrapeConfig CRD. #7516
 
 ## 0.82.1 / 2025-05-06
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -3798,7 +3798,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			configs[i] = []yaml.MapItem{
 				{
 					Key:   "role",
-					Value: string(config.Role),
+					Value: strings.ToLower(string(config.Role)),
 				},
 			}
 

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_OpenStackSDConfigValid.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_OpenStackSDConfigValid.golden
@@ -7,7 +7,7 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   openstack_sd_configs:
-  - role: Instance
+  - role: instance
     region: region-1
     identity_endpoint: http://identity.example.com:5000/v2.0
     username: nova-user-1


### PR DESCRIPTION
Fixes #7514

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
