### PR TITLE
fix: reconcile workload configurations when a referenced secret/configmap key is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [CHANGE/BUGFIX] Add the `--watch-referenced-objects-in-all-namespaces` CLI argument. When enabled, the operator watches for secrets and configmaps in both workload and configuration resources. It ensures that reconciliation happens when a referenced secret/configmap is updated. #7615
+
 ## 0.84.0 / 2025-07-14
 
 * [FEATURE] Add `telegram` field to AlertManager CRD global configuration. #7631

--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -106,6 +106,11 @@ Usage of ./operator:
     	- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.
   -version
     	Prints current version.
+  -watch-referenced-objects-in-all-namespaces
+    	When true the operator watches for configmaps and secrets in both workload and configuration resource namespaces.
+    	When false (default), the operator will only watch for secrets and configmaps in:
+    	* Workload namespaces for Prometheus and PrometheusAgent resources.
+    	* Configuration namespaces for Alertmanager resources.
   -web.cert-file string
     	Certficate file to be used for the web server. (default "/etc/tls/private/tls.crt")
   -web.client-ca-file string

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -168,6 +168,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(cfg.Namespaces.AlertmanagerAllowList, "alertmanager-instance-namespaces", "Namespaces where Alertmanager custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Alertmanager custom resources.")
 	fs.Var(cfg.Namespaces.AlertmanagerConfigAllowList, "alertmanager-config-namespaces", "Namespaces where AlertmanagerConfig custom resources and corresponding Secrets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for AlertmanagerConfig custom resources.")
 	fs.Var(cfg.Namespaces.ThanosRulerAllowList, "thanos-ruler-instance-namespaces", "Namespaces where ThanosRuler custom resources and corresponding StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for ThanosRuler custom resources.")
+	fs.BoolVar(&cfg.WatchObjectRefsInAllNamespaces, "watch-referenced-objects-in-all-namespaces", false, "When true the operator watches for configmaps and secrets in both workload and configuration resource namespaces.\nWhen false (default), the operator will only watch for secrets and configmaps in:\n* Workload namespaces for Prometheus and PrometheusAgent resources.\n* Configuration namespaces for Alertmanager resources.")
 
 	fs.Var(&cfg.Annotations, "annotations", "Annotations to be add to all resources created by the operator")
 	fs.Var(&cfg.Labels, "labels", "Labels to be add to all resources created by the operator")
@@ -212,19 +213,21 @@ func run(fs *flag.FlagSet) int {
 	}
 
 	logger.Info("Starting Prometheus Operator", "version", version.Info(), "build_context", version.BuildContext(), "feature_gates", cfg.Gates.String())
+	logger.Info("Operator's configuration",
+		"watch_referenced_objects_in_all_namespaces", cfg.WatchObjectRefsInAllNamespaces,
+		"controller_id", cfg.ControllerID,
+		"enable_config_reloader_probes", cfg.ReloaderConfig.EnableProbes)
 	goruntime.SetMaxProcs(logger)
 	goruntime.SetMemLimit(logger, memlimitRatio)
 
 	if len(cfg.Namespaces.AllowList) > 0 && len(cfg.Namespaces.DenyList) > 0 {
-		logger.Error(
-			"--namespaces and --deny-namespaces are mutually exclusive, only one should be provided",
-			"namespaces", cfg.Namespaces.AllowList,
-			"deny_namespaces", cfg.Namespaces.DenyList,
-		)
 		return 1
 	}
-	cfg.Namespaces.Finalize()
-	logger.Info("namespaces filtering configuration ", "config", cfg.Namespaces.String())
+	if err := cfg.Namespaces.Finalize(); err != nil {
+		logger.Error("failed to parse namespaces configuration", "configuration", cfg.Namespaces.String(), "error", err)
+		return 1
+	}
+	logger.Info("Namespaces filtering configuration ", "config", cfg.Namespaces.String())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -91,6 +91,7 @@ type Operator struct {
 
 	alrtInfs    *informers.ForResource
 	alrtCfgInfs *informers.ForResource
+	cmapInfs    *informers.ForResource
 	secrInfs    *informers.ForResource
 	ssetInfs    *informers.ForResource
 
@@ -245,11 +246,26 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 				options.LabelSelector = config.SecretListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource("secrets"),
+		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
 		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating secret informers: %w", err)
+	}
+
+	c.cmapInfs, err = informers.NewInformersForResourceWithTransform(
+		informers.NewMetadataInformerFactory(
+			allowList,
+			config.Namespaces.DenyList,
+			c.mdClient,
+			resyncPeriod,
+			nil,
+		),
+		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating configmap informers: %w", err)
 	}
 
 	c.ssetInfs, err = informers.NewInformersForResource(
@@ -314,6 +330,7 @@ func (c *Operator) waitForCacheSync(ctx context.Context) error {
 		{"Alertmanager", c.alrtInfs},
 		{"AlertmanagerConfig", c.alrtCfgInfs},
 		{"Secret", c.secrInfs},
+		{"ConfigMap", c.cmapInfs},
 		{"StatefulSet", c.ssetInfs},
 	} {
 		for _, inf := range infs.informersForResource.GetInformers() {
@@ -353,12 +370,26 @@ func (c *Operator) addHandlers() {
 		c.enqueueForNamespace,
 	))
 
-	c.secrInfs.AddEventHandler(operator.NewEventHandler(
+	hasRefFunc := operator.HasReferenceFunc(
+		c.alrtInfs,
+		c.reconciliations,
+	)
+	c.secrInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
 		c.enqueueForNamespace,
+		hasRefFunc,
+	))
+
+	c.cmapInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+		c.logger,
+		c.accessor,
+		c.metrics,
+		"ConfigMap",
+		c.enqueueForNamespace,
+		hasRefFunc,
 	))
 
 	// The controller needs to watch the namespaces in which the
@@ -428,6 +459,7 @@ func (c *Operator) Run(ctx context.Context) error {
 	go c.alrtInfs.Start(ctx.Done())
 	go c.alrtCfgInfs.Start(ctx.Done())
 	go c.secrInfs.Start(ctx.Done())
+	go c.cmapInfs.Start(ctx.Done())
 	go c.ssetInfs.Start(ctx.Done())
 	go c.nsAlrtCfgInf.Run(ctx.Done())
 	if c.nsAlrtInf != c.nsAlrtCfgInf {
@@ -559,6 +591,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {
 		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
+	c.reconciliations.UpdateReferenceTracker(key, assetStore.RefTracker())
 
 	tlsShardedSecret, err := operator.ReconcileShardedSecret(ctx, assetStore.TLSAssets(), c.kclient, c.newTLSAssetSecret(am))
 	if err != nil {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -226,9 +226,17 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 		return fmt.Errorf("error creating alertmanagerconfig informers: %w", err)
 	}
 
+	allowList := config.Namespaces.AlertmanagerConfigAllowList
+	if config.WatchObjectRefsInAllNamespaces {
+		allowList = operator.MergeAllowLists(
+			config.Namespaces.AlertmanagerAllowList,
+			config.Namespaces.AlertmanagerConfigAllowList,
+		)
+	}
+
 	c.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			operator.MergeStringSets(config.Namespaces.AlertmanagerAllowList, config.Namespaces.AlertmanagerConfigAllowList),
+			allowList,
 			config.Namespaces.DenyList,
 			c.mdClient,
 			resyncPeriod,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -374,22 +374,22 @@ func (c *Operator) addHandlers() {
 		c.alrtInfs,
 		c.reconciliations,
 	)
-	c.secrInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.secrInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
 		c.enqueueForNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
-	c.cmapInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"ConfigMap",
 		c.enqueueForNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
 	// The controller needs to watch the namespaces in which the

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -228,7 +228,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 
 	c.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			config.Namespaces.AlertmanagerConfigAllowList,
+			operator.MergeStringSets(config.Namespaces.AlertmanagerAllowList, config.Namespaces.AlertmanagerConfigAllowList),
 			config.Namespaces.DenyList,
 			c.mdClient,
 			resyncPeriod,
@@ -238,7 +238,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 			},
 		),
 		v1.SchemeGroupVersion.WithResource("secrets"),
-		informers.PartialObjectMetadataStrip,
+		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating secret informers: %w", err)

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -36,9 +38,10 @@ import (
 //
 // StoreBuilder doesn't support concurrent access.
 type StoreBuilder struct {
-	cmClient corev1client.ConfigMapsGetter
-	sClient  corev1client.SecretsGetter
-	objStore cache.Store
+	cmClient   corev1client.ConfigMapsGetter
+	sClient    corev1client.SecretsGetter
+	objStore   cache.Store
+	refTracker RefTracker
 
 	tlsAssetKeys map[tlsAssetKey]struct{}
 }
@@ -46,9 +49,7 @@ type StoreBuilder struct {
 // NewTestStoreBuilder returns a *StoreBuilder already initialized with the
 // provided objects. It is only used in tests.
 func NewTestStoreBuilder(objects ...interface{}) *StoreBuilder {
-	sb := &StoreBuilder{
-		objStore: cache.NewStore(assetKeyFunc),
-	}
+	sb := newStoreBuilder()
 
 	for _, o := range objects {
 		if err := sb.objStore.Add(o); err != nil {
@@ -61,24 +62,66 @@ func NewTestStoreBuilder(objects ...interface{}) *StoreBuilder {
 
 // NewStoreBuilder returns an object that can fetch data from ConfigMaps and Secrets.
 func NewStoreBuilder(cmClient corev1client.ConfigMapsGetter, sClient corev1client.SecretsGetter) *StoreBuilder {
+	sb := newStoreBuilder()
+	sb.cmClient = cmClient
+	sb.sClient = sClient
+
+	return sb
+}
+
+func newStoreBuilder() *StoreBuilder {
 	return &StoreBuilder{
-		cmClient:     cmClient,
-		sClient:      sClient,
-		tlsAssetKeys: make(map[tlsAssetKey]struct{}),
 		objStore:     cache.NewStore(assetKeyFunc),
+		tlsAssetKeys: make(map[tlsAssetKey]struct{}),
+		refTracker:   RefTracker{},
 	}
 }
 
-// assetKeyFunc returns a unique key for a ConfigMap or Secret object.
+// assetKeyFunc returns a unique key for a ConfigMap, a Secret or a runtime.Object.
 func assetKeyFunc(obj interface{}) (string, error) {
 	switch v := obj.(type) {
 	case *v1.ConfigMap:
-		return fmt.Sprintf("%d/%s/%s", fromConfigMap, v.GetNamespace(), v.GetName()), nil
+		return configMapKey(v), nil
+
 	case *v1.Secret:
-		return fmt.Sprintf("%d/%s/%s", fromSecret, v.GetNamespace(), v.GetName()), nil
+		return secretKey(v), nil
+
+	case runtime.Object:
+		gvk := v.GetObjectKind().GroupVersionKind()
+		if gvk.GroupVersion().String() != "v1" {
+			return "", fmt.Errorf("unsupported API Group %q", gvk.GroupVersion())
+		}
+
+		objMeta, err := meta.Accessor(obj)
+		if err != nil {
+			return "", fmt.Errorf("metadata missing: %w", err)
+		}
+
+		switch gvk.Kind {
+		case "ConfigMap":
+			return configMapKey(objMeta), nil
+		case "Secret":
+			return secretKey(objMeta), nil
+		}
+
+		return "", fmt.Errorf("unsupported kind %q", gvk.Kind)
 	}
 
 	return "", fmt.Errorf("unsupported type: %T", obj)
+}
+
+func configMapKey(objMeta metav1.Object) string {
+	return fmt.Sprintf("%d/%s/%s", fromConfigMap, objMeta.GetNamespace(), objMeta.GetName())
+}
+
+func secretKey(objMeta metav1.Object) string {
+	return fmt.Sprintf("%d/%s/%s", fromSecret, objMeta.GetNamespace(), objMeta.GetName())
+}
+
+// RefTracker returns a RefTracker for the items loaded in the store.
+// It is safe to use after the StoreBuilder has been deleted.
+func (s *StoreBuilder) RefTracker() RefTracker {
+	return s.refTracker
 }
 
 // AddBasicAuth processes the given *BasicAuth and adds the referenced credentials to the store.
@@ -237,12 +280,14 @@ func (s *StoreBuilder) GetConfigMapKey(ctx context.Context, namespace string, se
 		return "", errors.New("namespace cannot be empty")
 	}
 
-	obj, exists, err := s.objStore.Get(&v1.ConfigMap{
+	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sel.Name,
 			Namespace: namespace,
 		},
-	})
+	}
+	s.refTracker.insert(cm)
+	obj, exists, err := s.objStore.Get(cm)
 	if err != nil {
 		return "", fmt.Errorf("unexpected store error when getting configmap %q: %w", sel.Name, err)
 	}
@@ -258,7 +303,7 @@ func (s *StoreBuilder) GetConfigMapKey(ctx context.Context, namespace string, se
 		obj = cm
 	}
 
-	cm := obj.(*v1.ConfigMap)
+	cm = obj.(*v1.ConfigMap)
 	if _, found := cm.Data[sel.Key]; !found {
 		return "", fmt.Errorf("key %q in configmap %q not found", sel.Key, sel.Name)
 	}
@@ -272,12 +317,14 @@ func (s *StoreBuilder) GetSecretKey(ctx context.Context, namespace string, sel v
 		return "", errors.New("namespace cannot be empty")
 	}
 
-	obj, exists, err := s.objStore.Get(&v1.Secret{
+	sec := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sel.Name,
 			Namespace: namespace,
 		},
-	})
+	}
+	s.refTracker.insert(sec)
+	obj, exists, err := s.objStore.Get(sec)
 	if err != nil {
 		return "", fmt.Errorf("unexpected store error when getting secret %q: %w", sel.Name, err)
 	}

--- a/pkg/assets/tracker.go
+++ b/pkg/assets/tracker.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assets
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// RefTracker is a set-based struct which records the references to secrets and
+// configmaps.
+type RefTracker map[string]struct{}
+
+// insert records the object in the tracker.
+func (r RefTracker) insert(obj interface{}) {
+	key, err := assetKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	r[key] = struct{}{}
+}
+
+// Has returns true if the tracker knows about the given object.
+func (r RefTracker) Has(obj runtime.Object) bool {
+	key, err := assetKeyFunc(obj)
+	if err != nil {
+		return false
+	}
+
+	_, found := r[key]
+	return found
+}

--- a/pkg/assets/tracker_test.go
+++ b/pkg/assets/tracker_test.go
@@ -1,0 +1,157 @@
+// Copyright 2020 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestHasRefTo(t *testing.T) {
+	c := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "ns1",
+			},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "ns1",
+			},
+			Data: map[string][]byte{
+				"key1": []byte("val1"),
+			},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: "ns1",
+			},
+			Data: map[string][]byte{
+				"key1": []byte("val1"),
+			},
+		},
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cm",
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				"cmCA":   caPEM,
+				"cmCert": certPEM,
+				"cmKey":  keyPEM,
+			},
+		},
+	)
+
+	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
+
+	// This secret reference is valid.
+	_, err := store.GetSecretKey(
+		context.Background(),
+		"ns1",
+		v1.SecretKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: "secret",
+			},
+			Key: "key1",
+		})
+	require.NoError(t, err)
+
+	// This secret doesn't exist but it should be recorded in the RefTracker.
+	_, err = store.GetSecretKey(
+		context.Background(),
+		"ns1",
+		v1.SecretKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: "nosecret",
+			},
+			Key: "key1",
+		})
+	require.Error(t, err)
+
+	// This configmap reference is valid.
+	_, err = store.GetConfigMapKey(
+		context.Background(),
+		"ns1",
+		v1.ConfigMapKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: "cm",
+			},
+			Key: "cmCA",
+		})
+	require.NoError(t, err)
+
+	// This configmap doesn't exist but it should be recorded in the RefTracker.
+	_, err = store.GetConfigMapKey(
+		context.Background(),
+		"ns1",
+		v1.ConfigMapKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: "nocm",
+			},
+			Key: "key1",
+		})
+	require.Error(t, err)
+
+	refTracker := store.RefTracker()
+
+	secret, err := c.CoreV1().Secrets("ns1").Get(context.Background(), "secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, refTracker.Has(secret))
+
+	_, err = c.CoreV1().Secrets("ns1").Get(context.Background(), "nosecret", metav1.GetOptions{})
+	require.Error(t, err)
+	require.True(t, refTracker.Has(
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nosecret",
+				Namespace: "ns1",
+			},
+		}),
+	)
+
+	cm, err := c.CoreV1().ConfigMaps("ns1").Get(context.Background(), "cm", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, refTracker.Has(cm))
+
+	_, err = c.CoreV1().Secrets("ns1").Get(context.Background(), "nocm", metav1.GetOptions{})
+	require.Error(t, err)
+	require.True(t, refTracker.Has(
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nocm",
+				Namespace: "ns1",
+			},
+		}),
+	)
+
+	// This secret has no reference.
+	secret, err = c.CoreV1().Secrets("ns1").Get(context.Background(), "secret2", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.False(t, refTracker.Has(secret))
+
+	// This object's kind is not supported.
+	pod, err := c.CoreV1().Pods("ns1").Get(context.Background(), "pod", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.False(t, refTracker.Has(pod))
+}

--- a/pkg/informers/informers_test.go
+++ b/pkg/informers/informers_test.go
@@ -309,7 +309,7 @@ func TestPartialObjectMetadataStripOnDeletedFinalStateUnknown(t *testing.T) {
 			nil,
 		),
 		appsv1.SchemeGroupVersion.WithResource("secrets"),
-		PartialObjectMetadataStrip,
+		PartialObjectMetadataStrip(schema.GroupVersionKind{Version: "v1", Kind: "Secret"}),
 	)
 	require.NoError(t, err)
 

--- a/pkg/informers/kube.go
+++ b/pkg/informers/kube.go
@@ -59,7 +59,6 @@ func NewMetadataInformerFactory(
 	defaultResync time.Duration,
 	tweakListOptions func(*metav1.ListOptions),
 ) FactoriesForNamespaces {
-
 	tweaks, namespaces := newInformerOptions(allowNamespaces, denyNamespaces, tweakListOptions)
 
 	ret := metadataInformersForNamespace{}

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -369,6 +369,18 @@ func (s StringSet) Set(value string) error {
 	return nil
 }
 
+// MergeStringSets returns a StringSet which is the concatenation of a and b.
+func MergeStringSets(a, b StringSet) StringSet {
+	res := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		res[k] = struct{}{}
+	}
+	for k := range b {
+		res[k] = struct{}{}
+	}
+	return res
+}
+
 // String implements the flag.Value interface.
 func (s StringSet) String() string {
 	return strings.Join(s.Slice(), ",")

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"maps"
@@ -70,6 +71,8 @@ type Config struct {
 
 	// Feature gates.
 	Gates *FeatureGates
+
+	WatchObjectRefsInAllNamespaces bool
 }
 
 // DefaultConfig returns a default operator configuration.
@@ -244,18 +247,22 @@ func (m *Map) SortedKeys() []string {
 	return slices.Sorted(maps.Keys(*m))
 }
 
+// Namespaces defines the namespaces which are watched by the operator.
+// The zero value is valid and allows all namespaces.
 type Namespaces struct {
-	// Allow list for common custom resources.
+	// Allow list of namespaces for common custom resources.
+	// If not empty, DenyList must be empty.
 	AllowList StringSet
-	// Deny list for common custom resources.
+	// Deny list of namespaces for common custom resources.
+	// If not empty, AllowList must be empty.
 	DenyList StringSet
-	// Allow list for Prometheus custom resources.
+	// Allow list of namespaces for Prometheus custom resources.
 	PrometheusAllowList StringSet
-	// Allow list for Alertmanager custom resources.
+	// Allow list of namespaces for Alertmanager custom resources.
 	AlertmanagerAllowList StringSet
-	// Allow list for AlertmanagerConfig custom resources.
+	// Allow list of namespaces for AlertmanagerConfig custom resources.
 	AlertmanagerConfigAllowList StringSet
-	// Allow list for ThanosRuler custom resources.
+	// Allow list of namespaces for ThanosRuler custom resources.
 	ThanosRulerAllowList StringSet
 }
 
@@ -270,9 +277,14 @@ func (n *Namespaces) String() string {
 	)
 }
 
-func (n *Namespaces) Finalize() {
+// Finalize must be called to verify that the configuration is valid.
+func (n *Namespaces) Finalize() error {
+	if len(n.AllowList) > 0 && len(n.DenyList) > 0 {
+		return errors.New("allow and deny lists are mutually exclusive, only one should be provided")
+	}
+
 	if len(n.AllowList) == 0 {
-		n.AllowList.Insert(v1.NamespaceAll)
+		n.AllowList = StringSet{v1.NamespaceAll: struct{}{}}
 	}
 
 	if len(n.PrometheusAllowList) == 0 {
@@ -290,6 +302,8 @@ func (n *Namespaces) Finalize() {
 	if len(n.ThanosRulerAllowList) == 0 {
 		n.ThanosRulerAllowList = n.AllowList
 	}
+
+	return nil
 }
 
 type LabelSelector string
@@ -369,8 +383,25 @@ func (s StringSet) Set(value string) error {
 	return nil
 }
 
-// MergeStringSets returns a StringSet which is the concatenation of a and b.
-func MergeStringSets(a, b StringSet) StringSet {
+func (s StringSet) isAllNamespace() bool {
+	if len(s) != 1 {
+		return false
+	}
+
+	_, found := s[v1.NamespaceAll]
+	return found
+}
+
+// MergeAllowLists returns a StringSet which is the merge of a and b.
+func MergeAllowLists(a, b StringSet) StringSet {
+	if a.isAllNamespace() {
+		return a
+	}
+
+	if b.isAllNamespace() {
+		return b
+	}
+
 	res := make(map[string]struct{}, len(a)+len(b))
 	for k := range a {
 		res[k] = struct{}{}
@@ -384,10 +415,6 @@ func MergeStringSets(a, b StringSet) StringSet {
 // String implements the flag.Value interface.
 func (s StringSet) String() string {
 	return strings.Join(s.Slice(), ",")
-}
-
-func (s StringSet) Insert(value string) {
-	s[value] = struct{}{}
 }
 
 func (s StringSet) Slice() []string {

--- a/pkg/operator/informers.go
+++ b/pkg/operator/informers.go
@@ -34,9 +34,10 @@ type RefResolver interface {
 	HasRefTo(namespacedName string, obj runtime.Object) bool
 }
 
-// HasReferenceFunc returns a function which takes a object as input parameter
-// and returns true if at least one workload watched by the controller has a
-// reference to this object or is in the same namespace.
+// HasReferenceFunc returns a function which takes a object (secret or
+// configmap) as input parameter and returns true if at least one workload
+// watched by the controller has a reference to this object or is in the same
+// namespace.
 //
 // The object is expected to be a [*metav1.PartialObjectMetadata].
 func HasReferenceFunc(

--- a/pkg/operator/informers.go
+++ b/pkg/operator/informers.go
@@ -18,11 +18,67 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 )
+
+type InformerGetter interface {
+	GetInformers() []informers.InformLister
+}
+
+type RefResolver interface {
+	HasRefTo(namespacedName string, obj runtime.Object) bool
+}
+
+// HasReferenceFunc returns a function which takes a object as input parameter
+// and returns true if at least one workload watched by the controller has a
+// reference to this object or is in the same namespace.
+//
+// The object is expected to be a [*metav1.PartialObjectMetadata].
+func HasReferenceFunc(
+	informerGetter InformerGetter,
+	refResolver RefResolver,
+) FilterFunc {
+	return func(obj interface{}) bool {
+		partialObjMeta, ok := obj.(*metav1.PartialObjectMetadata)
+		if !ok {
+			return false
+		}
+
+		for _, informer := range informerGetter.GetInformers() {
+			workloads, err := informer.Lister().List(labels.Everything())
+			if err != nil {
+				continue
+			}
+
+			for _, workload := range workloads {
+				workloadMeta, ok := workload.(metav1.Object)
+				if !ok {
+					continue
+				}
+
+				// Check if the object is located in the same namespace as the
+				// workload resource. In this case, the operator should always
+				// trigger a reconciliation because the workload might use the
+				// object for its configuration or an external actor may have
+				// altered an object owned by the operator.
+				if workloadMeta.GetNamespace() == partialObjMeta.GetNamespace() {
+					return true
+				}
+
+				if refResolver.HasRefTo(fmt.Sprintf("%s/%s", workloadMeta.GetNamespace(), workloadMeta.GetName()), partialObjMeta) {
+					return true
+				}
+			}
+		}
+
+		return false
+	}
+}
 
 // GetObjectFromKey retrieves an object from the informer cache using the provided key. It returns a nil value and no error if the object is not found.
 // The function will panic if the caller provides an informer which doesn't reference objects of type T.

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -262,7 +262,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 
 	o.cmapInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			c.Namespaces.PrometheusAllowList,
+			operator.MergeStringSets(c.Namespaces.PrometheusAllowList, c.Namespaces.AllowList),
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,
@@ -271,7 +271,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
-		informers.PartialObjectMetadataStrip,
+		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating configmap informers: %w", err)
@@ -279,7 +279,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 
 	o.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			c.Namespaces.PrometheusAllowList,
+			operator.MergeStringSets(c.Namespaces.PrometheusAllowList, c.Namespaces.AllowList),
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,
@@ -289,7 +289,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
-		informers.PartialObjectMetadataStrip,
+		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating secrets informers: %w", err)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -527,22 +527,22 @@ func (c *Operator) addHandlers() {
 		c.promInfs,
 		c.reconciliations,
 	)
-	c.cmapInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"ConfigMap",
 		c.enqueueForPrometheusNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
-	c.secrInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.secrInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
 		c.enqueueForPrometheusNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
 	// The controller needs to watch the namespaces in which the service/pod

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -481,22 +481,22 @@ func (c *Operator) addHandlers() {
 		c.promInfs,
 		c.reconciliations,
 	)
-	c.cmapInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"ConfigMap",
 		c.enqueueForPrometheusNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
-	c.secrInfs.AddEventHandler(operator.NewEventHandlerWithFilter(
+	c.secrInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		"Secret",
 		c.enqueueForPrometheusNamespace,
-		hasRefFunc,
+		operator.WithFilter(hasRefFunc),
 	))
 
 	// The controller needs to watch the namespaces in which the service/pod

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -288,9 +288,13 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		return nil, fmt.Errorf("error creating prometheusrule informers: %w", err)
 	}
 
+	allowList := c.Namespaces.PrometheusAllowList
+	if c.WatchObjectRefsInAllNamespaces {
+		allowList = operator.MergeAllowLists(c.Namespaces.PrometheusAllowList, c.Namespaces.AllowList)
+	}
 	o.cmapInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			operator.MergeStringSets(c.Namespaces.PrometheusAllowList, c.Namespaces.AllowList),
+			allowList,
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,
@@ -307,7 +311,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 
 	o.secrInfs, err = informers.NewInformersForResourceWithTransform(
 		informers.NewMetadataInformerFactory(
-			operator.MergeStringSets(c.Namespaces.PrometheusAllowList, c.Namespaces.AllowList),
+			allowList,
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -173,7 +173,17 @@ func TestAllNS(t *testing.T) {
 
 	ns := framework.CreateNamespace(ctx, t, testCtx)
 
-	finalizers, err := framework.CreateOrUpdatePrometheusOperator(ctx, ns, nil, nil, nil, nil, true, true, true)
+	finalizers, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx,
+		operatorFramework.PrometheusOperatorOpts{
+			Namespace:              ns,
+			EnableAdmissionWebhook: true,
+			ClusterRoleBindings:    true,
+			EnableScrapeConfigs:    true,
+			// testPrometheusReconciliationOnSecretChanges needs this flag to be turned on.
+			AdditionalArgs: []string{"--watch-referenced-objects-in-all-namespaces=true"},
+		},
+	)
 	require.NoError(t, err)
 
 	for _, f := range finalizers {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -308,6 +308,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"ScrapeConfigCRDValidations":                testScrapeConfigCRDValidations,
 		"PrometheusServiceName":                     testPrometheusServiceName,
 		"PrometheusAgentSSetServiceName":            testPrometheusAgentSSetServiceName,
+		"PrometheusReconciliationOnSecretChanges":   testPrometheusReconciliationOnSecretChanges,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -5518,8 +5518,9 @@ func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 		Type: v1.SecretTypeOpaque,
 	}
 
-	_, err = framework.KubeClient.CoreV1().Secrets(ns2).Create(ctx, secret, metav1.CreateOptions{})
+	secret, err = framework.KubeClient.CoreV1().Secrets(ns2).Create(ctx, secret, metav1.CreateOptions{})
 	require.NoError(t, err)
+	t.Logf("secret %s/%s created", secret.GetNamespace(), secret.GetName())
 
 	err = framework.WaitForHealthyTargets(ctx, ns, "prometheus-operated", 1)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Closes #6018 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
