### PR TITLE
feat: added e2e tests for invalid shards and PVCRetentionClaim policy specs in PrometheusAgents DaemonSet deployment model 

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -33288,10 +33288,19 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
+<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
+=======
+            - message: shards cannot be greater than 1 when mode is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
+                && self.shards > 1)'
+            - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
+                is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
+>>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -33288,19 +33288,16 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
-=======
             - message: shards cannot be greater than 1 when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
                 && self.shards > 1)'
             - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
                 is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
->>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -10742,19 +10742,16 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
-=======
             - message: shards cannot be greater than 1 when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
                 && self.shards > 1)'
             - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
                 is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
->>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -10742,10 +10742,19 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
+<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
+=======
+            - message: shards cannot be greater than 1 when mode is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
+                && self.shards > 1)'
+            - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
+                is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
+>>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -10743,10 +10743,19 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
+<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
+=======
+            - message: shards cannot be greater than 1 when mode is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
+                && self.shards > 1)'
+            - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
+                is DaemonSet
+              rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
+>>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -10743,19 +10743,16 @@ spec:
                 type: object
             type: object
             x-kubernetes-validations:
-<<<<<<< HEAD
             - message: replicas cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.replicas))'
             - message: storage cannot be set when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.storage))'
-=======
             - message: shards cannot be greater than 1 when mode is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shards)
                 && self.shards > 1)'
             - message: persistentVolumeClaimRetentionPolicy cannot be set when mode
                 is DaemonSet
               rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.persistentVolumeClaimRetentionPolicy))'
->>>>>>> 967a83b64 (ran make generate)
           status:
             description: |-
               Most recent observed status of the Prometheus cluster. Read-only.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -8859,21 +8859,20 @@
                 "type": "object",
                 "x-kubernetes-validations": [
                   {
-<<<<<<< HEAD
                     "message": "replicas cannot be set when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.replicas))"
                   },
                   {
                     "message": "storage cannot be set when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.storage))"
-=======
+                  },
+                  {
                     "message": "shards cannot be greater than 1 when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.shards) && self.shards > 1)"
                   },
                   {
                     "message": "persistentVolumeClaimRetentionPolicy cannot be set when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.persistentVolumeClaimRetentionPolicy))"
->>>>>>> 967a83b64 (ran make generate)
                   }
                 ]
               },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -8859,12 +8859,21 @@
                 "type": "object",
                 "x-kubernetes-validations": [
                   {
+<<<<<<< HEAD
                     "message": "replicas cannot be set when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.replicas))"
                   },
                   {
                     "message": "storage cannot be set when mode is DaemonSet",
                     "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.storage))"
+=======
+                    "message": "shards cannot be greater than 1 when mode is DaemonSet",
+                    "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.shards) && self.shards > 1)"
+                  },
+                  {
+                    "message": "persistentVolumeClaimRetentionPolicy cannot be set when mode is DaemonSet",
+                    "rule": "!(has(self.mode) && self.mode == 'DaemonSet' && has(self.persistentVolumeClaimRetentionPolicy))"
+>>>>>>> 967a83b64 (ran make generate)
                   }
                 ]
               },

--- a/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+++ b/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
@@ -94,6 +94,8 @@ func (l *PrometheusAgentList) DeepCopyObject() runtime.Object {
 // +k8s:openapi-gen=true
 // +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'DaemonSet' && has(self.replicas))",message="replicas cannot be set when mode is DaemonSet"
 // +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'DaemonSet' && has(self.storage))",message="storage cannot be set when mode is DaemonSet"
+// +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'DaemonSet' && has(self.shards) && self.shards > 1)",message="shards cannot be greater than 1 when mode is DaemonSet"
+// +kubebuilder:validation:XValidation:rule="!(has(self.mode) && self.mode == 'DaemonSet' && has(self.persistentVolumeClaimRetentionPolicy))",message="persistentVolumeClaimRetentionPolicy cannot be set when mode is DaemonSet"
 type PrometheusAgentSpec struct {
 	// Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).
 	//

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -645,6 +645,8 @@ type TargetsResponse struct {
 func testPrometheusAgentDaemonSetCELValidations(t *testing.T) {
 	t.Run("DaemonSetInvalidReplicas", testDaemonSetInvalidReplicas)
 	t.Run("DaemonSetInvalidStorage", testDaemonSetInvalidStorage)
+	t.Run("DaemonSetInvalidShards", testDaemonSetInvalidShards)
+	t.Run("DaemonSetInvalidPVCRetentionPolicy", testDaemonSetInvalidPVCRetentionPolicy)
 }
 
 func testDaemonSetInvalidReplicas(t *testing.T) {
@@ -714,7 +716,7 @@ func testDaemonSetInvalidStorage(t *testing.T) {
 	require.Contains(t, err.Error(), "storage cannot be set when mode is DaemonSet")
 }
 
-func testPrometheusAgentDaemonSetInvalidShards(t *testing.T) {
+func testDaemonSetInvalidShards(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)
@@ -742,7 +744,7 @@ func testPrometheusAgentDaemonSetInvalidShards(t *testing.T) {
 	require.Contains(t, err.Error(), "shards cannot be greater than 1 when mode is DaemonSet")
 }
 
-func testPrometheusAgentDaemonSetInvalidPVCRetentionPolicy(t *testing.T) {
+func testDaemonSetInvalidPVCRetentionPolicy(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	testCtx := framework.NewTestCtx(t)


### PR DESCRIPTION
## Description

This PR adds `kubebuilder` validations to PromAgent Daemonset mode for shards and pvcRetentionClaim


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
