### PR TITLE
chore: remove step commenting on failed runs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,21 +33,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-  comment-generate-failure:
-    if: ${{ failure() }}
-    permissions:
-      pull-requests: write
-    needs: generate
-    name: Comment troubleshooting message for format and generate failure
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-         message: 'Auto-generated files are likely not up-to-date. Please make sure to run `make --always-make format generate`, commit the modifications and push the updated branch.'
-
   check-docs:
     runs-on: ubuntu-latest
     name: Check Documentation formatting and links
@@ -62,21 +47,6 @@ jobs:
     - run: make check-docs
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-  comment-docs-failure:
-    if: ${{ failure() }}
-    permissions:
-      pull-requests: write
-    needs: check-docs
-    name: Comment troubleshooting message for check-docs failure
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          message: 'Formatting and local/remote links likely not correct. Please make sure to run `make check-docs`, commit the modifications and push the updated branch.'
 
   check-golang:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

The intent was that the CI would post a comment when documentation or generated files were not up-to-date but it only works for PRs from the origin repository (e.g. not with forks).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
