### PR TITLE
feat: added e2e tests for CEL validations in PrometheusAgents DaemonSet deployment model 

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -420,6 +420,9 @@ func TestGatedFeatures(t *testing.T) {
 		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
 		"PrometheusAgentDaemonSetSelectPodMonitor":  testPrometheusAgentDaemonSetSelectPodMonitor,
 		"PrometheusRetentionPolicies":               testPrometheusRetentionPolicies,
+		"PrometheusAgentDaemonSetModeBasic":         testPrometheusAgentDaemonSetModeBasic,
+		"PrometheusAgentDaemonSetIgnoreReplicas":    testPrometheusAgentDaemonSetIgnoreReplicas,
+		"PrometheusAgentDaemonSetIgnoreStorage":     testPrometheusAgentDaemonSetIgnoreStorage,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -420,9 +420,8 @@ func TestGatedFeatures(t *testing.T) {
 		"PromAgentReconcileDaemonSetResourceDelete": testPromAgentReconcileDaemonSetResourceDelete,
 		"PrometheusAgentDaemonSetSelectPodMonitor":  testPrometheusAgentDaemonSetSelectPodMonitor,
 		"PrometheusRetentionPolicies":               testPrometheusRetentionPolicies,
-		"PrometheusAgentDaemonSetModeBasic":         testPrometheusAgentDaemonSetModeBasic,
-		"PrometheusAgentDaemonSetIgnoreReplicas":    testPrometheusAgentDaemonSetIgnoreReplicas,
-		"PrometheusAgentDaemonSetIgnoreStorage":     testPrometheusAgentDaemonSetIgnoreStorage,
+		"PrometheusAgentDaemonSetInvalidReplicas":    testPrometheusAgentDaemonSetInvalidReplicas,
+		"PrometheusAgentDaemonSetInvalidStorage":     testPrometheusAgentDaemonSetInvalidStorage,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -641,202 +641,97 @@ type TargetsResponse struct {
 	} `json:"data"`
 }
 
-// testPrometheusAgentDaemonSetModeBasic tests basic DaemonSet mode functionality
-func testPrometheusAgentDaemonSetModeBasic(t *testing.T) {
-	t.Parallel()
+func testPrometheusAgentDaemonSetInvalidReplicas(t *testing.T) {
+    t.Parallel()
+    ctx := context.Background()
+    testCtx := framework.NewTestCtx(t)
+    defer testCtx.Cleanup(t)
 
-	testCtx := framework.NewTestCtx(t)
-	defer testCtx.Cleanup(t)
+    ns := framework.CreateNamespace(ctx, t, testCtx)
+    framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+    _, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+        ctx, testFramework.PrometheusOperatorOpts{
+            Namespace:           ns,
+            AllowedNamespaces:   []string{ns},
+            EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+        },
+    )
+    require.NoError(t, err)
 
-	ctx := context.Background()
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+    name := "test-invalid-replicas"
+    p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	// Enable the DaemonSet feature gate
-	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
-		ctx, testFramework.PrometheusOperatorOpts{
-			Namespace:           ns,
-			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
-		},
-	)
-	require.NoError(t, err)
+    // no replicas should be set in Daemonsets
+    p.Spec.Replicas = ptr.To(int32(3))
 
-	// Create PrometheusAgent in DaemonSet mode
-	prometheusAgent := &monitoringv1alpha1.PrometheusAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-daemonset-mode",
-			Namespace: ns,
-		},
-		Spec: monitoringv1alpha1.PrometheusAgentSpec{
-			Mode: ptr.To(monitoringv1alpha1.DaemonSetPrometheusAgentMode),
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: operator.DefaultPrometheusVersion,
-			},
-		},
-	}
+    _, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, p)
+    require.Error(t, err)
 
-	prometheusAgent, err = framework.MonClientV1alpha1.PrometheusAgents(ns).Create(ctx, prometheusAgent, metav1.CreateOptions{})
-	require.NoError(t, err, "Failed to create PrometheusAgent in DaemonSet mode")
+    var loopError error
+    err = wait.PollUntilContextTimeout(ctx, 5*time.Second, framework.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
+        current, err := framework.MonClientV1alpha1.PrometheusAgents(ns).Get(ctx, name, metav1.GetOptions{})
+        if err != nil {
+            loopError = fmt.Errorf("failed to get object: %w", err)
+            return false, nil
+        }
 
-	// Wait for DaemonSet to be created (this should fail initially)
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		daemonSets, err := framework.KubeClient.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=prometheus-agent,app.kubernetes.io/instance=%s", prometheusAgent.Name),
-		})
-		if err != nil {
-			return false, err
-		}
-
-		if len(daemonSets.Items) == 0 {
-			t.Logf("Waiting for DaemonSet to be created...")
-			return false, nil
-		}
-
-		t.Logf("✅ DaemonSet created successfully")
-		return true, nil
-	})
-	require.NoError(t, err, "DaemonSet should be created for PrometheusAgent in DaemonSet mode")
-
-	// Verify no StatefulSet is created
-	statefulSets, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=prometheus-agent,app.kubernetes.io/instance=%s", prometheusAgent.Name),
-	})
-	require.NoError(t, err)
-	require.Len(t, statefulSets.Items, 0, "No StatefulSet should be created in DaemonSet mode")
+        if err := framework.AssertCondition(current.Status.Conditions, monitoringv1.Reconciled, monitoringv1.ConditionFalse); err == nil {
+            return true, nil
+        }
+        return false, nil
+    })
+    require.NoError(t, err, "%v: %v", err, loopError)
 }
 
-// testPrometheusAgentDaemonSetIgnoreReplicas tests that replicas field is ignored in DaemonSet mode
-func testPrometheusAgentDaemonSetIgnoreReplicas(t *testing.T) {
-	t.Parallel()
+func testPrometheusAgentDaemonSetInvalidStorage(t *testing.T) {
+    t.Parallel()
+    ctx := context.Background()
+    testCtx := framework.NewTestCtx(t)
+    defer testCtx.Cleanup(t)
 
-	testCtx := framework.NewTestCtx(t)
-	defer testCtx.Cleanup(t)
+    ns := framework.CreateNamespace(ctx, t, testCtx)
+    framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+    _, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+        ctx, testFramework.PrometheusOperatorOpts{
+            Namespace:           ns,
+            AllowedNamespaces:   []string{ns},
+            EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+        },
+    )
+    require.NoError(t, err)
 
-	ctx := context.Background()
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+    name := "test-invalid-storage"
+    p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	// Enable the DaemonSet feature gate
-	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
-		ctx, testFramework.PrometheusOperatorOpts{
-			Namespace:           ns,
-			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
-		},
-	)
-	require.NoError(t, err)
+    // storage should not be set in Daemonsets
+    p.Spec.CommonPrometheusFields.Storage = &monitoringv1.StorageSpec{
+        VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
+            Spec: v1.PersistentVolumeClaimSpec{
+                StorageClassName: ptr.To("standard"),
+                Resources: v1.VolumeResourceRequirements{
+                    Requests: v1.ResourceList{
+                        v1.ResourceStorage: resource.MustParse("200Mi"),
+                    },
+                },
+            },
+        },
+    }
 
-	// Create PrometheusAgent in DaemonSet mode WITH replicas (should be ignored)
-	prometheusAgent := &monitoringv1alpha1.PrometheusAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-daemonset-replicas",
-			Namespace: ns,
-		},
-		Spec: monitoringv1alpha1.PrometheusAgentSpec{
-			Mode: ptr.To(monitoringv1alpha1.DaemonSetPrometheusAgentMode),
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version:  operator.DefaultPrometheusVersion,
-				Replicas: ptr.To(int32(5)), // This should be ignored in DaemonSet mode
-			},
-		},
-	}
+    _, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, p)
+    require.Error(t, err) 
 
-	prometheusAgent, err = framework.MonClientV1alpha1.PrometheusAgents(ns).Create(ctx, prometheusAgent, metav1.CreateOptions{})
-	require.NoError(t, err, "PrometheusAgent with replicas should be created but replicas should be ignored")
+    var loopError error
+    err = wait.PollUntilContextTimeout(ctx, 5*time.Second, framework.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
+        current, err := framework.MonClientV1alpha1.PrometheusAgents(ns).Get(ctx, name, metav1.GetOptions{})
+        if err != nil {
+            loopError = fmt.Errorf("failed to get object: %w", err)
+            return false, nil
+        }
 
-	// Wait for DaemonSet to be created (replicas should be ignored)
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		daemonSets, err := framework.KubeClient.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=prometheus-agent,app.kubernetes.io/instance=%s", prometheusAgent.Name),
-		})
-		if err != nil {
-			return false, err
-		}
-
-		if len(daemonSets.Items) == 0 {
-			return false, nil
-		}
-
-		t.Logf("✅ DaemonSet created without replicas field")
-		return true, nil
-	})
-	require.NoError(t, err, "DaemonSet should be created and replicas should be ignored")
-}
-
-// testPrometheusAgentDaemonSetIgnoreStorage tests that storage field is ignored in DaemonSet mode
-func testPrometheusAgentDaemonSetIgnoreStorage(t *testing.T) {
-	t.Parallel()
-
-	testCtx := framework.NewTestCtx(t)
-	defer testCtx.Cleanup(t)
-
-	ctx := context.Background()
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
-
-	// Enable the DaemonSet feature gate
-	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
-		ctx, testFramework.PrometheusOperatorOpts{
-			Namespace:           ns,
-			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
-		},
-	)
-	require.NoError(t, err)
-
-	// Create PrometheusAgent in DaemonSet mode WITH storage (should be ignored)
-	prometheusAgent := &monitoringv1alpha1.PrometheusAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-daemonset-storage",
-			Namespace: ns,
-		},
-		Spec: monitoringv1alpha1.PrometheusAgentSpec{
-			Mode: ptr.To(monitoringv1alpha1.DaemonSetPrometheusAgentMode),
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Version: operator.DefaultPrometheusVersion,
-				Storage: &monitoringv1.StorageSpec{
-					VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-						Spec: v1.PersistentVolumeClaimSpec{
-							Resources: v1.VolumeResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse("10Gi"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	prometheusAgent, err = framework.MonClientV1alpha1.PrometheusAgents(ns).Create(ctx, prometheusAgent, metav1.CreateOptions{})
-	require.NoError(t, err, "PrometheusAgent with storage should be created but storage should be ignored")
-
-	// Wait for DaemonSet to be created and verify no PVCs
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		daemonSets, err := framework.KubeClient.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=prometheus-agent,app.kubernetes.io/instance=%s", prometheusAgent.Name),
-		})
-		if err != nil {
-			return false, err
-		}
-
-		if len(daemonSets.Items) == 0 {
-			return false, nil
-		}
-
-		// Verify no PVCs are created for DaemonSet mode
-		pvcs, err := framework.KubeClient.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", prometheusAgent.Name),
-		})
-		if err != nil {
-			return false, err
-		}
-
-		require.Len(t, pvcs.Items, 0, "No PVCs should be created in DaemonSet mode")
-		t.Logf("✅ DaemonSet created and no PVCs exist (storage ignored)")
-		return true, nil
-	})
-	require.NoError(t, err, "DaemonSet should be created and storage should be ignored")
+        if err := framework.AssertCondition(current.Status.Conditions, monitoringv1.Reconciled, monitoringv1.ConditionFalse); err == nil {
+            return true, nil
+        }
+        return false, nil
+    })
+    require.NoError(t, err, "%v: %v", err, loopError)
 }


### PR DESCRIPTION
## Description

WIP

Added e2e tests to check for replica and storage specifications in DaemonSet deployment for prometheusagent, which should not be allowed.

Basic PR for now, checking if the approach is correct. I'll continue to add more test cases to see if they fail. Have not put this as draft to ensure that the workflows run.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
