### PR TITLE
fix(config-reloader): use distinct port name for init container to av…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1581,4 +1581,3 @@ with the operator.
 
 * [CHANGE] Use StatefulSet instead of PetSet
 * [BUGFIX] Fix Prometheus config generation for labels containing "-"
-* [BUGFIX] Use distinct port name for init container to avoid duplicate port name warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1581,3 +1581,4 @@ with the operator.
 
 * [CHANGE] Use StatefulSet instead of PetSet
 * [BUGFIX] Fix Prometheus config generation for labels containing "-"
+* [BUGFIX] Use distinct port name for init container to avoid duplicate port name warnings

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -233,7 +233,6 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 		// Use distinct ports for the init and "regular" containers to avoid
 		// warnings from the k8s client.
 		if configReloader.initContainer {
-			portName = "reloader-web-init"
 			port = initConfigReloaderPort
 		}
 

--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -222,7 +222,7 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 	}
 
 	if configReloader.initContainer {
-		portName = "reloader-web-init"
+		portName = "reloader-init"
 		args = append(args, fmt.Sprintf("--watch-interval=%d", 0))
 	}
 


### PR DESCRIPTION
This PR fixes warnings about duplicate port names between the config-reloader and init-config-reloader containers.
Currently, both containers expose a port named reloader-web. With Kubernetes v1.34, the client-go library surfaces this as a warning:

Warning: duplicate port name "reloader-web" between init and regular containers


To resolve this, the init container now uses a distinct port name (reloader-web-init) while keeping a different port number (8081).
This avoids name clashes without affecting services, probes, or existing functionality (which rely on the regular container’s reloader-web port).

Closes: #7903

Type of change :

 BUGFIX (non-breaking change which fixes an issue)

Changelog entry
 [BUGFIX] Use distinct port name for init container to avoid duplicate port name warnings.