### PR TITLE
Add proposal for ClusterProber/Prober CRDs

### DIFF
--- a/Documentation/proposals/202507-prober.md
+++ b/Documentation/proposals/202507-prober.md
@@ -1,0 +1,126 @@
+# Prober/ClusterProber CRD
+
+* **Owners:**
+  * [sebhoss](https://github.com/sebhoss)
+* **Status:**
+  * `PROPOSED`
+* **Related Tickets:**
+  * [#7560](https://github.com/prometheus-operator/prometheus-operator/issues/7560)
+* **Other docs:**
+  * [Scrape Classes Design Proposal](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202305-scrapeclasses.md)
+
+This proposal describes how common configuration parameters for `Probe` resources can be defined once and re-used across a cluster.
+
+## Why
+
+Currently, the prober inside has to be configured for each individual `Probe` resource. This does not only include the `spec.prober` struct with its fields `url`, `scheme`, and `path`, but also fields like `spec.authorization`, `spec.basicAuth` and `spec.tlsConfig` that define how the configured prober can be reached.
+
+The idea behind this proposal is to allow Prometheus administrators to define re-usable prober configurations which can be referenced by `Probe` resources. This simplifies usage of `Probe` resources as it allows users to focus on the actual target to probe, while the rest of the configuration is defined by the Prometheus administrator. Likewise, it allows Prometheus administrators to rotate secrets, TLS certificates, and other configuration parameters without having to update each individual `Probe` resource.
+
+### Pitfalls of the current solution
+
+Administrators are in charge of setting up the prober itself, e.g., an instance of blackbox-exporter and configure how it can be accessed. Currently, all teams in all their namespaces have to duplicate this information, even though the prober configuration is typically not namespace-specific. This gets worse, once credentials for basic authentication are required since we have to place these credentials in the same namespace as the `Probe` resource. This is an unnecessary exposure of secrets, since no user actually needs to access the prober itself, but only the Prometheus instance that uses the `Probe` resource.
+
+Scrape classes were introduced to allow administrators to define reusable scrape configurations, but they do not cover prober configuration options. We could extend them to cover prober-specific configuration, but this would feel awkward, as scrape classes are used for other scrapable resources as well which do not need these prober-specific configuration options.
+
+## Audience
+
+* Prometheus administrators who want to define reusable prober configurations
+* Users who want to reference these reusable prober configurations in their `Probe` resources
+
+## Goals
+
+* Allow administrators to define re-usable Prober configurations
+* Allow users to reference these configurations in their `Probe` resources
+* Allow users to override specific fields in the referenced Prober configuration
+* Allow users to keep using the `Probe` resource as they do today, without having to change their existing resources
+* Allow users to define their own Prober configurations that are not defined by the administrator
+* Allow multiple prometheus-operators to run in the same cluster, each with their own set of Prober configurations
+
+## Non-goals
+
+- Provide a way for Prometheus administrators to enforce/override settings on `Probe` resources.
+
+## How
+
+Consider the following example first to get the general idea: We define 1) a cluster-wide `ClusterProber` resource and 2) reference it in a namespaced `Probe` resource.
+
+```yaml
+# new custom resource
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ClusterProber
+metadata:
+  name: example-prober
+spec:
+  url: blackbox-exporter.example.com
+  scheme: https
+  path: /probe
+```
+
+A `Probe` resource can then reference this `ClusterProber` resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v2alpha1 # <- version change
+kind: Probe
+metadata:
+  name: example-probe
+  namespace: some-namespace
+spec:
+  proberRef: # <- new field
+    kind: ClusterProber
+    name: example-prober
+  targets:
+    ...
+```
+
+The new field `proberRef` in the `Probe` resource allows users to reference a `ClusterProber` or a namespaced `Prober` resource. It is modeled similar to `RoleBinding`/`ClusterRoleBinding` resources (their `roleRef` field), so that people already familiar with these resources can easily understand it. Similar to `roleRef`, the `proberRef` field does not allow specifying the namespace of the referenced `ClusterProber` or `Prober` resource, as it is assumed that the referenced resource is either cluster-wide or in the same namespace as the `Probe` resource.
+
+### Prober Spec
+
+The `ClusterProber` and `Prober` resources have the same spec, which contains the following fields:
+
+- `url`: The same value as the `spec.prober.url` field in the `Probe` resource
+- `scheme`: The same value as the `spec.prober.scheme` field in the `Probe` resource
+- `path`: The same value as the `spec.prober.path` field in the `Probe` resource
+- `authorization`: The same value as the `spec.authorization` field in the `Probe` resource
+- `basicAuth`: The same value as the `spec.basicAuth` field in the `Probe` resource
+- `tlsConfig`: The same value as the `spec.tlsConfig` field in the `Probe` resource
+
+### Handling secrets
+
+The `ClusterProber` and `Prober` resources can reference secrets, e.g., for basic authentication or TLS certificates. Secrets for `ClusterProber` resources are looked up in the namespace of the acting prometheus-operator or the namespace specified by a newly added `--cluster-resource-namespace` flag (the same flag is used by the controller component of cert-manager). Secrets for `Prober` resources are looked up in the namespace of the `Prober` resource itself.
+
+### Handling overlapping prober configurations
+
+The above proposal allows users to reference a prober while still specifying prober configuration options in the `Probe` resource itself, e.g., fields like `spec.authorization`, `spec.basicAuth`, `spec.tlsConfig`, and `spec.prober`. If any such field is defined, it overrides the corresponding field in the referenced `ClusterProber` or `Prober` resource. This allows users to override specific fields in the referenced prober configuration, while still re-using the rest of the configuration.
+
+### Interaction with scrape classes
+
+The `proberRef` field in the `Probe` resource is orthogonal to the `scrapeClassName` field. If both fields are defined, the prober configuration is applied first, followed by the scrape class configuration. This allows users to define a prober configuration that is then further customized by a scrape class.
+
+The merge algorithm thus looks like this:
+
+1. Apply the prober configuration from the referenced `ClusterProber` or `Prober` resource
+2. Apply the scrape class configuration from the `scrapeClassName` field, if defined
+3. Apply the `Probe` resource configuration, overriding any fields that were set in the referenced `ClusterProber` or `Prober` resource or the scrape class configuration
+
+### Testing
+
+1. Test plain the construction of a plain `Probe` resource (should not change)
+2. Reference a `ClusterProber`/`Prober` resource in a `Probe` resource and ensure that the prober configuration is applied correctly compared to the plain `Probe` resource
+3. Reference a scrape class as well as a `ClusterProber`/`Prober` resource in a `Probe` resource and ensure that the prober configuration is applied first, followed by the scrape class configuration
+4. Ensure that the `Probe` resource can still be used as it is today, without having to change existing resources
+5. Ensure that users can overwrite specific fields in the referenced `ClusterProber` or `Prober` resource by defining them in the `Probe` resource itself
+
+## Alternatives
+
+1. We can define [mutating admission policies](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) (alpha as of Kubernetes 1.32) to automatically inject the prober configuration into the `Probe` resource (or use a similar out-of-cluster solution like kyverno). This would still require placing credentials in the same namespace as the `Probe` resource, and it would not cover changes to the prober configuration after the `Probe` resource has been created.
+2. We can extend scrape classes to cover prober-specific configuration options and simply ignore them in resources that do not use the prober. Again, this would require placing credentials in the same namespace as the `Probe` resource.
+3. We could keep everything as-is and require users to define the prober configuration in each `Probe` resource.
+
+## Action Plan
+
+* Introduce `--cluster-resource-namespace` CLI flag
+* Introduce new `ClusterProber` and `Prober` CRDs
+* Add `proberRef` field to the `Probe` CRD
+* OPTIONAL: Deprecate `spec.prober`, `spec.authorization`, `spec.basicAuth`, and `spec.tlsConfig` fields in the `Probe` CRD, so that users are forced to use the new `proberRef` field instead.


### PR DESCRIPTION
## Description

Proposal for `ClusterProber`/`Prober` CRDs that can be used to capture common configuration settings found in `Probe` resources.

Closes: #7560

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
