### PR TITLE
Update service monitor status binding only if a change is detected

### DIFF
--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -278,6 +278,12 @@ func UpdateServiceMonitorStatus(
 		if binding.Namespace == c.workload.GetNamespace() &&
 			binding.Name == c.workload.GetName() &&
 			binding.Resource == c.gvr.Resource {
+			if binding.Conditions[0].ObservedGeneration == conditions[0].ObservedGeneration &&
+				binding.Conditions[0].Status == conditions[0].Status &&
+				binding.Conditions[0].Reason == conditions[0].Reason &&
+				binding.Conditions[0].Message == conditions[0].Message {
+				return nil
+			}
 			binding.Conditions = conditions
 			found = true
 			break

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -278,14 +278,8 @@ func UpdateServiceMonitorStatus(
 		if binding.Namespace == c.workload.GetNamespace() &&
 			binding.Name == c.workload.GetName() &&
 			binding.Resource == c.gvr.Resource {
-
-			for _, cond := range binding.Conditions {
-				if cond.ObservedGeneration == conditions[0].ObservedGeneration &&
-					cond.Status == conditions[0].Status &&
-					cond.Reason == conditions[0].Reason &&
-					cond.Message == conditions[0].Message {
-					return nil
-				}
+			if configResStatusConditionsEqual(binding.Conditions, conditions) {
+				return nil
 			}
 			binding.Conditions = conditions
 			found = true
@@ -307,4 +301,21 @@ func UpdateServiceMonitorStatus(
 		return err
 	}
 	return nil
+}
+
+func configResStatusConditionsEqual(a, b []monitoringv1.ConfigResourceCondition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Type != b[i].Type ||
+			a[i].Status != b[i].Status ||
+			a[i].Reason != b[i].Reason ||
+			a[i].Message != b[i].Message ||
+			a[i].ObservedGeneration != b[i].ObservedGeneration {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -278,11 +278,14 @@ func UpdateServiceMonitorStatus(
 		if binding.Namespace == c.workload.GetNamespace() &&
 			binding.Name == c.workload.GetName() &&
 			binding.Resource == c.gvr.Resource {
-			if binding.Conditions[0].ObservedGeneration == conditions[0].ObservedGeneration &&
-				binding.Conditions[0].Status == conditions[0].Status &&
-				binding.Conditions[0].Reason == conditions[0].Reason &&
-				binding.Conditions[0].Message == conditions[0].Message {
-				return nil
+
+			for _, cond := range binding.Conditions {
+				if cond.ObservedGeneration == conditions[0].ObservedGeneration &&
+					cond.Status == conditions[0].Status &&
+					cond.Reason == conditions[0].Reason &&
+					cond.Message == conditions[0].Message {
+					return nil
+				}
 			}
 			binding.Conditions = conditions
 			found = true

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -309,22 +309,19 @@ func configResStatusConditionsEqual(a, b []monitoringv1.ConfigResourceCondition)
 		return false
 	}
 
-	ac := append([]monitoringv1.ConfigResourceCondition(nil), a...)
-	bc := append([]monitoringv1.ConfigResourceCondition(nil), b...)
-
-	sort.Slice(ac, func(i, j int) bool {
-		return ac[i].LastTransitionTime.After(ac[j].LastTransitionTime.Time)
+	sort.Slice(a, func(i, j int) bool {
+		return a[i].Type < a[j].Type
 	})
-	sort.Slice(bc, func(i, j int) bool {
-		return bc[i].LastTransitionTime.After(bc[j].LastTransitionTime.Time)
+	sort.Slice(b, func(i, j int) bool {
+		return b[i].Type < b[j].Type
 	})
 
-	for i := range ac {
-		if ac[i].Type != bc[i].Type ||
-			ac[i].Status != bc[i].Status ||
-			ac[i].Reason != bc[i].Reason ||
-			ac[i].Message != bc[i].Message ||
-			ac[i].ObservedGeneration != bc[i].ObservedGeneration {
+	for i := range a {
+		if a[i].Type != b[i].Type ||
+			a[i].Status != b[i].Status ||
+			a[i].Reason != b[i].Reason ||
+			a[i].Message != b[i].Message ||
+			a[i].ObservedGeneration != b[i].ObservedGeneration {
 			return false
 		}
 	}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -309,19 +309,22 @@ func configResStatusConditionsEqual(a, b []monitoringv1.ConfigResourceCondition)
 		return false
 	}
 
-	sort.Slice(a, func(i, j int) bool {
-		return a[i].Type < a[j].Type
+	ac := append([]monitoringv1.ConfigResourceCondition(nil), a...)
+	bc := append([]monitoringv1.ConfigResourceCondition(nil), b...)
+
+	sort.Slice(ac, func(i, j int) bool {
+		return ac[i].Type < ac[j].Type
 	})
-	sort.Slice(b, func(i, j int) bool {
-		return b[i].Type < b[j].Type
+	sort.Slice(bc, func(i, j int) bool {
+		return bc[i].Type < bc[j].Type
 	})
 
-	for i := range a {
-		if a[i].Type != b[i].Type ||
-			a[i].Status != b[i].Status ||
-			a[i].Reason != b[i].Reason ||
-			a[i].Message != b[i].Message ||
-			a[i].ObservedGeneration != b[i].ObservedGeneration {
+	for i := range ac {
+		if ac[i].Type != bc[i].Type ||
+			ac[i].Status != bc[i].Status ||
+			ac[i].Reason != bc[i].Reason ||
+			ac[i].Message != bc[i].Message ||
+			ac[i].ObservedGeneration != bc[i].ObservedGeneration {
 			return false
 		}
 	}

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -308,12 +309,22 @@ func configResStatusConditionsEqual(a, b []monitoringv1.ConfigResourceCondition)
 		return false
 	}
 
-	for i := range a {
-		if a[i].Type != b[i].Type ||
-			a[i].Status != b[i].Status ||
-			a[i].Reason != b[i].Reason ||
-			a[i].Message != b[i].Message ||
-			a[i].ObservedGeneration != b[i].ObservedGeneration {
+	ac := append([]monitoringv1.ConfigResourceCondition(nil), a...)
+	bc := append([]monitoringv1.ConfigResourceCondition(nil), b...)
+
+	sort.Slice(ac, func(i, j int) bool {
+		return ac[i].LastTransitionTime.After(ac[j].LastTransitionTime.Time)
+	})
+	sort.Slice(bc, func(i, j int) bool {
+		return bc[i].LastTransitionTime.After(bc[j].LastTransitionTime.Time)
+	})
+
+	for i := range ac {
+		if ac[i].Type != bc[i].Type ||
+			ac[i].Status != bc[i].Status ||
+			ac[i].Reason != bc[i].Reason ||
+			ac[i].Message != bc[i].Message ||
+			ac[i].ObservedGeneration != bc[i].ObservedGeneration {
 			return false
 		}
 	}

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -16,9 +16,11 @@ package prometheus
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -201,6 +203,201 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigResStatusConditionsEqual(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	earlier := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+
+	tests := []struct {
+		name     string
+		a        []monitoringv1.ConfigResourceCondition
+		b        []monitoringv1.ConfigResourceCondition
+		expected bool
+	}{
+		{
+			name: "equal conditions different order",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "True",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+				{
+					Type:               "Ready",
+					Status:             "False",
+					Reason:             "Init",
+					Message:            "initializing",
+					ObservedGeneration: 1,
+					LastTransitionTime: earlier,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Ready",
+					Status:             "False",
+					Reason:             "Init",
+					Message:            "initializing",
+					ObservedGeneration: 1,
+					LastTransitionTime: earlier,
+				},
+				{
+					Type:               "Accepted",
+					Status:             "True",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "different status",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "True",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different message",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "Issue detected",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different observed generation",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 2,
+					LastTransitionTime: now,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different reason",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "Issue",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different type",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Ready",
+					Status:             "False",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "different lengths",
+			a: []monitoringv1.ConfigResourceCondition{
+				{
+					Type:               "Accepted",
+					Status:             "True",
+					Reason:             "OK",
+					Message:            "all good",
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+				},
+			},
+			b:        []monitoringv1.ConfigResourceCondition{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := configResStatusConditionsEqual(tt.a, tt.b)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -266,17 +266,15 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b: []monitoringv1.ConfigResourceCondition{
 				{
 					Type:               "Accepted",
-					Status:             "False",
+					Status:             "False", // different
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			expected: false,
@@ -290,7 +288,6 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b: []monitoringv1.ConfigResourceCondition{
@@ -298,9 +295,8 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Type:               "Accepted",
 					Status:             "False",
 					Reason:             "OK",
-					Message:            "Issue detected",
+					Message:            "Issue detected", // different
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			expected: false,
@@ -314,7 +310,6 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b: []monitoringv1.ConfigResourceCondition{
@@ -323,8 +318,7 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Status:             "False",
 					Reason:             "OK",
 					Message:            "all good",
-					ObservedGeneration: 2,
-					LastTransitionTime: now,
+					ObservedGeneration: 2, // different
 				},
 			},
 			expected: false,
@@ -338,17 +332,15 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b: []monitoringv1.ConfigResourceCondition{
 				{
 					Type:               "Accepted",
 					Status:             "False",
-					Reason:             "Issue",
+					Reason:             "Issue", // different
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			expected: false,
@@ -362,17 +354,15 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b: []monitoringv1.ConfigResourceCondition{
 				{
-					Type:               "Ready",
+					Type:               "Ready", // different
 					Status:             "False",
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			expected: false,
@@ -386,7 +376,6 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 					Reason:             "OK",
 					Message:            "all good",
 					ObservedGeneration: 1,
-					LastTransitionTime: now,
 				},
 			},
 			b:        []monitoringv1.ConfigResourceCondition{},


### PR DESCRIPTION
fixes: #7792  

## Description

Update service monitor status binding only if a change is detected

_Closes: #ISSUE-NUMBER_

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
