### PR TITLE
add ApplyConfigurationFromServiceMonitor for Smon status update

### DIFF
--- a/pkg/prometheus/applyconfiguration.go
+++ b/pkg/prometheus/applyconfiguration.go
@@ -70,3 +70,39 @@ func prometheusStatusApplyConfigurationFromPrometheusStatus(status *monitoringv1
 
 	return psac
 }
+
+// ApplyConfigurationFromServiceMonitor updates the ServiceMonitor Status subresource.
+func ApplyConfigurationFromServiceMonitor(sm *monitoringv1.ServiceMonitor) *monitoringv1ac.ServiceMonitorApplyConfiguration {
+	smsac := configResourceStatusApplyConfigurationFromConfigResourceStatus(&sm.Status)
+	return monitoringv1ac.ServiceMonitor(sm.Name, sm.Namespace).
+		WithStatus(smsac)
+}
+
+func configResourceStatusApplyConfigurationFromConfigResourceStatus(status *monitoringv1.ConfigResourceStatus) *monitoringv1ac.ConfigResourceStatusApplyConfiguration {
+	crsac := monitoringv1ac.ConfigResourceStatus()
+
+	for _, binding := range status.Bindings {
+		bg := monitoringv1ac.WorkloadBinding().
+			WithGroup(binding.Group).
+			WithName(binding.Name).
+			WithNamespace(binding.Namespace).
+			WithResource(binding.Resource)
+
+		var conditions []*monitoringv1ac.ConfigResourceConditionApplyConfiguration
+		for _, condition := range binding.Conditions {
+			conditions = append(conditions, monitoringv1ac.ConfigResourceCondition().
+				WithType(condition.Type).
+				WithStatus(condition.Status).
+				WithLastTransitionTime(condition.LastTransitionTime).
+				WithReason(condition.Reason).
+				WithMessage(condition.Message).
+				WithObservedGeneration(condition.ObservedGeneration),
+			)
+		}
+
+		bg.WithConditions(conditions...)
+		crsac.WithBindings(bg)
+	}
+
+	return crsac
+}


### PR DESCRIPTION

## Description
add ApplyConfigurationFromServiceMonitor for Smon status update

_Closes: #7714 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
