### PR TITLE
feat: Add Location support to AlertmanagerConfig/TimeInterval 

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -27395,6 +27395,14 @@ bool
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1alpha1.Location">Location
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.TimeInterval">TimeInterval</a>)
+</p>
+<div>
+<p>Location defines the location in string.</p>
+</div>
 <h3 id="monitoring.coreos.com/v1alpha1.MSTeamsConfig">MSTeamsConfig
 </h3>
 <p>
@@ -33957,6 +33965,20 @@ HTTPConfig
 <td>
 <em>(Optional)</em>
 <p>Years is a list of YearRange</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>location</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1alpha1.Location">
+Location
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Location maps time instants to the zone in use at that time</p>
 </td>
 </tr>
 </tbody>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -170,6 +170,10 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location maps time instants to the zone in
+                              use at that time
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -171,6 +171,10 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                          location:
+                            description: Location maps time instants to the zone in
+                              use at that time
+                            type: string
                           months:
                             description: Months is a list of MonthRange
                             items:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -169,6 +169,10 @@
                                 },
                                 "type": "array"
                               },
+                              "location": {
+                                "description": "Location maps time instants to the zone in use at that time",
+                                "type": "string"
+                              },
                               "months": {
                                 "description": "Months is a list of MonthRange",
                                 "items": {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -19,12 +19,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log/slog"
-	"net"
-	"net/url"
-	"path"
-	"strings"
-
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/timeinterval"
@@ -33,6 +27,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"log/slog"
+	"net"
+	"net/url"
+	"path"
+	"strings"
 
 	sortutil "github.com/prometheus-operator/prometheus-operator/internal/sortutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
@@ -1587,7 +1586,11 @@ func convertMuteTimeInterval(in *monitoringv1alpha1.MuteTimeInterval, crKey type
 				},
 			})
 		}
-
+		loc, err := timeInterval.Location.Parse()
+		if err != nil {
+			return nil, fmt.Errorf("parse location: %w", err)
+		}
+		ti.Location = &timeinterval.Location{Location: loc}
 		muteTimeInterval.Name = makeNamespacedString(in.Name, crKey)
 		muteTimeInterval.TimeIntervals = append(muteTimeInterval.TimeIntervals, ti)
 	}

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -3107,6 +3107,87 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "CR_with_Mute_Time_Intervals.golden",
 		},
 		{
+			name:    "CR with Mute Time Intervals with a Location",
+			kclient: fake.NewSimpleClientset(),
+			baseConfig: alertmanagerConfig{
+				Global: &globalConfig{
+					SlackAPIURLFile: "/etc/test",
+				},
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver:          "test",
+							MuteTimeIntervals: []string{"test"},
+						},
+						MuteTimeIntervals: []monitoringv1alpha1.MuteTimeInterval{
+							{
+								Name: "test",
+								TimeIntervals: []monitoringv1alpha1.TimeInterval{
+									{
+										Times: []monitoringv1alpha1.TimeRange{
+											{
+												StartTime: "08:00",
+												EndTime:   "17:00",
+											},
+										},
+										Weekdays: []monitoringv1alpha1.WeekdayRange{
+											monitoringv1alpha1.WeekdayRange("Saturday"),
+											monitoringv1alpha1.WeekdayRange("Sunday"),
+										},
+										Months: []monitoringv1alpha1.MonthRange{
+											"January:March",
+										},
+										DaysOfMonth: []monitoringv1alpha1.DayOfMonthRange{
+											{
+												Start: 1,
+												End:   10,
+											},
+										},
+										Years: []monitoringv1alpha1.YearRange{
+											"2030:2050",
+										},
+										Location: "Europe/Amsterdam",
+									},
+								},
+							},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{
+							Name: "test",
+							SlackConfigs: []monitoringv1alpha1.SlackConfig{{
+								Actions: []monitoringv1alpha1.SlackAction{
+									{
+										Type: "type",
+										Text: "text",
+										Name: "my-action",
+										ConfirmField: &monitoringv1alpha1.SlackConfirmationField{
+											Text: "text",
+										},
+									},
+								},
+								Fields: []monitoringv1alpha1.SlackField{
+									{
+										Title: "title",
+										Value: "value",
+									},
+								},
+							}},
+						}},
+					},
+				},
+			},
+			golden: "CR_with_Mute_Time_Intervals_Location.golden",
+		},
+		{
 			name:    "CR with Active Time Intervals",
 			kclient: fake.NewSimpleClientset(),
 			baseConfig: alertmanagerConfig{

--- a/pkg/alertmanager/testdata/CR_with_Mute_Time_Intervals_Location.golden
+++ b/pkg/alertmanager/testdata/CR_with_Mute_Time_Intervals_Location.golden
@@ -1,0 +1,36 @@
+global:
+  slack_api_url_file: /etc/test
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+    mute_time_intervals:
+    - mynamespace/myamc/test
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  slack_configs:
+  - fields:
+    - title: title
+      value: value
+    actions:
+    - type: type
+      text: text
+      name: my-action
+      confirm:
+        text: text
+mute_time_intervals:
+- name: mynamespace/myamc/test
+  time_intervals:
+  - times:
+    - start_time: "08:00"
+      end_time: "17:00"
+    weekdays: [saturday, sunday]
+    days_of_month: ["1:10"]
+    months: ["1:3"]
+    years: ['2030:2050']
+    location: "Europe/Amsterdam"
+templates: []

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -1245,7 +1245,13 @@ type TimeInterval struct {
 	// Years is a list of YearRange
 	// +optional
 	Years []YearRange `json:"years,omitempty"`
+	// Location maps time instants to the zone in use at that time
+	// +optional
+	Location Location `json:"location,omitempty"`
 }
+
+// Location defines the location in string.
+type Location string
 
 // Time defines a time in 24hr format
 // +kubebuilder:validation:Pattern=`^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)`

--- a/pkg/apis/monitoring/v1alpha1/validation.go
+++ b/pkg/apis/monitoring/v1alpha1/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func (hc *HTTPConfig) Validate() error {
@@ -99,6 +100,9 @@ func (mti MuteTimeInterval) Validate() error {
 			if err := year.Validate(); err != nil {
 				return fmt.Errorf("year range at %d is invalid: %w", i, err)
 			}
+		}
+		if err := ti.Location.Validate(); err != nil {
+			return fmt.Errorf("location at %d is invalid: %w", i, err)
 		}
 	}
 	return nil
@@ -299,6 +303,21 @@ func (mr MonthRange) Parse() (*ParsedRange, error) {
 		Start: start,
 		End:   end,
 	}, nil
+}
+
+// Validate the Location
+func (l Location) Validate() error {
+	_, err := l.Parse()
+	return err
+}
+
+// Parse returns parsed time.Location
+func (l Location) Parse() (*time.Location, error) {
+	loc, err := time.LoadLocation(string(l))
+	if err != nil {
+		return nil, err
+	}
+	return loc, err
 }
 
 // ParsedRange is an integer representation of a range

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/timeinterval.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/timeinterval.go
@@ -28,6 +28,7 @@ type TimeIntervalApplyConfiguration struct {
 	DaysOfMonth []DayOfMonthRangeApplyConfiguration `json:"daysOfMonth,omitempty"`
 	Months      []monitoringv1alpha1.MonthRange     `json:"months,omitempty"`
 	Years       []monitoringv1alpha1.YearRange      `json:"years,omitempty"`
+	Location    *monitoringv1alpha1.Location        `json:"location,omitempty"`
 }
 
 // TimeIntervalApplyConfiguration constructs a declarative configuration of the TimeInterval type for use with
@@ -89,5 +90,13 @@ func (b *TimeIntervalApplyConfiguration) WithYears(values ...monitoringv1alpha1.
 	for i := range values {
 		b.Years = append(b.Years, values[i])
 	}
+	return b
+}
+
+// WithLocation sets the Location field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Location field is set to the value of the last call.
+func (b *TimeIntervalApplyConfiguration) WithLocation(value monitoringv1alpha1.Location) *TimeIntervalApplyConfiguration {
+	b.Location = &value
 	return b
 }

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1382,6 +1382,43 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 		},
 	}
 
+	// A valid AlertmanagerConfig resource with active time intervals with location defined.
+	configCR = &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "e2e-test-amconfig-active-ti-location",
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver:            "e2e",
+				Matchers:            []monitoringv1alpha1.Matcher{},
+				ActiveTimeIntervals: []string{"weekend"},
+				Continue:            true,
+			},
+			Receivers: []monitoringv1alpha1.Receiver{{
+				Name: "e2e",
+				WebhookConfigs: []monitoringv1alpha1.WebhookConfig{{
+					URL: func(s string) *string {
+						return &s
+					}("http://test.url"),
+				}},
+			}},
+			MuteTimeIntervals: []monitoringv1alpha1.MuteTimeInterval{
+				{
+					Name: "weekend",
+					TimeIntervals: []monitoringv1alpha1.TimeInterval{
+						{
+							Weekdays: []monitoringv1alpha1.WeekdayRange{
+								"Saturday",
+								"Sunday",
+							},
+							Location: "Europe/Amsterdam",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	_, err = framework.MonClientV1alpha1.AlertmanagerConfigs(configNs).Create(context.Background(), configCR, metav1.CreateOptions{})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Given native Alertmanager supports Location for `time_intervals` to manage time zones, therefore, added to the CRD to set it accordingly.

See https://prometheus.io/docs/alerting/latest/configuration/#time_interval for more.

> location: A string that matches a location in the IANA time zone database. For example, 'Australia/Sydney'. The location provides the time zone for the time interval. For example, a time interval with a location of 'Australia/Sydney' that contained something like

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
