### PR TITLE
Include scraped targets info in config res status,  in config res status proposal 

### DIFF
--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -113,7 +113,7 @@ spec:
           down: 1
           lastCheckedTime: "2025-05-20T12:34:56Z"
         conditions:
-          - type: Reconciled
+          - type: Accepted
             status: "True"
             observedGeneration: 3
             lastTransitionTime: "2025-05-20T12:34:56Z"
@@ -128,7 +128,7 @@ spec:
           down: 1
           lastCheckedTime: "2025-05-20T12:34:56Z"
         conditions:
-          - type: Reconciled
+          - type: Accepted
             status: "False"
             observedGeneration: 2
             lastTransitionTime: "2024-02-08T23:52:22Z"
@@ -143,7 +143,7 @@ spec:
           down: 1
           lastCheckedTime: "2025-05-20T12:34:56Z"
         conditions:
-          - type: Reconciled
+          - type: Accepted
             status: "False"
             observedGeneration: 3
             lastTransitionTime: "2024-02-08T23:52:22Z"
@@ -183,7 +183,7 @@ spec:
         name: prometheus-main
         namespace: monitoring
         conditions:
-          - type: Reconciled
+          - type: Accepted
             status: "False"
             observedGeneration: 1
             lastTransitionTime: "2025-05-20T12:34:56Z"
@@ -215,7 +215,7 @@ spec:
         name: alertmanager-main
         namespace: monitoring
         conditions:
-          - type: Reconciled
+          - type: Accepted
             status: "True"
             observedGeneration: 1
             lastTransitionTime: "2025-05-20T12:34:56Z"

--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -207,6 +207,10 @@ The operator sends the GET request at regular interval to the config-reloader si
 
 Finalizers are used during the deletion of the config-resource and workload-resource to clear the refrences in the status-subresource.
 
+#### How to remove invalid bindings from config-resources status ?
+
+A dedicated goroutine runs continuously to monitor config and workload resources for any invalid bindings.
+
 ## Alternatives
 
 #### Dedicated CRD Approach for Configuration-Workload Mapping

--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -117,18 +117,28 @@ spec:
             status: "True"
             observedGeneration: 3
             lastTransitionTime: "2025-05-20T12:34:56Z"
-          - type: Reconciled
-            status: "False"
-            observedGeneration: 2
-            lastTransitionTime: "2024-02-08T23:52:22Z"
-            reason: InvalidConfiguration
-            message: "'KeepEqual' relabel action is only supported with Prometheus >= 2.41.0"
-          - type: Reconciled
-            status: "False"
-            observedGeneration: 1
-            lastTransitionTime: "2024-02-08T23:52:22Z"
-            reason: InvalidConfiguration
-            message: "Referenced Secret 'my-secret' in namespace 'monitoring' is missing or does not contain the required key 'basic-auth-password'."
+```
+
+some other example conditions which can take place,
+
+```yaml
+conditions:
+  - type: Reconciled
+    status: "False"
+    observedGeneration: 2
+    lastTransitionTime: "2024-02-08T23:52:22Z"
+    reason: InvalidConfiguration
+    message: "'KeepEqual' relabel action is only supported with Prometheus >= 2.41.0"
+```
+
+```yaml
+conditions:
+  - type: Reconciled
+    status: "False"
+    observedGeneration: 1
+    lastTransitionTime: "2024-02-08T23:52:22Z"
+    reason: InvalidConfiguration
+    message: "Referenced Secret 'my-secret' in namespace 'monitoring' is missing or does not contain the required key 'basic-auth-password'."
 ```
 
 #### `PrometheusRule`

--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -3,7 +3,7 @@
 * **Owners:**
   * [yp969803](https://github.com/yp969803)
 * **Status:**
-  * `Accepted`
+  * `In-Progress`
 * **Related Tickets:**
   * [#3385](https://github.com/prometheus-operator/prometheus-operator/issues/3335)
 * **Other docs:**
@@ -18,7 +18,9 @@ This will enhance observability by allowing users to verify whether their config
 
 ## Pitfalls of the current solution
 
-Currently, the status subresource is only implemented for workload resources. This makes it difficult to determine which workloads are using which configurations—especially since a single workload can reference multiple configurations. Additionally, there is no straightforward way to observe the reconciliation status of configuration resources. While Kubernetes events are available when a configuration is rejected by a workload, they are not sufficient for ongoing visibility or troubleshooting.
+Prometheus operator allows users to define their observability workloads through "workload" resources like `Prometheus`, `PrometheusAgent`, `AlertManager`. The configuration of these workloads can be done dynamically by orchestrating "configuration" resources like `ServiceMonitor`, `PodMonitor`, `ScrapeConfig`, etc which in turn are used to generate the configuration for the workloads that the Prometheus-Operator manages.
+
+Currently, the status subresource is only implemented for workload resources. The absence of the status subresource for configuration resources makes it difficult to determine the source of the generated configuration of the workload resources. Additionally, there is no straightforward way to observe the reconciliation status of configuration resources. While Kubernetes events are available when a configuration is rejected by a workload, they are not sufficient for ongoing visibility or troubleshooting.
 
 ## Goals
 
@@ -35,23 +37,20 @@ Currently, the status subresource is only implemented for workload resources. Th
 
 ### Audience
 
-Can use the status subresource to debug configuration issues like:
-
-* Misconfigured selectors
-* Network issues
-* Misconfigured secrets
+* Users of Prometheus-Operator
+* Maintainers and Contributors of Prometheus-Operator
 
 ## Non-Goals
 
-* The status subresource offers only a summary (e.g., counts of up/down targets), not detailed per-target scrape status.
+* The status subresource is intended to offer only a summary (e.g., counts of up/down targets) of the scrape status.
 * No information about the fired alerts in the status subresource of PrometheusRule (too heavy for the operator to query the prometheus pod for the alerts information. Prometheus may have a significant number of alerts, and fetching them repeatedly increases significant load in the operator).
-* The information about the targets is not realtime.
+* The status subresource is not intended to provide realtime information of the targets.
 
 ## How
 
-#### CRDs
+### CRDs
 
-An example CRD of serviceMonitor
+#### `ServiceMonitor`
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -99,7 +98,7 @@ CRDs of podMonitor, scrapeCOnfig and Probes looks similar to above.
 
 The operator sends the GET request at regular interval to the config-reloader sidecar with the serviceMonitor selector labels as the request body, the sidecar container after receiving the request sends the /api/v1/targets request to prometheus-container, from the response it gets from the prometheus, it modifies the response based on the labels and send the response to the operator. The sidecar will remove information from the response which can be used by attackers.
 
-CRD of PrometheusRule
+#### `PrometheusRule`
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -137,7 +136,7 @@ spec:
             message: "Successfully reconciled with Prometheus"
 ```
 
-CRD of AlertManagerConfig
+#### `AlertManagerConfig`
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1alpha1

--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -223,6 +223,18 @@ spec:
 
 ### Working
 
+#### Details of the Status API fields
+
+* `bindings`:  Lists the workload resources that reference or use the configuration resource.
+  * `conditions`: Describes the latest status of the configuration resource.
+    * `type`: The only condition type used is `Reconciled`, which indicates that the workload resource controller has successfully discovered the associated configuration resource and completed the necessary reconciliation steps.
+    * `status`: It can be either `true` or `false`.
+      * `true` indicates that the configuration resource was successfully accepted by the controller and written to the configuration secret.
+      * `false` means the controller rejected the configuration due to an error.
+    * `reason`: Specifies the reason for rejection, if the configuration was not accepted.
+    * `message`: Provides the detailed error message returned by the controller during reconciliation.
+    * `observedGeneration`: Represents the generation of the configuration resource that the controller has most recently reconciled.
+
 #### How to get targets information in scrape resources ?
 
 The operator sends the GET request at regular interval to the config-reloader sidecar with the serviceMonitor selector labels as the request body, the sidecar container after receiving the request sends the /api/v1/targets request to prometheus-container, from the response it gets from the prometheus, it modifies the response based on the labels and send the response to the operator. The sidecar will remove critical informations from the response which can be used by attackers.

--- a/Documentation/proposals/202501-configuration-object-status-subresource.md
+++ b/Documentation/proposals/202501-configuration-object-status-subresource.md
@@ -1,0 +1,193 @@
+## Status Subresource For Config-Based Resources
+
+* **Owners:**
+  * [yp969803](https://github.com/yp969803)
+* **Status:**
+  * `Accepted`
+* **Related Tickets:**
+  * [#3385](https://github.com/prometheus-operator/prometheus-operator/issues/3335)
+* **Other docs:**
+  * NA
+
+> This proposal describes how we will extend the Prometheus operator configuration Custom
+> Resource Definitions (CRDs) with a Status subresource field.
+
+## Why
+
+This will enhance observability by allowing users to verify whether their configurations have been successfully applied to Workload.
+
+## Pitfalls of the current solution
+
+Currently, the status subresource is only implemented for workload resources. This makes it difficult to determine which workloads are using which configurations—especially since a single workload can reference multiple configurations. Additionally, there is no straightforward way to observe the reconciliation status of configuration resources. While Kubernetes events are available when a configuration is rejected by a workload, they are not sufficient for ongoing visibility or troubleshooting.
+
+## Goals
+
+* Define the structure of the status subresource for the custom resource definitions
+  * `ServiceMonitor`
+  * `PodMonitor`
+  * `ScrapeConfig`
+  * `Probes`
+  * `PrometheusRule`
+  * `AlertmanagerConfig`
+* Information about number of Up/Down targets in status subresource for PodMonitor, ServiceMonitor, Probes and ScrapeConfig.
+* Define how the operator would reconcile the status subresource.
+* Feature gate to help the user to enable/disable the feature.
+
+### Audience
+
+Can use the status subresource to debug configuration issues like:
+
+* Misconfigured selectors
+* Network issues
+* Misconfigured secrets
+
+## Non-Goals
+
+* The status subresource offers only a summary (e.g., counts of up/down targets), not detailed per-target scrape status.
+* No information about the fired alerts in the status subresource of PrometheusRule (too heavy for the operator to query the prometheus pod for the alerts information. Prometheus may have a significant number of alerts, and fetching them repeatedly increases significant load in the operator).
+* The information about the targets is not realtime.
+
+## How
+
+#### CRDs
+
+An example CRD of serviceMonitor
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-servicemonitor
+  namespace: monitoring
+  labels:
+    team: backend
+spec:
+  selector:
+    matchLabels:
+      app: my-service
+  namespaceSelector:
+    matchNames:
+      - default
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scheme: http
+  status:
+    bindings:
+      - resource: prometheus
+        name: prometheus-main
+        namespace: monitoring
+        conditions:
+          - type: Reconciled
+            status: "True"
+            observedGeneration: 1
+            lastTransitionTime: "2025-05-20T12:34:56Z"
+            reason: ReconcileSucceeded
+            message: "Successfully reconciled with Prometheus"
+        pods:
+          - name: prometheus-main-0
+            namespace: monitoring
+            endpoint: http://10.42.0.10:9090
+            totalScrapedTargets: 3
+            totalUpTargets: 2
+            totalDownTargets: 1
+            lastCheckedTime: "2025-05-20T12:34:56Z"
+```
+
+CRDs of podMonitor, scrapeCOnfig and Probes looks similar to above.
+
+The operator sends the GET request at regular interval to the config-reloader sidecar with the serviceMonitor selector labels as the request body, the sidecar container after receiving the request sends the /api/v1/targets request to prometheus-container, from the response it gets from the prometheus, it modifies the response based on the labels and send the response to the operator. The sidecar will remove information from the response which can be used by attackers.
+
+CRD of PrometheusRule
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: example-prometheus-rules
+  namespace: monitoring
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: example.rules
+      interval: 30s
+      rules:
+        - alert: HighPodCPUUsage
+          expr: sum(rate(container_cpu_usage_seconds_total{container!="", pod!=""}[5m])) by (pod) > 0.5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High CPU usage on pod {{ $labels.pod }}"
+            description: "Pod {{ $labels.pod }} is using more than 0.5 cores for 5 minutes."
+  status:
+    bindings:
+      - resource: prometheus
+        name: prometheus-main
+        namespace: monitoring
+        conditions:
+          - type: Reconciled
+            status: "True"
+            observedGeneration: 1
+            lastTransitionTime: "2025-05-20T12:34:56Z"
+            reason: ReconcileSucceeded
+            message: "Successfully reconciled with Prometheus"
+```
+
+CRD of AlertManagerConfig
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: minimal-alertmanager-config
+  namespace: monitoring
+spec:
+  route:
+    receiver: "webhook-receiver"
+  receivers:
+    - name: "webhook-receiver"
+      webhookConfigs:
+        - url: "http://my-webhook-service.monitoring.svc:8080/"
+          sendResolved: true
+  status:
+    bindings:
+      - resource: alertmanager
+        name: alertmanager-main
+        namespace: monitoring
+        conditions:
+          - type: Reconciled
+            status: "True"
+            observedGeneration: 1
+            lastTransitionTime: "2025-05-20T12:34:56Z"
+            reason: ReconcileSucceeded
+            message: "Successfully reconciled with Prometheus"
+```
+
+Finalizers are used during the deletion of the config-resource and workload-resource to clear the refrences in the status-subresource.
+
+## Alternatives
+
+#### Dedicated CRD Approach for Configuration-Workload Mapping
+
+A potential solution to mapping a configuration resource to a workload resource is the introduction of a Custom Resource Definition (CRD). This new CRD would act as an intermediary, maintaining a clear association between configurations and workloads.
+
+It comes with the following drawbacks:
+- Introducing a new CRD means extra operational complexity.
+- It requires installation, maintenance, and versioning, which could increase the administrative burden.
+
+#### Storing Information in the Workload Resource
+
+Another approach is to store configuration mappings directly within the workload resource.
+
+It comes with the following drawbacks:
+- Workload resources could reference a high number of configuration resources.
+- Storing all these mappings within a single workload resource could lead to excessive API payload sizes.
+- Configuration resources won’t have a direct view of where their configurations are being used.
+
+## Action Plan
+
+...


### PR DESCRIPTION
## Description

Fixes: #7643 
Include scraped targets info in config res status,  in config res status proposal

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
