### PR TITLE
 shouldUpdate to check if the resource should updated if the finalizer is present

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -647,6 +647,6 @@ func FinalizerDeletePatch(finalizers []string, finalizerName string) ([]byte, er
 	return nil, nil
 }
 
-func IsFinalizerPresent(finalizers []string, finalizerName string) bool {
-	return slices.Contains(finalizers, finalizerName)
+func HasStatusCleanupFinalizer(obj metav1.Object) bool {
+	return slices.Contains(obj.GetFinalizers(), StatusCleanupFinalizerName)
 }

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -338,7 +338,7 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 		return
 	}
 
-	if !rr.shouldUpdate(mCur) {
+	if !k8sutil.HasStatusCleanupFinalizer(mCur) && rr.DeletionInProgress(mCur) {
 		return
 	}
 
@@ -613,11 +613,4 @@ func (rr *ResourceReconciler) isManagedByController(obj metav1.Object) bool {
 	}
 
 	return true
-}
-
-// ShouldUpdate returns true if:
-//   - It contains the status cleanup finalizer, meaning finalization logic must run before deletion, or
-//   - It is not marked for deletion.
-func (rr *ResourceReconciler) shouldUpdate(cur metav1.Object) bool {
-	return k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) || !rr.DeletionInProgress(cur)
 }

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -338,7 +338,7 @@ func (rr *ResourceReconciler) OnUpdate(old, cur interface{}) {
 		return
 	}
 
-	if !k8sutil.IsFinalizerPresent(mCur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) && rr.DeletionInProgress(mCur) {
+	if !rr.shouldUpdate(mCur) {
 		return
 	}
 
@@ -613,4 +613,11 @@ func (rr *ResourceReconciler) isManagedByController(obj metav1.Object) bool {
 	}
 
 	return true
+}
+
+// ShouldUpdate returns true if:
+//   - It contains the status cleanup finalizer, meaning finalization logic must run before deletion, or
+//   - It is not marked for deletion.
+func (rr *ResourceReconciler) shouldUpdate(cur metav1.Object) bool {
+	return k8sutil.IsFinalizerPresent(cur.GetFinalizers(), k8sutil.StatusCleanupFinalizerName) || !rr.DeletionInProgress(cur)
 }


### PR DESCRIPTION
…er is present

## Description

fixes: #7608 

shouldUpdate to check if the resource should updated if the finalizer is present

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
