### PR TITLE
fix: validate route matchers

### DIFF
--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -409,6 +409,23 @@ func validateRoute(r *monitoringv1alpha1.Route, receivers, muteTimeIntervals map
 		}
 	}
 
+	// Validate matchers, so they don't end up crashing the main instance: https://github.com/prometheus/alertmanager/blob/v0.26.0/config/coordinator.go#L124.
+	if len(r.Matchers) > 0 {
+		for _, matcher := range r.Matchers {
+			if matcher.MatchType == "" {
+				matcher.MatchType = monitoringv1alpha1.MatchEqual
+				if matcher.Regex {
+					matcher.MatchType = monitoringv1alpha1.MatchRegexp
+				}
+			}
+			_, err := monitoringv1alpha1.ParseMatcher(matcher.String())
+			if err != nil {
+				return fmt.Errorf("invalid matcher %q: %w", matcher, err)
+			}
+		}
+	}
+
+	// validate that if defaults are set, they match regex
 	if r.GroupInterval != "" && !durationRe.MatchString(r.GroupInterval) {
 		return fmt.Errorf("groupInterval %s does not match required regex: %s", r.GroupInterval, durationRe.String())
 

--- a/pkg/apis/monitoring/v1alpha1/validation_test.go
+++ b/pkg/apis/monitoring/v1alpha1/validation_test.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -515,4 +516,448 @@ func TestOpsGenieConfigResponder_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMatchers(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  []*Matcher
+		err   string
+	}{
+		{
+			input: `{}`,
+			want:  make([]*Matcher, 0),
+		},
+		{
+			input: `,`,
+			err:   "bad matcher format: ",
+		},
+		{
+			input: `{,}`,
+			err:   "bad matcher format: ",
+		},
+		{
+			input: `{foo='}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "'")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: "{foo=`}",
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "`")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: "{foo=\\\"}",
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "\"")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=~bar.*}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=~"bar.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!=bar}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!="bar"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!~bar.*}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!~"bar.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!="quux"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "baz", "quux")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!~"quux.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", "quux.*")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo="bar",baz!~".*quux", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", ".*quux")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!="quux", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "baz", "quux")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!~".*quux.*", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", ".*quux.*")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", instance=~"some-api.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchRegexp, "instance", "some-api.*")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo=""}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar,quux", job="job1"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar,quux")
+				m2, _ := NewMatcher(MatchEqual, "job", "job1")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo = "bar", dings != "bums", }`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "dings", "bums")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `foo=bar,dings!=bums`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "dings", "bums")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{quote="She said: \"Hi, ladies! That's gender-neutral…\""}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "quote", `She said: "Hi, ladies! That's gender-neutral…"`)
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `statuscode=~"5.."`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "statuscode", "5..")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `tricky=~~~`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "tricky", "~~")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `trickier==\\=\=\"`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "trickier", `=\=\="`)
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `contains_quote != "\"" , contains_comma !~ "foo,bar" , `,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "contains_quote", `"`)
+				m2, _ := NewMatcher(MatchNotRegexp, "contains_comma", "foo,bar")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo=bar}}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar}")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar}},}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar}}")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=,bar=}}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m1, _ := NewMatcher(MatchEqual, "foo", "")
+				m2, _ := NewMatcher(MatchEqual, "bar", "}")
+				return append(ms, m1, m2)
+			}(),
+		},
+		{
+			input: `{foo=bar\t}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\\t")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar\n}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\n")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `job=`,
+			want: func() []*Matcher {
+				m, _ := NewMatcher(MatchEqual, "job", "")
+				return []*Matcher{m}
+			}(),
+		},
+		{
+			input: `job="value`,
+			err:   `matcher value contains unescaped double quote: "value`,
+		},
+		{
+			input: `job=value"`,
+			err:   `matcher value contains unescaped double quote: value"`,
+		},
+		{
+			input: `trickier==\\=\=\""`,
+			err:   `matcher value contains unescaped double quote: =\\=\=\""`,
+		},
+		{
+			input: `contains_unescaped_quote = foo"bar`,
+			err:   `matcher value contains unescaped double quote: foo"bar`,
+		},
+		{
+			input: `{invalid-name = "valid label"}`,
+			err:   `bad matcher format: invalid-name = "valid label"`,
+		},
+		{
+			input: `{foo=~"invalid[regexp"}`,
+			err:   "error parsing regexp: missing closing ]: `[regexp)$`",
+		},
+		// Double escaped strings.
+		{
+			input: `"{foo=\"bar"}`,
+			err:   `bad matcher format: "{foo=\"bar"`,
+		},
+		{
+			input: `"foo=\"bar"`,
+			err:   `bad matcher format: "foo=\"bar"`,
+		},
+		{
+			input: `"foo=\"bar\""`,
+			err:   `bad matcher format: "foo=\"bar\""`,
+		},
+		{
+			input: `"foo=\"bar\"`,
+			err:   `bad matcher format: "foo=\"bar\"`,
+		},
+		{
+			input: `"{foo=\"bar\"}"`,
+			err:   `bad matcher format: "{foo=\"bar\"}"`,
+		},
+		{
+			input: `"foo="bar""`,
+			err:   `bad matcher format: "foo="bar""`,
+		},
+		{
+			input: `{{foo=`,
+			err:   `bad matcher format: {foo=`,
+		},
+		{
+			input: `{foo=`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=}b`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "}b")
+				return append(ms, m)
+			}(),
+		},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			if tc.input == "" {
+				t.Skip("empty matchers are implicitly ignored, skipping")
+			}
+			got, err := ParseMatchers(tc.input)
+			if err != nil && tc.err == "" {
+				t.Fatalf("got error where none expected: %v", err)
+			}
+			if err == nil && tc.err != "" {
+				t.Fatalf("expected error but got none: %v", tc.err)
+			}
+			if err != nil && err.Error() != tc.err {
+				t.Fatalf("error not equal:\ngot  %v\nwant %v", err, tc.err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("labels not equal:\ngot  %v\nwant %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ParseMatchers parses a comma-separated list of Matchers. A leading '{' and/or
+// a trailing '}' is optional and will be trimmed before further
+// parsing. Individual Matchers are separated by commas outside of quoted parts
+// of the input string. Those commas may be surrounded by whitespace. Parts of the
+// string inside unescaped double quotes ('"…"') are considered quoted (and
+// commas don't act as separators there). If double quotes are escaped with a
+// single backslash ('\"'), they are ignored for the purpose of identifying
+// quoted parts of the input string. If the input string, after trimming the
+// optional trailing '}', ends with a comma, followed by optional whitespace,
+// this comma and whitespace will be trimmed.
+//
+// Examples for valid input strings:
+//
+//	{foo = "bar", dings != "bums", }
+//	foo=bar,dings!=bums
+//	foo=bar, dings!=bums
+//	{quote="She said: \"Hi, ladies! That's gender-neutral…\""}
+//	statuscode=~"5.."
+//
+// See ParseMatcher for details on how an individual Matcher is parsed.
+func ParseMatchers(s string) ([]*Matcher, error) {
+	matchers := []*Matcher{}
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
+
+	var (
+		insideQuotes bool
+		escaped      bool
+		token        strings.Builder
+		tokens       []string
+	)
+	for _, r := range s {
+		switch r {
+		case ',':
+			if !insideQuotes {
+				tokens = append(tokens, token.String())
+				token.Reset()
+				continue
+			}
+		case '"':
+			if !escaped {
+				insideQuotes = !insideQuotes
+			} else {
+				escaped = false
+			}
+		case '\\':
+			escaped = !escaped
+		default:
+			escaped = false
+		}
+		token.WriteRune(r)
+	}
+	if s := strings.TrimSpace(token.String()); s != "" {
+		tokens = append(tokens, s)
+	}
+	for _, token := range tokens {
+		m, err := ParseMatcher(token)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, m)
+	}
+
+	return matchers, nil
 }

--- a/pkg/apis/monitoring/v1beta1/validation.go
+++ b/pkg/apis/monitoring/v1beta1/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 func (hc *HTTPConfig) Validate() error {
@@ -348,4 +349,85 @@ func parseRange(in string) (start, end string, err error) {
 		return start, end, fmt.Errorf("invalid range provided %s", in)
 	}
 	return parts[0], parts[1], nil
+}
+
+// Upstream alertmanager@v0.26.0: pkg/labels/parse.go (at the time of this commit).
+
+// ParseMatcher parses a matcher with a syntax inspired by PromQL and
+// OpenMetrics. This syntax is convenient to describe filters and selectors in
+// UIs and config files. To support the interactive nature of the use cases, the
+// parser is in various aspects fairly tolerant.
+//
+// The syntax of a matcher consists of three tokens: (1) A valid Prometheus
+// label name. (2) One of '=', '!=', '=~', or '!~', with the same meaning as
+// known from PromQL selectors. (3) A UTF-8 string, which may be enclosed in
+// double quotes. Before or after each token, there may be any amount of
+// whitespace, which will be discarded. The 3rd token may be the empty
+// string. Within the 3rd token, OpenMetrics escaping rules apply: '\"' for a
+// double-quote, '\n' for a line feed, '\\' for a literal backslash. Unescaped
+// '"' must not occur inside the 3rd token (only as the 1st or last
+// character). However, literal line feed characters are tolerated, as are
+// single '\' characters not followed by '\', 'n', or '"'. They act as a literal
+// backslash in that case.
+func ParseMatcher(s string) (*Matcher, error) {
+	ms := re.FindStringSubmatch(s)
+	if len(ms) == 0 {
+		return nil, fmt.Errorf("bad matcher format: %s", s)
+	}
+
+	var (
+		rawValue            = ms[3]
+		value               strings.Builder
+		escaped             bool
+		expectTrailingQuote bool
+	)
+
+	if strings.HasPrefix(rawValue, "\"") {
+		rawValue = strings.TrimPrefix(rawValue, "\"")
+		expectTrailingQuote = true
+	}
+
+	if !utf8.ValidString(rawValue) {
+		return nil, fmt.Errorf("matcher value not valid UTF-8: %s", ms[3])
+	}
+
+	// Unescape the rawValue:
+	for i, r := range rawValue {
+		if escaped {
+			escaped = false
+			switch r {
+			case 'n':
+				value.WriteByte('\n')
+			case '"', '\\':
+				value.WriteRune(r)
+			default:
+				// This was a spurious escape, so treat the '\' as literal.
+				value.WriteByte('\\')
+				value.WriteRune(r)
+			}
+			continue
+		}
+		switch r {
+		case '\\':
+			if i < len(rawValue)-1 {
+				escaped = true
+				continue
+			}
+			// '\' encountered as last byte. Treat it as literal.
+			value.WriteByte('\\')
+		case '"':
+			if !expectTrailingQuote || i < len(rawValue)-1 {
+				return nil, fmt.Errorf("matcher value contains unescaped double quote: %s", ms[3])
+			}
+			expectTrailingQuote = false
+		default:
+			value.WriteRune(r)
+		}
+	}
+
+	if expectTrailingQuote {
+		return nil, fmt.Errorf("matcher value contains unescaped double quote: %s", ms[3])
+	}
+
+	return NewMatcher(typeMap[ms[2]], ms[1], value.String())
 }

--- a/pkg/apis/monitoring/v1beta1/validation_test.go
+++ b/pkg/apis/monitoring/v1beta1/validation_test.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -453,6 +454,385 @@ func TestHTTPClientConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchers(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  []*Matcher
+		err   string
+	}{
+		{
+			input: `{}`,
+			want:  make([]*Matcher, 0),
+		},
+		{
+			input: `,`,
+			err:   "bad matcher format: ",
+		},
+		{
+			input: `{,}`,
+			err:   "bad matcher format: ",
+		},
+		{
+			input: `{foo='}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "'")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: "{foo=`}",
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "`")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: "{foo=\\\"}",
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "\"")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=~bar.*}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=~"bar.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!=bar}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!="bar"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "foo", "bar")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!~bar.*}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo!~"bar.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotRegexp, "foo", "bar.*")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!="quux"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "baz", "quux")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!~"quux.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", "quux.*")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo="bar",baz!~".*quux", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", ".*quux")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!="quux", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "baz", "quux")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", baz!~".*quux.*", derp="wat"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotRegexp, "baz", ".*quux.*")
+				m3, _ := NewMatcher(MatchEqual, "derp", "wat")
+				return append(ms, m, m2, m3)
+			}(),
+		},
+		{
+			input: `{foo="bar", instance=~"some-api.*"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchRegexp, "instance", "some-api.*")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo=""}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo="bar,quux", job="job1"}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar,quux")
+				m2, _ := NewMatcher(MatchEqual, "job", "job1")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo = "bar", dings != "bums", }`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "dings", "bums")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `foo=bar,dings!=bums`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar")
+				m2, _ := NewMatcher(MatchNotEqual, "dings", "bums")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{quote="She said: \"Hi, ladies! That's gender-neutral…\""}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "quote", `She said: "Hi, ladies! That's gender-neutral…"`)
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `statuscode=~"5.."`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "statuscode", "5..")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `tricky=~~~`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchRegexp, "tricky", "~~")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `trickier==\\=\=\"`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "trickier", `=\=\="`)
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `contains_quote != "\"" , contains_comma !~ "foo,bar" , `,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchNotEqual, "contains_quote", `"`)
+				m2, _ := NewMatcher(MatchNotRegexp, "contains_comma", "foo,bar")
+				return append(ms, m, m2)
+			}(),
+		},
+		{
+			input: `{foo=bar}}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar}")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar}},}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar}}")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=,bar=}}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m1, _ := NewMatcher(MatchEqual, "foo", "")
+				m2, _ := NewMatcher(MatchEqual, "bar", "}")
+				return append(ms, m1, m2)
+			}(),
+		},
+		{
+			input: `{foo=bar\t}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\\t")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar\n}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\n")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `job=`,
+			want: func() []*Matcher {
+				m, _ := NewMatcher(MatchEqual, "job", "")
+				return []*Matcher{m}
+			}(),
+		},
+		{
+			input: `job="value`,
+			err:   `matcher value contains unescaped double quote: "value`,
+		},
+		{
+			input: `job=value"`,
+			err:   `matcher value contains unescaped double quote: value"`,
+		},
+		{
+			input: `trickier==\\=\=\""`,
+			err:   `matcher value contains unescaped double quote: =\\=\=\""`,
+		},
+		{
+			input: `contains_unescaped_quote = foo"bar`,
+			err:   `matcher value contains unescaped double quote: foo"bar`,
+		},
+		{
+			input: `{invalid-name = "valid label"}`,
+			err:   `bad matcher format: invalid-name = "valid label"`,
+		},
+		{
+			input: `{foo=~"invalid[regexp"}`,
+			err:   "error parsing regexp: missing closing ]: `[regexp)$`",
+		},
+		// Double escaped strings.
+		{
+			input: `"{foo=\"bar"}`,
+			err:   `bad matcher format: "{foo=\"bar"`,
+		},
+		{
+			input: `"foo=\"bar"`,
+			err:   `bad matcher format: "foo=\"bar"`,
+		},
+		{
+			input: `"foo=\"bar\""`,
+			err:   `bad matcher format: "foo=\"bar\""`,
+		},
+		{
+			input: `"foo=\"bar\"`,
+			err:   `bad matcher format: "foo=\"bar\"`,
+		},
+		{
+			input: `"{foo=\"bar\"}"`,
+			err:   `bad matcher format: "{foo=\"bar\"}"`,
+		},
+		{
+			input: `"foo="bar""`,
+			err:   `bad matcher format: "foo="bar""`,
+		},
+		{
+			input: `{{foo=`,
+			err:   `bad matcher format: {foo=`,
+		},
+		{
+			input: `{foo=`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=}b`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "}b")
+				return append(ms, m)
+			}(),
+		},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			if tc.input == "" {
+				t.Skip("empty matchers are implicitly ignored, skipping")
+			}
+			got, err := ParseMatchers(tc.input)
+			if err != nil && tc.err == "" {
+				t.Fatalf("got error where none expected: %v", err)
+			}
+			if err == nil && tc.err != "" {
+				t.Fatalf("expected error but got none: %v", tc.err)
+			}
+			if err != nil && err.Error() != tc.err {
+				t.Fatalf("error not equal:\ngot  %v\nwant %v", err, tc.err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("labels not equal:\ngot  %v\nwant %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestOpsGenieConfigResponder_Validate(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -513,5 +893,70 @@ func TestOpsGenieConfigResponder_Validate(t *testing.T) {
 			}
 		})
 	}
+}
 
+// ParseMatchers parses a comma-separated list of Matchers. A leading '{' and/or
+// a trailing '}' is optional and will be trimmed before further
+// parsing. Individual Matchers are separated by commas outside of quoted parts
+// of the input string. Those commas may be surrounded by whitespace. Parts of the
+// string inside unescaped double quotes ('"…"') are considered quoted (and
+// commas don't act as separators there). If double quotes are escaped with a
+// single backslash ('\"'), they are ignored for the purpose of identifying
+// quoted parts of the input string. If the input string, after trimming the
+// optional trailing '}', ends with a comma, followed by optional whitespace,
+// this comma and whitespace will be trimmed.
+//
+// Examples for valid input strings:
+//
+//	{foo = "bar", dings != "bums", }
+//	foo=bar,dings!=bums
+//	foo=bar, dings!=bums
+//	{quote="She said: \"Hi, ladies! That's gender-neutral…\""}
+//	statuscode=~"5.."
+//
+// See ParseMatcher for details on how an individual Matcher is parsed.
+func ParseMatchers(s string) ([]*Matcher, error) {
+	matchers := []*Matcher{}
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
+
+	var (
+		insideQuotes bool
+		escaped      bool
+		token        strings.Builder
+		tokens       []string
+	)
+	for _, r := range s {
+		switch r {
+		case ',':
+			if !insideQuotes {
+				tokens = append(tokens, token.String())
+				token.Reset()
+				continue
+			}
+		case '"':
+			if !escaped {
+				insideQuotes = !insideQuotes
+			} else {
+				escaped = false
+			}
+		case '\\':
+			escaped = !escaped
+		default:
+			escaped = false
+		}
+		token.WriteRune(r)
+	}
+	if s := strings.TrimSpace(token.String()); s != "" {
+		tokens = append(tokens, s)
+	}
+	for _, token := range tokens {
+		m, err := ParseMatcher(token)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, m)
+	}
+
+	return matchers, nil
 }


### PR DESCRIPTION

## Description

Validate route matchers for AlertmanagerConfigurations, so they don't crash the main instance.

Resumes: #6007
Fixes: #5163

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
