### PR TITLE
Fix no-storage.tsdb.allow-overlapping-compaction argument

### DIFF
--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -246,7 +246,7 @@ func makeStatefulSetSpec(
 	if cpf.TSDB != nil && cpf.TSDB.OutOfOrderTimeWindow != nil &&
 		compactionDisabled(p) &&
 		cg.WithMinimumVersion("2.55.0").IsCompatible() {
-		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.allow-overlapping-compaction"})
+		promArgs = append(promArgs, monitoringv1.Argument{Name: "no-storage.tsdb.allow-overlapping-compaction"})
 	}
 
 	var watchedDirectories []string


### PR DESCRIPTION
## Description

Code comment describe that if all condition are met, `no-storage.tsdb.allow-overlapping-compaction` should be added to the arg list. But the code adds `storage.tsdb.allow-overlapping-compaction`

_Closes: https://github.com/prometheus-community/helm-charts/issues/5895_

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Set `no-storage.tsdb.allow-overlapping-compaction`, if thanos sidecar and OOO are enabled.
```
