### PR TITLE
feat: add thanos rule concurrent evaluation options

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -4773,6 +4773,19 @@ It requires Thanos &gt;= v0.38.0.</p>
 </tr>
 <tr>
 <td>
+<code>ruleConcurrentEval</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+It requires Thanos &gt;= v0.37.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>retention</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.Duration">
@@ -18040,6 +18053,19 @@ Duration
 <em>(Optional)</em>
 <p>The default rule group&rsquo;s query offset duration to use.
 It requires Thanos &gt;= v0.38.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ruleConcurrentEval</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+It requires Thanos &gt;= v0.37.0.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -66369,6 +66369,13 @@ spec:
                 description: The route prefix ThanosRuler registers HTTP handlers
                   for. This allows thanos UI to be served on a sub-path.
                 type: string
+              ruleConcurrentEval:
+                description: |-
+                  Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+                  It requires Thanos >= v0.37.0.
+                format: int64
+                minimum: 1
+                type: integer
               ruleNamespaceSelector:
                 description: |-
                   Namespaces to be selected for Rules discovery. If unspecified, only

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5715,6 +5715,13 @@ spec:
                 description: The route prefix ThanosRuler registers HTTP handlers
                   for. This allows thanos UI to be served on a sub-path.
                 type: string
+              ruleConcurrentEval:
+                description: |-
+                  Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+                  It requires Thanos >= v0.37.0.
+                format: int64
+                minimum: 1
+                type: integer
               ruleNamespaceSelector:
                 description: |-
                   Namespaces to be selected for Rules discovery. If unspecified, only

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5716,6 +5716,13 @@ spec:
                 description: The route prefix ThanosRuler registers HTTP handlers
                   for. This allows thanos UI to be served on a sub-path.
                 type: string
+              ruleConcurrentEval:
+                description: |-
+                  Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+                  It requires Thanos >= v0.37.0.
+                format: int64
+                minimum: 1
+                type: integer
               ruleNamespaceSelector:
                 description: |-
                   Namespaces to be selected for Rules discovery. If unspecified, only

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -5032,6 +5032,12 @@
                     "description": "The route prefix ThanosRuler registers HTTP handlers for. This allows thanos UI to be served on a sub-path.",
                     "type": "string"
                   },
+                  "ruleConcurrentEval": {
+                    "description": "Rule concurrent evaluation used for how many rules can be evaluated concurrently.\nIt requires Thanos >= v0.37.0.",
+                    "format": "int64",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
                   "ruleNamespaceSelector": {
                     "description": "Namespaces to be selected for Rules discovery. If unspecified, only\nthe same namespace as the ThanosRuler object is in is used.",
                     "properties": {

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -292,6 +292,13 @@ type ThanosRulerSpec struct {
 	// +optional
 	RuleQueryOffset *Duration `json:"ruleQueryOffset,omitempty"`
 
+	// Rule concurrent evaluation used for how many rules can be evaluated concurrently.
+	// It requires Thanos >= v0.37.0.
+	// +kubebuilder:validation:Minimum=1
+	//
+	// +optional
+	RuleConcurrentEval *int64 `json:"ruleConcurrentEval,omitempty"`
+
 	// Time duration ThanosRuler shall retain data for. Default is '24h', and
 	// must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
 	// seconds minutes hours days weeks years).

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -3673,6 +3673,11 @@ func (in *ThanosRulerSpec) DeepCopyInto(out *ThanosRulerSpec) {
 		*out = new(Duration)
 		**out = **in
 	}
+	if in.RuleConcurrentEval != nil {
+		in, out := &in.RuleConcurrentEval, &out.RuleConcurrentEval
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]corev1.Container, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
@@ -64,6 +64,7 @@ type ThanosRulerSpecApplyConfiguration struct {
 	PortName                           *string                                         `json:"portName,omitempty"`
 	EvaluationInterval                 *monitoringv1.Duration                          `json:"evaluationInterval,omitempty"`
 	RuleQueryOffset                    *monitoringv1.Duration                          `json:"ruleQueryOffset,omitempty"`
+	RuleConcurrentEval                 *int64                                          `json:"ruleConcurrentEval,omitempty"`
 	Retention                          *monitoringv1.Duration                          `json:"retention,omitempty"`
 	Containers                         []corev1.Container                              `json:"containers,omitempty"`
 	InitContainers                     []corev1.Container                              `json:"initContainers,omitempty"`
@@ -430,6 +431,14 @@ func (b *ThanosRulerSpecApplyConfiguration) WithEvaluationInterval(value monitor
 // If called multiple times, the RuleQueryOffset field is set to the value of the last call.
 func (b *ThanosRulerSpecApplyConfiguration) WithRuleQueryOffset(value monitoringv1.Duration) *ThanosRulerSpecApplyConfiguration {
 	b.RuleQueryOffset = &value
+	return b
+}
+
+// WithRuleConcurrentEval sets the RuleConcurrentEval field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RuleConcurrentEval field is set to the value of the last call.
+func (b *ThanosRulerSpecApplyConfiguration) WithRuleConcurrentEval(value int64) *ThanosRulerSpecApplyConfiguration {
+	b.RuleConcurrentEval = &value
 	return b
 }
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
@@ -164,6 +165,10 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 
 	if version.GTE(semver.MustParse("0.38.0")) && tr.Spec.RuleQueryOffset != nil && len(*tr.Spec.RuleQueryOffset) > 0 {
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "rule-query-offset", Value: string(*tr.Spec.RuleQueryOffset)})
+	}
+
+	if version.GTE(semver.MustParse("0.37.0")) && tr.Spec.RuleConcurrentEval != nil && *tr.Spec.RuleConcurrentEval > 0 {
+		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "rule-concurrent-evaluation", Value: strconv.FormatInt(*tr.Spec.RuleConcurrentEval, 10)})
 	}
 
 	trEnvVars := []v1.EnvVar{

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -1112,3 +1112,57 @@ func TestRuleQueryOffset(t *testing.T) {
 		})
 	}
 }
+
+func TestRuleConcurrentEval(t *testing.T) {
+	ruleConcurrentEval := int64(5)
+
+	tt := []struct {
+		scenario           string
+		version            string
+		ruleConcurrentEval *int64
+		shouldHaveArg      bool
+	}{{
+		scenario:           "version >= 0.37.0 with rule concurrent evaluation",
+		version:            "0.37.0",
+		ruleConcurrentEval: &ruleConcurrentEval,
+		shouldHaveArg:      true,
+	}, {
+		scenario:           "version < 0.37.0 with rule concurrent evaluation",
+		version:            "0.36.0",
+		ruleConcurrentEval: &ruleConcurrentEval,
+		shouldHaveArg:      false,
+	}, {
+		scenario:           "version >= 0.37.0 without rule concurrent evaluation",
+		version:            "0.37.0",
+		ruleConcurrentEval: nil,
+		shouldHaveArg:      false,
+	}}
+
+	for _, ts := range tt {
+		t.Run(ts.scenario, func(t *testing.T) {
+			version := ts.version
+
+			sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+				Spec: monitoringv1.ThanosRulerSpec{
+					Version:            &version,
+					RuleConcurrentEval: ts.ruleConcurrentEval,
+					QueryEndpoints:     emptyQueryEndpoints,
+				},
+			}, defaultTestConfig, nil, "", &operator.ShardedSecret{})
+
+			require.NoError(t, err)
+
+			trArgs := sset.Spec.Template.Spec.Containers[0].Args
+
+			found := false
+			for _, flag := range trArgs {
+				if strings.HasPrefix(flag, "--rule-concurrent-evaluation=") {
+					found = true
+					break
+				}
+			}
+
+			require.Equal(t, ts.shouldHaveArg, found)
+		})
+	}
+}


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

add thanos `--rule-concurrent-evaluation` options

ref: https://github.com/thanos-io/thanos/pull/7835

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add thanos `--rule-concurrent-evaluation` options
```
