### PR TITLE
feat: optimize statefulset informers

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -274,7 +274,9 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 			config.Namespaces.DenyList,
 			c.kclient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = operator.ManagedByOperatorLabelSelector()
+			},
 		),
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
 	)

--- a/pkg/operator/factory.go
+++ b/pkg/operator/factory.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,10 @@ const (
 	managedByOperatorLabel      = "managed-by"
 	managedByOperatorLabelValue = "prometheus-operator"
 )
+
+func ManagedByOperatorLabelSelector() string {
+	return fmt.Sprintf("%s in (%s)", managedByOperatorLabel, managedByOperatorLabelValue)
+}
 
 type ObjectOption func(metav1.Object)
 

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -59,7 +59,7 @@ func makeDaemonSet(
 		operator.WithLabels(objMeta.GetLabels()),
 		operator.WithLabels(map[string]string{
 			prompkg.PrometheusNameLabelName: objMeta.GetName(),
-			prompkg.PrometheusModeLabeLName: prometheusMode,
+			prompkg.PrometheusModeLabelName: prometheusMode,
 		}),
 		operator.WithLabels(config.Labels),
 		operator.WithManagingOwner(p),

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -307,7 +307,9 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			c.Namespaces.DenyList,
 			o.kclient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = prompkg.LabelSelectorForStatefulSets(prometheusMode)
+			},
 		),
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
 	)
@@ -845,7 +847,7 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 		ssets[ssetName] = struct{}{}
 	}
 
-	err := c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabeLName: prometheusMode}), func(obj interface{}) {
+	err := c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabelName: prometheusMode}), func(obj interface{}) {
 		s := obj.(*appsv1.StatefulSet)
 
 		if _, ok := ssets[s.Name]; ok {

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -72,7 +72,7 @@ func makeStatefulSet(
 		operator.WithLabels(map[string]string{
 			prompkg.ShardLabelName:          fmt.Sprintf("%d", shard),
 			prompkg.PrometheusNameLabelName: objMeta.GetName(),
-			prompkg.PrometheusModeLabeLName: prometheusMode,
+			prompkg.PrometheusModeLabelName: prometheusMode,
 		}),
 		operator.WithLabels(config.Labels),
 		operator.WithManagingOwner(p),

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -59,13 +59,31 @@ const (
 )
 
 var (
-	ShardLabelName                = "operator.prometheus.io/shard"
-	PrometheusNameLabelName       = "operator.prometheus.io/name"
-	PrometheusModeLabeLName       = "operator.prometheus.io/mode"
-	PrometheusK8sLabelName        = "app.kubernetes.io/name"
-	ProbeTimeoutSeconds     int32 = 3
-	LabelPrometheusName           = "prometheus-name"
+	// ShardLabelName is the statefulset's label identifying the Prometheus/PrometheusAgent resource's shard.
+	ShardLabelName = "operator.prometheus.io/shard"
+
+	// PrometheusNameLabelName is the statefulset's label identifying the Prometheus/PrometheusAgent resource.
+	PrometheusNameLabelName = "operator.prometheus.io/name"
+
+	// PrometheusModeLabelName is the statefulset's label identifying whether the owning resource is a Prometheus or PrometheusAgent.
+	PrometheusModeLabelName = "operator.prometheus.io/mode"
+
+	PrometheusK8sLabelName = "app.kubernetes.io/name"
+
+	ProbeTimeoutSeconds int32 = 3
+	LabelPrometheusName       = "prometheus-name"
 )
+
+// LabelSelectorForStatefulSets returns a label selector which selects statefulsets deployed with the server or agent mode.
+func LabelSelectorForStatefulSets(mode string) string {
+	return fmt.Sprintf(
+		"%s,%s,%s,%s in (%s)",
+		operator.ManagedByOperatorLabelSelector(),
+		ShardLabelName,
+		PrometheusNameLabelName,
+		PrometheusModeLabelName, mode,
+	)
+}
 
 func ExpectedStatefulSetShardNames(
 	p monitoringv1.PrometheusInterface,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -340,7 +340,9 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			c.Namespaces.DenyList,
 			o.kclient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = prompkg.LabelSelectorForStatefulSets(prometheusMode)
+			},
 		),
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
 	)
@@ -997,7 +999,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		ssets[ssetName] = struct{}{}
 	}
 
-	err = c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabeLName: prometheusMode}), func(obj interface{}) {
+	err = c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabelName: prometheusMode}), func(obj interface{}) {
 		s := obj.(*appsv1.StatefulSet)
 
 		if _, ok := ssets[s.Name]; ok {

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -77,7 +77,7 @@ func makeStatefulSet(
 		operator.WithLabels(map[string]string{
 			prompkg.ShardLabelName:          fmt.Sprintf("%d", shard),
 			prompkg.PrometheusNameLabelName: objMeta.GetName(),
-			prompkg.PrometheusModeLabeLName: prometheusMode,
+			prompkg.PrometheusModeLabelName: prometheusMode,
 		}),
 		operator.WithLabels(config.Labels),
 		operator.WithManagingOwner(p),

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -227,7 +227,9 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			c.Namespaces.DenyList,
 			o.kclient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.LabelSelector = operator.ManagedByOperatorLabelSelector()
+			},
 		),
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
 	)


### PR DESCRIPTION
## Description

This change adds label selectors to statefulset informers so each controller only watches the needed resources.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
