### PR TITLE
Ability to update asset store from package consumers

### DIFF
--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -389,7 +389,9 @@ func (cos *cacheOnlyStore) TLSAsset(sel interface{}) string {
 	return k.toString()
 }
 
-func (s *StoreBuilder) UpdateObjStore(obj interface{}) error {
+// UpdateObject updates the object in the underlying store.
+// This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
+func (s *StoreBuilder) UpdateObject(obj interface{}) error {
 	if obj == nil {
 		return errors.New("object cannot be nil")
 	}

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -388,3 +388,15 @@ func (cos *cacheOnlyStore) TLSAsset(sel interface{}) string {
 
 	return k.toString()
 }
+
+func (s *StoreBuilder) UpdateObjStore(obj interface{}) error {
+	if obj == nil {
+		return errors.New("object cannot be nil")
+	}
+
+	if err := s.objStore.Update(obj); err != nil {
+		return fmt.Errorf("failed to update object in store: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -1171,7 +1171,7 @@ func TestAddAzureOAuth(t *testing.T) {
 	}
 }
 
-func TestUpdateObjStore(t *testing.T) {
+func TestUpdateObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1206,7 +1206,7 @@ func TestUpdateObjStore(t *testing.T) {
 			"key1": []byte("val2"),
 		},
 	}
-	err = store.UpdateObjStore(updatedSecret)
+	err = store.UpdateObject(updatedSecret)
 	require.NoError(t, err)
 
 	// Now, getting the key should return the updated value
@@ -1215,6 +1215,6 @@ func TestUpdateObjStore(t *testing.T) {
 	require.Equal(t, "val2", val)
 
 	// Test updating with nil object
-	err = store.UpdateObjStore(nil)
+	err = store.UpdateObject(nil)
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

[Opentelemetry operator](https://github.com/open-telemetry/opentelemetry-operator/tree/main) has a dependeny on prometheus-operator's packages to support detection of pod and service monitors. The targetallocator's [promOperator](https://github.com/open-telemetry/opentelemetry-operator/blob/16e6ccb3aa51c149278432e399ce31c8902af0e2/cmd/otel-allocator/internal/watcher/promOperator.go#L279) component responsible for watching pod and service monitors lacks the ability to pick up the latest changes to the secrets when they are updated. In order to do so a new secretinformer can be added which watches for the events and when a change is detected it needs to be able to update/delete objects from the object store so that the CRs can pick up the latest changes.

Currently the [storebuilder](https://github.com/prometheus-operator/prometheus-operator/blob/c4ebc762d0d2263541c67ebfe1ba7f2b419ed547/pkg/assets/store.go#L63) doesn't provide the ability to update the objStore when objects are updated. Can we extend this to add a couple methods that will provide for updating the store from consumers of this package - in this case promOperator.

Resolves #7591 
## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Tested with unit tests

## Changelog entry

Ability to update assets obj store

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Ability to update assets obj store for consumers of the assets package
```
