### PR TITLE
tools: add KAL tools for golangci-linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ linters:
     - exptostd
     - godot
     - iface
+    # linter for Kube API conventions
+    - kubeapilinter
     - nilnesserr
     - recvcheck
     - revive
@@ -17,6 +19,14 @@ linters:
     - testifylint
     - unconvert
   settings:
+    custom:
+      kubeapilinter:
+        path: "./tmp/bin/kube-api-linter.so"
+        original-url: sigs.k8s.io/kube-api-linter
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters: {}
+          lintersConfig: {}
     depguard:
       rules:
         forbid-pkg-errors:
@@ -41,6 +51,10 @@ linters:
           - staticcheck
           - testifylint
         path: _test.go
+      # KAL should only run on API folders.
+      - linters:
+          - kubeapilinter
+        path-except: 'pkg/apis/*'
     paths:
       - zz_generated.*\.go$
       - examples$

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ PROMLINTER_BINARY=$(TOOLS_BIN_DIR)/promlinter
 GOLANGCILINTER_BINARY=$(TOOLS_BIN_DIR)/golangci-lint
 MDOX_BINARY=$(TOOLS_BIN_DIR)/mdox
 API_DOC_GEN_BINARY=$(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
-TOOLING=$(CONTROLLER_GEN_BINARY) $(GOBINDATA_BINARY) $(JB_BINARY) $(GOJSONTOYAML_BINARY) $(JSONNET_BINARY) $(JSONNETFMT_BINARY) $(SHELLCHECK_BINARY) $(PROMLINTER_BINARY) $(GOLANGCILINTER_BINARY) $(MDOX_BINARY) $(API_DOC_GEN_BINARY)
+GOLANGCIKUBEAPILINTER_SO=$(TOOLS_BIN_DIR)/kube-api-linter.so
+TOOLING=$(CONTROLLER_GEN_BINARY) $(GOBINDATA_BINARY) $(JB_BINARY) $(GOJSONTOYAML_BINARY) $(JSONNET_BINARY) $(JSONNETFMT_BINARY) $(SHELLCHECK_BINARY) $(PROMLINTER_BINARY) $(GOLANGCILINTER_BINARY) $(MDOX_BINARY) $(API_DOC_GEN_BINARY) $(GOLANGCIKUBEAPILINTER_SO)
 
 K8S_GEN_BINARIES:=informer-gen lister-gen client-gen applyconfiguration-gen
 K8S_GEN_ARGS:=--go-header-file $(shell pwd)/.header --v=1 --logtostderr
@@ -424,6 +425,8 @@ $(TOOLING): $(TOOLS_BIN_DIR)
 	@echo Installing tools from scripts/tools.go
 	@cat scripts/tools.go | grep _ | awk -F'"' '{print $$2}' | GOBIN=$(TOOLS_BIN_DIR) xargs -tI % go install -mod=readonly -modfile=scripts/go.mod %
 	@GOBIN=$(TOOLS_BIN_DIR) go install $(GO_PKG)/cmd/po-docgen
+	@echo Building golangci-lint plugins
+	@GOBIN=$(TOOLS_BIN_DIR) go build -buildmode=plugin -modfile=scripts/go.mod -o $(GOLANGCIKUBEAPILINTER_SO) sigs.k8s.io/kube-api-linter/pkg/plugin
 	@echo Downloading shellcheck
 	@cd $(TOOLS_BIN_DIR) && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.$(GOOS).x86_64.tar.xz" | tar -xJv --strip=1 shellcheck-stable/shellcheck
 

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/yeya24/promlinter v0.3.0
 	k8s.io/code-generator v0.33.0
 	sigs.k8s.io/controller-tools v0.18.0
+	sigs.k8s.io/kube-api-linter v0.0.0-20250516124914-6df69a12c92c
 )
 
 require (

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -1853,6 +1853,8 @@ sigs.k8s.io/controller-tools v0.18.0 h1:rGxGZCZTV2wJreeRgqVoWab/mfcumTMmSwKzoM9x
 sigs.k8s.io/controller-tools v0.18.0/go.mod h1:gLKoiGBriyNh+x1rWtUQnakUYEujErjXs9pf+x/8n1U=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
+sigs.k8s.io/kube-api-linter v0.0.0-20250516124914-6df69a12c92c h1:sybeA6NAACfxBiZLdY9iRNAT9jVs25TwBnLnqG+TyTs=
+sigs.k8s.io/kube-api-linter v0.0.0-20250516124914-6df69a12c92c/go.mod h1:tnzp9Oj2Qi0qPg5t5tbDrUixTlZLjPpEjzk1kxO/2EE=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -33,4 +33,5 @@ import (
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+	_ "sigs.k8s.io/kube-api-linter"
 )


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Close https://github.com/prometheus-operator/prometheus-operator/issues/7534

Add kube-api-linter for golangci-linter

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add kube-api-linter for golangci-linter
```
