### PR TITLE
chore: add e2e test for lazy status updates

### DIFF
--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -385,7 +385,7 @@ func TestConfigResStatusConditionsEqual(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := configResStatusConditionsEqual(tt.a, tt.b)
+			result := equalConfigResourceConditions(tt.a, tt.b)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/test/framework/status.go
+++ b/test/framework/status.go
@@ -122,7 +122,31 @@ func (f *Framework) WaitForResourceAvailable(ctx context.Context, getResourceSta
 	return nil
 }
 
-// WaitForConfigResourceCondition waits for a configuration resource (serviceMonitor, podMonitor, scrapeConfig and probes) to meet the expected condition.
+// GetWorkloadBinding returns the binding matching the workload.
+func (f *Framework) GetWorkloadBinding(bindings []monitoringv1.WorkloadBinding, workload metav1.Object, resource string) (monitoringv1.WorkloadBinding, error) {
+	for _, binding := range bindings {
+		if binding.Resource == resource && binding.Name == workload.GetName() && binding.Namespace == workload.GetNamespace() {
+			return binding, nil
+		}
+	}
+
+	return monitoringv1.WorkloadBinding{}, fmt.Errorf("binding not found")
+}
+
+// GetConfigResourceCondition returns the condition type.
+func (f *Framework) GetConfigResourceCondition(conditions []monitoringv1.ConfigResourceCondition, conditionType monitoringv1.ConditionType) (monitoringv1.ConfigResourceCondition, error) {
+	for _, cond := range conditions {
+		if cond.Type == conditionType {
+			return cond, nil
+		}
+	}
+
+	return monitoringv1.ConfigResourceCondition{}, fmt.Errorf("condition %q not found", conditionType)
+}
+
+// WaitForConfigResourceCondition waits for a configuration resource
+// (serviceMonitor, podMonitor, scrapeConfig and probes) to meet the expected
+// condition.
 // If the condition isn't met within the given timeout, it returns an error.
 func (f *Framework) WaitForConfigResourceCondition(ctx context.Context, getConfigResourceStatus func(context.Context) ([]monitoringv1.WorkloadBinding, error), workload metav1.Object, resource string, conditionType monitoringv1.ConditionType, conditionStatus monitoringv1.ConditionStatus, timeout time.Duration) error {
 	var pollErr error
@@ -133,29 +157,28 @@ func (f *Framework) WaitForConfigResourceCondition(ctx context.Context, getConfi
 			return false, nil
 		}
 
-		for _, binding := range bindings {
-			if binding.Resource == resource && binding.Name == workload.GetName() && binding.Namespace == workload.GetNamespace() {
-				for _, cond := range binding.Conditions {
-					if cond.Type == conditionType {
-						if cond.Status == conditionStatus {
-							return true, nil
-						}
-						pollErr = fmt.Errorf(
-							"got condition %q for resource %q with name %q in namespace %q with status %q, expected %q",
-							conditionType, resource, workload.GetName(), workload.GetNamespace(), cond.Status, conditionStatus)
-						return false, nil
-					}
-				}
-
-				pollErr = fmt.Errorf("condition %q not found for resource %q with name %q in namespace %q", conditionType, resource, workload.GetName(), workload.GetNamespace())
-				return false, nil
-			}
+		var binding monitoringv1.WorkloadBinding
+		binding, pollErr = f.GetWorkloadBinding(bindings, workload, resource)
+		if pollErr != nil {
+			return false, nil
 		}
 
-		pollErr = fmt.Errorf("binding not found for resource %q with name %q in namespace %q", resource, workload.GetName(), workload.GetNamespace())
-		return false, nil
+		var cond monitoringv1.ConfigResourceCondition
+		cond, pollErr = f.GetConfigResourceCondition(binding.Conditions, conditionType)
+		if pollErr != nil {
+			return false, nil
+		}
+
+		if cond.Status != conditionStatus {
+			pollErr = fmt.Errorf(
+				"expected condition %q with status %q, got %q",
+				conditionType, conditionStatus, cond.Status)
+			return false, nil
+		}
+
+		return true, nil
 	}); err != nil {
-		return fmt.Errorf("%v: %w", err, pollErr)
+		return fmt.Errorf("%v: resource %q %s/%s: %w", err, resource, workload.GetNamespace(), workload.GetName(), pollErr)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This commit extends the existing end-to-end test on the ServiceMonitor status to ensure that the operator only updates the status when a change actually happened.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
