### PR TITLE
Feat: Add webhook validation for MSTeams V2 config

### DIFF
--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -112,7 +112,7 @@ func validateReceivers(receivers []monitoringv1alpha1.Receiver) (map[string]stru
 		}
 
 		if err := validateMSTeamsV2Configs(receiver.MSTeamsV2Configs); err != nil {
-			return nil, fmt.Errorf("failed to validate 'msteamsv2Config' - reciever %s: %w", receiver.Name, err)
+			return nil, fmt.Errorf("failed to validate 'msteamsv2Config' - receiver %s: %w", receiver.Name, err)
 		}
 
 	}

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -112,7 +112,7 @@ func validateReceivers(receivers []monitoringv1beta1.Receiver) (map[string]struc
 		}
 
 		if err := validateMSTeamsV2Configs(receiver.MSTeamsV2Configs); err != nil {
-			return nil, fmt.Errorf("failed to validate 'msteamsv2Config' - reciever %s: %w", receiver.Name, err)
+			return nil, fmt.Errorf("failed to validate 'msteamsv2Config' - receiver %s: %w", receiver.Name, err)
 		}
 
 	}


### PR DESCRIPTION
## Description

This PR adds the validation step for the MSTeamsV2Configs in the Alert Manager Receiver

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification


## Changelog entry


```release-note
- Add a webhook validation step for validating the MSTeamsV2 receiver
```
