### PR TITLE
[release-0.82] Use the AlertmanagerConfig builder outside of the operator repo

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -200,9 +200,11 @@ func (ne *namespaceEnforcer) processRoute(crKey types.NamespacedName, r *route) 
 	return r
 }
 
-// configBuilder knows how to build an Alertmanager configuration from a raw
+// ConfigBuilder knows how to build an Alertmanager configuration from a raw
 // configuration and/or AlertmanagerConfig objects.
-type configBuilder struct {
+// The API is public because it's used by Grafana Alloy (https://github.com/grafana/alloy).
+// Note that the project makes no API stability guarantees.
+type ConfigBuilder struct {
 	cfg       *alertmanagerConfig
 	logger    *slog.Logger
 	amVersion semver.Version
@@ -210,8 +212,8 @@ type configBuilder struct {
 	enforcer  enforcer
 }
 
-func newConfigBuilder(logger *slog.Logger, amVersion semver.Version, store *assets.StoreBuilder, matcherStrategy monitoringv1.AlertmanagerConfigMatcherStrategy) *configBuilder {
-	cg := &configBuilder{
+func NewConfigBuilder(logger *slog.Logger, amVersion semver.Version, store *assets.StoreBuilder, matcherStrategy monitoringv1.AlertmanagerConfigMatcherStrategy) *ConfigBuilder {
+	cg := &ConfigBuilder{
 		logger:    logger,
 		amVersion: amVersion,
 		store:     store,
@@ -234,12 +236,12 @@ func getEnforcer(matcherStrategy monitoringv1.AlertmanagerConfigMatcherStrategy,
 	return &continueToNextRoute{e: e}
 }
 
-func (cb *configBuilder) marshalJSON() ([]byte, error) {
+func (cb *ConfigBuilder) MarshalJSON() ([]byte, error) {
 	return yaml.Marshal(cb.cfg)
 }
 
 // initializeFromAlertmanagerConfig initializes the configuration from an AlertmanagerConfig object.
-func (cb *configBuilder) initializeFromAlertmanagerConfig(ctx context.Context, globalConfig *monitoringv1.AlertmanagerGlobalConfig, amConfig *monitoringv1alpha1.AlertmanagerConfig) error {
+func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, globalConfig *monitoringv1.AlertmanagerGlobalConfig, amConfig *monitoringv1alpha1.AlertmanagerConfig) error {
 	globalAlertmanagerConfig := &alertmanagerConfig{}
 
 	crKey := types.NamespacedName{
@@ -300,8 +302,8 @@ func (cb *configBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 	return nil
 }
 
-// initializeFromRawConfiguration initializes the configuration from raw data.
-func (cb *configBuilder) initializeFromRawConfiguration(b []byte) error {
+// InitializeFromRawConfiguration initializes the configuration from raw data.
+func (cb *ConfigBuilder) InitializeFromRawConfiguration(b []byte) error {
 	globalAlertmanagerConfig, err := alertmanagerConfigFromBytes(b)
 	if err != nil {
 		return err
@@ -311,8 +313,8 @@ func (cb *configBuilder) initializeFromRawConfiguration(b []byte) error {
 	return nil
 }
 
-// addAlertmanagerConfigs adds AlertmanagerConfig objects to the current configuration.
-func (cb *configBuilder) addAlertmanagerConfigs(ctx context.Context, amConfigs map[string]*monitoringv1alpha1.AlertmanagerConfig) error {
+// AddAlertmanagerConfigs adds AlertmanagerConfig objects to the current configuration.
+func (cb *ConfigBuilder) AddAlertmanagerConfigs(ctx context.Context, amConfigs map[string]*monitoringv1alpha1.AlertmanagerConfig) error {
 	subRoutes := make([]*route, 0, len(amConfigs))
 	for _, amConfigIdentifier := range util.SortedKeys(amConfigs) {
 		crKey := types.NamespacedName{
@@ -373,7 +375,7 @@ func (cb *configBuilder) addAlertmanagerConfigs(ctx context.Context, amConfigs m
 	return cb.cfg.sanitize(cb.amVersion, cb.logger)
 }
 
-func (cb *configBuilder) getValidURLFromSecret(ctx context.Context, namespace string, selector v1.SecretKeySelector) (string, error) {
+func (cb *ConfigBuilder) getValidURLFromSecret(ctx context.Context, namespace string, selector v1.SecretKeySelector) (string, error) {
 	url, err := cb.store.GetSecretKey(ctx, namespace, selector)
 	if err != nil {
 		return "", fmt.Errorf("failed to get URL: %w", err)
@@ -386,7 +388,7 @@ func (cb *configBuilder) getValidURLFromSecret(ctx context.Context, namespace st
 	return url, nil
 }
 
-func (cb *configBuilder) convertGlobalConfig(ctx context.Context, in *monitoringv1.AlertmanagerGlobalConfig, crKey types.NamespacedName) (*globalConfig, error) {
+func (cb *ConfigBuilder) convertGlobalConfig(ctx context.Context, in *monitoringv1.AlertmanagerGlobalConfig, crKey types.NamespacedName) (*globalConfig, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -467,7 +469,7 @@ func (cb *configBuilder) convertGlobalConfig(ctx context.Context, in *monitoring
 	return out, nil
 }
 
-func (cb *configBuilder) convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName) *route {
+func (cb *ConfigBuilder) convertRoute(in *monitoringv1alpha1.Route, crKey types.NamespacedName) *route {
 	if in == nil {
 		return nil
 	}
@@ -539,7 +541,7 @@ func (cb *configBuilder) convertRoute(in *monitoringv1alpha1.Route, crKey types.
 }
 
 // convertReceiver converts a monitoringv1alpha1.Receiver to an alertmanager.receiver.
-func (cb *configBuilder) convertReceiver(ctx context.Context, in *monitoringv1alpha1.Receiver, crKey types.NamespacedName) (*receiver, error) {
+func (cb *ConfigBuilder) convertReceiver(ctx context.Context, in *monitoringv1alpha1.Receiver, crKey types.NamespacedName) (*receiver, error) {
 	var pagerdutyConfigs []*pagerdutyConfig
 	if l := len(in.PagerDutyConfigs); l > 0 {
 		pagerdutyConfigs = make([]*pagerdutyConfig, l)
@@ -727,7 +729,7 @@ func (cb *configBuilder) convertReceiver(ctx context.Context, in *monitoringv1al
 	}, nil
 }
 
-func (cb *configBuilder) convertWebhookConfig(ctx context.Context, in monitoringv1alpha1.WebhookConfig, crKey types.NamespacedName) (*webhookConfig, error) {
+func (cb *ConfigBuilder) convertWebhookConfig(ctx context.Context, in monitoringv1alpha1.WebhookConfig, crKey types.NamespacedName) (*webhookConfig, error) {
 	out := &webhookConfig{
 		VSendResolved: in.SendResolved,
 	}
@@ -769,7 +771,7 @@ func (cb *configBuilder) convertWebhookConfig(ctx context.Context, in monitoring
 	return out, nil
 }
 
-func (cb *configBuilder) convertDiscordConfig(ctx context.Context, in monitoringv1alpha1.DiscordConfig, crKey types.NamespacedName) (*discordConfig, error) {
+func (cb *ConfigBuilder) convertDiscordConfig(ctx context.Context, in monitoringv1alpha1.DiscordConfig, crKey types.NamespacedName) (*discordConfig, error) {
 	out := &discordConfig{
 		VSendResolved: in.SendResolved,
 	}
@@ -809,7 +811,7 @@ func (cb *configBuilder) convertDiscordConfig(ctx context.Context, in monitoring
 	return out, nil
 }
 
-func (cb *configBuilder) convertSlackConfig(ctx context.Context, in monitoringv1alpha1.SlackConfig, crKey types.NamespacedName) (*slackConfig, error) {
+func (cb *ConfigBuilder) convertSlackConfig(ctx context.Context, in monitoringv1alpha1.SlackConfig, crKey types.NamespacedName) (*slackConfig, error) {
 	out := &slackConfig{
 		VSendResolved: in.SendResolved,
 		Channel:       in.Channel,
@@ -891,7 +893,7 @@ func (cb *configBuilder) convertSlackConfig(ctx context.Context, in monitoringv1
 	return out, nil
 }
 
-func (cb *configBuilder) convertPagerdutyConfig(ctx context.Context, in monitoringv1alpha1.PagerDutyConfig, crKey types.NamespacedName) (*pagerdutyConfig, error) {
+func (cb *ConfigBuilder) convertPagerdutyConfig(ctx context.Context, in monitoringv1alpha1.PagerDutyConfig, crKey types.NamespacedName) (*pagerdutyConfig, error) {
 	out := &pagerdutyConfig{
 		VSendResolved: in.SendResolved,
 		Class:         in.Class,
@@ -967,7 +969,7 @@ func (cb *configBuilder) convertPagerdutyConfig(ctx context.Context, in monitori
 	return out, nil
 }
 
-func (cb *configBuilder) convertOpsgenieConfig(ctx context.Context, in monitoringv1alpha1.OpsGenieConfig, crKey types.NamespacedName) (*opsgenieConfig, error) {
+func (cb *ConfigBuilder) convertOpsgenieConfig(ctx context.Context, in monitoringv1alpha1.OpsGenieConfig, crKey types.NamespacedName) (*opsgenieConfig, error) {
 	out := &opsgenieConfig{
 		VSendResolved: in.SendResolved,
 		APIURL:        in.APIURL,
@@ -1023,7 +1025,7 @@ func (cb *configBuilder) convertOpsgenieConfig(ctx context.Context, in monitorin
 	return out, nil
 }
 
-func (cb *configBuilder) convertWeChatConfig(ctx context.Context, in monitoringv1alpha1.WeChatConfig, crKey types.NamespacedName) (*weChatConfig, error) {
+func (cb *ConfigBuilder) convertWeChatConfig(ctx context.Context, in monitoringv1alpha1.WeChatConfig, crKey types.NamespacedName) (*weChatConfig, error) {
 	out := &weChatConfig{
 		VSendResolved: in.SendResolved,
 		APIURL:        in.APIURL,
@@ -1053,7 +1055,7 @@ func (cb *configBuilder) convertWeChatConfig(ctx context.Context, in monitoringv
 	return out, nil
 }
 
-func (cb *configBuilder) convertWebexConfig(ctx context.Context, in monitoringv1alpha1.WebexConfig, crKey types.NamespacedName) (*webexConfig, error) {
+func (cb *ConfigBuilder) convertWebexConfig(ctx context.Context, in monitoringv1alpha1.WebexConfig, crKey types.NamespacedName) (*webexConfig, error) {
 	out := &webexConfig{
 		VSendResolved: in.SendResolved,
 		RoomID:        in.RoomID,
@@ -1076,7 +1078,7 @@ func (cb *configBuilder) convertWebexConfig(ctx context.Context, in monitoringv1
 	return out, nil
 }
 
-func (cb *configBuilder) convertEmailConfig(ctx context.Context, in monitoringv1alpha1.EmailConfig, crKey types.NamespacedName) (*emailConfig, error) {
+func (cb *ConfigBuilder) convertEmailConfig(ctx context.Context, in monitoringv1alpha1.EmailConfig, crKey types.NamespacedName) (*emailConfig, error) {
 	out := &emailConfig{
 		VSendResolved: in.SendResolved,
 		To:            in.To,
@@ -1136,7 +1138,7 @@ func (cb *configBuilder) convertEmailConfig(ctx context.Context, in monitoringv1
 	return out, nil
 }
 
-func (cb *configBuilder) convertVictorOpsConfig(ctx context.Context, in monitoringv1alpha1.VictorOpsConfig, crKey types.NamespacedName) (*victorOpsConfig, error) {
+func (cb *ConfigBuilder) convertVictorOpsConfig(ctx context.Context, in monitoringv1alpha1.VictorOpsConfig, crKey types.NamespacedName) (*victorOpsConfig, error) {
 	out := &victorOpsConfig{
 		VSendResolved:     in.SendResolved,
 		APIURL:            in.APIURL,
@@ -1186,7 +1188,7 @@ func (cb *configBuilder) convertVictorOpsConfig(ctx context.Context, in monitori
 	return out, nil
 }
 
-func (cb *configBuilder) convertPushoverConfig(ctx context.Context, in monitoringv1alpha1.PushoverConfig, crKey types.NamespacedName) (*pushoverConfig, error) {
+func (cb *ConfigBuilder) convertPushoverConfig(ctx context.Context, in monitoringv1alpha1.PushoverConfig, crKey types.NamespacedName) (*pushoverConfig, error) {
 	out := &pushoverConfig{
 		VSendResolved: in.SendResolved,
 		Title:         in.Title,
@@ -1254,7 +1256,7 @@ func (cb *configBuilder) convertPushoverConfig(ctx context.Context, in monitorin
 	return out, nil
 }
 
-func (cb *configBuilder) convertTelegramConfig(ctx context.Context, in monitoringv1alpha1.TelegramConfig, crKey types.NamespacedName) (*telegramConfig, error) {
+func (cb *ConfigBuilder) convertTelegramConfig(ctx context.Context, in monitoringv1alpha1.TelegramConfig, crKey types.NamespacedName) (*telegramConfig, error) {
 	out := &telegramConfig{
 		VSendResolved:        in.SendResolved,
 		APIUrl:               in.APIURL,
@@ -1288,7 +1290,7 @@ func (cb *configBuilder) convertTelegramConfig(ctx context.Context, in monitorin
 	return out, nil
 }
 
-func (cb *configBuilder) convertSnsConfig(ctx context.Context, in monitoringv1alpha1.SNSConfig, crKey types.NamespacedName) (*snsConfig, error) {
+func (cb *ConfigBuilder) convertSnsConfig(ctx context.Context, in monitoringv1alpha1.SNSConfig, crKey types.NamespacedName) (*snsConfig, error) {
 	out := &snsConfig{
 		VSendResolved: in.SendResolved,
 		APIUrl:        in.ApiURL,
@@ -1332,7 +1334,7 @@ func (cb *configBuilder) convertSnsConfig(ctx context.Context, in monitoringv1al
 	return out, nil
 }
 
-func (cb *configBuilder) convertMSTeamsConfig(
+func (cb *ConfigBuilder) convertMSTeamsConfig(
 	ctx context.Context, in monitoringv1alpha1.MSTeamsConfig, crKey types.NamespacedName,
 ) (*msTeamsConfig, error) {
 	out := &msTeamsConfig{
@@ -1367,7 +1369,7 @@ func (cb *configBuilder) convertMSTeamsConfig(
 	return out, nil
 }
 
-func (cb *configBuilder) convertMSTeamsV2Config(
+func (cb *ConfigBuilder) convertMSTeamsV2Config(
 	ctx context.Context, in monitoringv1alpha1.MSTeamsV2Config, crKey types.NamespacedName,
 ) (*msTeamsV2Config, error) {
 	out := &msTeamsV2Config{
@@ -1400,7 +1402,7 @@ func (cb *configBuilder) convertMSTeamsV2Config(
 	return out, nil
 }
 
-func (cb *configBuilder) convertInhibitRule(in *monitoringv1alpha1.InhibitRule) *inhibitRule {
+func (cb *ConfigBuilder) convertInhibitRule(in *monitoringv1alpha1.InhibitRule) *inhibitRule {
 	matchersV2Allowed := cb.amVersion.GTE(semver.MustParse("0.22.0"))
 	var sourceMatchers []string
 	var targetMatchers []string
@@ -1548,7 +1550,7 @@ func makeNamespacedString(in string, crKey types.NamespacedName) string {
 	return crKey.Namespace + "/" + crKey.Name + "/" + in
 }
 
-func (cb *configBuilder) convertSMTPConfig(ctx context.Context, out *globalConfig, in monitoringv1.GlobalSMTPConfig, crKey types.NamespacedName) error {
+func (cb *ConfigBuilder) convertSMTPConfig(ctx context.Context, out *globalConfig, in monitoringv1.GlobalSMTPConfig, crKey types.NamespacedName) error {
 	if in.From != nil {
 		out.SMTPFrom = *in.From
 	}
@@ -1588,7 +1590,7 @@ func (cb *configBuilder) convertSMTPConfig(ctx context.Context, out *globalConfi
 }
 
 // convertHTTPConfig converts the HTTPConfig CRD field to the internal configuration struct.
-func (cb *configBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1alpha1.HTTPConfig, crKey types.NamespacedName) (*httpClientConfig, error) {
+func (cb *ConfigBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1alpha1.HTTPConfig, crKey types.NamespacedName) (*httpClientConfig, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -1682,7 +1684,7 @@ func (cb *configBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1
 	return out, nil
 }
 
-func (cb *configBuilder) convertTLSConfig(in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) *tlsConfig {
+func (cb *ConfigBuilder) convertTLSConfig(in *monitoringv1.SafeTLSConfig, crKey types.NamespacedName) *tlsConfig {
 	out := tlsConfig{}
 
 	if in.ServerName != nil {
@@ -1710,7 +1712,7 @@ func (cb *configBuilder) convertTLSConfig(in *monitoringv1.SafeTLSConfig, crKey 
 	return &out
 }
 
-func (cb *configBuilder) convertProxyConfig(ctx context.Context, in monitoringv1.ProxyConfig, crKey types.NamespacedName) (proxyConfig, error) {
+func (cb *ConfigBuilder) convertProxyConfig(ctx context.Context, in monitoringv1.ProxyConfig, crKey types.NamespacedName) (proxyConfig, error) {
 	out := proxyConfig{}
 
 	if in.ProxyURL != nil {

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -790,7 +790,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 				},
 			},
 		)
-		cb := newConfigBuilder(
+		cb := NewConfigBuilder(
 			newNopLogger(t),
 			*tt.amVersion,
 			assets.NewStoreBuilder(kclient.CoreV1(), kclient.CoreV1()),
@@ -2564,16 +2564,16 @@ func TestGenerateConfig(t *testing.T) {
 				tc.amVersion = &version
 			}
 
-			cb := newConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
+			cb := NewConfigBuilder(logger, *tc.amVersion, store, tc.matcherStrategy)
 			cb.cfg = &tc.baseConfig
 
 			if tc.expectedError {
-				require.Error(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
+				require.Error(t, cb.AddAlertmanagerConfigs(context.Background(), tc.amConfigs))
 				return
 			}
-			require.NoError(t, cb.addAlertmanagerConfigs(context.Background(), tc.amConfigs))
+			require.NoError(t, cb.AddAlertmanagerConfigs(context.Background(), tc.amConfigs))
 
-			cfgBytes, err := cb.marshalJSON()
+			cfgBytes, err := cb.MarshalJSON()
 			require.NoError(t, err)
 
 			// Verify the generated yaml is as expected
@@ -4890,7 +4890,7 @@ func TestConvertHTTPConfig(t *testing.T) {
 			v, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 			require.NoError(t, err)
 
-			cb := newConfigBuilder(
+			cb := NewConfigBuilder(
 				newNopLogger(t),
 				v,
 				nil,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -861,7 +861,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 	var (
 		additionalData map[string][]byte
-		cfgBuilder     = newConfigBuilder(namespacedLogger, version, store, am.Spec.AlertmanagerConfigMatcherStrategy)
+		cfgBuilder     = NewConfigBuilder(namespacedLogger, version, store, am.Spec.AlertmanagerConfigMatcherStrategy)
 	)
 
 	if am.Spec.AlertmanagerConfiguration != nil {
@@ -897,17 +897,17 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
-		err = cfgBuilder.initializeFromRawConfiguration(amRawConfiguration)
+		err = cfgBuilder.InitializeFromRawConfiguration(amRawConfiguration)
 		if err != nil {
 			return fmt.Errorf("failed to initialize from secret: %w", err)
 		}
 	}
 
-	if err := cfgBuilder.addAlertmanagerConfigs(ctx, amConfigs); err != nil {
+	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigs); err != nil {
 		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 
-	generatedConfig, err := cfgBuilder.marshalJSON()
+	generatedConfig, err := cfgBuilder.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}


### PR DESCRIPTION
This change cherry picks  #7486 onto the [release-0.82](https://github.com/prometheus-operator/prometheus-operator/commits/release-0.82/) branch. I hope that this is ok? I [asked](https://github.com/prometheus-operator/prometheus-operator/pull/7486#issuecomment-2980632149) about it in the PR which was merged to `main` but didn't get a reply so I decided to open a PR for us to discuss it here.

It is difficult to use v0.83 in projects which also import OTel Collector and Prometheus, because the Prometheus Operator uses a more recent version of `k8s.io/api`.
* [Updating OTel](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39725) is not straightforward because it also requires an update of the Go version, but the project [can't do that](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38970#issuecomment-2980476964) until Go 1.25 is released.
* Updating Prometheus would be easier, but it requires transitioning away from some deprecated fields which I didn't have time to do and test just for the Alertmanager CRD project.

If it's a standard practice to patch the release branch then I'd be very grateful if we do 🙏  But if it's not desirable I could wait a while for Prometheus and OTel to be updated, it shouldn't be a huge problem.