### PR TITLE
fix(alertmanager, framework): use named ports for services

### DIFF
--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -187,13 +187,13 @@ func makeStatefulSetService(a *monitoringv1.Alertmanager, config Config) *v1.Ser
 				{
 					Name:       "tcp-mesh",
 					Port:       9094,
-					TargetPort: intstr.FromInt(9094),
+					TargetPort: intstr.FromString("mesh-tcp"),
 					Protocol:   v1.ProtocolTCP,
 				},
 				{
 					Name:       "udp-mesh",
 					Port:       9094,
-					TargetPort: intstr.FromInt(9094),
+					TargetPort: intstr.FromString("mesh-udp"),
 					Protocol:   v1.ProtocolUDP,
 				},
 			},

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -518,7 +518,7 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 
 	service.Namespace = opts.Namespace
 	service.Spec.ClusterIP = ""
-	service.Spec.Ports = []v1.ServicePort{{Name: "https", Port: 443, TargetPort: intstr.FromInt(8443)}}
+	service.Spec.Ports = []v1.ServicePort{{Name: "https", Port: 443, TargetPort: intstr.FromString("web")}}
 
 	if _, err := f.CreateOrUpdateServiceAndWaitUntilReady(ctx, opts.Namespace, service); err != nil {
 		return finalizers, fmt.Errorf("failed to create or update prometheus operator service: %w", err)

--- a/test/framework/probe.go
+++ b/test/framework/probe.go
@@ -41,8 +41,9 @@ func (f *Framework) MakeBlackBoxExporterService(ns, name string) *v1.Service {
 			},
 			Ports: []v1.ServicePort{
 				{
+					Name:       "http",
 					Port:       9115,
-					TargetPort: intstr.FromInt(9115),
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 		},
@@ -107,6 +108,7 @@ func (f *Framework) createBlackBoxExporterDeploymentAndWaitReady(ctx context.Con
 							},
 							Ports: []v1.ContainerPort{
 								{
+									Name:          "http",
 									ContainerPort: 9115,
 									Protocol:      v1.ProtocolTCP,
 								},


### PR DESCRIPTION
Use named ports instead of hard-coded port numbers in Alertmanager manifests and framework tests.

Fixes #7491

## Description

Since Prometheus and Thanos services already use named ports for their `targetPort`, only Alertmanager needed to be updated. Additionally, some framework test examples specified `targetPort` as an integer, so those have been changed to use the named port approach as well.
- pkg/alertmanager/statefulset.go
- test/framework/framework.go
- test/framework/probe.go

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
All existing unit tests pass successfully

## Changelog entry

```release-note
Use named ports for all services instead of hard-coded port numbers.
```
