### PR TITLE
feat: getPrometheusFromKey to sync with codestyle of other controller

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -943,21 +943,31 @@ func createSSetInputHash(p monitoringv1alpha1.PrometheusAgent, c prompkg.Config,
 	return fmt.Sprintf("%d", hash), nil
 }
 
+// getPrometheusFromKey returns a copy of the Prometheus object identified by key.
+// If the object is not found, it returns a nil pointer.
+func (c *Operator) getPrometheusFromKey(key string) (*monitoringv1alpha1.PrometheusAgent, error) {
+	obj, err := c.promInfs.Get(key)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.logger.Info("Prometheus not found", "key", key)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve Prometheus from informer: %w", err)
+	}
+
+	return obj.(*monitoringv1alpha1.PrometheusAgent).DeepCopy(), nil
+}
+
 // UpdateStatus updates the status subresource of the object identified by the given
 // key.
 // UpdateStatus implements the operator.Syncer interface.
 func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
-	pobj, err := c.promInfs.Get(key)
-
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
+	p, err := c.getPrometheusFromKey(key)
 	if err != nil {
 		return err
 	}
-	p := pobj.(*monitoringv1alpha1.PrometheusAgent)
-	p = p.DeepCopy()
-	if c.rr.DeletionInProgress(p) {
+
+	if p == nil || c.rr.DeletionInProgress(p) {
 		return nil
 	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1035,23 +1035,31 @@ func (c *Operator) shouldRetain(p *monitoringv1.Prometheus) (bool, error) {
 	return false, nil
 }
 
+// getPrometheusFromKey returns a copy of the Prometheus object identified by key.
+// If the object is not found, it returns a nil pointer.
+func (c *Operator) getPrometheusFromKey(key string) (*monitoringv1.Prometheus, error) {
+	obj, err := c.promInfs.Get(key)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.logger.Info("Prometheus not found", "key", key)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve Prometheus from informer: %w", err)
+	}
+
+	return obj.(*monitoringv1.Prometheus).DeepCopy(), nil
+}
+
 // UpdateStatus updates the status subresource of the object identified by the given
 // key.
 // UpdateStatus implements the operator.Syncer interface.
 func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
-	pobj, err := c.promInfs.Get(key)
-
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
+	p, err := c.getPrometheusFromKey(key)
 	if err != nil {
 		return err
 	}
 
-	p := pobj.(*monitoringv1.Prometheus)
-	p = p.DeepCopy()
-
-	if c.rr.DeletionInProgress(p) {
+	if p == nil || c.rr.DeletionInProgress(p) {
 		return nil
 	}
 	pStatus, err := c.statusReporter.Process(ctx, p, key)


### PR DESCRIPTION
## Description

fixes: #7600 


feat: getPrometheusFromKey to sync with codestyle of other controller

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```
NONE

```
