### PR TITLE
chore: update description of `minReadySeconds` fields

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -762,15 +762,14 @@ process incoming alerts.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -2968,16 +2967,14 @@ It requires Prometheus &gt;= v3.5.0.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created Pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)</p>
-<p>This is an alpha field from kubernetes 1.22 until 1.24 which requires
-enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -5039,15 +5036,14 @@ Maps to the &lsquo;&ndash;alert.query-url&rsquo; CLI arg.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -6757,15 +6753,14 @@ process incoming alerts.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -8746,16 +8741,14 @@ It requires Prometheus &gt;= v3.5.0.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created Pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)</p>
-<p>This is an alpha field from kubernetes 1.22 until 1.24 which requires
-enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -14397,16 +14390,14 @@ It requires Prometheus &gt;= v3.5.0.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created Pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)</p>
-<p>This is an alpha field from kubernetes 1.22 until 1.24 which requires
-enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -18941,15 +18932,14 @@ Maps to the &lsquo;&ndash;alert.query-url&rsquo; CLI arg.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)
-This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -21678,16 +21668,14 @@ It requires Prometheus &gt;= v3.5.0.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created Pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)</p>
-<p>This is an alpha field from kubernetes 1.22 until 1.24 which requires
-enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>
@@ -30130,16 +30118,14 @@ It requires Prometheus &gt;= v3.5.0.</p>
 <td>
 <code>minReadySeconds</code><br/>
 <em>
-uint32
+int32
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>Minimum number of seconds for which a newly created Pod should be ready
-without any of its container crashing for it to be considered available.
-Defaults to 0 (pod will be considered available as soon as it is ready)</p>
-<p>This is an alpha field from kubernetes 1.22 until 1.24 which requires
-enabling the StatefulSetMinReadySeconds feature gate.</p>
+without any of its container crashing for it to be considered available.</p>
+<p>If unset, pods will be considered available as soon as they are ready.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16700,9 +16700,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:
@@ -27596,11 +27597,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               mode:
                 description: |-
@@ -39356,11 +39356,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nameEscapingScheme:
                 description: |-
@@ -65492,9 +65491,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -5898,9 +5898,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4785,11 +4785,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               mode:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5565,11 +5565,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nameEscapingScheme:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -4385,9 +4385,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -5899,9 +5899,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4786,11 +4786,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               mode:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5566,11 +5566,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created Pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
 
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires
-                  enabling the StatefulSetMinReadySeconds feature gate.
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nameEscapingScheme:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -4386,9 +4386,10 @@ spec:
                 description: |-
                   Minimum number of seconds for which a newly created pod should be ready
                   without any of its container crashing for it to be considered available.
-                  Defaults to 0 (pod will be considered available as soon as it is ready)
-                  This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+
+                  If unset, pods will be considered available as soon as they are ready.
                 format: int32
+                minimum: 0
                 type: integer
               nodeSelector:
                 additionalProperties:

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -5282,8 +5282,9 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready\nwithout any of its container crashing for it to be considered available.\nDefaults to 0 (pod will be considered available as soon as it is ready)\nThis is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready\nwithout any of its container crashing for it to be considered available.\n\nIf unset, pods will be considered available as soon as they are ready.",
                     "format": "int32",
+                    "minimum": 0,
                     "type": "integer"
                   },
                   "nodeSelector": {

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4071,8 +4071,9 @@
                     "type": "integer"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created Pod should be ready\nwithout any of its container crashing for it to be considered available.\nDefaults to 0 (pod will be considered available as soon as it is ready)\n\nThis is an alpha field from kubernetes 1.22 until 1.24 which requires\nenabling the StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created Pod should be ready\nwithout any of its container crashing for it to be considered available.\n\nIf unset, pods will be considered available as soon as they are ready.",
                     "format": "int32",
+                    "minimum": 0,
                     "type": "integer"
                   },
                   "mode": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4730,8 +4730,9 @@
                     "type": "integer"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created Pod should be ready\nwithout any of its container crashing for it to be considered available.\nDefaults to 0 (pod will be considered available as soon as it is ready)\n\nThis is an alpha field from kubernetes 1.22 until 1.24 which requires\nenabling the StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created Pod should be ready\nwithout any of its container crashing for it to be considered available.\n\nIf unset, pods will be considered available as soon as they are ready.",
                     "format": "int32",
+                    "minimum": 0,
                     "type": "integer"
                   },
                   "nameEscapingScheme": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -3862,8 +3862,9 @@
                     "type": "string"
                   },
                   "minReadySeconds": {
-                    "description": "Minimum number of seconds for which a newly created pod should be ready\nwithout any of its container crashing for it to be considered available.\nDefaults to 0 (pod will be considered available as soon as it is ready)\nThis is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.",
+                    "description": "Minimum number of seconds for which a newly created pod should be ready\nwithout any of its container crashing for it to be considered available.\n\nIf unset, pods will be considered available as soon as they are ready.",
                     "format": "int32",
+                    "minimum": 0,
                     "type": "integer"
                   },
                   "nodeSelector": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -745,11 +745,6 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
 	}
 
-	var minReadySeconds int32
-	if a.Spec.MinReadySeconds != nil {
-		minReadySeconds = int32(*a.Spec.MinReadySeconds)
-	}
-
 	operatorInitContainers = append(operatorInitContainers,
 		operator.CreateConfigReloader(
 			"init-config-reloader",
@@ -774,7 +769,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 	spec := appsv1.StatefulSetSpec{
 		ServiceName:     getServiceName(a),
 		Replicas:        a.Spec.Replicas,
-		MinReadySeconds: minReadySeconds,
+		MinReadySeconds: ptr.Deref(a.Spec.MinReadySeconds, 0),
 		// PodManagementPolicy is set to Parallel to mitigate issues in kubernetes: https://github.com/kubernetes/kubernetes/issues/60164
 		// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 		PodManagementPolicy: appsv1.ParallelPodManagement,

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1090,21 +1090,19 @@ func TestClusterListenAddressForMultiReplica(t *testing.T) {
 
 func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 	a := monitoringv1.Alertmanager{}
-	replicas := int32(3)
 	a.Spec.Version = operator.DefaultAlertmanagerVersion
-	a.Spec.Replicas = &replicas
+	a.Spec.Replicas = ptr.To(int32(3))
 
 	// assert defaults to zero if nil
 	statefulSet, err := makeStatefulSetSpec(nil, &a, defaultTestConfig, &operator.ShardedSecret{})
 	require.NoError(t, err)
-	require.Equal(t, int32(0), statefulSet.MinReadySeconds, "expected MinReadySeconds to be zero but got %d", statefulSet.MinReadySeconds)
+	require.Equal(t, int32(0), statefulSet.MinReadySeconds)
 
 	// assert set correctly if not nil
-	var expect uint32 = 5
-	a.Spec.MinReadySeconds = &expect
+	a.Spec.MinReadySeconds = ptr.To(int32(5))
 	statefulSet, err = makeStatefulSetSpec(nil, &a, defaultTestConfig, &operator.ShardedSecret{})
 	require.NoError(t, err)
-	require.Equal(t, int32(expect), statefulSet.MinReadySeconds, "expected MinReadySeconds to be %d but got %d", expect, statefulSet.MinReadySeconds)
+	require.Equal(t, int32(5), statefulSet.MinReadySeconds)
 }
 
 func TestPodTemplateConfig(t *testing.T) {

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -266,10 +266,12 @@ type AlertmanagerSpec struct {
 
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
-	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+	//
+	// If unset, pods will be considered available as soon as they are ready.
+	//
+	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 	// Pods' hostAliases configuration
 	// +listType=map
 	// +listMapKey=ip

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -725,13 +725,12 @@ type CommonPrometheusFields struct {
 
 	// Minimum number of seconds for which a newly created Pod should be ready
 	// without any of its container crashing for it to be considered available.
-	// Defaults to 0 (pod will be considered available as soon as it is ready)
 	//
-	// This is an alpha field from kubernetes 1.22 until 1.24 which requires
-	// enabling the StatefulSetMinReadySeconds feature gate.
+	// If unset, pods will be considered available as soon as they are ready.
 	//
+	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// Optional list of hosts and IPs that will be injected into the Pod's
 	// hosts file if specified.

--- a/pkg/apis/monitoring/v1/thanos_types.go
+++ b/pkg/apis/monitoring/v1/thanos_types.go
@@ -408,10 +408,12 @@ type ThanosRulerSpec struct {
 
 	// Minimum number of seconds for which a newly created pod should be ready
 	// without any of its container crashing for it to be considered available.
-	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	// This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate.
+	//
+	// If unset, pods will be considered available as soon as they are ready.
+	//
+	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	MinReadySeconds *uint32 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// Configures alert relabeling in Thanos Ruler.
 	//

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -480,7 +480,7 @@ func (in *AlertmanagerSpec) DeepCopyInto(out *AlertmanagerSpec) {
 	out.AlertmanagerConfigMatcherStrategy = in.AlertmanagerConfigMatcherStrategy
 	if in.MinReadySeconds != nil {
 		in, out := &in.MinReadySeconds, &out.MinReadySeconds
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.HostAliases != nil {
@@ -1061,7 +1061,7 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 	}
 	if in.MinReadySeconds != nil {
 		in, out := &in.MinReadySeconds, &out.MinReadySeconds
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.HostAliases != nil {
@@ -3912,7 +3912,7 @@ func (in *ThanosRulerSpec) DeepCopyInto(out *ThanosRulerSpec) {
 	}
 	if in.MinReadySeconds != nil {
 		in, out := &in.MinReadySeconds, &out.MinReadySeconds
-		*out = new(uint32)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.AlertRelabelConfigs != nil {

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
@@ -74,7 +74,7 @@ type AlertmanagerSpecApplyConfiguration struct {
 	AlertmanagerConfigSelector           *metav1.LabelSelectorApplyConfiguration                 `json:"alertmanagerConfigSelector,omitempty"`
 	AlertmanagerConfigNamespaceSelector  *metav1.LabelSelectorApplyConfiguration                 `json:"alertmanagerConfigNamespaceSelector,omitempty"`
 	AlertmanagerConfigMatcherStrategy    *AlertmanagerConfigMatcherStrategyApplyConfiguration    `json:"alertmanagerConfigMatcherStrategy,omitempty"`
-	MinReadySeconds                      *uint32                                                 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds                      *int32                                                  `json:"minReadySeconds,omitempty"`
 	HostAliases                          []HostAliasApplyConfiguration                           `json:"hostAliases,omitempty"`
 	Web                                  *AlertmanagerWebSpecApplyConfiguration                  `json:"web,omitempty"`
 	Limits                               *AlertmanagerLimitsSpecApplyConfiguration               `json:"limits,omitempty"`
@@ -505,7 +505,7 @@ func (b *AlertmanagerSpecApplyConfiguration) WithAlertmanagerConfigMatcherStrate
 // WithMinReadySeconds sets the MinReadySeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MinReadySeconds field is set to the value of the last call.
-func (b *AlertmanagerSpecApplyConfiguration) WithMinReadySeconds(value uint32) *AlertmanagerSpecApplyConfiguration {
+func (b *AlertmanagerSpecApplyConfiguration) WithMinReadySeconds(value int32) *AlertmanagerSpecApplyConfiguration {
 	b.MinReadySeconds = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -99,7 +99,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	NameEscapingScheme                   *monitoringv1.NameEscapingSchemeOptions                 `json:"nameEscapingScheme,omitempty"`
 	ConvertClassicHistogramsToNHCB       *bool                                                   `json:"convertClassicHistogramsToNHCB,omitempty"`
 	ScrapeClassicHistograms              *bool                                                   `json:"scrapeClassicHistograms,omitempty"`
-	MinReadySeconds                      *uint32                                                 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds                      *int32                                                  `json:"minReadySeconds,omitempty"`
 	HostAliases                          []HostAliasApplyConfiguration                           `json:"hostAliases,omitempty"`
 	AdditionalArgs                       []ArgumentApplyConfiguration                            `json:"additionalArgs,omitempty"`
 	WALCompression                       *bool                                                   `json:"walCompression,omitempty"`
@@ -762,7 +762,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithScrapeClassicHistograms(v
 // WithMinReadySeconds sets the MinReadySeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MinReadySeconds field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithMinReadySeconds(value uint32) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithMinReadySeconds(value int32) *CommonPrometheusFieldsApplyConfiguration {
 	b.MinReadySeconds = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -689,7 +689,7 @@ func (b *PrometheusSpecApplyConfiguration) WithScrapeClassicHistograms(value boo
 // WithMinReadySeconds sets the MinReadySeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MinReadySeconds field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithMinReadySeconds(value uint32) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithMinReadySeconds(value int32) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.MinReadySeconds = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosrulerspec.go
@@ -79,7 +79,7 @@ type ThanosRulerSpecApplyConfiguration struct {
 	RoutePrefix                        *string                                         `json:"routePrefix,omitempty"`
 	GRPCServerTLSConfig                *TLSConfigApplyConfiguration                    `json:"grpcServerTlsConfig,omitempty"`
 	AlertQueryURL                      *string                                         `json:"alertQueryUrl,omitempty"`
-	MinReadySeconds                    *uint32                                         `json:"minReadySeconds,omitempty"`
+	MinReadySeconds                    *int32                                          `json:"minReadySeconds,omitempty"`
 	AlertRelabelConfigs                *corev1.SecretKeySelector                       `json:"alertRelabelConfigs,omitempty"`
 	AlertRelabelConfigFile             *string                                         `json:"alertRelabelConfigFile,omitempty"`
 	HostAliases                        []HostAliasApplyConfiguration                   `json:"hostAliases,omitempty"`
@@ -573,7 +573,7 @@ func (b *ThanosRulerSpecApplyConfiguration) WithAlertQueryURL(value string) *Tha
 // WithMinReadySeconds sets the MinReadySeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MinReadySeconds field is set to the value of the last call.
-func (b *ThanosRulerSpecApplyConfiguration) WithMinReadySeconds(value uint32) *ThanosRulerSpecApplyConfiguration {
+func (b *ThanosRulerSpecApplyConfiguration) WithMinReadySeconds(value int32) *ThanosRulerSpecApplyConfiguration {
 	b.MinReadySeconds = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -677,7 +677,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithScrapeClassicHistograms(valu
 // WithMinReadySeconds sets the MinReadySeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MinReadySeconds field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithMinReadySeconds(value uint32) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithMinReadySeconds(value int32) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.MinReadySeconds = &value
 	return b
 }

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -133,11 +133,6 @@ func makeDaemonSetSpec(
 
 	var watchedDirectories []string
 
-	var minReadySeconds int32
-	if cpf.MinReadySeconds != nil {
-		minReadySeconds = int32(*cpf.MinReadySeconds)
-	}
-
 	operatorInitContainers = append(operatorInitContainers,
 		prompkg.BuildConfigReloader(
 			p,
@@ -200,7 +195,7 @@ func makeDaemonSetSpec(
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},
-		MinReadySeconds: minReadySeconds,
+		MinReadySeconds: ptr.Deref(cpf.MinReadySeconds, 0),
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -208,11 +208,6 @@ func makeStatefulSetSpec(
 
 	var watchedDirectories []string
 
-	var minReadySeconds int32
-	if cpf.MinReadySeconds != nil {
-		minReadySeconds = int32(*cpf.MinReadySeconds)
-	}
-
 	operatorInitContainers = append(operatorInitContainers,
 		prompkg.BuildConfigReloader(
 			p,
@@ -305,7 +300,7 @@ func makeStatefulSetSpec(
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},
-		MinReadySeconds: minReadySeconds,
+		MinReadySeconds: ptr.Deref(p.Spec.MinReadySeconds, 0),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -262,11 +262,6 @@ func makeStatefulSetSpec(
 		}
 	}
 
-	var minReadySeconds int32
-	if cpf.MinReadySeconds != nil {
-		minReadySeconds = int32(*cpf.MinReadySeconds)
-	}
-
 	operatorInitContainers = append(operatorInitContainers,
 		prompkg.BuildConfigReloader(
 			p,
@@ -341,7 +336,7 @@ func makeStatefulSetSpec(
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},
-		MinReadySeconds: minReadySeconds,
+		MinReadySeconds: ptr.Deref(p.Spec.MinReadySeconds, 0),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -1823,19 +1823,18 @@ func TestExpectStatefulSetMinReadySeconds(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert defaults to zero if nil
-	require.Equal(t, int32(0), sset.Spec.MinReadySeconds, "expected MinReadySeconds to be zero but got %d", sset.Spec.MinReadySeconds)
+	require.Equal(t, int32(0), sset.Spec.MinReadySeconds)
 
-	var expect uint32 = 5
 	sset, err = makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				MinReadySeconds: &expect,
+				MinReadySeconds: ptr.To(int32(5)),
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, int32(expect), sset.Spec.MinReadySeconds, "expected MinReadySeconds to be %d but got %d", expect, sset.Spec.MinReadySeconds)
+	require.Equal(t, int32(5), sset.Spec.MinReadySeconds)
 }
 
 func TestConfigReloader(t *testing.T) {

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -486,15 +486,10 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
 	}
 
-	var minReadySeconds int32
-	if tr.Spec.MinReadySeconds != nil {
-		minReadySeconds = int32(*tr.Spec.MinReadySeconds)
-	}
-
 	spec := appsv1.StatefulSetSpec{
 		ServiceName:     ptr.Deref(tr.Spec.ServiceName, governingServiceName),
 		Replicas:        tr.Spec.Replicas,
-		MinReadySeconds: minReadySeconds,
+		MinReadySeconds: ptr.Deref(tr.Spec.MinReadySeconds, 0),
 		// PodManagementPolicy is set to Parallel to mitigate issues in kubernetes: https://github.com/kubernetes/kubernetes/issues/60164
 		// This is also mentioned as one of limitations of StatefulSets: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
 		PodManagementPolicy: appsv1.ParallelPodManagement,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -836,11 +836,10 @@ func TestStatefulSetMinReadySeconds(t *testing.T) {
 	require.Equal(t, int32(0), statefulSet.MinReadySeconds)
 
 	// assert set correctly if not nil
-	var expect uint32 = 5
-	tr.Spec.MinReadySeconds = &expect
+	tr.Spec.MinReadySeconds = ptr.To(int32(5))
 	statefulSet, err = makeStatefulSetSpec(&tr, defaultTestConfig, nil, &operator.ShardedSecret{})
 	require.NoError(t, err)
-	require.Equal(t, int32(expect), statefulSet.MinReadySeconds)
+	require.Equal(t, int32(5), statefulSet.MinReadySeconds)
 }
 
 func TestStatefulSetServiceName(t *testing.T) {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2355,24 +2355,22 @@ func testAlertManagerMinReadySeconds(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
-	var setMinReadySecondsInitial uint32 = 5
 	am := framework.MakeBasicAlertmanager(ns, "basic-am", 3)
-	am.Spec.MinReadySeconds = &setMinReadySecondsInitial
+	am.Spec.MinReadySeconds = ptr.To(int32(5))
 	am, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), am)
 	require.NoError(t, err)
 
 	amSS, err := framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), "alertmanager-basic-am", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	require.Equal(t, int32(setMinReadySecondsInitial), amSS.Spec.MinReadySeconds)
+	require.Equal(t, int32(5), amSS.Spec.MinReadySeconds)
 
-	var updated uint32 = 10
-	_, err = framework.PatchAlertmanagerAndWaitUntilReady(context.Background(), am.Name, am.Namespace, monitoringv1.AlertmanagerSpec{MinReadySeconds: &updated})
+	_, err = framework.PatchAlertmanagerAndWaitUntilReady(context.Background(), am.Name, am.Namespace, monitoringv1.AlertmanagerSpec{MinReadySeconds: ptr.To(int32(10))})
 	require.NoError(t, err)
 
 	amSS, err = framework.KubeClient.AppsV1().StatefulSets(ns).Get(context.Background(), "alertmanager-basic-am", metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, int32(updated), amSS.Spec.MinReadySeconds)
+	require.Equal(t, int32(10), amSS.Spec.MinReadySeconds)
 }
 
 func testAlertmanagerCRDValidation(t *testing.T) {


### PR DESCRIPTION
## Description

This commit also changes the field type from `*uint32` to `*int32` (with a validation marker ensuring a greater than or equal to zero value) to align with the Kubernetes API conventions. While theorically a breaking change, it's safe to modify the type because nobody should be using values larger than MaxInt32 (e.g. 2147483647).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
