### PR TITLE
Config Status Subresource finalizer in prometheusAgent

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -616,7 +616,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	logger := c.logger.With("key", key)
 
-	finalizersChanged, err := c.finalizerSyncer.Sync(ctx, p, c.rr.DeletionInProgress(p), func() error {return nil})
+	finalizersChanged, err := c.finalizerSyncer.Sync(ctx, p, c.rr.DeletionInProgress(p), func() error { return nil })
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -96,6 +96,8 @@ type Operator struct {
 
 	daemonSetFeatureGateEnabled  bool
 	configResourcesStatusEnabled bool
+
+	finalizerSyncer *operator.FinalizerSyncer
 }
 
 type ControllerOption func(*Operator)
@@ -612,12 +614,24 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	// Check if the Agent instance is marked for deletion.
-	if c.rr.DeletionInProgress(p) {
+	logger := c.logger.With("key", key)
+
+	finalizersChanged, err := c.finalizerSyncer.Sync(ctx, p, c.rr.DeletionInProgress(p), func() error {return nil})
+	if err != nil {
+		return err
+	}
+
+	if finalizersChanged {
+		// Since the object has been updated, let's trigger another sync.
+		c.rr.EnqueueForReconciliation(p)
 		return nil
 	}
 
-	logger := c.logger.With("key", key)
+	// Check if the Agent instance is marked for deletion.
+	if c.rr.DeletionInProgress(p) {
+		c.reconciliations.ForgetObject(key)
+		return nil
+	}
 
 	if p.Spec.Paused {
 		logger.Info("the resource is paused, not reconciling")

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -164,6 +164,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		controllerID:                 c.ControllerID,
 		eventRecorder:                c.EventRecorderFactory(client, controllerName),
 		configResourcesStatusEnabled: c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature),
+		finalizerSyncer:              operator.NewFinalizerSyncer(mdClient, monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.PrometheusAgentName), c.Gates.Enabled(operator.StatusForConfigurationResourcesFeature)),
 	}
 	o.metrics.MustRegister(
 		o.reconciliations,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -426,18 +426,19 @@ const (
 func TestGatedFeatures(t *testing.T) {
 	skipFeatureGatedTests(t)
 	testFuncs := map[string]func(t *testing.T){
-		"CreatePrometheusAgentDaemonSet":               testCreatePrometheusAgentDaemonSet,
-		"PromAgentDaemonSetResourceUpdate":             testPromAgentDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceUpdate":    testPromAgentReconcileDaemonSetResourceUpdate,
-		"PromAgentReconcileDaemonSetResourceDelete":    testPromAgentReconcileDaemonSetResourceDelete,
-		"PrometheusAgentDaemonSetSelectPodMonitor":     testPrometheusAgentDaemonSetSelectPodMonitor,
-		"PrometheusRetentionPolicies":                  testPrometheusRetentionPolicies,
-		"FinalizerWhenStatusForConfigResourcesEnabled": testFinalizerWhenStatusForConfigResourcesEnabled,
-		"PrometheusAgentDaemonSetCELValidations":       testPrometheusAgentDaemonSetCELValidations,
-		"ServiceMonitorStatusSubresource":              testServiceMonitorStatusSubresource,
-		"ServiceMonitorStatusWithMultipleWorkloads":    testServiceMonitorStatusWithMultipleWorkloads,
-		"GarbageCollectionOfServiceMonitorBinding":     testGarbageCollectionOfServiceMonitorBinding,
-		"RmServiceMonitorBindingDuringWorkloadDelete":  testRmServiceMonitorBindingDuringWorkloadDelete,
+		"CreatePrometheusAgentDaemonSet":                     testCreatePrometheusAgentDaemonSet,
+		"PromAgentDaemonSetResourceUpdate":                   testPromAgentDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceUpdate":          testPromAgentReconcileDaemonSetResourceUpdate,
+		"PromAgentReconcileDaemonSetResourceDelete":          testPromAgentReconcileDaemonSetResourceDelete,
+		"PrometheusAgentDaemonSetSelectPodMonitor":           testPrometheusAgentDaemonSetSelectPodMonitor,
+		"PrometheusRetentionPolicies":                        testPrometheusRetentionPolicies,
+		"FinalizerWhenStatusForConfigResourcesEnabled":       testFinalizerWhenStatusForConfigResourcesEnabled,
+		"PrometheusAgentDaemonSetCELValidations":             testPrometheusAgentDaemonSetCELValidations,
+		"ServiceMonitorStatusSubresource":                    testServiceMonitorStatusSubresource,
+		"ServiceMonitorStatusWithMultipleWorkloads":          testServiceMonitorStatusWithMultipleWorkloads,
+		"GarbageCollectionOfServiceMonitorBinding":           testGarbageCollectionOfServiceMonitorBinding,
+		"RmServiceMonitorBindingDuringWorkloadDelete":        testRmServiceMonitorBindingDuringWorkloadDelete,
+		"FinalizerForPromAgentWhenStatusForConfigResEnabled": testFinalizerForPromAgentWhenStatusForConfigResEnabled,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -288,6 +288,6 @@ func testFinalizerForPromAgentWhenStatusForConfigResEnabled(t *testing.T) {
 	finalizers := p.GetFinalizers()
 	require.NotEmpty(t, finalizers)
 
-	err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name)
+	err = framework.DeletePrometheusAgentAndWaitUntilGone(ctx, ns, name)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Config Status Subresource finalizer in prometheusAgent

Closes: #7884

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
