### PR TITLE
feat: add ConfigurationUnmanaged reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [ENHANCEMENT] Set `reason: ConfigurationUnmanaged` in the `Reconciled` condition when the operator doesn't managed the Prometheus configuration. #7661
+
 ## 0.83.0 / 2025-05-30
 
 * [FEATURE] Add `limits` option for Alertmanager silences. #7478


### PR DESCRIPTION
## Description

When a Prometheus selects no scrape resources, the operator (by default) expects that users provide the configuration secret themselves. More often than not this type of situation is unintentional and users have a hard time figuring out why the generated configuration remains empty.

When the Prometheus configuration is unmanaged, this change sets `reason: ConfigurationUnmanaged` on the `Reconciled` condition to improve the user experience. Eventually we may want to make unmanaged configuration an opt-in feature (e.g.  having
`--disable-unmanaged-prometheus-configuration=true` by default).

Closes #7649

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
