### PR TITLE
feat: add e2e test for testing PrometheusAgent with Volumes

### DIFF
--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -109,7 +109,9 @@ func makeDaemonSetSpec(
 
 	promArgs = append(promArgs, confArg)
 	volumes = append(volumes, configVol...)
+	volumes = append(volumes, cpf.Volumes...)
 	promVolumeMounts = append(promVolumeMounts, configMount...)
+	promVolumeMounts = append(promVolumeMounts, cpf.VolumeMounts...)
 
 	configReloaderWebConfigFile = confArg.Value
 	configReloaderVolumeMounts = append(configReloaderVolumeMounts, configMount...)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -435,6 +435,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PrometheusRetentionPolicies":                          testPrometheusRetentionPolicies,
 		"FinalizerWhenStatusForConfigResourcesEnabled":         testFinalizerWhenStatusForConfigResourcesEnabled,
 		"PrometheusAgentDaemonSetCELValidations":               testPrometheusAgentDaemonSetCELValidations,
+		"PrometheusAgentDaemonSetWithVolumes":                  testPrometheusAgentDaemonSetWithVolumes,
 		"ServiceMonitorStatusSubresource":                      testServiceMonitorStatusSubresource,
 		"ServiceMonitorStatusWithMultipleWorkloads":            testServiceMonitorStatusWithMultipleWorkloads,
 		"GarbageCollectionOfServiceMonitorBinding":             testGarbageCollectionOfServiceMonitorBinding,

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -1009,3 +1009,48 @@ func testDaemonSetInvalidAdditionalScrapeConfigs(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "additionalScrapeConfigs cannot be set when mode is DaemonSet")
 }
+
+func testPrometheusAgentDaemonSetWithVolumes(t *testing.T) {
+	t.Parallel()
+
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ctx := context.Background()
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "test-agent-with-volumes"
+	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
+
+	// Add a simple volume and volumeMount to reproduce the bug
+	p.Spec.Volumes = []v1.Volume{
+		{
+			Name: "test-vol",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+
+	p.Spec.VolumeMounts = []v1.VolumeMount{
+		{
+			Name:      "test-vol",
+			MountPath: "/test-mount",
+		},
+	}
+
+	// This should fail with the bug: "Not found: test-vol"
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, p)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Not found: \"test-vol\"")
+}

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -1032,7 +1032,6 @@ func testPrometheusAgentDaemonSetWithVolumes(t *testing.T) {
 	name := "test-agent-with-volumes"
 	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	// Add a simple volume and volumeMount to reproduce the bug
 	p.Spec.Volumes = []v1.Volume{
 		{
 			Name: "test-vol",
@@ -1045,35 +1044,12 @@ func testPrometheusAgentDaemonSetWithVolumes(t *testing.T) {
 	p.Spec.VolumeMounts = []v1.VolumeMount{
 		{
 			Name:      "test-vol",
-			MountPath: "/test-mount",
+			MountPath: "/var/run/po-test-mount-unique",
 		},
 	}
 
-	// With the fix, creation should succeed and the resulting DaemonSet should include the volume and mount
-	created, err := framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, p)
-	require.NoError(t, err)
-
-	dmsName := fmt.Sprintf("prom-agent-%s", created.Name)
-	dms, err := framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
-	require.NoError(t, err)
-
-	// verify volume present
-	foundVol := false
-	for _, vol := range dms.Spec.Template.Spec.Volumes {
-		if vol.Name == "test-vol" && vol.EmptyDir != nil {
-			foundVol = true
-			break
-		}
-	}
-	require.True(t, foundVol, "expected DaemonSet to contain test-vol volume")
-
-	// verify mount present on prometheus container
-	foundMount := false
-	for _, m := range dms.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if m.Name == "test-vol" && m.MountPath == "/test-mount" {
-			foundMount = true
-			break
-		}
-	}
-	require.True(t, foundMount, "expected prometheus container to mount test-vol at /test-mount")
+	// Expect failure (pre-fix behavior): missing volume in generated DaemonSet
+	_, err = framework.CreatePrometheusAgentAndWaitUntilReady(ctx, ns, p)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Not found: \"test-vol\"")
 }


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

This PR intends to add a e2e test case which tries to deploy PrometheusAgent with a volume and volumeMount initially.

Based on the existing code, this test should fail.


_If it fixes an existing issue (bug or feature), use the following keyword:_

_Closes: #ISSUE-NUMBER_

Related issue: #7813 
## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
