### PR TITLE
feat: remove the feature gate from PrometheusAgent Daemonset mode

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -20644,7 +20644,6 @@ PrometheusAgentMode
 <td>
 <em>(Optional)</em>
 <p>Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).</p>
-<p>(Alpha) Using this field requires the <code>PrometheusAgentDaemonSet</code> feature gate to be enabled.</p>
 </td>
 </tr>
 <tr>
@@ -29111,7 +29110,6 @@ PrometheusAgentMode
 <td>
 <em>(Optional)</em>
 <p>Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).</p>
-<p>(Alpha) Using this field requires the <code>PrometheusAgentDaemonSet</code> feature gate to be enabled.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -56,7 +56,6 @@ Usage of ./operator:
   -feature-gates value
     	Feature gates are a set of key=value pairs that describe Prometheus-Operator features.
     	Available feature gates:
-    	  PrometheusAgentDaemonSet: Enables the DaemonSet mode for PrometheusAgent (enabled: false)
     	  PrometheusShardRetentionPolicy: Enables shard retention policy for Prometheus (enabled: false)
     	  PrometheusTopologySharding: Enables the zone aware sharding for Prometheus (enabled: false)
     	  StatusForConfigurationResources: Updates the status subresource for configuration resources (enabled: false)

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -4984,10 +4984,8 @@ spec:
                 minimum: 0
                 type: integer
               mode:
-                description: |-
-                  Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).
-
-                  (Alpha) Using this field requires the `PrometheusAgentDaemonSet` feature gate to be enabled.
+                description: Mode defines how the Prometheus operator deploys the
+                  PrometheusAgent pod(s).
                 enum:
                 - StatefulSet
                 - DaemonSet

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -4985,10 +4985,8 @@ spec:
                 minimum: 0
                 type: integer
               mode:
-                description: |-
-                  Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).
-
-                  (Alpha) Using this field requires the `PrometheusAgentDaemonSet` feature gate to be enabled.
+                description: Mode defines how the Prometheus operator deploys the
+                  PrometheusAgent pod(s).
                 enum:
                 - StatefulSet
                 - DaemonSet

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4219,7 +4219,7 @@
                     "type": "integer"
                   },
                   "mode": {
-                    "description": "Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).\n\n(Alpha) Using this field requires the `PrometheusAgentDaemonSet` feature gate to be enabled.",
+                    "description": "Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).",
                     "enum": [
                       "StatefulSet",
                       "DaemonSet"

--- a/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
+++ b/pkg/apis/monitoring/v1alpha1/prometheusagent_types.go
@@ -101,8 +101,6 @@ func (l *PrometheusAgentList) DeepCopyObject() runtime.Object {
 type PrometheusAgentSpec struct {
 	// Mode defines how the Prometheus operator deploys the PrometheusAgent pod(s).
 	//
-	// (Alpha) Using this field requires the `PrometheusAgentDaemonSet` feature gate to be enabled.
-	//
 	// +optional
 	Mode *PrometheusAgentMode `json:"mode,omitempty"`
 

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -93,10 +93,6 @@ func DefaultConfig(cpu, memory string) Config {
 			ThanosRulerAllowList:        StringSet{},
 		},
 		Gates: &FeatureGates{
-			PrometheusAgentDaemonSetFeature: FeatureGate{
-				description: "Enables the DaemonSet mode for PrometheusAgent",
-				enabled:     false,
-			},
 			PrometheusTopologyShardingFeature: FeatureGate{
 				description: "Enables the zone aware sharding for Prometheus",
 				enabled:     false,

--- a/pkg/operator/feature_gates.go
+++ b/pkg/operator/feature_gates.go
@@ -23,9 +23,6 @@ import (
 )
 
 const (
-	// PrometheusAgentDaemonSetFeature enables the DaemonSet mode for PrometheusAgent.
-	PrometheusAgentDaemonSetFeature FeatureGateName = "PrometheusAgentDaemonSet"
-
 	// PrometheusTopologySharding enables the zone-aware sharding for Prometheus.
 	PrometheusTopologyShardingFeature FeatureGateName = "PrometheusTopologySharding"
 

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -76,7 +76,7 @@ func testCreatePrometheusAgentDaemonSet(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -206,7 +206,7 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -278,7 +278,7 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -343,7 +343,7 @@ func testPromAgentReconcileDaemonSetResourceDelete(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -373,7 +373,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -671,7 +671,7 @@ func testDaemonSetInvalidReplicas(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -699,7 +699,7 @@ func testDaemonSetInvalidStorage(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -738,7 +738,7 @@ func testDaemonSetInvalidShards(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -766,7 +766,7 @@ func testDaemonSetInvalidPVCRetentionPolicy(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -797,7 +797,7 @@ func testDaemonSetInvalidScrapeConfigSelector(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)
@@ -829,7 +829,7 @@ func testDaemonSetInvalidProbeSelector(t *testing.T) {
 		ctx, testFramework.PrometheusOperatorOpts{
 			Namespace:           ns,
 			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusAgentDaemonSetFeature},
+			EnabledFeatureGates: []operator.FeatureGateName{},
 		},
 	)
 	require.NoError(t, err)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 	"testing"
 	"time"

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -282,14 +282,14 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 	clusterRole.Name = fmt.Sprintf("%s-%x", clusterRole.Name, xxh.Sum64())
 
 	clusterRole.Rules = append(clusterRole.Rules, CRDCreateRule, CRDMonitoringRule)
-	if slices.Contains(opts.EnabledFeatureGates, operator.PrometheusAgentDaemonSetFeature) {
-		daemonsetRule := rbacv1.PolicyRule{
-			APIGroups: []string{"apps"},
-			Resources: []string{"daemonsets"},
-			Verbs:     []string{"*"},
-		}
-		clusterRole.Rules = append(clusterRole.Rules, daemonsetRule)
+
+	// Always include DaemonSet RBAC rules for PrometheusAgent DaemonSet mode
+	daemonsetRule := rbacv1.PolicyRule{
+		APIGroups: []string{"apps"},
+		Resources: []string{"daemonsets"},
+		Verbs:     []string{"*"},
 	}
+	clusterRole.Rules = append(clusterRole.Rules, daemonsetRule)
 
 	clusterRole, err = f.CreateOrUpdateClusterRole(ctx, clusterRole)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR aims to remove the feature gate from PrometheusAgent Daemonset mode and pushes the mode to GA (Draft until all the due PRs and features are merged)

Closes: #7857 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

I ran both modes explicitly on a local kind cluster with the net changes and it's working as expected.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
PrometheusAgent DaemonSet mode is now generally available; removed the feature gate.
```
