### PR TITLE
fix: allow lower case role field in openstackSDConfigs in ScrapeConfig CRD

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -57591,8 +57591,11 @@ spec:
                         Note: The `LoadBalancer` role requires Prometheus >= v3.2.0.
                       enum:
                       - Instance
+                      - instance
                       - Hypervisor
+                      - hypervisor
                       - LoadBalancer
+                      - loadbalancer
                       type: string
                     tlsConfig:
                       description: TLS configuration applying to the target HTTP endpoint.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -10845,8 +10845,11 @@ spec:
                         Note: The `LoadBalancer` role requires Prometheus >= v3.2.0.
                       enum:
                       - Instance
+                      - instance
                       - Hypervisor
+                      - hypervisor
                       - LoadBalancer
+                      - loadbalancer
                       type: string
                     tlsConfig:
                       description: TLS configuration applying to the target HTTP endpoint.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -10846,8 +10846,11 @@ spec:
                         Note: The `LoadBalancer` role requires Prometheus >= v3.2.0.
                       enum:
                       - Instance
+                      - instance
                       - Hypervisor
+                      - hypervisor
                       - LoadBalancer
+                      - loadbalancer
                       type: string
                     tlsConfig:
                       description: TLS configuration applying to the target HTTP endpoint.

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -10256,8 +10256,11 @@
                           "description": "The OpenStack role of entities that should be discovered.\n\nNote: The `LoadBalancer` role requires Prometheus >= v3.2.0.",
                           "enum": [
                             "Instance",
+                            "instance",
                             "Hypervisor",
-                            "LoadBalancer"
+                            "hypervisor",
+                            "LoadBalancer",
+                            "loadbalancer"
                           ],
                           "type": "string"
                         },

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -780,7 +780,7 @@ type GCESDConfig struct {
 	TagSeparator *string `json:"tagSeparator,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Instance;Hypervisor;LoadBalancer
+// +kubebuilder:validation:Enum=Instance;instance;Hypervisor;hypervisor;LoadBalancer;loadbalancer
 type OpenStackRole string
 
 const (


### PR DESCRIPTION
## Description
This is a follow-up for https://github.com/prometheus-operator/prometheus-operator/issues/7514, and its fix - https://github.com/prometheus-operator/prometheus-operator/pull/7516/files. The fix is valid, but current CRD requires (`Instance`) the exact opposite of what Prometheus requires (`instance`).

I think that CRD should support both cases - lower case (`instance`) as the one with Capital letter (`Instance`). If only one case should be supported, imho it should not be the opposite of what Prometheus requires (as it is now). :)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

* [BUGFIX] Allow lowercase `role` field in openstackSDConfigs in ScrapeConfig CRD.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
