### PR TITLE
docs: add internal architecture overview to operator documentation\n\…

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -13,6 +13,33 @@ description: Command line arguments for the operator binary
 
 > Note this document is automatically generated from the `cmd/operator/main.go` file and shouldn't be edited directly.
 
+# Internal Architecture Overview
+
+The Prometheus Operator is a Kubernetes Operator that automates the deployment, configuration, and management of Prometheus, Alertmanager, ThanosRuler, and related monitoring resources using Kubernetes Custom Resource Definitions (CRDs). Its core responsibilities include:
+
+- **Custom Resource Management:** The Operator introduces and manages several CRDs, such as `Prometheus`, `Alertmanager`, `ThanosRuler`, `PrometheusAgent`, `ServiceMonitor`, `PodMonitor`, `Probe`, `ScrapeConfig`, `AlertmanagerConfig`, and `PrometheusRule`. These CRDs allow users to declaratively define monitoring infrastructure and scrape configurations in a Kubernetes-native way.
+
+- **Reconciliation Loop:** At the heart of the Operator is a reconciliation loop. The Operator continuously watches for changes to its managed CRDs and associated Kubernetes resources (e.g., StatefulSets, Services, ConfigMaps, Secrets). When a change is detected (creation, update, or deletion), the Operator reconciles the actual state of the cluster to match the desired state specified in the CRDs. This ensures that Prometheus and related components are always correctly configured and running as intended.
+
+- **Controllers:** The Operator is composed of multiple controllers, each responsible for a specific resource type (e.g., Prometheus, Alertmanager, ThanosRuler). Each controller:
+  - Watches for changes to its CRD and related resources.
+  - Validates and processes the resource specification.
+  - Creates, updates, or deletes Kubernetes resources (such as StatefulSets, DaemonSets, Services, and ConfigMaps) to realize the desired state.
+  - Handles configuration reloads and rolling updates in a safe and automated manner.
+
+- **Resource Management:**
+  - For each `Prometheus`, `Alertmanager`, or `ThanosRuler` resource, the Operator creates and manages the corresponding StatefulSet (or DaemonSet for PrometheusAgent in DaemonSet mode), Service, and configuration resources.
+  - The Operator automatically generates Prometheus configuration based on `ServiceMonitor`, `PodMonitor`, `Probe`, and `ScrapeConfig` resources selected by the user, abstracting away the complexity of manual configuration.
+  - It manages secrets and RBAC resources required for secure operation.
+
+- **Validation and Safety:** The Operator performs validation of custom resources and ensures safe updates, minimizing downtime and configuration errors. It also supports admission webhooks for additional validation and mutation of resources.
+
+- **Extensibility:** The Operator is designed to be extensible, supporting new CRDs and features as the Prometheus ecosystem evolves.
+
+This architecture enables Kubernetes users to manage complex monitoring setups declaratively, reliably, and at scale, following Kubernetes best practices.
+
+---
+
 ```console mdox-exec="./operator --help"
 Usage of ./operator:
   -alertmanager-config-namespaces value


### PR DESCRIPTION
…nThis adds a new section to the top of the operator CLI reference page, providing a clear and concise overview of the internal architecture and workings of the Prometheus Operator. It covers the reconciliation loop, controllers, CRDs, and resource management, making it easier for new contributors and users to understand how the operator functions. No code or logic changes are included.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

_If it fixes an existing issue (bug or feature), use the following keyword:_

_Closes: #ISSUE-NUMBER_

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
