### PR TITLE
chore: remove po-lint from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /operator
 /admission-webhook
-/po-lint
 /prometheus-config-reloader
 example/alertmanager-webhook/linux/
 .build/


### PR DESCRIPTION
This tool has been deprecated so the corresponding gitignore entry
can now be removed.
