### PR TITLE
chore: change the `record` api to the new `events` api

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/clustertlsconfig"
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
@@ -101,7 +101,7 @@ type Operator struct {
 	metrics         *operator.Metrics
 	reconciliations *operator.ReconciliationTracker
 
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 
 	canReadStorageClass bool
 
@@ -1063,7 +1063,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			c.eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			c.eventRecorder.Eventf(amc, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -61,8 +61,7 @@ const (
 	controllerName            = "alertmanager-controller"
 	applicationNameLabelValue = "alertmanager"
 
-	// Generic reason for AlertmanagerConfig that are not valid.
-	invalidConfiguration = "InvalidConfiguration"
+	selectingAlertmanagerConfigResourcesAction = "SelectingAlertmanagerConfigResources"
 )
 
 // Config defines the operator's parameters for the Alertmanager controller.
@@ -1066,7 +1065,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			c.eventRecorder.Eventf(amc, am, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			c.eventRecorder.Eventf(amc, am, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -60,6 +60,9 @@ const (
 	resyncPeriod              = 5 * time.Minute
 	controllerName            = "alertmanager-controller"
 	applicationNameLabelValue = "alertmanager"
+
+	// Generic reason for AlertmanagerConfig that are not valid.
+	invalidConfiguration = "InvalidConfiguration"
 )
 
 // Config defines the operator's parameters for the Alertmanager controller.
@@ -1063,7 +1066,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			c.eventRecorder.Eventf(amc, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			c.eventRecorder.Eventf(amc, am, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -313,8 +313,7 @@ func NewEventRecorderFactory(emitEvents bool) EventRecorderFactory {
 		eventBroadcaster.StartStructuredLogging(0)
 
 		if emitEvents {
-			stopCh := make(chan struct{})
-			eventBroadcaster.StartRecordingToSink(stopCh)
+			eventBroadcaster.StartRecordingToSinkWithContext(context.Background())
 		}
 
 		return eventBroadcaster.NewRecorder(scheme.Scheme, component)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -313,7 +313,7 @@ func NewEventRecorderFactory(emitEvents bool) EventRecorderFactory {
 		eventBroadcaster.StartStructuredLogging(0)
 
 		if emitEvents {
-			eventBroadcaster.StartRecordingToSinkWithContext(context.Background())
+			_ = eventBroadcaster.StartRecordingToSinkWithContext(context.Background())
 		}
 
 		return eventBroadcaster.NewRecorder(scheme.Scheme, component)

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -26,7 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
@@ -65,12 +65,12 @@ type PrometheusRuleSelector struct {
 	nsLabeler    *namespacelabeler.Labeler
 	ruleInformer *informers.ForResource
 
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 
 	logger *slog.Logger
 }
 
-func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder record.EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
+func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder events.EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
 	componentVersion, err := semver.ParseTolerant(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)
@@ -238,7 +238,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, v1.EventTypeWarning, "InvalidConfiguration", "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, "InvalidConfiguration", "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -50,6 +50,9 @@ type RuleConfigurationFormat int
 const (
 	PrometheusFormat RuleConfigurationFormat = iota
 	ThanosFormat
+
+	// Generic reason for PrometheusRule that are not valid.
+	invalidConfiguration = "InvalidConfiguration"
 )
 
 // The maximum `Data` size of a ConfigMap seems to differ between
@@ -238,7 +241,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, "InvalidConfiguration", "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, invalidConfiguration, InvalidConfigurationEvent, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -51,8 +51,7 @@ const (
 	PrometheusFormat RuleConfigurationFormat = iota
 	ThanosFormat
 
-	// Generic reason for PrometheusRule that are not valid.
-	invalidConfiguration = "InvalidConfiguration"
+	selectingPrometheusRuleSelectorResourcesAction = "SelectingPrometheusRuleSelectorResources"
 )
 
 // The maximum `Data` size of a ConfigMap seems to differ between
@@ -241,7 +240,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, invalidConfiguration, InvalidConfigurationEvent, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleSelectorResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -51,7 +51,7 @@ const (
 	PrometheusFormat RuleConfigurationFormat = iota
 	ThanosFormat
 
-	selectingPrometheusRuleSelectorResourcesAction = "SelectingPrometheusRuleSelectorResources"
+	selectingPrometheusRuleResourcesAction = "SelectingPrometheusRuleResources"
 )
 
 // The maximum `Data` size of a ConfigMap seems to differ between
@@ -240,7 +240,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleSelectorResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -90,7 +90,7 @@ type Operator struct {
 	scrapeConfigSupported  bool
 	canReadStorageClass    bool
 
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 
 	statusReporter prompkg.StatusReporter
 

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -66,7 +66,7 @@ type ResourceSelector struct {
 	metrics            *operator.Metrics
 	accessor           *operator.Accessor
 
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 }
 
 // TypedConfigurationResource is a generic type that holds a configuration resource with its validation status.
@@ -116,7 +116,7 @@ func NewResourceSelector(
 	store *assets.StoreBuilder,
 	namespaceInformers cache.SharedIndexInformer,
 	metrics *operator.Metrics,
-	eventRecorder record.EventRecorder,
+	eventRecorder events.EventRecorder,
 ) (*ResourceSelector, error) {
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 	version, err := semver.ParseTolerant(promVersion)
@@ -208,7 +208,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -45,8 +45,9 @@ import (
 )
 
 const (
-	invalidConfiguration                            = "InvalidConfiguration"
-	selectingPrometheusConfigurationResourcesAction = "SelectingPrometheusConfigurationResourcesAction"
+	// Generic reason for selected resources that are not valid.
+	invalidConfiguration                  = "InvalidConfiguration"
+	selectingConfigurationResourcesAction = "SelectingConfigurationResources"
 )
 
 // ConfigurationResource is a type constraint that permits only the specific pointer types for configuration resources

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -45,8 +45,8 @@ import (
 )
 
 const (
-	// Generic reason for selected resources that are not valid.
-	invalidConfiguration = "InvalidConfiguration"
+	invalidConfiguration                            = "InvalidConfiguration"
+	selectingPrometheusConfigurationResourcesAction = "SelectingPrometheusConfigurationResourcesAction"
 )
 
 // ConfigurationResource is a type constraint that permits only the specific pointer types for configuration resources
@@ -208,7 +208,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingPrometheusConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -208,7 +208,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, o, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -209,7 +209,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingPrometheusConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -208,7 +208,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, o, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, invalidConfiguration, operator.InvalidConfigurationEvent, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -772,7 +772,7 @@ func TestSelectProbes(t *testing.T) {
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				record.NewFakeRecorder(1),
+				events.NewFakeRecorder(1),
 			)
 			require.NoError(t, err)
 
@@ -1358,7 +1358,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				record.NewFakeRecorder(1),
+				events.NewFakeRecorder(1),
 			)
 			require.NoError(t, err)
 
@@ -1661,7 +1661,7 @@ func TestSelectPodMonitors(t *testing.T) {
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				record.NewFakeRecorder(1),
+				events.NewFakeRecorder(1),
 			)
 			require.NoError(t, err)
 
@@ -4637,7 +4637,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				record.NewFakeRecorder(1),
+				events.NewFakeRecorder(1),
 			)
 			require.NoError(t, err)
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -97,7 +97,7 @@ type Operator struct {
 	retentionPoliciesEnabled      bool
 	configResourcesStatusEnabled  bool
 
-	eventRecorder   record.EventRecorder
+	eventRecorder   events.EventRecorder
 	finalizerSyncer *operator.FinalizerSyncer
 }
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -85,7 +85,7 @@ type Operator struct {
 	reconciliations     *operator.ReconciliationTracker
 	canReadStorageClass bool
 
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 
 	config Config
 


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

_If it fixes an existing issue (bug or feature), use the following keyword:_

_Closes: #ISSUE-NUMBER_

This Pull Request migrates from the old events API (`k8s.io/client-go/tools/record`) to the new API (`k8s.io/client-go/tools/events`).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
None
```
