### PR TITLE
Ability to add, get and delete objects from asset store from package consumers

### DIFF
--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -389,6 +389,24 @@ func (cos *cacheOnlyStore) TLSAsset(sel interface{}) string {
 	return k.toString()
 }
 
+func (s *StoreBuilder) HasObject(obj interface{}) (bool, error) {
+	if obj == nil {
+		return false, errors.New("object cannot be nil")
+	}
+
+	key, err := assetKeyFunc(obj)
+	if err != nil {
+		return false, fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	_, exists, err := s.objStore.GetByKey(key)
+	if err != nil {
+		return false, fmt.Errorf("failed to check object in store: %w", err)
+	}
+
+	return exists, nil
+}
+
 // AddObject adds an object to the underlying store.
 // This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
 

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -402,3 +402,17 @@ func (s *StoreBuilder) UpdateObject(obj interface{}) error {
 
 	return nil
 }
+
+// DeleteObject updates the object in the underlying store.
+// This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
+func (s *StoreBuilder) DeleteObject(obj interface{}) error {
+	if obj == nil {
+		return errors.New("object cannot be nil")
+	}
+
+	if err := s.objStore.Delete(obj); err != nil {
+		return fmt.Errorf("failed to delete object in store: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -389,6 +389,45 @@ func (cos *cacheOnlyStore) TLSAsset(sel interface{}) string {
 	return k.toString()
 }
 
+// AddObject adds an object to the underlying store.
+// This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
+
+func (s *StoreBuilder) AddObject(obj interface{}) error {
+	if obj == nil {
+		return errors.New("object cannot be nil")
+	}
+
+	if err := s.objStore.Add(obj); err != nil {
+		return fmt.Errorf("failed to add object to store: %w", err)
+	}
+
+	return nil
+}
+
+// GetObject retrieves an object from the underlying store.
+// This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
+func (s *StoreBuilder) GetObject(obj interface{}) (interface{}, error) {
+	if obj == nil {
+		return nil, errors.New("object cannot be nil")
+	}
+
+	key, err := assetKeyFunc(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	item, exists, err := s.objStore.GetByKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get object from store: %w", err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("object with key %s not found in store", key)
+	}
+
+	return item, nil
+}
+
 // UpdateObject updates the object in the underlying store.
 // This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
 func (s *StoreBuilder) UpdateObject(obj interface{}) error {

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -389,6 +389,8 @@ func (cos *cacheOnlyStore) TLSAsset(sel interface{}) string {
 	return k.toString()
 }
 
+// HasObject checks if the object exists in the underlying store.
+// This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
 func (s *StoreBuilder) HasObject(obj interface{}) (bool, error) {
 	if obj == nil {
 		return false, errors.New("object cannot be nil")
@@ -409,7 +411,6 @@ func (s *StoreBuilder) HasObject(obj interface{}) (bool, error) {
 
 // AddObject adds an object to the underlying store.
 // This method is only used by external clients of the assets package such as the OpenTelemetry collector operator.
-
 func (s *StoreBuilder) AddObject(obj interface{}) error {
 	if obj == nil {
 		return errors.New("object cannot be nil")

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -1218,3 +1218,85 @@ func TestUpdateObject(t *testing.T) {
 	err = store.UpdateObject(nil)
 	require.Error(t, err)
 }
+func TestDeleteObject(t *testing.T) {
+	c := fake.NewSimpleClientset(
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "ns1",
+			},
+			Data: map[string][]byte{
+				"key1": []byte("val1"),
+			},
+		},
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm",
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				"cmKey": "cmVal",
+			},
+		},
+	)
+	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
+
+	// Add secret and configmap to the store by fetching them
+	secretSel := v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: "secret",
+		},
+		Key: "key1",
+	}
+	val, err := store.GetSecretKey(context.Background(), "ns1", secretSel)
+	require.NoError(t, err)
+	require.Equal(t, "val1", val)
+
+	cmSel := v1.ConfigMapKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{
+			Name: "cm",
+		},
+		Key: "cmKey",
+	}
+	_, err = store.GetConfigMapKey(context.Background(), "ns1", cmSel)
+	require.NoError(t, err)
+
+	// Try deleting the secret object
+	secretObj := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "ns1",
+		},
+	}
+	err = store.DeleteObject(secretObj)
+	require.NoError(t, err)
+
+	// Also delete the secret from the fake clientset to simulate full removal
+	err = c.CoreV1().Secrets("ns1").Delete(context.Background(), "secret", metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Now, getting the key should fail since the secret is deleted from the store
+	val, err = store.GetSecretKey(context.Background(), "ns1", secretSel)
+	require.Error(t, err)
+
+	// Try deleting the configmap object (should not error even if it doesn't exist in the client)
+	cmObj := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm",
+			Namespace: "ns1",
+		},
+	}
+	err = store.DeleteObject(cmObj)
+	require.NoError(t, err)
+
+	err = c.CoreV1().ConfigMaps("ns1").Delete(context.Background(), "cm", metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Now, getting the key should fail since the configmap is deleted from the store
+	_, err = store.GetConfigMapKey(context.Background(), "ns1", cmSel)
+	require.Error(t, err)
+
+	// Test deleting with nil object
+	err = store.DeleteObject(nil)
+	require.Error(t, err)
+}

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -1277,7 +1277,7 @@ func TestDeleteObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now, getting the key should fail since the secret is deleted from the store
-	val, err = store.GetSecretKey(context.Background(), "ns1", secretSel)
+	_, err = store.GetSecretKey(context.Background(), "ns1", secretSel)
 	require.Error(t, err)
 
 	// Try deleting the configmap object (should not error even if it doesn't exist in the client)

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -1218,6 +1218,7 @@ func TestUpdateObject(t *testing.T) {
 	err = store.UpdateObject(nil)
 	require.Error(t, err)
 }
+
 func TestDeleteObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
 		&v1.Secret{


### PR DESCRIPTION
## Description

[Opentelemetry operator](https://github.com/open-telemetry/opentelemetry-operator/tree/main) has a dependeny on prometheus-operator's packages to support detection of pod and service monitors. The targetallocator's [promOperator](https://github.com/open-telemetry/opentelemetry-operator/blob/16e6ccb3aa51c149278432e399ce31c8902af0e2/cmd/otel-allocator/internal/watcher/promOperator.go#L279) component responsible for watching pod and service monitors lacks the ability to pick up the latest changes to the secrets when they are updated/deleted. In order to do so a new secretinformer can be added which watches for the events and when a change is detected it needs to be able to update/delete objects( need add and get too to check the store before performing the operation) so that the CRs can pick up the latest changes.

Currently the [storebuilder](https://github.com/prometheus-operator/prometheus-operator/blob/c4ebc762d0d2263541c67ebfe1ba7f2b419ed547/pkg/assets/store.go#L63) doesn't provide the ability to update the objStore when objects are updated. Can we extend this to add methods to get, add, update and delete objects that will provide for updating the store from consumers of this package - in this case promOperator.

Resolves #7591 
## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Tested with unit tests

## Changelog entry

Ability to get, add and delete objects from assets obj store

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Ability to add, get and delete objects from assets obj store for consumers of the assets package
```
