### PR TITLE
Add Materials Page to docs

### DIFF
--- a/Documentation/Materials.md
+++ b/Documentation/Materials.md
@@ -1,0 +1,28 @@
+---
+title: Materials
+draft: false
+---
+
+This page contains all the presentations and blogs that demonstrate and explain about the concepts and examples of Prometheus-Operator.
+
+> If you have made a presentation or blog that demonstrated or referenced Prometheus-Operator, please open a PR to add it to this page!
+
+## Presentations
+
+* [Optimizing Scrape Configs with Prometheus Operator](https://youtu.be/Yd0kuAHaWjE?si=fta8nhRhCH5NRatY) - Nicolas Takashi - PromCon 2024 Lightning Talk
+
+* [Harnessing the Potential of Prometheus Agent Mode](https://youtu.be/wkkXh8X0N8s?si=PVqsvzxM5O0sfvMd) - M Viswanath Sai and S Ashwin - PromCon 2024
+
+* [Architecting Growth: Scaling Tactics for Prometheus Metrics Collection](https://youtu.be/bVICOulH5IY?si=M1GKX0lDmuBzyCzH) - Arthur Silva Sens & Nicolas Takashi - KubeCon + CloudNativeCon North America 2024
+
+* [ScrapeConfig CRD: The Rising Star in the Prometheus-Operator Ecosystem](https://youtu.be/RabXsaOl1TE?si=Sc82jMpIgddcR212) - Jayapriya Pai - KCD Kerala
+
+* [Prometheus-Operator: What's next?](https://www.youtube.com/live/ymR57Q0qqg4?si=JUmYjkfSOJe4qpam&t=27386) - Simon Pasquier - PromCon 2023
+
+* [Deep Dive into the Prometheus Operator Ecosystem](https://youtu.be/P__R4CFFxEQ?si=1YPkY-X-4ST4YJ7j) - Jayapriya Pai - KCD Bengaluru 2023
+
+* [How to Be 10x SRE? A Deep Dive to Prometheus Operator](https://youtu.be/Uph_Say4D3M?si=Z3mmdBMWjA9PjBt2) - Jayapriya Pai & Haoyu Sun - Prometheus Day Europe 2022
+
+* [Monitoring Kubernetes with Prometheus-Operator](https://youtu.be/MuHPMXCGiLc?si=2tpfuyMzRVh0MR8-) - Lili Cosic - Cloud Native Computing Berlin Meetup 2021
+
+## Blogs


### PR DESCRIPTION
## Description

Related Issue: #7636 

This PR adds **Materials** page to the documentation. A separate PR to add this page to the website will be implemented after this PR gets merged.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

