### PR TITLE
feat: add configurable sync period for kubelet endpoints controller

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -73,7 +73,7 @@ Usage of ./operator:
   -kubelet-service string
     	Service/Endpoints object to write kubelets into in format "namespace/name"
   -kubelet-sync-period duration
-    	Duration for sync period of kubelet endpoints (e.g., 10s, 2m, 1h30m) (default 3m0s)
+    	Sync period duration for updating kubelet endpoints (e.g., 10s, 2m, 1h30m). (default 3m0s)
   -labels value
     	Labels to be add to all resources created by the operator
   -localhost string

--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -73,7 +73,7 @@ Usage of ./operator:
   -kubelet-service string
     	Service/Endpoints object to write kubelets into in format "namespace/name"
   -kubelet-sync-period duration
-    	Sync period duration for updating kubelet endpoints (e.g., 10s, 2m, 1h30m). (default 3m0s)
+    	How often the operator reconciles the kubelet Endpoints and EndpointSlice objects (e.g., 10s, 2m, 1h30m). (default 3m0s)
   -labels value
     	Labels to be add to all resources created by the operator
   -localhost string

--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -72,6 +72,8 @@ Usage of ./operator:
     	Label selector to filter nodes.
   -kubelet-service string
     	Service/Endpoints object to write kubelets into in format "namespace/name"
+  -kubelet-sync-period duration
+    	Duration for sync period of kubelet endpoints (e.g., 10s, 2m, 1h30m) (default 3m0s)
   -labels value
     	Labels to be add to all resources created by the operator
   -localhost string

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -147,7 +147,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&nodeAddressPriority, "kubelet-node-address-priority", "Node address priority used by kubelet. Either 'internal' or 'external'. Default: 'internal'.")
 	fs.BoolVar(&kubeletEndpointSlice, "kubelet-endpointslice", false, "Create EndpointSlice objects for kubelet targets.")
 	fs.BoolVar(&kubeletEndpoints, "kubelet-endpoints", true, "Create Endpoints objects for kubelet targets.")
-	fs.DurationVar(&kubeletSyncPeriod, "kubelet-sync-period", 3*time.Minute, "Sync period duration for updating kubelet endpoints (e.g., 10s, 2m, 1h30m).")
+	fs.DurationVar(&kubeletSyncPeriod, "kubelet-sync-period", 3*time.Minute, "How often the operator reconciles the kubelet Endpoints and EndpointSlice objects (e.g., 10s, 2m, 1h30m).")
 
 	// The Prometheus config reloader image is released along with the
 	// Prometheus Operator image, tagged with the same semver version. Default to

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -124,6 +125,7 @@ var (
 	nodeAddressPriority  operator.NodeAddressPriority
 	kubeletEndpoints     bool
 	kubeletEndpointSlice bool
+	kubeletSyncPeriod    time.Duration
 
 	featureGates = k8sflag.NewMapStringBool(ptr.To(map[string]bool{}))
 )
@@ -145,6 +147,7 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&nodeAddressPriority, "kubelet-node-address-priority", "Node address priority used by kubelet. Either 'internal' or 'external'. Default: 'internal'.")
 	fs.BoolVar(&kubeletEndpointSlice, "kubelet-endpointslice", false, "Create EndpointSlice objects for kubelet targets.")
 	fs.BoolVar(&kubeletEndpoints, "kubelet-endpoints", true, "Create Endpoints objects for kubelet targets.")
+	fs.DurationVar(&kubeletSyncPeriod, "kubelet-sync-period", 3*time.Minute, "Sync period duration for updating kubelet endpoints (e.g., 10s, 2m, 1h30m).")
 
 	// The Prometheus config reloader image is released along with the
 	// Prometheus Operator image, tagged with the same semver version. Default to
@@ -528,7 +531,10 @@ func run(fs *flag.FlagSet) int {
 
 	var kec *kubelet.Controller
 	if kubeletObject != "" {
-		opts := []kubelet.ControllerOption{kubelet.WithNodeAddressPriority(nodeAddressPriority.String())}
+		opts := []kubelet.ControllerOption{
+			kubelet.WithNodeAddressPriority(nodeAddressPriority.String()),
+			kubelet.WithSyncPeriod(kubeletSyncPeriod),
+		}
 
 		kubeletService := strings.Split(kubeletObject, "/")
 		if len(kubeletService) != 2 {

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	resyncPeriod = 3 * time.Minute
-
 	maxEndpointsPerSlice = 512
 
 	endpointsLabel     = "endpoints"
@@ -73,6 +71,7 @@ type Controller struct {
 
 	manageEndpointSlice bool
 	manageEndpoints     bool
+	syncPeriod          time.Duration
 }
 
 type ControllerOption func(*Controller)
@@ -98,6 +97,12 @@ func WithEndpoints() ControllerOption {
 func WithNodeAddressPriority(s string) ControllerOption {
 	return func(c *Controller) {
 		c.nodeAddressPriority = s
+	}
+}
+
+func WithSyncPeriod(d time.Duration) ControllerOption {
+	return func(c *Controller) {
+		c.syncPeriod = d
 	}
 }
 
@@ -206,7 +211,7 @@ func New(
 func (c *Controller) Run(ctx context.Context) error {
 	c.logger.Info("Starting controller")
 
-	ticker := time.NewTicker(resyncPeriod)
+	ticker := time.NewTicker(c.syncPeriod)
 	defer ticker.Stop()
 	for {
 		c.sync(ctx)


### PR DESCRIPTION

## Description

Add `--kubelet-sync-period` flag to allow customization of how often the kubelet endpoints controller syncs with the Kubernetes API. Default remains 3 minutes to maintain backward compatibility.

The hardcoded 3-minute sync period can cause timing issues in environments with
  regular node scaling - when nodes are scaled down every 3 minutes, the sync timing can align in a way that causes Prometheus targets to remain persistently unhealthy, triggering false alarms.

Related Issue: N/A

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

```release-note
Add configurable sync period for kubelet endpoints controller
```
