### PR TITLE
feat: reconcile on underlying data updates

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -938,6 +938,8 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		}
 
 		sset, err := makeStatefulSet(
+			c.kclient,
+			c.logger,
 			ssetName,
 			p,
 			c.config,

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -53,7 +53,7 @@ func makeStatefulSetFromPrometheus(p monitoringv1.Prometheus) (*appsv1.StatefulS
 		return nil, err
 	}
 
-	return makeStatefulSet(
+	return makeStatefulSet(nil, nil,
 		"test",
 		&p,
 		defaultTestConfig,
@@ -426,7 +426,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(
+	sset, err := makeStatefulSet(nil, nil,
 		"volume-init-test",
 		&p,
 		defaultTestConfig,
@@ -821,7 +821,7 @@ func TestPrometheusDefaultBaseImageFlag(t *testing.T) {
 	cg, err := prompkg.NewConfigGenerator(logger, &p)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(
+	sset, err := makeStatefulSet(nil, nil,
 		"test",
 		&p,
 		operatorConfig,
@@ -863,7 +863,7 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 	cg, err := prompkg.NewConfigGenerator(logger, &p)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(
+	sset, err := makeStatefulSet(nil, nil,
 		"test",
 		&p,
 		thanosBaseImageConfig,
@@ -1388,7 +1388,7 @@ func TestReplicasConfigurationWithSharding(t *testing.T) {
 	cg, err := prompkg.NewConfigGenerator(logger, &p)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(
+	sset, err := makeStatefulSet(nil, nil,
 		"test",
 		&p,
 		testConfig,
@@ -1429,7 +1429,7 @@ func TestSidecarResources(t *testing.T) {
 		cg, err := prompkg.NewConfigGenerator(logger, &p)
 		require.NoError(t, err)
 
-		sset, err := makeStatefulSet(
+		sset, err := makeStatefulSet(nil, nil,
 			"test",
 			&p,
 			testConfig,
@@ -1852,7 +1852,7 @@ func TestConfigReloader(t *testing.T) {
 	cg, err := prompkg.NewConfigGenerator(logger, &p)
 	require.NoError(t, err)
 
-	sset, err := makeStatefulSet(
+	sset, err := makeStatefulSet(nil, nil,
 		"test",
 		&p,
 		defaultTestConfig,
@@ -1911,6 +1911,8 @@ func TestConfigReloaderWithSignal(t *testing.T) {
 	require.NoError(t, err)
 
 	sset, err := makeStatefulSet(
+		nil,
+		nil,
 		"test",
 		&p,
 		defaultTestConfig,


### PR DESCRIPTION
## Description

Trigger reconciliation when the data included in a dependant configmap or secret is modified. This commit addresses this issue for all such EnvVarSource-based instances.

Resumes: #6049

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Reconcile on Thanos tracing and object store configuration modifications.
```
