### PR TITLE
finalizer added to workload resources if statusFOrConfigRes flag is enabled

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -539,7 +539,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to set Alertmanager type information: %w", err)
 	}
 
-	if c.configResourcesStatusEnabled {
+	if c.configResourcesStatusEnabled && !c.rr.DeletionInProgress(am) {
 		// Add finalizer to the Prometheus resource if it doesn't have one.
 		finalizers := am.GetFinalizers()
 		if !slices.Contains(finalizers, finalizerName) {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -104,6 +104,8 @@ type Operator struct {
 	canReadStorageClass bool
 
 	config Config
+
+	configResourcesStatusEnabled bool
 }
 
 type ControllerOption func(*Operator)
@@ -161,6 +163,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Annotations:                  c.Annotations,
 			Labels:                       c.Labels,
 		},
+		configResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
 	}
 	for _, opt := range options {
 		opt(o)
@@ -178,6 +181,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.AlertmanagersKind,
 		r,
 		o.controllerID,
+		o.configResourcesStatusEnabled,
 	)
 
 	return o, nil

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -182,7 +182,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.AlertmanagersKind,
 		r,
 		o.controllerID,
-		o.configResourcesStatusEnabled,
 	)
 
 	return o, nil

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -697,7 +697,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 		return err
 	}
 
-	if c.rr.DeletionInProgress(a) {
+	if a == nil || c.rr.DeletionInProgress(a) {
 		return nil
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -534,6 +534,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to set Alertmanager type information: %w", err)
 	}
 
+	// Check if the Alertmanager instance is marked for deletion.
+	if c.rr.DeletionInProgress(am) {
+		return nil
+	}
+
 	if am.Spec.Paused {
 		return nil
 	}
@@ -542,10 +547,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logDeprecatedFields(logger, am)
 
 	logger.Info("sync alertmanager")
-
-	if c.rr.DeletionInProgress(am) {
-		return nil
-	}
 
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, am.Spec.Storage); err != nil {
 		return err
@@ -696,7 +697,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 		return err
 	}
 
-	if a == nil || c.rr.DeletionInProgress(a) {
+	if c.rr.DeletionInProgress(a) {
 		return nil
 	}
 

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -605,7 +605,7 @@ func EnsureCustomGoverningService(ctx context.Context, namespace string, service
 }
 
 // AddFinalizerPatch generates the JSON patch payload which adds the finalizer to the object's metadata.
-// If the finalizer is already present, it returns empty []byte slice.
+// If the finalizer is already present, it returns an empty []byte slice.
 func FinalizerAddPatch(finalizers []string, finalizerName string) ([]byte, error) {
 	if slices.Contains(finalizers, finalizerName) {
 		return []byte{}, nil
@@ -630,8 +630,8 @@ func FinalizerAddPatch(finalizers []string, finalizerName string) ([]byte, error
 	return json.Marshal(patch)
 }
 
-// FinalizerDeletePatch generates the JSON patch payload which delete the finalizer to the object's metadata.
-// If the finalizer is not present, it returns empty []byte slice.
+// FinalizerDeletePatch generates the JSON patch payload which deletes the finalizer from the object's metadata.
+// If the finalizer is not present, it returns an empty []byte slice.
 func FinalizerDeletePatch(finalizers []string, finalizerName string) ([]byte, error) {
 	for i, f := range finalizers {
 		if f == finalizerName {

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -630,3 +630,7 @@ func DeleteStatusCleanupFinalizer(finalizers []string) ([]byte, error) {
 	patchBytes, err := json.Marshal(patchData)
 	return patchBytes, err
 }
+
+func IsStatusCleanupFinalizerPresent(finalizers []string) bool {
+	return slices.Contains(finalizers, statusCleanupFinalizerName)
+}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -631,7 +631,7 @@ func FinalizerAddPatch(finalizers []string, finalizerName string) ([]byte, error
 }
 
 // FinalizerDeletePatch generates the JSON patch payload which deletes the finalizer from the object's metadata.
-// If the finalizer is not present, it returns an empty []byte slice.
+// If the finalizer is not present, it returns nil.
 func FinalizerDeletePatch(finalizers []string, finalizerName string) ([]byte, error) {
 	for i, f := range finalizers {
 		if f == finalizerName {
@@ -644,7 +644,7 @@ func FinalizerDeletePatch(finalizers []string, finalizerName string) ([]byte, er
 			return json.Marshal(patch)
 		}
 	}
-	return []byte{}, nil
+	return nil, nil
 }
 
 func IsFinalizerPresent(finalizers []string, finalizerName string) bool {

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -609,7 +609,8 @@ func EnsureCustomGoverningService(ctx context.Context, namespace string, service
 func FinalizerAddPatch(finalizers []string, finalizerName string) ([]byte, error) {
 	if slices.Contains(finalizers, finalizerName) {
 		return []byte{}, nil
-	} else if len(finalizers) == 0 {
+	}
+	if len(finalizers) == 0 {
 		patch := []map[string]interface{}{
 			{
 				"op":    "add",

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -559,6 +559,7 @@ func TestConvertToK8sDNSConfig(t *testing.T) {
 }
 
 func TestFinalizerAddPatch(t *testing.T) {
+	finalizerName := "cleanup.kubernetes.io/finalizer"
 	tests := []struct {
 		name          string
 		finalizers    []string
@@ -569,23 +570,23 @@ func TestFinalizerAddPatch(t *testing.T) {
 		{
 			name:          "empty finalizers",
 			finalizers:    []string{},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizerName: finalizerName,
 			expectedPatch: []map[string]interface{}{
-				{"op": "add", "path": "/metadata/finalizers", "value": []string{"cleanup.kubernetes.io/finalizer"}},
+				{"op": "add", "path": "/metadata/finalizers", "value": []string{finalizerName}},
 			},
 		},
 		{
 			name:          "finalizer not present",
 			finalizers:    []string{"a", "b"},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizerName: finalizerName,
 			expectedPatch: []map[string]interface{}{
-				{"op": "add", "path": "/metadata/finalizers/-", "value": "cleanup.kubernetes.io/finalizer"},
+				{"op": "add", "path": "/metadata/finalizers/-", "value": finalizerName},
 			},
 		},
 		{
 			name:          "finalizer already present",
-			finalizers:    []string{"a", "cleanup.kubernetes.io/finalizer", "b"},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizers:    []string{"a", finalizerName, "b"},
+			finalizerName: finalizerName,
 			expectEmpty:   true,
 		},
 	}
@@ -607,6 +608,7 @@ func TestFinalizerAddPatch(t *testing.T) {
 }
 
 func TestFinalizerDeletePatch(t *testing.T) {
+	finalizerName := "cleanup.kubernetes.io/finalizer"
 	tests := []struct {
 		name          string
 		finalizers    []string
@@ -616,21 +618,21 @@ func TestFinalizerDeletePatch(t *testing.T) {
 	}{
 		{
 			name:          "finalizer present at index 1",
-			finalizers:    []string{"a", "cleanup.kubernetes.io/finalizer", "b"},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizers:    []string{"a", finalizerName, "b"},
+			finalizerName: finalizerName,
 			expectPatch:   true,
 			expectedIndex: 1,
 		},
 		{
 			name:          "finalizer not present",
 			finalizers:    []string{"a", "b"},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizerName: finalizerName,
 			expectPatch:   false,
 		},
 		{
 			name:          "empty finalizers",
 			finalizers:    []string{},
-			finalizerName: "cleanup.kubernetes.io/finalizer",
+			finalizerName: finalizerName,
 			expectPatch:   false,
 		},
 	}

--- a/pkg/k8sutil/k8sutil_test.go
+++ b/pkg/k8sutil/k8sutil_test.go
@@ -654,6 +654,117 @@ func TestFinalizerDeletePatch(t *testing.T) {
 	}
 }
 
+func TestEnsureCustomGoverningService(t *testing.T) {
+	name := "test-k8sutil"
+	serviceName := "test-svc"
+	ns := "test-ns"
+	testcases := []struct {
+		name           string
+		service        v1.Service
+		selectorLabels map[string]string
+		expectedErr    bool
+	}{
+		{
+			name: "custom service selects k8sutil",
+			service: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: ns,
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"k8sutil":                      name,
+						"app.kubernetes.io/name":       "k8sutil",
+						"app.kubernetes.io/instance":   name,
+						"app.kubernetes.io/managed-by": "prometheus-operator",
+					},
+				},
+			},
+			selectorLabels: map[string]string{
+				"k8sutil":                      name,
+				"app.kubernetes.io/name":       "k8sutil",
+				"app.kubernetes.io/instance":   name,
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "custom service does not select k8sutil",
+			service: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-svc",
+					Namespace: ns,
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"k8sutil":                      "different-name",
+						"app.kubernetes.io/name":       "k8sutil",
+						"app.kubernetes.io/instance":   "different-name",
+						"app.kubernetes.io/managed-by": "prometheus-operator",
+					},
+				},
+			},
+			selectorLabels: map[string]string{
+				"k8sutil":                      name,
+				"app.kubernetes.io/name":       "k8sutil",
+				"app.kubernetes.io/instance":   name,
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "custom service selects k8sutil but in different ns",
+			service: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-svc",
+					Namespace: "wrong-ns",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"k8sutil":                      name,
+						"app.kubernetes.io/name":       "k8sutil",
+						"app.kubernetes.io/instance":   name,
+						"app.kubernetes.io/managed-by": "prometheus-operator",
+					},
+				},
+			},
+			selectorLabels: map[string]string{
+				"k8sutil":                      name,
+				"app.kubernetes.io/name":       "k8sutil",
+				"app.kubernetes.io/instance":   name,
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "custom svc doesn't exist",
+			selectorLabels: map[string]string{
+				"k8sutil":                      name,
+				"app.kubernetes.io/name":       "k8sutil",
+				"app.kubernetes.io/instance":   name,
+				"app.kubernetes.io/managed-by": "prometheus-operator",
+			},
+			expectedErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := makeBarebonesPrometheus(name, ns)
+			p.Spec.ServiceName = &serviceName
+
+			clientSet := fake.NewSimpleClientset(&tc.service)
+			svcClient := clientSet.CoreV1().Services(ns)
+
+			err := EnsureCustomGoverningService(context.Background(), p.Namespace, *p.Spec.ServiceName, svcClient, tc.selectorLabels)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func makeBarebonesPrometheus(name, ns string) *monitoringv1.Prometheus {
 	return &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -409,7 +409,7 @@ func (rr *ResourceReconciler) onDaemonSetAdd(ds *appsv1.DaemonSet) {
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
 	rr.logger.Debug("update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	if !k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(cur) {
+	if rr.DeletionInProgress(cur) {
 		return
 	}
 
@@ -439,7 +439,7 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 	rr.logger.Debug("update handler", "resource", "daemonset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	if !k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(cur) {
+	if rr.DeletionInProgress(cur) {
 		return
 	}
 

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -336,10 +336,6 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 		return
 	}
 
-	if rr.DeletionInProgress(mCur) {
-		return
-	}
-
 	if !rr.hasStateChanged(mOld, mCur) {
 		return
 	}
@@ -407,10 +403,6 @@ func (rr *ResourceReconciler) onDaemonSetAdd(ds *appsv1.DaemonSet) {
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
 	rr.logger.Debug("update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	if rr.DeletionInProgress(cur) {
-		return
-	}
-
 	if !rr.hasObjectChanged(old, cur) {
 		return
 	}
@@ -436,10 +428,6 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 
 func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 	rr.logger.Debug("update handler", "resource", "daemonset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
-
-	if rr.DeletionInProgress(cur) {
-		return
-	}
 
 	if !rr.hasObjectChanged(old, cur) {
 		return

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -339,7 +339,7 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 		return
 	}
 
-	if !k8sutil.IsStatusCleanupFinalizerPresent(mCur.GetFinalizers()) && rr.DeletionInProgress(mCur) {
+	if !k8sutil.IsFinalizerPresent(mCur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(mCur) {
 		return
 	}
 
@@ -410,7 +410,7 @@ func (rr *ResourceReconciler) onDaemonSetAdd(ds *appsv1.DaemonSet) {
 func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) {
 	rr.logger.Debug("update handler", "resource", "statefulset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	if !k8sutil.IsStatusCleanupFinalizerPresent(cur.GetFinalizers()) && rr.DeletionInProgress(cur) {
+	if !k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(cur) {
 		return
 	}
 
@@ -440,7 +440,7 @@ func (rr *ResourceReconciler) onStatefulSetUpdate(old, cur *appsv1.StatefulSet) 
 func (rr *ResourceReconciler) onDaemonSetUpdate(old, cur *appsv1.DaemonSet) {
 	rr.logger.Debug("update handler", "resource", "daemonset", "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
-	if !k8sutil.IsStatusCleanupFinalizerPresent(cur.GetFinalizers()) && rr.DeletionInProgress(cur) {
+	if !k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(cur) {
 		return
 	}
 

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 )
 
 // Syncer knows how to synchronize statefulset-based or daemonset-based resources.

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -201,7 +201,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1alpha1.PrometheusAgentsKind,
 		r,
 		o.controllerID,
-		o.configResourcesStatusEnabled,
 	)
 
 	o.smonInfs, err = informers.NewInformersForResource(
@@ -989,7 +988,9 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	}
 	p := pobj.(*monitoringv1alpha1.PrometheusAgent)
 	p = p.DeepCopy()
-
+	if p == nil || c.rr.DeletionInProgress(p) {
+		return nil
+	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)
 	if err != nil {
 		return fmt.Errorf("failed to get prometheus agent status: %w", err)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -572,6 +572,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	logger := c.logger.With("key", key)
 
+	// Check if the Agent instance is marked for deletion.
 	if c.rr.DeletionInProgress(p) {
 		return nil
 	}
@@ -956,7 +957,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	}
 	p := pobj.(*monitoringv1alpha1.PrometheusAgent)
 	p = p.DeepCopy()
-	if p == nil || c.rr.DeletionInProgress(p) {
+	if c.rr.DeletionInProgress(p) {
 		return nil
 	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -573,38 +573,15 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	logger := c.logger.With("key", key)
 
-	if c.configResourcesStatusEnabled && !c.rr.DeletionInProgress(p) {
-		// Add finalizer to the Prometheus resource if it doesn't have one.
-		finalizers := p.GetFinalizers()
-		patchBytes, err := k8sutil.AddStatusCleanupFinalizer(finalizers)
-
-		if err != nil {
-			return fmt.Errorf("failed to marshal patch: %w", err)
-		}
-		if patchBytes == nil {
-			if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return fmt.Errorf("failed to add statusCleanup finalizer: %w", err)
-			}
-		}
+	if !c.configResourcesStatusEnabled && c.rr.DeletionInProgress(p) {
+		return nil
 	}
 
-	// Check if the Prometheus instance is marked for deletion.
-	if c.rr.DeletionInProgress(p) {
-		if c.configResourcesStatusEnabled {
-			// If the Prometheus instance is marked for deletion, we remove the finalizer.
-			finalizers := p.GetFinalizers()
-			patchBytes, err := k8sutil.DeleteStatusCleanupFinalizer(finalizers)
-			if err != nil {
-				return fmt.Errorf("failed to marshal patch: %w", err)
-			}
-			if patchBytes != nil {
-				if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-					return fmt.Errorf("failed to remove statusCleanup finalizer: %w", err)
-				}
-			}
-			c.reconciliations.ForgetObject(key)
-			return nil
-		}
+	finalizersChanged, err := c.syncFinalizers(ctx, p, key)
+	if err != nil {
+		return err
+	}
+	if finalizersChanged {
 		return nil
 	}
 
@@ -661,6 +638,44 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	return err
+}
+
+// add or remove finalizers for the PrometheusAgent resource.
+func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, key string) (bool, error) {
+	if c.configResourcesStatusEnabled {
+		var finalizersChanged bool
+		if !c.rr.DeletionInProgress(p) {
+			// Add finalizer to the PrometheusAgent resource if it doesn't have one.
+			finalizers := p.GetFinalizers()
+			patchBytes, err := k8sutil.AddStatusCleanupFinalizer(finalizers)
+			if err != nil {
+				return false, fmt.Errorf("failed to marshal patch: %w", err)
+			}
+			if patchBytes != nil {
+				if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+					return false, fmt.Errorf("failed to add statusCleanup finalizer: %w", err)
+				}
+				finalizersChanged = true
+			}
+		} else {
+			// If the PrometheusAgent instance is marked for deletion, we remove the finalizer.
+			finalizers := p.GetFinalizers()
+			patchBytes, err := k8sutil.DeleteStatusCleanupFinalizer(finalizers)
+			if err != nil {
+				return false, fmt.Errorf("failed to marshal patch: %w", err)
+			}
+			if patchBytes != nil {
+				if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+					return false, fmt.Errorf("failed to remove statusCleanup finalizer: %w", err)
+				}
+				finalizersChanged = true
+			}
+
+			c.reconciliations.ForgetObject(key)
+		}
+		return finalizersChanged, nil
+	}
+	return false, nil
 }
 
 func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, tlsAssets *operator.ShardedSecret) error {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -577,7 +577,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	logger := c.logger.With("key", key)
 
-	if c.configResourcesStatusEnabled {
+	if c.configResourcesStatusEnabled && !c.rr.DeletionInProgress(p) {
 		// Add finalizer to the Prometheus resource if it doesn't have one.
 		finalizers := p.GetFinalizers()
 		if !slices.Contains(finalizers, finalizerName) {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -646,38 +646,44 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1alpha1.Pro
 	if !c.configResourcesStatusEnabled {
 		return false, nil
 	}
-	finalizersChanged := false
+
+	// The resource isn't being deleted, add the finalizer if missing.
 	if !c.rr.DeletionInProgress(p) {
 		// Add finalizer to the PrometheusAgent resource if it doesn't have one.
 		finalizers := p.GetFinalizers()
 		patchBytes, err := k8sutil.FinalizerAddPatch(finalizers, k8sutil.StatusCleanupFinalizerName)
 		if err != nil {
-			return finalizersChanged, fmt.Errorf("failed to marshal patch: %w", err)
+			return false, fmt.Errorf("failed to marshal patch: %w", err)
 		}
-		if len(patchBytes) > 0 {
-			if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return finalizersChanged, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
-			}
-			finalizersChanged = true
+
+		if len(patchBytes) == 0 {
+			return false, nil
 		}
-		return finalizersChanged, nil
+
+		if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+		}
+		return true, nil
 	}
+
 	// If the PrometheusAgent instance is marked for deletion, we remove the finalizer.
 	finalizers := p.GetFinalizers()
 	patchBytes, err := k8sutil.FinalizerDeletePatch(finalizers, k8sutil.StatusCleanupFinalizerName)
 	if err != nil {
-		return finalizersChanged, fmt.Errorf("failed to marshal patch: %w", err)
+		return false, fmt.Errorf("failed to marshal patch: %w", err)
 	}
-	if len(patchBytes) > 0 {
-		if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-			return finalizersChanged, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
-		}
-		finalizersChanged = true
+
+	if len(patchBytes) == 0 {
+		c.reconciliations.ForgetObject(key)
+		return false, nil
+	}
+
+	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
 
 	c.reconciliations.ForgetObject(key)
-
-	return finalizersChanged, nil
+	return true, nil
 }
 
 func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, tlsAssets *operator.ShardedSecret) error {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -94,7 +94,8 @@ type Operator struct {
 
 	statusReporter prompkg.StatusReporter
 
-	daemonSetFeatureGateEnabled bool
+	daemonSetFeatureGateEnabled  bool
+	configResourcesStatusEnabled bool
 }
 
 type ControllerOption func(*Operator)
@@ -156,10 +157,11 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Annotations:                c.Annotations,
 			Labels:                     c.Labels,
 		},
-		metrics:         operator.NewMetrics(r),
-		reconciliations: &operator.ReconciliationTracker{},
-		controllerID:    c.ControllerID,
-		eventRecorder:   c.EventRecorderFactory(client, controllerName),
+		metrics:                      operator.NewMetrics(r),
+		reconciliations:              &operator.ReconciliationTracker{},
+		controllerID:                 c.ControllerID,
+		eventRecorder:                c.EventRecorderFactory(client, controllerName),
+		configResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
 	}
 	o.metrics.MustRegister(
 		o.reconciliations,
@@ -198,6 +200,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1alpha1.PrometheusAgentsKind,
 		r,
 		o.controllerID,
+		o.configResourcesStatusEnabled,
 	)
 
 	o.smonInfs, err = informers.NewInformersForResource(

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -641,41 +641,43 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 }
 
 // add or remove finalizers for the PrometheusAgent resource.
+// Returns true if the finalizers were modified, otherwise false. The second return value is an error, if any.
 func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1alpha1.PrometheusAgent, key string) (bool, error) {
-	if c.configResourcesStatusEnabled {
-		var finalizersChanged bool
-		if !c.rr.DeletionInProgress(p) {
-			// Add finalizer to the PrometheusAgent resource if it doesn't have one.
-			finalizers := p.GetFinalizers()
-			patchBytes, err := k8sutil.AddStatusCleanupFinalizer(finalizers)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal patch: %w", err)
+	if !c.configResourcesStatusEnabled {
+		return false, nil
+	}
+	finalizersChanged := false
+	if !c.rr.DeletionInProgress(p) {
+		// Add finalizer to the PrometheusAgent resource if it doesn't have one.
+		finalizers := p.GetFinalizers()
+		patchBytes, err := k8sutil.FinalizerAddPatch(finalizers, k8sutil.StatusCleanupFinalizerName)
+		if err != nil {
+			return finalizersChanged, fmt.Errorf("failed to marshal patch: %w", err)
+		}
+		if len(patchBytes) > 0 {
+			if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+				return finalizersChanged, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 			}
-			if patchBytes != nil {
-				if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-					return false, fmt.Errorf("failed to add statusCleanup finalizer: %w", err)
-				}
-				finalizersChanged = true
-			}
-		} else {
-			// If the PrometheusAgent instance is marked for deletion, we remove the finalizer.
-			finalizers := p.GetFinalizers()
-			patchBytes, err := k8sutil.DeleteStatusCleanupFinalizer(finalizers)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal patch: %w", err)
-			}
-			if patchBytes != nil {
-				if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-					return false, fmt.Errorf("failed to remove statusCleanup finalizer: %w", err)
-				}
-				finalizersChanged = true
-			}
-
-			c.reconciliations.ForgetObject(key)
+			finalizersChanged = true
 		}
 		return finalizersChanged, nil
 	}
-	return false, nil
+	// If the PrometheusAgent instance is marked for deletion, we remove the finalizer.
+	finalizers := p.GetFinalizers()
+	patchBytes, err := k8sutil.FinalizerDeletePatch(finalizers, k8sutil.StatusCleanupFinalizerName)
+	if err != nil {
+		return finalizersChanged, fmt.Errorf("failed to marshal patch: %w", err)
+	}
+	if len(patchBytes) > 0 {
+		if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+			return finalizersChanged, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+		}
+		finalizersChanged = true
+	}
+
+	c.reconciliations.ForgetObject(key)
+
+	return finalizersChanged, nil
 }
 
 func (c *Operator) syncDaemonSet(ctx context.Context, key string, p *monitoringv1alpha1.PrometheusAgent, cg *prompkg.ConfigGenerator, tlsAssets *operator.ShardedSecret) error {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -582,6 +582,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 	if finalizersChanged {
+		c.rr.EnqueueForReconciliation(p)
 		return nil
 	}
 
@@ -663,6 +664,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1alpha1.Pro
 		if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 		}
+		c.logger.Debug("added finalizer to PrometheusAgent resource", "name", p.Name, "namespace", p.Namespace)
 		return true, nil
 	}
 
@@ -681,6 +683,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1alpha1.Pro
 	if _, err = c.mclient.MonitoringV1alpha1().PrometheusAgents(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
+	c.logger.Debug("removed finalizer from PrometheusAgent resource", "name", p.Name, "namespace", p.Namespace)
 
 	c.reconciliations.ForgetObject(key)
 	return true, nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -763,6 +763,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 	if finalizersChanged {
+		c.rr.EnqueueForReconciliation(p)
 		return nil
 	}
 
@@ -994,7 +995,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheu
 		if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 		}
-		c.logger.Info("added finalizer to Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
+		c.logger.Debug("added finalizer to Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
 		return true, nil
 	}
 
@@ -1012,7 +1013,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheu
 	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
-	c.logger.Info("removed finalizer from Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
+	c.logger.Debug("removed finalizer from Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
 	c.reconciliations.ForgetObject(key)
 
 	return true, nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -758,7 +758,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
 
-	if c.configResourcesStatusEnabled {
+	if c.configResourcesStatusEnabled && !c.rr.DeletionInProgress(p) {
 		// Add finalizer to the Prometheus resource if it doesn't have one.
 		finalizers := p.GetFinalizers()
 		if !slices.Contains(finalizers, finalizerName) {

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1051,7 +1051,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	p := pobj.(*monitoringv1.Prometheus)
 	p = p.DeepCopy()
 
-	if p == nil || c.rr.DeletionInProgress(p) {
+	if c.rr.DeletionInProgress(p) {
 		return nil
 	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -214,6 +214,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.PrometheusesKind,
 		r,
 		o.controllerID,
+		o.configResourcesStatusEnabled,
 	)
 
 	o.smonInfs, err = informers.NewInformersForResource(

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -754,10 +754,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
 
-	if !c.configResourcesStatusEnabled && c.rr.DeletionInProgress(p) {
-		return nil
-	}
-
 	finalizersChanged, err := c.syncFinalizers(ctx, p, key)
 	if err != nil {
 		return err
@@ -765,6 +761,10 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	if finalizersChanged {
 		// Since the object has been updated, let's trigger another sync.
 		c.rr.EnqueueForReconciliation(p)
+		return nil
+	}
+
+	if c.rr.DeletionInProgress(p) {
 		return nil
 	}
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -54,7 +54,7 @@ import (
 const (
 	resyncPeriod   = 5 * time.Minute
 	controllerName = "prometheus-controller"
-	finalizerName  = "monitoring.coreos.com/config-res-status-cleanup"
+	finalizerName  = "monitoring.coreos.com/status-cleanup"
 )
 
 // Operator manages life cycle of Prometheus deployments and
@@ -762,7 +762,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			finalizers = append(finalizers, finalizerName)
 			p.SetFinalizers(finalizers)
 			if _, err := c.mclient.MonitoringV1().Prometheuses(p.Namespace).Update(ctx, p, metav1.UpdateOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return fmt.Errorf("adding finalizer %q to Prometheus %q failed: %w", finalizerName, p.Name, err)
+				return fmt.Errorf("failed to add %q finalizer: %w", finalizerName, err)
 			}
 		}
 	}
@@ -777,7 +777,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			})
 			p.SetFinalizers(finalizers)
 			if _, err := c.mclient.MonitoringV1().Prometheuses(p.Namespace).Update(ctx, p, metav1.UpdateOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return fmt.Errorf("removing finalizer %q from Prometheus %q failed: %w", finalizerName, p.Name, err)
+				return fmt.Errorf("failed to remove %q finalizer: %w", finalizerName, err)
 			}
 
 			c.reconciliations.ForgetObject(key)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -16,11 +16,9 @@ package prometheus
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"reflect"
-	"slices"
 	"strings"
 	"time"
 
@@ -56,7 +54,6 @@ import (
 const (
 	resyncPeriod   = 5 * time.Minute
 	controllerName = "prometheus-controller"
-	finalizerName  = "monitoring.coreos.com/status-cleanup"
 )
 
 // Operator manages life cycle of Prometheus deployments and
@@ -761,19 +758,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	if c.configResourcesStatusEnabled && !c.rr.DeletionInProgress(p) {
 		// Add finalizer to the Prometheus resource if it doesn't have one.
 		finalizers := p.GetFinalizers()
-		if !slices.Contains(finalizers, finalizerName) {
-			finalizers = append(finalizers, finalizerName)
-			patchData := map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"finalizers": finalizers,
-				},
-			}
-			patchBytes, err := json.Marshal(patchData)
-			if err != nil {
-				return fmt.Errorf("failed to marshal patch: %w", err)
-			}
+		patchBytes, err := k8sutil.AddStatusCleanupFinalizer(finalizers)
+		if err != nil {
+			return fmt.Errorf("failed to marshal patch: %w", err)
+		}
+		if patchBytes != nil {
 			if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return fmt.Errorf("failed to add %q finalizer: %w", finalizerName, err)
+				return fmt.Errorf("failed to add statusCleanup finalizer: %w", err)
 			}
 		}
 	}
@@ -783,20 +774,14 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		if c.configResourcesStatusEnabled {
 			// If the Prometheus instance is marked for deletion, we remove the finalizer.
 			finalizers := p.GetFinalizers()
-			finalizers = slices.DeleteFunc(finalizers, func(f string) bool {
-				return f == finalizerName
-			})
-			patchData := map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"finalizers": finalizers,
-				},
-			}
-			patchBytes, err := json.Marshal(patchData)
+			patchBytes, err := k8sutil.DeleteStatusCleanupFinalizer(finalizers)
 			if err != nil {
 				return fmt.Errorf("failed to marshal patch: %w", err)
 			}
-			if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-				return fmt.Errorf("failed to add %q finalizer: %w", finalizerName, err)
+			if patchBytes != nil {
+				if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+					return fmt.Errorf("failed to remove statusCleanup finalizer: %w", err)
+				}
 			}
 
 			c.reconciliations.ForgetObject(key)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -211,7 +211,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.PrometheusesKind,
 		r,
 		o.controllerID,
-		o.configResourcesStatusEnabled,
 	)
 
 	o.smonInfs, err = informers.NewInformersForResource(
@@ -1027,6 +1026,9 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	p := pobj.(*monitoringv1.Prometheus)
 	p = p.DeepCopy()
 
+	if p == nil || c.rr.DeletionInProgress(p) {
+		return nil
+	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)
 	if err != nil {
 		return fmt.Errorf("failed to get prometheus status: %w", err)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -994,6 +994,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheu
 		if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 		}
+		c.logger.Info("added finalizer to Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
 		return true, nil
 	}
 
@@ -1011,6 +1012,7 @@ func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheu
 	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
 		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
+	c.logger.Info("removed finalizer from Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
 	c.reconciliations.ForgetObject(key)
 
 	return true, nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -763,6 +763,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 	if finalizersChanged {
+		// Since the object has been updated, let's trigger another sync.
 		c.rr.EnqueueForReconciliation(p)
 		return nil
 	}
@@ -973,8 +974,8 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	return nil
 }
 
-// add or remove finalizers for the Prometheus resource.
-// Returns true if the finalizers were modified, otherwise false. The second return value is an error, if any.
+// syncFinalizers adds or removes the finalizer for the Prometheus resource.
+// It returns true if the finalizers were modified, otherwise false. The second return value is an error, if any.
 func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheus, key string) (bool, error) {
 	if !c.configResourcesStatusEnabled {
 		return false, nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -53,6 +54,7 @@ import (
 const (
 	resyncPeriod   = 5 * time.Minute
 	controllerName = "prometheus-controller"
+	finalizerName  = "monitoring.coreos.com/config-res-status-cleanup"
 )
 
 // Operator manages life cycle of Prometheus deployments and
@@ -752,6 +754,18 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
+
+	if c.configResourcesStatusEnabled {
+		// Add finalizer to the Prometheus resource if it doesn't have one.
+		finalizers := p.GetFinalizers()
+		if !slices.Contains(finalizers, finalizerName) {
+			finalizers = append(finalizers, finalizerName)
+			p.SetFinalizers(finalizers)
+			if _, err := c.mclient.MonitoringV1().Prometheuses(p.Namespace).Update(ctx, p, metav1.UpdateOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
+				return fmt.Errorf("adding finalizer %q to Prometheus %q failed: %w", finalizerName, p.Name, err)
+			}
+		}
+	}
 
 	// Check if the Prometheus instance is marked for deletion.
 	if c.rr.DeletionInProgress(p) {

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -456,9 +456,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to set ThanosRuler type information: %w", err)
 	}
 
-	logger := o.logger.With("key", key)
-	logger.Info("sync thanos-ruler")
-
+	// Check if the Thanos instance is marked for deletion.
 	if o.rr.DeletionInProgress(tr) {
 		return nil
 	}
@@ -466,6 +464,9 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	if tr.Spec.Paused {
 		return nil
 	}
+
+	logger := o.logger.With("key", key)
+	logger.Info("sync thanos-ruler")
 
 	if err := operator.CheckStorageClass(ctx, o.canReadStorageClass, o.kclient, tr.Spec.Storage); err != nil {
 		return err
@@ -615,7 +616,7 @@ func (o *Operator) UpdateStatus(ctx context.Context, key string) error {
 		return err
 	}
 
-	if tr == nil || o.rr.DeletionInProgress(tr) {
+	if o.rr.DeletionInProgress(tr) {
 		return nil
 	}
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -89,6 +89,8 @@ type Operator struct {
 	eventRecorder record.EventRecorder
 
 	config Config
+
+	configResourcesStatusEnabled bool
 }
 
 // Config defines the operator's parameters for the Thanos controller.
@@ -151,6 +153,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Labels:                 c.Labels,
 			LocalHost:              c.LocalHost,
 		},
+		configResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
 	}
 	for _, opt := range options {
 		opt(o)
@@ -202,6 +205,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.ThanosRulerKind,
 		r,
 		o.controllerID,
+		o.configResourcesStatusEnabled,
 	)
 
 	o.ruleInfs, err = informers.NewInformersForResource(

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -616,7 +616,7 @@ func (o *Operator) UpdateStatus(ctx context.Context, key string) error {
 		return err
 	}
 
-	if o.rr.DeletionInProgress(tr) {
+	if tr == nil || o.rr.DeletionInProgress(tr) {
 		return nil
 	}
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -206,7 +206,6 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		monitoringv1.ThanosRulerKind,
 		r,
 		o.controllerID,
-		o.configResourcesStatusEnabled,
 	)
 
 	o.ruleInfs, err = informers.NewInformersForResource(

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -464,7 +464,7 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	logger := o.logger.With("key", key)
 	logger.Info("sync thanos-ruler")
 
-	if o.configResourcesStatusEnabled {
+	if o.configResourcesStatusEnabled && !o.rr.DeletionInProgress(tr) {
 		// Add finalizer to the thanos resource if it doesn't have one.
 		finalizers := tr.GetFinalizers()
 		if !slices.Contains(finalizers, finalizerName) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -414,13 +414,13 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet":            testCreatePrometheusAgentDaemonSet,
-		"PromAgentDaemonSetResourceUpdate":          testPromAgentDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceUpdate": testPromAgentReconcileDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
-		"PrometheusAgentDaemonSetSelectPodMonitor":  testPrometheusAgentDaemonSetSelectPodMonitor,
-		"PrometheusRetentionPolicies":               testPrometheusRetentionPolicies,
-		"StatusForConfigResources":                  testStatusForConfigResources,
+		"CreatePrometheusAgentDaemonSet":               testCreatePrometheusAgentDaemonSet,
+		"PromAgentDaemonSetResourceUpdate":             testPromAgentDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceUpdate":    testPromAgentReconcileDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceDelete":    testPromAgentReconcileDaemonSetResourceDelete,
+		"PrometheusAgentDaemonSetSelectPodMonitor":     testPrometheusAgentDaemonSetSelectPodMonitor,
+		"PrometheusRetentionPolicies":                  testPrometheusRetentionPolicies,
+		"FinalizerWhenStatusForConfigResourcesEnabled": testFinalizerWhenStatusForConfigResourcesEnabled,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -420,6 +420,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
 		"PrometheusAgentDaemonSetSelectPodMonitor":  testPrometheusAgentDaemonSetSelectPodMonitor,
 		"PrometheusRetentionPolicies":               testPrometheusRetentionPolicies,
+		"StatusForConfigResources":                  testStatusForConfigResources,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
+)
+
+// testStatusForConfigResources tests the adding/removing of status-cleanup finalizer for Prometheus when StatusForConfigurationResourcesFeature is enable.
+func testStatusForConfigResources(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.StatusForConfigurationResourcesFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "status-cleanup-finalizer-test"
+	t.Run(name, func(t *testing.T) {
+		p := framework.MakeBasicPrometheus(ns, name, name, 1)
+		framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+		pm, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+		require.NoError(t, err, "failed to create Prometheus")
+		finalizers := pm.GetFinalizers()
+		require.Contains(t, finalizers, k8sutil.StatusCleanupFinalizerName, "expected Prometheus to have status-cleanup finalizer")
+		err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name)
+		require.NoError(t, err, "failed to delete Prometheus with status-cleanup finalizer")
+	})
+}

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -24,8 +24,8 @@ import (
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
-// testStatusForConfigResources tests the adding/removing of status-cleanup finalizer for Prometheus when StatusForConfigurationResourcesFeature is enable.
-func testStatusForConfigResources(t *testing.T) {
+// testFinalizerWhenStatusForConfigResourcesEnabled tests the adding/removing of status-cleanup finalizer for Prometheus when StatusForConfigurationResourcesFeature is enabled.
+func testFinalizerWhenStatusForConfigResourcesEnabled(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -44,14 +43,12 @@ func testStatusForConfigResources(t *testing.T) {
 	require.NoError(t, err)
 
 	name := "status-cleanup-finalizer-test"
-	t.Run(name, func(t *testing.T) {
-		p := framework.MakeBasicPrometheus(ns, name, name, 1)
-		framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
-		pm, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
-		require.NoError(t, err, "failed to create Prometheus")
-		finalizers := pm.GetFinalizers()
-		require.Contains(t, finalizers, k8sutil.StatusCleanupFinalizerName, "expected Prometheus to have status-cleanup finalizer")
-		err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name)
-		require.NoError(t, err, "failed to delete Prometheus with status-cleanup finalizer")
-	})
+
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
+	pm, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	require.NoError(t, err, "failed to create Prometheus")
+	finalizers := pm.GetFinalizers()
+	require.NotEmpty(t, finalizers, "finalizers list should not be empty")
+	err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name)
+	require.NoError(t, err, "failed to delete Prometheus with status-cleanup finalizer")
 }


### PR DESCRIPTION
## Description

fixes: #7583 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```finalizer added to workload resources if statusFOrConfigRes flag is enabled

```
