### PR TITLE
Fix `maximumStartupDurationSeconds` default value in docs

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -3224,7 +3224,7 @@ int32
 <td>
 <em>(Optional)</em>
 <p>Defines the maximum time that the <code>prometheus</code> container&rsquo;s startup probe will wait before being considered failed. The startup probe will return success after the WAL replay is complete.
-If set, the value should be greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15 minutes).</p>
+If set, the value should be greater than 60 (seconds). Otherwise it will be equal to 900 seconds (15 minutes).</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Small Typo that confused me for a moment... 