### PR TITLE
fix: support hostUsers for daemonset mode

### DIFF
--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -218,6 +218,7 @@ func makeDaemonSetSpec(
 				HostAliases:                   operator.MakeHostAliases(cpf.HostAliases),
 				HostNetwork:                   cpf.HostNetwork,
 				EnableServiceLinks:            cpf.EnableServiceLinks,
+				HostUsers:                     cpf.HostUsers,
 			},
 		},
 	}

--- a/pkg/prometheus/agent/daemonset_test.go
+++ b/pkg/prometheus/agent/daemonset_test.go
@@ -210,3 +210,29 @@ func TestDaemonSetenableServiceLinks(t *testing.T) {
 		}
 	}
 }
+
+func TestHostUsersForDaemonSet(t *testing.T) {
+	for _, tc := range []struct {
+		hostUsers *bool
+	}{
+		{
+			hostUsers: ptr.To(true),
+		},
+		{
+			hostUsers: ptr.To(false),
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			dset, err := makeDaemonSetFromPrometheus(
+				monitoringv1alpha1.PrometheusAgent{
+					Spec: monitoringv1alpha1.PrometheusAgentSpec{
+						CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+							HostUsers: tc.hostUsers,
+						},
+					}},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.hostUsers, dset.Spec.Template.Spec.HostUsers)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Follow-up of #7771

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
