### PR TITLE
ci: decrease kubelet sync frequency

### DIFF
--- a/test/e2e/kind-conf.yaml
+++ b/test/e2e/kind-conf.yaml
@@ -3,7 +3,28 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind
 
+# We decrease the interval at which kubelet synchronizes the mounted configmaps
+# and secrets from the default 1 minute to 10 seconds. It helps speeding up the
+# tests because the configuration changes are propagated faster to the
+# containers.
+#
+# While we apply the same settings to all nodes, there's a current limitation
+# with Kind that kubelet configuration is cluster-wide so only the first patch
+# is applied in fact. See https://github.com/kubernetes-sigs/kind/issues/3849
+# for details.
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    syncFrequency: 10s
 - role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    syncFrequency: 10s
 - role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    syncFrequency: 10s


### PR DESCRIPTION
## Description

With kubelet syncing the mounted configmaps/secrets more frequently, the tests take a bit less time to execute because the configuration changes are propagated faster.

Before

![image](https://github.com/user-attachments/assets/28275fc8-eae9-4db7-b7bd-1db6275fd5e0)

After

![image](https://github.com/user-attachments/assets/cc6a17fa-eb93-4203-b0aa-f11b0b619906)

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
