### PR TITLE
feat: add `promote_all_resource_attributes` and `ignore_resource_attributes` option in OTLPConfig

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -11463,6 +11463,34 @@ string
 </tr>
 <tr>
 <td>
+<code>promoteAllResourceAttributes</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Promoting all resource attributes to labels, except for the ones configured with &lsquo;ignore_resource_attributes&rsquo;.
+Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+It cannot be set to &lsquo;true&rsquo; simultaneously with &lsquo;promote_resource_attributes&rsquo;.</p>
+<p>It requires Prometheus &gt;= v3.5.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoreResourceAttributes</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Which resource attributes to ignore, can only be set when &lsquo;promote_all_resource_attributes&rsquo; is true.</p>
+<p>It requires Prometheus &gt;= v3.5.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>translationStrategy</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.TranslationStrategyOption">

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -27648,12 +27648,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted
@@ -39377,12 +39396,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4837,12 +4837,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5608,12 +5608,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4838,12 +4838,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5609,12 +5609,31 @@ spec:
                       Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
                       It requires Prometheus >= v3.4.0.
                     type: boolean
+                  ignoreResourceAttributes:
+                    description: |-
+                      Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+
+                      It requires Prometheus >= v3.5.0.
+                    items:
+                      minLength: 1
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
                   keepIdentifyingResourceAttributes:
                     description: |-
                       Enables adding `service.name`, `service.namespace` and `service.instance.id`
                       resource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.
 
                       It requires Prometheus >= v3.1.0.
+                    type: boolean
+                  promoteAllResourceAttributes:
+                    description: |-
+                      Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+                      Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+                      It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+
+                      It requires Prometheus >= v3.5.0.
                     type: boolean
                   promoteResourceAttributes:
                     description: List of OpenTelemetry Attributes that should be promoted

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4115,8 +4115,22 @@
                         "description": "Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.\nIt requires Prometheus >= v3.4.0.",
                         "type": "boolean"
                       },
+                      "ignoreResourceAttributes": {
+                        "description": "Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.\n\nIt requires Prometheus >= v3.5.0.",
+                        "items": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "keepIdentifyingResourceAttributes": {
                         "description": "Enables adding `service.name`, `service.namespace` and `service.instance.id`\nresource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.\n\nIt requires Prometheus >= v3.1.0.",
+                        "type": "boolean"
+                      },
+                      "promoteAllResourceAttributes": {
+                        "description": "Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.\nBe aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.\nIt cannot be set to 'true' simultaneously with 'promote_resource_attributes'.\n\nIt requires Prometheus >= v3.5.0.",
                         "type": "boolean"
                       },
                       "promoteResourceAttributes": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4766,8 +4766,22 @@
                         "description": "Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.\nIt requires Prometheus >= v3.4.0.",
                         "type": "boolean"
                       },
+                      "ignoreResourceAttributes": {
+                        "description": "Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.\n\nIt requires Prometheus >= v3.5.0.",
+                        "items": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "keepIdentifyingResourceAttributes": {
                         "description": "Enables adding `service.name`, `service.namespace` and `service.instance.id`\nresource attributes to the `target_info` metric, on top of converting them into the `instance` and `job` labels.\n\nIt requires Prometheus >= v3.1.0.",
+                        "type": "boolean"
+                      },
+                      "promoteAllResourceAttributes": {
+                        "description": "Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.\nBe aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.\nIt cannot be set to 'true' simultaneously with 'promote_resource_attributes'.\n\nIt requires Prometheus >= v3.5.0.",
                         "type": "boolean"
                       },
                       "promoteResourceAttributes": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -2358,6 +2359,23 @@ type OTLPConfig struct {
 	// +optional
 	PromoteResourceAttributes []string `json:"promoteResourceAttributes,omitempty"`
 
+	// Promoting all resource attributes to labels, except for the ones configured with 'ignore_resource_attributes'.
+	// Be aware that changes in attributes received by the OTLP endpoint may result in time series churn and lead to high memory usage by the Prometheus server.
+	// It cannot be set to 'true' simultaneously with 'promote_resource_attributes'.
+	//
+	// It requires Prometheus >= v3.5.0.
+	// +optional
+	PromoteAllResourceAttributes *bool `json:"promoteAllResourceAttributes,omitempty"`
+
+	// Which resource attributes to ignore, can only be set when 'promote_all_resource_attributes' is true.
+	//
+	// It requires Prometheus >= v3.5.0.
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:items:MinLength=1
+	// +listType=set
+	// +optional
+	IgnoreResourceAttributes []string `json:"ignoreResourceAttributes,omitempty"`
+
 	// Configures how the OTLP receiver endpoint translates the incoming metrics.
 	//
 	// It requires Prometheus >= v3.0.0.
@@ -2375,4 +2393,21 @@ type OTLPConfig struct {
 	// It requires Prometheus >= v3.4.0.
 	// +optional
 	ConvertHistogramsToNHCB *bool `json:"convertHistogramsToNHCB,omitempty"`
+}
+
+// Validate semantically validates the given OTLPConfig.
+func (c *OTLPConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if len(c.PromoteResourceAttributes) > 0 && c.PromoteAllResourceAttributes != nil && *c.PromoteAllResourceAttributes {
+		return fmt.Errorf("promote_all_resource_attributes cannot be set to 'true' simultaneously with 'promote_resource_attributes'")
+	}
+
+	if len(c.IgnoreResourceAttributes) > 0 && (c.PromoteAllResourceAttributes == nil || !*c.PromoteAllResourceAttributes) {
+		return fmt.Errorf("ignore_resource_attributes can only be set when 'promote_all_resource_attributes' is true")
+	}
+
+	return nil
 }

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1887,6 +1887,16 @@ func (in *OTLPConfig) DeepCopyInto(out *OTLPConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PromoteAllResourceAttributes != nil {
+		in, out := &in.PromoteAllResourceAttributes, &out.PromoteAllResourceAttributes
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IgnoreResourceAttributes != nil {
+		in, out := &in.IgnoreResourceAttributes, &out.IgnoreResourceAttributes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TranslationStrategy != nil {
 		in, out := &in.TranslationStrategy, &out.TranslationStrategy
 		*out = new(TranslationStrategyOption)

--- a/pkg/client/applyconfiguration/monitoring/v1/otlpconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/otlpconfig.go
@@ -24,6 +24,8 @@ import (
 // with apply.
 type OTLPConfigApplyConfiguration struct {
 	PromoteResourceAttributes         []string                                `json:"promoteResourceAttributes,omitempty"`
+	PromoteAllResourceAttributes      *bool                                   `json:"promoteAllResourceAttributes,omitempty"`
+	IgnoreResourceAttributes          []string                                `json:"ignoreResourceAttributes,omitempty"`
 	TranslationStrategy               *monitoringv1.TranslationStrategyOption `json:"translationStrategy,omitempty"`
 	KeepIdentifyingResourceAttributes *bool                                   `json:"keepIdentifyingResourceAttributes,omitempty"`
 	ConvertHistogramsToNHCB           *bool                                   `json:"convertHistogramsToNHCB,omitempty"`
@@ -41,6 +43,24 @@ func OTLPConfig() *OTLPConfigApplyConfiguration {
 func (b *OTLPConfigApplyConfiguration) WithPromoteResourceAttributes(values ...string) *OTLPConfigApplyConfiguration {
 	for i := range values {
 		b.PromoteResourceAttributes = append(b.PromoteResourceAttributes, values[i])
+	}
+	return b
+}
+
+// WithPromoteAllResourceAttributes sets the PromoteAllResourceAttributes field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PromoteAllResourceAttributes field is set to the value of the last call.
+func (b *OTLPConfigApplyConfiguration) WithPromoteAllResourceAttributes(value bool) *OTLPConfigApplyConfiguration {
+	b.PromoteAllResourceAttributes = &value
+	return b
+}
+
+// WithIgnoreResourceAttributes adds the given value to the IgnoreResourceAttributes field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the IgnoreResourceAttributes field.
+func (b *OTLPConfigApplyConfiguration) WithIgnoreResourceAttributes(values ...string) *OTLPConfigApplyConfiguration {
+	for i := range values {
+		b.IgnoreResourceAttributes = append(b.IgnoreResourceAttributes, values[i])
 	}
 	return b
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -4769,12 +4769,31 @@ func (cg *ConfigGenerator) appendOTLPConfig(cfg yaml.MapSlice) (yaml.MapSlice, e
 		return cfg, fmt.Errorf("nameValidationScheme %q is only supported from Prometheus version 3.4.0 ", monitoringv1.NoTranslation)
 	}
 
+	if cg.version.GTE(semver.MustParse("3.5.0")) {
+		err := otlpConfig.Validate()
+		if err != nil {
+			return cfg, err
+		}
+	}
+
 	otlp := yaml.MapSlice{}
 
 	if len(otlpConfig.PromoteResourceAttributes) > 0 {
 		otlp = cg.WithMinimumVersion("2.55.0").AppendMapItem(otlp,
 			"promote_resource_attributes",
 			otlpConfig.PromoteResourceAttributes)
+	}
+
+	if otlpConfig.PromoteAllResourceAttributes != nil {
+		otlp = cg.WithMinimumVersion("3.5.0").AppendMapItem(otlp,
+			"promote_all_resource_attributes",
+			otlpConfig.PromoteAllResourceAttributes)
+	}
+
+	if len(otlpConfig.IgnoreResourceAttributes) > 0 {
+		otlp = cg.WithMinimumVersion("3.5.0").AppendMapItem(otlp,
+			"ignore_resource_attributes",
+			otlpConfig.IgnoreResourceAttributes)
 	}
 
 	if otlpConfig.TranslationStrategy != nil {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -9729,6 +9729,56 @@ func TestOTLPConfig(t *testing.T) {
 			},
 			golden: "OTLPConfig_Config_convert_histograms_to_nhcb_with_old_version.golden",
 		},
+		{
+			name:    "Config IgnoreResourceAttributes with old version",
+			version: "v3.4.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				IgnoreResourceAttributes: []string{"aa", "bb", "cc"},
+			},
+			golden: "OTLPConfig_Config_ignore_resource_attributes_with_old_version.golden",
+		},
+		{
+			name:    "Config IgnoreResourceAttributes",
+			version: "v3.5.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				IgnoreResourceAttributes: []string{"aa", "bb", "cc"},
+			},
+			expectedErr: true,
+		},
+		{
+			name:    "Config IgnoreResourceAttributes with PromoteAllResourceAttributes true",
+			version: "v3.5.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				IgnoreResourceAttributes:     []string{"aa", "bb", "cc"},
+				PromoteAllResourceAttributes: ptr.To(true),
+			},
+			golden: "OTLPConfig_Config_ignore_resource_attributes_with_true.golden",
+		},
+		{
+			name:    "Config PromoteAllResourceAttributes",
+			version: "v3.5.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				PromoteAllResourceAttributes: ptr.To(true),
+			},
+			golden: "OTLPConfig_Config_promote_all_resource_attributes.golden",
+		},
+		{
+			name:    "Config PromoteAllResourceAttributes",
+			version: "v3.5.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				PromoteResourceAttributes:    []string{"aa", "bb", "cc"},
+				PromoteAllResourceAttributes: ptr.To(true),
+			},
+			expectedErr: true,
+		},
+		{
+			name:    "Config PromoteAllResourceAttributes with_old_version",
+			version: "v3.4.0",
+			otlpConfig: &monitoringv1.OTLPConfig{
+				PromoteAllResourceAttributes: ptr.To(true),
+			},
+			golden: "OTLPConfig_Config_promote_all_resource_attributes_with_old_version.golden",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/prometheus/testdata/OTLPConfig_Config_ignore_resource_attributes_with_old_version.golden
+++ b/pkg/prometheus/testdata/OTLPConfig_Config_ignore_resource_attributes_with_old_version.golden
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []

--- a/pkg/prometheus/testdata/OTLPConfig_Config_ignore_resource_attributes_with_true.golden
+++ b/pkg/prometheus/testdata/OTLPConfig_Config_ignore_resource_attributes_with_true.golden
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+otlp:
+  promote_all_resource_attributes: true
+  ignore_resource_attributes:
+  - aa
+  - bb
+  - cc

--- a/pkg/prometheus/testdata/OTLPConfig_Config_promote_all_resource_attributes.golden
+++ b/pkg/prometheus/testdata/OTLPConfig_Config_promote_all_resource_attributes.golden
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+otlp:
+  promote_all_resource_attributes: true

--- a/pkg/prometheus/testdata/OTLPConfig_Config_promote_all_resource_attributes_with_old_version.golden
+++ b/pkg/prometheus/testdata/OTLPConfig_Config_promote_all_resource_attributes_with_old_version.golden
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

_If it fixes an existing issue (bug or feature), use the following keyword:_

_Closes: #ISSUE-NUMBER_

ref: https://github.com/prometheus/prometheus/pull/16426

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add `promote_all_resource_attributes` and `ignore_resource_attributes` option in OTLPConfig
```
