### PR TITLE
Fix `MatchType` is empty in AM matchers

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -470,39 +470,11 @@ func (cb *ConfigBuilder) convertGlobalConfig(ctx context.Context, in *monitoring
 }
 
 func (cb *ConfigBuilder) convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName) *route {
-	matchersV2Allowed := cb.amVersion.GTE(semver.MustParse("0.22.0"))
-
 	if in == nil {
 		return nil
 	}
-	var matchers []string
 
-	// deprecated
-	match := map[string]string{}
-	matchRE := map[string]string{}
-
-	for _, matcher := range in.Matchers {
-		// prefer matchers to deprecated config
-		if matcher.MatchType != "" {
-			matchers = append(matchers, matcher.String())
-			continue
-		}
-
-		if matchersV2Allowed {
-			if matcher.Regex {
-				matchers = append(matchers, inhibitRuleRegexToV2(matcher.Name, matcher.Value))
-			} else {
-				matchers = append(matchers, inhibitRuleToV2(matcher.Name, matcher.Value))
-			}
-			continue
-		}
-
-		if matcher.Regex {
-			matchRE[matcher.Name] = matcher.Value
-		} else {
-			match[matcher.Name] = matcher.Value
-		}
-	}
+	matchers, match, matchRE := cb.convertMatchersV2(in.Matchers)
 
 	var routes []*route
 	if len(in.Routes) > 0 {
@@ -1414,62 +1386,8 @@ func (cb *ConfigBuilder) convertMSTeamsV2Config(
 }
 
 func (cb *ConfigBuilder) convertInhibitRule(in *monitoringv1alpha1.InhibitRule) *inhibitRule {
-	matchersV2Allowed := cb.amVersion.GTE(semver.MustParse("0.22.0"))
-	var sourceMatchers []string
-	var targetMatchers []string
-
-	// todo (pgough) the following config are deprecated and can be removed when
-	// support matrix has reached >= 0.22.0
-	sourceMatch := map[string]string{}
-	sourceMatchRE := map[string]string{}
-	targetMatch := map[string]string{}
-	targetMatchRE := map[string]string{}
-
-	for _, sm := range in.SourceMatch {
-		// prefer matchers to deprecated syntax
-		if sm.MatchType != "" {
-			sourceMatchers = append(sourceMatchers, sm.String())
-			continue
-		}
-
-		if matchersV2Allowed {
-			if sm.Regex {
-				sourceMatchers = append(sourceMatchers, inhibitRuleRegexToV2(sm.Name, sm.Value))
-			} else {
-				sourceMatchers = append(sourceMatchers, inhibitRuleToV2(sm.Name, sm.Value))
-			}
-			continue
-		}
-
-		if sm.Regex {
-			sourceMatchRE[sm.Name] = sm.Value
-		} else {
-			sourceMatch[sm.Name] = sm.Value
-		}
-	}
-
-	for _, tm := range in.TargetMatch {
-		// prefer matchers to deprecated config
-		if tm.MatchType != "" {
-			targetMatchers = append(targetMatchers, tm.String())
-			continue
-		}
-
-		if matchersV2Allowed {
-			if tm.Regex {
-				targetMatchers = append(targetMatchers, inhibitRuleRegexToV2(tm.Name, tm.Value))
-			} else {
-				targetMatchers = append(targetMatchers, inhibitRuleToV2(tm.Name, tm.Value))
-			}
-			continue
-		}
-
-		if tm.Regex {
-			targetMatchRE[tm.Name] = tm.Value
-		} else {
-			targetMatch[tm.Name] = tm.Value
-		}
-	}
+	sourceMatchers, sourceMatch, sourceMatchRE := cb.convertMatchersV2(in.SourceMatch)
+	targetMatchers, targetMatch, targetMatchRE := cb.convertMatchersV2(in.TargetMatch)
 
 	return &inhibitRule{
 		SourceMatch:    sourceMatch,
@@ -1480,6 +1398,38 @@ func (cb *ConfigBuilder) convertInhibitRule(in *monitoringv1alpha1.InhibitRule) 
 		TargetMatchers: targetMatchers,
 		Equal:          in.Equal,
 	}
+}
+
+func (cb *ConfigBuilder) convertMatchersV2(ms []monitoringv1alpha1.Matcher) ([]string, map[string]string, map[string]string) {
+	matchersV2Allowed := cb.amVersion.GTE(semver.MustParse("0.22.0"))
+
+	var matchers []string
+	match := map[string]string{}
+	matchRE := map[string]string{}
+
+	for _, m := range ms {
+		if m.MatchType != "" {
+			matchers = append(matchers, m.String())
+			continue
+		}
+
+		if matchersV2Allowed {
+			if m.Regex {
+				matchers = append(matchers, inhibitRuleRegexToV2(m.Name, m.Value))
+			} else {
+				matchers = append(matchers, inhibitRuleToV2(m.Name, m.Value))
+			}
+			continue
+		}
+
+		if m.Regex {
+			matchRE[m.Name] = m.Value
+		} else {
+			match[m.Name] = m.Value
+		}
+	}
+
+	return matchers, match, matchRE
 }
 
 func convertMuteTimeInterval(in *monitoringv1alpha1.MuteTimeInterval, crKey types.NamespacedName) (*timeInterval, error) {

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -62,6 +62,11 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				Value: "myvalue",
 				Regex: false,
 			},
+			{
+				Name:  "mykey1",
+				Value: "myvalue1",
+				Regex: false,
+			},
 		},
 	})
 

--- a/pkg/alertmanager/testdata/valid_global_config.golden
+++ b/pkg/alertmanager/testdata/valid_global_config.golden
@@ -28,6 +28,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config.golden
+++ b/pkg/alertmanager/testdata/valid_global_config.golden
@@ -26,8 +26,8 @@ route:
   receiver: mynamespace/global-config/null
   routes:
   - receiver: mynamespace/global-config/myreceiver
-    match:
-      mykey: myvalue
+    matchers:
+    - mykey="myvalue"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_smtp_tlsconfig_email_receiver.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_smtp_tlsconfig_email_receiver.golden
@@ -17,6 +17,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_KEY.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_KEY.golden
@@ -4,8 +4,8 @@ route:
   receiver: mynamespace/global-config/null
   routes:
   - receiver: mynamespace/global-config/myreceiver
-    match:
-      mykey: myvalue
+    matchers:
+    - mykey="myvalue"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_KEY.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_KEY.golden
@@ -6,6 +6,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_URL.golden
@@ -4,8 +4,8 @@ route:
   receiver: mynamespace/global-config/null
   routes:
   - receiver: mynamespace/global-config/myreceiver
-    match:
-      mykey: myvalue
+    matchers:
+    - mykey="myvalue"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_OpsGenie_API_URL.golden
@@ -6,6 +6,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_Pagerduty_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_Pagerduty_URL.golden
@@ -4,8 +4,8 @@ route:
   receiver: mynamespace/global-config/null
   routes:
   - receiver: mynamespace/global-config/myreceiver
-    match:
-      mykey: myvalue
+    matchers:
+    - mykey="myvalue"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_Pagerduty_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_Pagerduty_URL.golden
@@ -6,6 +6,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_Slack_API_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_Slack_API_URL.golden
@@ -4,8 +4,8 @@ route:
   receiver: mynamespace/global-config/null
   routes:
   - receiver: mynamespace/global-config/myreceiver
-    match:
-      mykey: myvalue
+    matchers:
+    - mykey="myvalue"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_Slack_API_URL.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_Slack_API_URL.golden
@@ -6,6 +6,7 @@ route:
   - receiver: mynamespace/global-config/myreceiver
     matchers:
     - mykey="myvalue"
+    - mykey1="myvalue1"
 receivers:
 - name: mynamespace/global-config/null
 - name: mynamespace/global-config/myreceiver

--- a/pkg/alertmanager/testdata/valid_global_config_with_amVersion21.golden
+++ b/pkg/alertmanager/testdata/valid_global_config_with_amVersion21.golden
@@ -1,4 +1,15 @@
 global:
+  resolve_timeout: 30s
+  http_config:
+    oauth2:
+      client_id: clientID
+      client_secret: clientSecret
+      scopes:
+      - any
+      token_url: https://test.com
+      endpoint_params:
+        some: value
+    follow_redirects: true
   smtp_from: from
   smtp_hello: smtp.example.org
   smtp_smarthost: smtp.example.org:587
@@ -11,19 +22,4 @@ global:
     insecure_skip_verify: true
     min_version: TLS12
     max_version: TLS13
-route:
-  receiver: mynamespace/global-config/null
-  routes:
-  - receiver: mynamespace/global-config/myreceiver
-    matchers:
-    - mykey="myvalue"
-receivers:
-- name: mynamespace/global-config/null
-- name: mynamespace/global-config/myreceiver
-  email_configs:
-  - send_resolved: true
-    to: b
-    from: a
-    smarthost: abc:1234
-    auth_username: foo
 templates: []

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1516,9 +1516,8 @@ route:
     continue: true
   - receiver: %s/e2e-test-amconfig-sub-routes/e2e
     matchers:
-    - service="webapp"
-    matchers:
     - namespace="%s"
+    - service="webapp"
     continue: true
     routes:
     - receiver: %s/e2e-test-amconfig-sub-routes/e2e
@@ -2619,9 +2618,8 @@ route:
   routes:
   - receiver: %s/amcfg-v1alpha1/webhook
     matchers:
-    - test="test"
-    matchers:
     - namespace="%s"
+    - test="test"
     continue: true
   - receiver: "null"
     matchers:

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1626,6 +1626,7 @@ templates: []
 		require.NoError(t, err)
 		if diff := cmp.Diff(uncompressed, expected); diff != "" {
 			lastErr = fmt.Errorf("got(-), want(+):\n%s", diff)
+			fmt.Println(lastErr)
 			return false, nil
 		}
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1536,8 +1536,8 @@ route:
         mute_time_intervals:
         - %s/e2e-test-amconfig-sub-routes/test
   - receiver: "null"
-    matchers:
-    - alertname="DeadMansSwitch"
+    match:
+      alertname: DeadMansSwitch
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
@@ -2671,8 +2671,8 @@ route:
     - test="test"
     continue: true
   - receiver: "null"
-    matchers:
-    - alertname="DeadMansSwitch"
+    match:
+      alertname: DeadMansSwitch
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1659,8 +1659,8 @@ route:
   - job
   routes:
   - receiver: "null"
-    matchers:
-    - alertname="DeadMansSwitch"
+    match:
+      alertname: DeadMansSwitch
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
@@ -2618,12 +2618,12 @@ route:
   routes:
   - receiver: %s/amcfg-v1alpha1/webhook
     matchers:
-    - namespace="%s"
     - test="test"
+    - namespace="%s"
     continue: true
   - receiver: "null"
-    matchers:
-    - alertname="DeadMansSwitch"
+    match:
+      alertname: DeadMansSwitch
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1516,8 +1516,8 @@ route:
     continue: true
   - receiver: %s/e2e-test-amconfig-sub-routes/e2e
     matchers:
-    - namespace="%s"
     - service="webapp"
+    - namespace="%s"
     continue: true
     routes:
     - receiver: %s/e2e-test-amconfig-sub-routes/e2e
@@ -1528,11 +1528,11 @@ route:
       - job="db"
       routes:
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
-        match:
-          alertname: TargetDown
+        matchers:
+        - alertname="TargetDown"
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
-        match_re:
-          severity: critical|warning
+        matchers:
+        - severity=~"critical|warning"
         mute_time_intervals:
         - %s/e2e-test-amconfig-sub-routes/test
   - receiver: "null"
@@ -1626,7 +1626,6 @@ templates: []
 		require.NoError(t, err)
 		if diff := cmp.Diff(uncompressed, expected); diff != "" {
 			lastErr = fmt.Errorf("got(-), want(+):\n%s", diff)
-			fmt.Println(lastErr)
 			return false, nil
 		}
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1515,8 +1515,8 @@ route:
     - namespace="%s"
     continue: true
   - receiver: %s/e2e-test-amconfig-sub-routes/e2e
-    match:
-      service: webapp
+    matchers:
+    - service="webapp"
     matchers:
     - namespace="%s"
     continue: true
@@ -1525,20 +1525,20 @@ route:
       group_by:
       - env
       - instance
-      match:
-        job: db
+      matchers:
+      - job="db"
       routes:
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
-        match:
-          alertname: TargetDown
+        matchers:
+        - alertname="TargetDown"
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
         match_re:
           severity: critical|warning
         mute_time_intervals:
         - %s/e2e-test-amconfig-sub-routes/test
   - receiver: "null"
-    match:
-      alertname: DeadMansSwitch
+    matchers:
+    - alertname="DeadMansSwitch"
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
@@ -1660,8 +1660,8 @@ route:
   - job
   routes:
   - receiver: "null"
-    match:
-      alertname: DeadMansSwitch
+    matchers:
+    - alertname="DeadMansSwitch"
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
@@ -1922,8 +1922,8 @@ route:
   receiver: %[1]s
   routes:
   - receiver: %[1]s
-    match:
-      mykey: myvalue-1
+    matchers:
+    - mykey="myvalue-1"
 inhibit_rules:
 - target_matchers:
   - mykey="myvalue-2"
@@ -2618,14 +2618,14 @@ route:
   - job
   routes:
   - receiver: %s/amcfg-v1alpha1/webhook
-    match:
-      test: test
+    matchers:
+    - test="test"
     matchers:
     - namespace="%s"
     continue: true
   - receiver: "null"
-    match:
-      alertname: DeadMansSwitch
+    matchers:
+    - alertname="DeadMansSwitch"
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
@@ -2669,12 +2669,12 @@ route:
   - job
   routes:
   - receiver: %s/amcfg-v1alpha1/webhook
-    match:
-      test: test
+    matchers:
+    - test="test"
     continue: true
   - receiver: "null"
-    match:
-      alertname: DeadMansSwitch
+    matchers:
+    - alertname="DeadMansSwitch"
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1528,8 +1528,8 @@ route:
       - job="db"
       routes:
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
-        matchers:
-        - alertname="TargetDown"
+        match:
+          alertname: TargetDown
       - receiver: %s/e2e-test-amconfig-sub-routes/e2e
         match_re:
           severity: critical|warning


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Close #7569

Fix When MatchType is empty and AM version >= v0.22,  match to Regex bug

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
When MatchType is empty and AM version >= v0.22,  match to Regex bug
```
