### PR TITLE
Feat: add health check for config reloader

### DIFF
--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -179,6 +179,13 @@ func ImagePullPolicy(imagePullPolicy v1.PullPolicy) ReloaderOption {
 	}
 }
 
+// EnableProbes sets the livenessProbe and readinessProbe options for the config-reloader container.
+func EnableProbes(enableProbes bool) ReloaderOption {
+	return func(c *ConfigReloader) {
+		c.config.EnableProbes = enableProbes
+	}
+}
+
 // DaemonSet sets the options that work for DaemonSet mode.
 // Currently we set SHARD env equal to 0, eventhough DaemonSet doesn't use this env.
 // TODO: Remove SHARD env for DaemonSet mode.

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -146,6 +146,7 @@ func TestCreateConfigReloader(t *testing.T) {
 	watchedDirectories := []string{"directory1", "directory2"}
 	shard := int32(1)
 	expectedImagePullPolicy := v1.PullAlways
+	expectedEnableProbes := true
 	var container = CreateConfigReloader(
 		containerName,
 		ReloaderConfig(reloaderConfig),
@@ -164,6 +165,7 @@ func TestCreateConfigReloader(t *testing.T) {
 		WebConfigFile(webConfigFile),
 		Shard(shard),
 		ImagePullPolicy(expectedImagePullPolicy),
+		EnableProbes(expectedEnableProbes),
 	)
 
 	if container.Name != "config-reloader" {
@@ -210,12 +212,18 @@ func TestCreateConfigReloader(t *testing.T) {
 		t.Errorf("Expected imagePullPolicy %s, but found %s", expectedImagePullPolicy, container.ImagePullPolicy)
 	}
 
-	if container.LivenessProbe != nil {
+	/*if container.LivenessProbe != nil {
 		t.Errorf("expected no LivenessProbe but got %v", container.LivenessProbe)
 	}
 
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
+	}*/
+	if container.LivenessProbe == nil {
+		t.Errorf("expected LivenessProbe but got %v", container.LivenessProbe)
+	}
+	if container.ReadinessProbe == nil {
+		t.Errorf("expected ReadinessProbe but got %v", container.ReadinessProbe)
 	}
 }
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Add config reloader liveness and readiness probes.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Using the test file.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

- Add the configuration about probes.
<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
