### PR TITLE
go generic support in syncFinalizer function

### DIFF
--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -29,9 +29,9 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
 )
 
-// FinalizerSyncOptions holds the configuration and dependencies
+// FinalizerSyncer holds the configuration and dependencies
 // required to perform finalizer synchronization.
-type SyncFinalizerOptions struct {
+type FinalizerSyncer struct {
 	ConfigResourcesStatusEnabled bool
 	Reconciliations              *ReconciliationTracker
 	Logger                       *slog.Logger
@@ -44,7 +44,7 @@ type SyncFinalizerOptions struct {
 // Returns true if the finalizer list was modified, otherwise false.
 // If the object is being deleted, it is also removed from the reconciliation tracker.
 // The second return value indicates any error encountered during the operation.
-func (s *SyncFinalizerOptions) Sync(ctx context.Context, p metav1.Object, key string, deletionInProgress bool) (bool, error) {
+func (s *FinalizerSyncer) Sync(ctx context.Context, p metav1.Object, key string, deletionInProgress bool) (bool, error) {
 	logger := s.Logger.With("key", key)
 	if !s.ConfigResourcesStatusEnabled {
 		return false, nil

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -30,7 +30,7 @@ import (
 )
 
 // FinalizerSyncOptions holds the configuration and dependencies
-// required to perform finalizer synchronization
+// required to perform finalizer synchronization.
 type SyncFinalizerOptions struct {
 	ConfigResourcesStatusEnabled bool
 	Reconciliations              *ReconciliationTracker

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -91,16 +91,16 @@ func updateObject[T metav1.Object](
 
 	switch any(p).(type) {
 	case *monitoringv1.Prometheus:
-		gvr = monitoringv1.SchemeGroupVersion.WithResource("prometheuses")
+		gvr = monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PrometheusName)
 
 	case *monitoringv1.Alertmanager:
-		gvr = monitoringv1.SchemeGroupVersion.WithResource("alertmanagers")
+		gvr = monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.AlertmanagerName)
 
 	case *monitoringv1.ThanosRuler:
-		gvr = monitoringv1.SchemeGroupVersion.WithResource("thanosrulers")
+		gvr = monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ThanosRulerName)
 
 	case *monitoringv1alpha1.PrometheusAgent:
-		gvr = monitoringv1alpha1.SchemeGroupVersion.WithResource("prometheusagents")
+		gvr = monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName)
 
 	default:
 		return fmt.Errorf("unknown object type %T", p)

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -51,7 +51,6 @@ func NewFinalizerSyncer(
 // (Prometheus, PrometheusAgent, Alertmanager, or ThanosRuler). It adds the finalizer if necessary, or removes it when appropriate.
 //
 // Returns true if the finalizer list was modified, otherwise false.
-// If the object is being deleted, it is also removed from the reconciliation tracker.
 // The second return value indicates any error encountered during the operation.
 func (s *FinalizerSyncer) Sync(ctx context.Context, p metav1.Object, logger *slog.Logger, deletionInProgress bool) (bool, error) {
 	if !s.configResourcesStatusEnabled {
@@ -72,7 +71,7 @@ func (s *FinalizerSyncer) Sync(ctx context.Context, p metav1.Object, logger *slo
 			return false, nil
 		}
 		if err = s.updateObject(ctx, p, patchBytes); err != nil {
-			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+			return false, fmt.Errorf("failed to add %q finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 		}
 		logger.Debug("added finalizer to object")
 		return true, nil
@@ -88,7 +87,7 @@ func (s *FinalizerSyncer) Sync(ctx context.Context, p metav1.Object, logger *slo
 	}
 
 	if err = s.updateObject(ctx, p, patchBytes); err != nil {
-		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+		return false, fmt.Errorf("failed to remove %q finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
 	logger.Debug("removed finalizer from object")
 

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8sutil"
+)
+
+// SyncFinalizers adds or removes the finalizer form the workload resource(Prometheus, PrometheusAgent, Alertmanager and ThanosRuler).
+// It returns true if the finalizers were modified, otherwise false. The second return value is an error, if any.
+func SyncFinalizers[T metav1.Object](ctx context.Context, p T, key string, mclient monitoringclient.Interface, reconciliations *ReconciliationTracker, logger *slog.Logger, deletionInProgress bool, configResourcesStatusEnabled bool) (bool, error) {
+	if !configResourcesStatusEnabled {
+		return false, nil
+	}
+
+	// The resource isn't being deleted, add the finalizer if missing.
+	if !deletionInProgress {
+		// Add finalizer to the Prometheus resource if it doesn't have one.
+		finalizers := p.GetFinalizers()
+		patchBytes, err := k8sutil.FinalizerAddPatch(finalizers, k8sutil.StatusCleanupFinalizerName)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal patch: %w", err)
+		}
+
+		if len(patchBytes) == 0 {
+			return false, nil
+		}
+		if err = updateObject[T](ctx, mclient, p, patchBytes); err != nil {
+			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+		}
+		logger.Debug("added finalizer to object")
+		return true, nil
+	}
+
+	// If the Prometheus instance is marked for deletion, we remove the finalizer.
+	finalizers := p.GetFinalizers()
+	patchBytes, err := k8sutil.FinalizerDeletePatch(finalizers, k8sutil.StatusCleanupFinalizerName)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal patch: %w", err)
+	}
+	if len(patchBytes) == 0 {
+		reconciliations.ForgetObject(key)
+		return false, nil
+	}
+
+	if err = updateObject[T](ctx, mclient, p, patchBytes); err != nil {
+		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
+	}
+	logger.Debug("removed finalizer from object")
+	reconciliations.ForgetObject(key)
+
+	return true, nil
+}
+
+// updateObject updates the given object in the cluster using a JSON patch.
+func updateObject[T metav1.Object](
+	ctx context.Context,
+	mclient monitoringclient.Interface,
+	p T,
+	patchBytes []byte,
+) error {
+	var err error
+	opts := metav1.PatchOptions{FieldManager: PrometheusOperatorFieldManager}
+
+	switch obj := any(p).(type) {
+	case *monitoringv1.Prometheus:
+		_, err = mclient.MonitoringV1().
+			Prometheuses(obj.GetNamespace()).
+			Patch(ctx, obj.GetName(), types.JSONPatchType, patchBytes, opts)
+
+	case *monitoringv1.Alertmanager:
+		_, err = mclient.MonitoringV1().
+			Alertmanagers(obj.GetNamespace()).
+			Patch(ctx, obj.GetName(), types.JSONPatchType, patchBytes, opts)
+
+	case *monitoringv1.ThanosRuler:
+		_, err = mclient.MonitoringV1().
+			ThanosRulers(obj.GetNamespace()).
+			Patch(ctx, obj.GetName(), types.JSONPatchType, patchBytes, opts)
+
+	case *monitoringv1alpha1.PrometheusAgent:
+		_, err = mclient.MonitoringV1alpha1().
+			PrometheusAgents(obj.GetNamespace()).
+			Patch(ctx, obj.GetName(), types.JSONPatchType, patchBytes, opts)
+
+	default:
+		return fmt.Errorf("unknown object type %T", p)
+	}
+
+	return err
+}

--- a/pkg/operator/finalizer.go
+++ b/pkg/operator/finalizer.go
@@ -35,7 +35,7 @@ import (
 // Returns true if the finalizer list was modified, otherwise false.
 // If the object is being deleted, it is also removed from the reconciliation tracker.
 // The second return value indicates any error encountered during the operation.
-func SyncFinalizers[T metav1.Object](ctx context.Context, p T, key string, mdClient metadata.Interface, reconciliations *ReconciliationTracker, logger *slog.Logger, deletionInProgress bool, configResourcesStatusEnabled bool) (bool, error) {
+func SyncFinalizers(ctx context.Context, p metav1.Object, key string, mdClient metadata.Interface, reconciliations *ReconciliationTracker, logger *slog.Logger, deletionInProgress bool, configResourcesStatusEnabled bool) (bool, error) {
 	if !configResourcesStatusEnabled {
 		return false, nil
 	}
@@ -53,7 +53,7 @@ func SyncFinalizers[T metav1.Object](ctx context.Context, p T, key string, mdCli
 		if len(patchBytes) == 0 {
 			return false, nil
 		}
-		if err = updateObject[T](ctx, mdClient, p, patchBytes); err != nil {
+		if err = updateObject(ctx, mdClient, p, patchBytes); err != nil {
 			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 		}
 		logger.Debug("added finalizer to object")
@@ -70,7 +70,7 @@ func SyncFinalizers[T metav1.Object](ctx context.Context, p T, key string, mdCli
 		return false, nil
 	}
 
-	if err = updateObject[T](ctx, mdClient, p, patchBytes); err != nil {
+	if err = updateObject(ctx, mdClient, p, patchBytes); err != nil {
 		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
 	}
 	logger.Debug("removed finalizer from object")
@@ -80,10 +80,10 @@ func SyncFinalizers[T metav1.Object](ctx context.Context, p T, key string, mdCli
 }
 
 // updateObject applies a JSON patch to update the metadata of the given workload object (Prometheus, PrometheusAgent, Alertmanager, or ThanosRuler) in the cluster.
-func updateObject[T metav1.Object](
+func updateObject(
 	ctx context.Context,
 	mdClient metadata.Interface,
-	p T,
+	p metav1.Object,
 	patchBytes []byte,
 ) error {
 	var err error

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -98,7 +98,7 @@ type Operator struct {
 	configResourcesStatusEnabled  bool
 
 	eventRecorder        record.EventRecorder
-	syncFinalizerOptions *operator.SyncFinalizerOptions
+	syncFinalizerOptions *operator.FinalizerSyncer
 }
 
 type ControllerOption func(*Operator)
@@ -177,7 +177,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		eventRecorder:                c.EventRecorderFactory(client, controllerName),
 		retentionPoliciesEnabled:     c.Gates.Enabled(operator.PrometheusShardRetentionPolicyFeature),
 		configResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
-		syncFinalizerOptions: &operator.SyncFinalizerOptions{
+		syncFinalizerOptions: &operator.FinalizerSyncer{
 			ConfigResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
 			MdClient:                     mdClient,
 			Logger:                       logger,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -751,7 +751,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
 
-	finalizersChanged, err := operator.SyncFinalizers[*monitoringv1.Prometheus](ctx, p, key, c.mdClient, c.reconciliations, logger, c.rr.DeletionInProgress(p), c.configResourcesStatusEnabled)
+	finalizersChanged, err := operator.SyncFinalizers(ctx, p, key, c.mdClient, c.reconciliations, logger, c.rr.DeletionInProgress(p), c.configResourcesStatusEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
@@ -752,7 +751,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
 
-	finalizersChanged, err := c.syncFinalizers(ctx, p, key)
+	finalizersChanged, err := operator.SyncFinalizers[*monitoringv1.Prometheus](ctx, p, key, c.mclient, c.reconciliations, logger, c.rr.DeletionInProgress(p), c.configResourcesStatusEnabled)
 	if err != nil {
 		return err
 	}
@@ -970,52 +969,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	return nil
-}
-
-// syncFinalizers adds or removes the finalizer for the Prometheus resource.
-// It returns true if the finalizers were modified, otherwise false. The second return value is an error, if any.
-func (c *Operator) syncFinalizers(ctx context.Context, p *monitoringv1.Prometheus, key string) (bool, error) {
-	if !c.configResourcesStatusEnabled {
-		return false, nil
-	}
-
-	// The resource isn't being deleted, add the finalizer if missing.
-	if !c.rr.DeletionInProgress(p) {
-		// Add finalizer to the Prometheus resource if it doesn't have one.
-		finalizers := p.GetFinalizers()
-		patchBytes, err := k8sutil.FinalizerAddPatch(finalizers, k8sutil.StatusCleanupFinalizerName)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal patch: %w", err)
-		}
-
-		if len(patchBytes) == 0 {
-			return false, nil
-		}
-		if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-			return false, fmt.Errorf("failed to add %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
-		}
-		c.logger.Debug("added finalizer to Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
-		return true, nil
-	}
-
-	// If the Prometheus instance is marked for deletion, we remove the finalizer.
-	finalizers := p.GetFinalizers()
-	patchBytes, err := k8sutil.FinalizerDeletePatch(finalizers, k8sutil.StatusCleanupFinalizerName)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal patch: %w", err)
-	}
-	if len(patchBytes) == 0 {
-		c.reconciliations.ForgetObject(key)
-		return false, nil
-	}
-
-	if _, err = c.mclient.MonitoringV1().Prometheuses(p.Namespace).Patch(ctx, p.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: operator.PrometheusOperatorFieldManager}); err != nil {
-		return false, fmt.Errorf("failed to remove %s finalizer: %w", k8sutil.StatusCleanupFinalizerName, err)
-	}
-	c.logger.Debug("removed finalizer from Prometheus resource", "name", p.Name, "namespace", p.Namespace, "finalizer", k8sutil.StatusCleanupFinalizerName)
-	c.reconciliations.ForgetObject(key)
-
-	return true, nil
 }
 
 // As the ShardRetentionPolicy feature evolves, should retain will evolve accordingly.

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -751,7 +751,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	logger := c.logger.With("key", key)
 	c.logDeprecatedFields(logger, p)
 
-	finalizersChanged, err := operator.SyncFinalizers[*monitoringv1.Prometheus](ctx, p, key, c.mclient, c.reconciliations, logger, c.rr.DeletionInProgress(p), c.configResourcesStatusEnabled)
+	finalizersChanged, err := operator.SyncFinalizers[*monitoringv1.Prometheus](ctx, p, key, c.mdClient, c.reconciliations, logger, c.rr.DeletionInProgress(p), c.configResourcesStatusEnabled)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

fixes: #7607 
go generic support in syncFinalizer function


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
