### PR TITLE
feat: add workqueue metrics

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -193,6 +193,7 @@ func TestAllNS(t *testing.T) {
 	t.Run("TestServerTLS", func(t *testing.T) {
 		testServerTLS(t, ns)
 	})
+
 	t.Run("TestPrometheusOperatorMetrics", func(t *testing.T) {
 		t.Helper()
 		testPrometheusOperatorMetrics(t, ns)

--- a/test/e2e/prometheus_operator_test.go
+++ b/test/e2e/prometheus_operator_test.go
@@ -46,56 +46,59 @@ func testPrometheusOperatorMetrics(t *testing.T, namespace string) {
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	operatorMetrics := []string{
+		// Kubernetes client metrics.
 		"prometheus_operator_kubernetes_client_http_requests_total",
 		"prometheus_operator_kubernetes_client_http_request_duration_seconds_count",
 		"prometheus_operator_kubernetes_client_http_request_duration_seconds_sum",
 		"prometheus_operator_kubernetes_client_rate_limiter_duration_seconds_count",
 		"prometheus_operator_kubernetes_client_rate_limiter_duration_seconds_sum",
+
+		// Operator's info metrics.
 		"prometheus_operator_build_info",
 		"prometheus_operator_feature_gate",
 		"prometheus_operator_kubelet_managed_resource",
+
 		"prometheus_operator_list_operations_failed_total",
 		"prometheus_operator_list_operations_total",
 		"prometheus_operator_node_address_lookup_errors_total",
 		"prometheus_operator_node_syncs_failed_total",
 		"prometheus_operator_node_syncs_total",
 		"prometheus_operator_ready",
+
+		// Resource reconciler metrics.
 		"prometheus_operator_reconcile_duration_seconds_bucket",
 		"prometheus_operator_reconcile_duration_seconds_count",
 		"prometheus_operator_reconcile_duration_seconds_sum",
 		"prometheus_operator_reconcile_errors_total",
 		"prometheus_operator_reconcile_operations_total",
 		"prometheus_operator_reconcile_sts_delete_create_total",
+
+		// Kubernetes work queue metrics.
+		"prometheus_operator_workqueue_depth",
+		"prometheus_operator_workqueue_adds_total",
+		"prometheus_operator_workqueue_latency_seconds_bucket",
+		"prometheus_operator_workqueue_latency_seconds_count",
+		"prometheus_operator_workqueue_latency_seconds_sum",
+		"prometheus_operator_workqueue_work_duration_seconds_bucket",
+		"prometheus_operator_workqueue_work_duration_seconds_count",
+		"prometheus_operator_workqueue_work_duration_seconds_sum",
+		"prometheus_operator_workqueue_unfinished_work_seconds",
+		"prometheus_operator_workqueue_longest_running_processor_seconds",
+		"prometheus_operator_workqueue_retries_total",
+
 		"prometheus_operator_status_update_errors_total",
 		"prometheus_operator_status_update_operations_total",
 		"prometheus_operator_syncs",
 		"prometheus_operator_triggered_total",
 		"prometheus_operator_watch_operations_failed_total",
 		"prometheus_operator_watch_operations_total",
-	}
-	operatorOperationalMetrics := []string{
+
 		"prometheus_operator_managed_resources",
 		"prometheus_operator_spec_replicas",
 		"prometheus_operator_spec_shards",
 	}
 
-	ctx := context.Background()
-	err := framework.WaitForServiceReady(ctx, namespace, prometheusOperatorServiceName)
-	require.NoError(t, err)
-
-	err = framework.EnsureMetricsFromService(
-		ctx,
-		"https",
-		namespace,
-		prometheusOperatorServiceName,
-		"https",
-		operatorMetrics...,
-	)
-
-	require.NoError(t, err)
-
 	name := "test"
-
 	prometheusCRD := framework.MakeBasicPrometheus(ns, name, name, 1)
 	prometheusCRD.Namespace = ns
 
@@ -103,13 +106,13 @@ func testPrometheusOperatorMetrics(t *testing.T, namespace string) {
 		t.Fatal(err)
 	}
 
-	err = framework.EnsureMetricsFromService(
-		ctx,
+	err := framework.EnsureMetricsFromService(
+		context.Background(),
 		"https",
 		namespace,
 		prometheusOperatorServiceName,
 		"https",
-		operatorOperationalMetrics...,
+		operatorMetrics...,
 	)
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This commit adds the following metrics on controller's workqueues:
* prometheus_operator_workqueue_depth
* prometheus_operator_workqueue_adds_total
* prometheus_operator_workqueue_latency_seconds_bucket
* prometheus_operator_workqueue_latency_seconds_count
* prometheus_operator_workqueue_latency_seconds_sum
* prometheus_operator_workqueue_work_duration_seconds_bucket
* prometheus_operator_workqueue_work_duration_seconds_count
* prometheus_operator_workqueue_work_duration_seconds_sum
* prometheus_operator_workqueue_unfinished_work_seconds
* prometheus_operator_workqueue_longest_running_processor_seconds
* prometheus_operator_workqueue_retries_total

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
