### PR TITLE
enhancement: `s/staticConfig_targets/staticConfig_hosts`

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -13031,6 +13031,18 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </em>
 </td>
 <td>
+<p>The list of hosts to probe.
+Deprecated: Use <code>hosts</code> instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hosts</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
 <p>The list of hosts to probe.</p>
 </td>
 </tr>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -987,6 +987,11 @@ spec:
                       If `ingress` is also defined, `staticConfig` takes precedence.
                       More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config.
                     properties:
+                      hosts:
+                        description: The list of hosts to probe.
+                        items:
+                          type: string
+                        type: array
                       labels:
                         additionalProperties:
                           type: string
@@ -1084,7 +1089,9 @@ spec:
                           type: object
                         type: array
                       static:
-                        description: The list of hosts to probe.
+                        description: |-
+                          The list of hosts to probe.
+                          Deprecated: Use `hosts` instead.
                         items:
                           type: string
                         type: array

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -988,6 +988,11 @@ spec:
                       If `ingress` is also defined, `staticConfig` takes precedence.
                       More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config.
                     properties:
+                      hosts:
+                        description: The list of hosts to probe.
+                        items:
+                          type: string
+                        type: array
                       labels:
                         additionalProperties:
                           type: string
@@ -1085,7 +1090,9 @@ spec:
                           type: object
                         type: array
                       static:
-                        description: The list of hosts to probe.
+                        description: |-
+                          The list of hosts to probe.
+                          Deprecated: Use `hosts` instead.
                         items:
                           type: string
                         type: array

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -882,6 +882,13 @@
                       "staticConfig": {
                         "description": "staticConfig defines the static list of targets to probe and the\nrelabeling configuration.\nIf `ingress` is also defined, `staticConfig` takes precedence.\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config.",
                         "properties": {
+                          "hosts": {
+                            "description": "The list of hosts to probe.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "labels": {
                             "additionalProperties": {
                               "type": "string"
@@ -959,7 +966,7 @@
                             "type": "array"
                           },
                           "static": {
-                            "description": "The list of hosts to probe.",
+                            "description": "The list of hosts to probe.\nDeprecated: Use `hosts` instead.",
                             "items": {
                               "type": "string"
                             },

--- a/pkg/apis/monitoring/v1/probe_types.go
+++ b/pkg/apis/monitoring/v1/probe_types.go
@@ -196,7 +196,10 @@ func (e *ProbeTargetsValidationError) Error() string {
 // +k8s:openapi-gen=true
 type ProbeTargetStaticConfig struct {
 	// The list of hosts to probe.
+	// Deprecated: Use `hosts` instead.
 	Targets []string `json:"static,omitempty"`
+	// The list of hosts to probe.
+	Hosts []string `json:"hosts,omitempty"`
 	// Labels assigned to all metrics scraped from the targets.
 	Labels map[string]string `json:"labels,omitempty"`
 	// RelabelConfigs to apply to the label set of the targets before it gets

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2432,6 +2432,11 @@ func (in *ProbeTargetStaticConfig) DeepCopyInto(out *ProbeTargetStaticConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Hosts != nil {
+		in, out := &in.Hosts, &out.Hosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1/probetargetstaticconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/probetargetstaticconfig.go
@@ -20,6 +20,7 @@ package v1
 // with apply.
 type ProbeTargetStaticConfigApplyConfiguration struct {
 	Targets        []string                          `json:"static,omitempty"`
+	Hosts          []string                          `json:"hosts,omitempty"`
 	Labels         map[string]string                 `json:"labels,omitempty"`
 	RelabelConfigs []RelabelConfigApplyConfiguration `json:"relabelingConfigs,omitempty"`
 }
@@ -36,6 +37,16 @@ func ProbeTargetStaticConfig() *ProbeTargetStaticConfigApplyConfiguration {
 func (b *ProbeTargetStaticConfigApplyConfiguration) WithTargets(values ...string) *ProbeTargetStaticConfigApplyConfiguration {
 	for i := range values {
 		b.Targets = append(b.Targets, values[i])
+	}
+	return b
+}
+
+// WithHosts adds the given value to the Hosts field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Hosts field.
+func (b *ProbeTargetStaticConfigApplyConfiguration) WithHosts(values ...string) *ProbeTargetStaticConfigApplyConfiguration {
+	for i := range values {
+		b.Hosts = append(b.Hosts, values[i])
 	}
 	return b
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1624,6 +1624,10 @@ func (cg *ConfigGenerator) generateProbeConfig(
 	switch {
 	case m.Spec.Targets.StaticConfig != nil:
 		// Generate static_config section.
+		// Hosts takes precedence over Targets, since the latter is deprecated.
+		if len(m.Spec.Targets.StaticConfig.Hosts) > 0 {
+			m.Spec.Targets.StaticConfig.Targets = m.Spec.Targets.StaticConfig.Hosts
+		}
 		staticConfig := yaml.MapSlice{
 			{Key: "targets", Value: m.Spec.Targets.StaticConfig.Targets},
 		}


### PR DESCRIPTION

## Description

Deprecate Probe `targets` in favor of Probe `hosts` to address the inconsistency between the currently exported `Targets` field and its corresponding JSON representation, "static".

Resumes: #6047
Fixes: #3480 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Introduce a `hosts` field in `staticConfig`, that will replace `targets` within the same schema section, in an effort to make the exported field match the JSON representation (earlier: `Targets,static", now: "Hosts,hosts").

```
