### PR TITLE
feat: add startupProbe to config-reloader

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -52,7 +52,7 @@ Usage of ./operator:
   -disable-unmanaged-prometheus-configuration
     	Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.
   -enable-config-reloader-probes
-    	Enable liveness and readiness for the config-reloader container. Default: false
+    	Enable liveness, readiness, and startup probes for the config-reloader container. Default: false
   -feature-gates value
     	Feature gates are a set of key=value pairs that describe Prometheus-Operator features.
     	Available feature gates:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -155,7 +155,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.ReloaderConfig.CPULimits, "config-reloader-cpu-limit", "Config Reloader CPU limits. Value \"0\" disables it and causes no limit to be configured.")
 	fs.Var(&cfg.ReloaderConfig.MemoryRequests, "config-reloader-memory-request", "Config Reloader memory requests. Value \"0\" disables it and causes no request to be configured.")
 	fs.Var(&cfg.ReloaderConfig.MemoryLimits, "config-reloader-memory-limit", "Config Reloader memory limits. Value \"0\" disables it and causes no limit to be configured.")
-	fs.BoolVar(&cfg.ReloaderConfig.EnableProbes, "enable-config-reloader-probes", false, "Enable liveness and readiness for the config-reloader container. Default: false")
+	fs.BoolVar(&cfg.ReloaderConfig.EnableProbes, "enable-config-reloader-probes", false, "Enable liveness, readiness, and startup probes for the config-reloader container. Default: false")
 
 	fs.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")
 	fs.StringVar(&cfg.PrometheusDefaultBaseImage, "prometheus-default-base-image", operator.DefaultPrometheusBaseImage, "Prometheus default base image (path without tag/version)")

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -337,6 +337,7 @@ func (cr *ConfigReloader) addProbes(c v1.Container) v1.Container {
 
 	c.LivenessProbe = &v1.Probe{ProbeHandler: handler}
 	c.ReadinessProbe = &v1.Probe{ProbeHandler: handler}
+	c.StartupProbe = &v1.Probe{ProbeHandler: handler}
 
 	return c
 }

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -60,6 +60,10 @@ func TestCreateConfigReloaderEnableProbes(t *testing.T) {
 	if container.ReadinessProbe == nil {
 		t.Errorf("expected ReadinessProbe but got none")
 	}
+
+	if container.StartupProbe == nil {
+		t.Errorf("expected StartupProbe but got none")
+	}
 }
 
 func TestCreateInitConfigReloaderEnableProbes(t *testing.T) {
@@ -87,6 +91,10 @@ func TestCreateInitConfigReloaderEnableProbes(t *testing.T) {
 
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
+	}
+
+	if container.StartupProbe != nil {
+		t.Errorf("expected no StartupProbe but got %v", container.StartupProbe)
 	}
 }
 
@@ -133,6 +141,10 @@ func TestCreateInitConfigReloader(t *testing.T) {
 
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
+	}
+
+	if container.StartupProbe != nil {
+		t.Errorf("expected no StartupProbe but got %v", container.StartupProbe)
 	}
 }
 
@@ -216,6 +228,10 @@ func TestCreateConfigReloader(t *testing.T) {
 
 	if container.ReadinessProbe != nil {
 		t.Errorf("expected no ReadinessProbe but got %v", container.ReadinessProbe)
+	}
+
+	if container.StartupProbe != nil {
+		t.Errorf("expected no StartupProbe but got %v", container.StartupProbe)
 	}
 }
 


### PR DESCRIPTION
## Description

This is for GitHub issue #7494.
Adds startup probe to the config-reloader sidecar for Prometheus pods. Only takes affect if the --enable-config-reloader-probes flag is set on the prometheus-operator pod.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

Unit tests pass. Local build of prometheus-operator in a local kind cluster passes.

## Changelog entry

Startup probe added to config-reloader sidecar if --enable-config-reloader-probes set.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Added startup probe to the config-reloader sidecar for Prometheus pods. Only takes affect if the --enable-config-reloader-probes flag is set on the prometheus-operator pod.
```
