### PR TITLE
rfac: status-subresource propsal doc to include only workload crds

### DIFF
--- a/Documentation/proposals/202409-status-subresource.md
+++ b/Documentation/proposals/202409-status-subresource.md
@@ -1,4 +1,4 @@
-# Status subresource for Prometheus operator CRDs
+# Status subresource for Prometheus operator Workload CRDs
 
 * **Owners:**
   * [simonpasquier](https://github.com/simonpasquier)
@@ -9,7 +9,7 @@
 * **Other docs:**
   * N/A
 
-This proposal describes how we will extend the Prometheus operator Custom
+This proposal describes how we will extend the Prometheus operator workload Custom
 Resource Definitions (CRDs) with a Status subresource field.
 
 ## Why

--- a/Documentation/proposals/202409-status-subresource.md
+++ b/Documentation/proposals/202409-status-subresource.md
@@ -16,7 +16,7 @@ Resource Definitions (CRDs) with a Status subresource field.
 
 Core Kubernetes resources differentiate between the desired state of an object
 (the `spec` field) and the current status of the object (the `status` field)
-([details][https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)).
+[details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 Before this proposal, the current status of the objects was never reflected by
 the Prometheus operator which makes it harder for external actors to know if
 the underlying resource is available or not.


### PR DESCRIPTION
## Description

Fixes: #7545 


## Type of change
status-subresource propsal doc to include only workload crds

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```
```
