### PR TITLE
feat: add thanos rule resend-delay flag

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -4789,6 +4789,20 @@ Duration
 </tr>
 <tr>
 <td>
+<code>resendDelay</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.Duration">
+Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Minimum amount of time to wait before resending an alert to Alertmanager.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ruleOutageTolerance</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1.Duration">
@@ -18654,6 +18668,20 @@ Duration
 </td>
 <td>
 <p>Interval between consecutive evaluations.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resendDelay</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.Duration">
+Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Minimum amount of time to wait before resending an alert to Alertmanager.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -66745,7 +66745,6 @@ spec:
                 format: int32
                 type: integer
               resendDelay:
-                default: 1m
                 description: Minimum amount of time to wait before resending an alert
                   to Alertmanager.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -66744,6 +66744,12 @@ spec:
                 description: Number of thanos ruler instances to deploy.
                 format: int32
                 type: integer
+              resendDelay:
+                default: 1m
+                description: Minimum amount of time to wait before resending an alert
+                  to Alertmanager.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
               resources:
                 description: |-
                   Resources defines the resource requirements for single Pods.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5640,7 +5640,6 @@ spec:
                 format: int32
                 type: integer
               resendDelay:
-                default: 1m
                 description: Minimum amount of time to wait before resending an alert
                   to Alertmanager.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5639,6 +5639,12 @@ spec:
                 description: Number of thanos ruler instances to deploy.
                 format: int32
                 type: integer
+              resendDelay:
+                default: 1m
+                description: Minimum amount of time to wait before resending an alert
+                  to Alertmanager.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
               resources:
                 description: |-
                   Resources defines the resource requirements for single Pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5641,7 +5641,6 @@ spec:
                 format: int32
                 type: integer
               resendDelay:
-                default: 1m
                 description: Minimum amount of time to wait before resending an alert
                   to Alertmanager.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5640,6 +5640,12 @@ spec:
                 description: Number of thanos ruler instances to deploy.
                 format: int32
                 type: integer
+              resendDelay:
+                default: 1m
+                description: Minimum amount of time to wait before resending an alert
+                  to Alertmanager.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
               resources:
                 description: |-
                   Resources defines the resource requirements for single Pods.

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4960,7 +4960,6 @@
                     "type": "integer"
                   },
                   "resendDelay": {
-                    "default": "1m",
                     "description": "Minimum amount of time to wait before resending an alert to Alertmanager.",
                     "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4959,6 +4959,12 @@
                     "format": "int32",
                     "type": "integer"
                   },
+                  "resendDelay": {
+                    "default": "1m",
+                    "description": "Minimum amount of time to wait before resending an alert to Alertmanager.",
+                    "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                    "type": "string"
+                  },
                   "resources": {
                     "description": "Resources defines the resource requirements for single Pods.\nIf not provided, no requests/limits will be set",
                     "properties": {

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -288,7 +288,6 @@ type ThanosRulerSpec struct {
 	EvaluationInterval Duration `json:"evaluationInterval,omitempty"`
 
 	// Minimum amount of time to wait before resending an alert to Alertmanager.
-	// +kubebuilder:default:="1m"
 	// +optional
 	ResendDelay *Duration `json:"resendDelay,omitempty"`
 

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -287,6 +287,11 @@ type ThanosRulerSpec struct {
 	// +kubebuilder:default:="15s"
 	EvaluationInterval Duration `json:"evaluationInterval,omitempty"`
 
+	// Minimum amount of time to wait before resending an alert to Alertmanager.
+	// +kubebuilder:default:="1m"
+	// +optional
+	ResendDelay *Duration `json:"resendDelay,omitempty"`
+
 	// Max time to tolerate prometheus outage for restoring "for" state of alert.
 	// It requires Thanos >= v0.30.0.
 	// +optional

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -3849,6 +3849,11 @@ func (in *ThanosRulerSpec) DeepCopyInto(out *ThanosRulerSpec) {
 		*out = make([]PrometheusRuleExcludeConfig, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResendDelay != nil {
+		in, out := &in.ResendDelay, &out.ResendDelay
+		*out = new(Duration)
+		**out = **in
+	}
 	if in.RuleOutageTolerance != nil {
 		in, out := &in.RuleOutageTolerance, &out.RuleOutageTolerance
 		*out = new(Duration)

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
@@ -63,6 +63,7 @@ type ThanosRulerSpecApplyConfiguration struct {
 	LogFormat                          *string                                         `json:"logFormat,omitempty"`
 	PortName                           *string                                         `json:"portName,omitempty"`
 	EvaluationInterval                 *monitoringv1.Duration                          `json:"evaluationInterval,omitempty"`
+	ResendDelay                        *monitoringv1.Duration                          `json:"resendDelay,omitempty"`
 	RuleOutageTolerance                *monitoringv1.Duration                          `json:"ruleOutageTolerance,omitempty"`
 	RuleQueryOffset                    *monitoringv1.Duration                          `json:"ruleQueryOffset,omitempty"`
 	RuleConcurrentEval                 *int32                                          `json:"ruleConcurrentEval,omitempty"`
@@ -425,6 +426,14 @@ func (b *ThanosRulerSpecApplyConfiguration) WithPortName(value string) *ThanosRu
 // If called multiple times, the EvaluationInterval field is set to the value of the last call.
 func (b *ThanosRulerSpecApplyConfiguration) WithEvaluationInterval(value monitoringv1.Duration) *ThanosRulerSpecApplyConfiguration {
 	b.EvaluationInterval = &value
+	return b
+}
+
+// WithResendDelay sets the ResendDelay field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ResendDelay field is set to the value of the last call.
+func (b *ThanosRulerSpecApplyConfiguration) WithResendDelay(value monitoringv1.Duration) *ThanosRulerSpecApplyConfiguration {
+	b.ResendDelay = &value
 	return b
 }
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -179,6 +179,10 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "for-grace-period", Value: string(*tr.Spec.RuleGracePeriod)})
 	}
 
+	if tr.Spec.ResendDelay != nil && len(*tr.Spec.ResendDelay) > 0 {
+		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "resend-delay", Value: string(*tr.Spec.ResendDelay)})
+	}
+
 	trEnvVars := []v1.EnvVar{
 		{
 			Name: "POD_NAME",

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -1276,18 +1276,16 @@ func TestRuleGracePeriod(t *testing.T) {
 }
 
 func TestRuleResendDelay(t *testing.T) {
-	resendDelay := monitoringv1.Duration("1h")
-
 	tt := []struct {
 		scenario      string
 		resendDelay   *monitoringv1.Duration
 		shouldHaveArg bool
 	}{{
 		scenario:      "resend delay defined",
-		resendDelay:   &resendDelay,
+		resendDelay:   ptr.To(monitoringv1.Duration("1h")),
 		shouldHaveArg: true,
 	}, {
-		scenario:      "resend-delay is nill",
+		scenario:      "resend-delay is nil",
 		resendDelay:   nil,
 		shouldHaveArg: false,
 	}}


### PR DESCRIPTION
## Description

Add Thanos Rule `resend-delay` flag, available in Thanos since [v0.8.0](https://github.com/thanos-io/thanos/releases/tag/v0.8.0).

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
