### PR TITLE
Add resource cleanup on stop with deletion functions for service, endpoints and endpointslices

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -267,6 +267,12 @@ func CreateOrUpdateService(ctx context.Context, sclient clientv1.ServiceInterfac
 	return ret, err
 }
 
+func DeleteService(ctx context.Context, sclient clientv1.ServiceInterface, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return sclient.Delete(ctx, name, metav1.DeleteOptions{})
+	})
+}
+
 // CreateOrUpdateEndpoints creates or updates an endpoint resource.
 //
 //nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
@@ -287,6 +293,12 @@ func CreateOrUpdateEndpoints(ctx context.Context, eclient clientv1.EndpointsInte
 
 		_, err = eclient.Update(ctx, eps, metav1.UpdateOptions{})
 		return err
+	})
+}
+
+func DeleteEndpoints(ctx context.Context, eclient clientv1.EndpointsInterface, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return eclient.Delete(ctx, name, metav1.DeleteOptions{})
 	})
 }
 
@@ -312,6 +324,12 @@ func CreateOrUpdateEndpointSlice(ctx context.Context, c clientdiscoveryv1.Endpoi
 
 		_, err = c.Update(ctx, eps, metav1.UpdateOptions{})
 		return err
+	})
+}
+
+func DeleteEndpointSlice(ctx context.Context, c clientdiscoveryv1.EndpointSliceInterface, listOpts metav1.ListOptions) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return c.DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts)
 	})
 }
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Ensure cleanup of kubelet service, endpoints and endpointslices created by the Prometheus Operator upon its termination. This change prevents orphaned resources from persisting in the cluster after operator shutdown.

https://github.com/prometheus-community/helm-charts/issues/5343
https://github.com/prometheus-community/helm-charts/issues/1523

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add automatic cleanup of kubelet service, endpoints and endpointslices upon operator termination
```
