### PR TITLE
Add CR Validation for requested limits/requests

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -6060,6 +6060,11 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: "CPU requests must not exceed CPU limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.cpu) || !has(self.limits.cpu) || quantity(self.requests.cpu).isLessThanOrEqual(quantity(self.limits.cpu))"
+                - message: "Memory requests must not exceed memory limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.memory) || !has(self.limits.memory) || quantity(self.requests.memory).isLessThanOrEqual(quantity(self.limits.memory))"
               retention:
                 default: 120h
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6405,6 +6405,11 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: "CPU requests must not exceed CPU limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.cpu) || !has(self.limits.cpu) || quantity(self.requests.cpu).isLessThanOrEqual(quantity(self.limits.cpu))"
+                - message: "Memory requests must not exceed memory limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.memory) || !has(self.limits.memory) || quantity(self.requests.memory).isLessThanOrEqual(quantity(self.limits.memory))"
               routePrefix:
                 description: |-
                   The route prefix Prometheus registers HTTP handlers for.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7971,6 +7971,11 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: "CPU requests must not exceed CPU limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.cpu) || !has(self.limits.cpu) || quantity(self.requests.cpu).isLessThanOrEqual(quantity(self.limits.cpu))"
+                - message: "Memory requests must not exceed memory limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.memory) || !has(self.limits.memory) || quantity(self.requests.memory).isLessThanOrEqual(quantity(self.limits.memory))"
               retention:
                 description: |-
                   How long to retain the Prometheus data.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5731,6 +5731,11 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: "CPU requests must not exceed CPU limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.cpu) || !has(self.limits.cpu) || quantity(self.requests.cpu).isLessThanOrEqual(quantity(self.limits.cpu))"
+                - message: "Memory requests must not exceed memory limits"
+                  rule: "!has(self.requests) || !has(self.limits) || !has(self.requests.memory) || !has(self.limits.memory) || quantity(self.requests.memory).isLessThanOrEqual(quantity(self.limits.memory))"
               retention:
                 default: 24h
                 description: |-

--- a/example/temp.yaml
+++ b/example/temp.yaml
@@ -1,0 +1,349 @@
+apiVersion: v1
+data:
+  application.yaml: |-
+    management:
+      metrics:
+        export:
+          statsd:
+            host: localhost
+            port: 8125
+            protocol: tcp
+    activity-pipeline:
+      scoped-deployment:
+        enabled: true
+        cached: true
+      tenant-configuration:
+        cached: true
+      subnet-rules:
+        cached: true
+      location-rules-cache:
+        enabled: true
+      tg-rejector:
+        regex: .*
+      actor-writing:
+        enabled: true
+      standardization:
+        enabled: true
+     cache:
+        configs:
+          scoped-deployment:
+            ttl: PT1H
+            maxSize: 10000
+            scheduler: caches
+            refresh:
+              enabled: true
+              refreshAfterWrite: PT45M
+            preload:
+              enabled: true
+          tenant-configuration:
+            ttl: PT1H
+            maxSize: 60000
+            scheduler: caches
+            refresh:
+              enabled: true
+              refreshAfterWrite: PT45M
+            preload:
+              enabled: true
+          subnet-rules:
+            ttl: PT1H
+            maxSize: 7000
+            scheduler: caches
+            refresh:
+              enabled: true
+              refreshAfterWrite: PT45M
+            preload:
+              enabled: true
+        tenant-lookup:
+          size: 1000
+          ttl: PT1H
+        entities:
+          size: 50000
+          ttl: PT5M
+        user-agent:
+          size: 100000
+      entities:
+        type: service
+        service:
+          useTokenCache: true
+          refreshInterval: PT1M
+          maxConnections: 30
+          poolAcquirePendingLimit: 2500
+          entitiesUrl: https://gccm-core-usm-usmv-entapv2.aa.mda.securitycenter.microsoft.us/api/tp/entitiesapv2/
+      geo-provider-cache:
+        enabled: true
+        ttl: PT5M
+        size: 100000
+      source: apv2
+      interflow:
+        cache:
+          ttl: PT15M
+          size: 1000
+        provider:
+          client-url: https://gov-o-geo-main.usgovtrafficmanager.net
+          key-vault-name: https://adallom-certs-gccm1.vault.usgovcloudapi.net
+      dedup-temp:
+        enabled: false
+        cosmos-account-temp: dedupepic
+    kepi:
+      health-indicator:
+        subscriber: true
+        checkpoint: true
+      batching:
+        enabled: true
+        scheduler: batching
+        timeout-in-ms: 500
+        max-batch-size: 100
+      cosmossql:
+        enabled: true
+        accounts:
+          dedupapv2:
+            fully-qualified-endpoint: https://tp-gccm-usmv-acdb-activityreplicator-dedup.documents.azure.us:443/
+            database-name: Dedup
+            credentials: default
+      mongo:
+        enabled: true
+        clients:
+          appName: apv2
+          list:
+          - id: data
+            secretName: dataMongo
+            isSecondaryPreferred: true
+            maxConnectionPoolSize: 2
+          - id: entities
+            secretName: entitiesMongo
+            isSecondaryPreferred: true
+            maxConnectionPoolSize: 2
+          - id: mgmt
+            secretName: mgmtMongo
+            isSecondaryPreferred: true
+            maxConnectionPoolSize: 1
+            maxConnectionIdleTimeMinutes: 5
+        templates:
+          list:
+          - id: AllTenants
+            databaseName: AllTenants
+            clientId: data
+          - id: Entities
+            databaseName: AllTenants
+            clientId: entities
+          - id: cpanel
+            databaseName: cpanel
+            clientId: mgmt
+          - id: data-kb
+            databaseName: kb
+            clientId: data
+          - id: mgmt-kb
+            databaseName: kb
+            clientId: mgmt
+          - id: AlertsEngine
+            databaseName: alerts_engine
+            clientId: data
+      appconfiguration:
+        cache:
+          ttl: PT15M
+          size: 1000
+      azure-table:
+        event-hub:
+          storageConnectionStringPath: /vault-folder/adallomcertsglobal/EventHubsManagementStore
+          consumerEncryptionKeySecretPath: /vault-folder/ehconsumerenc/EventHubEncryptionConsumer
+          producerEncryptionKeySecretPath: /vault-folder/ehproducerenc/EventHubEncryptionProducer
+          clusterId: gccm-1
+        path: /vault-folder/primary/acdb-activitypipelinestore-usmv-rw
+        tableName: checkpoints
+      dispatchStrategy:
+        transform: splitMax
+        compressor: snappy
+        scheduler: publishers
+      schedulers:
+        list:
+        - name: processor
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+        - name: publishers
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+        - name: subscriber
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+        - name: batching
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+        - name: dispatch
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+        - name: caches
+          corePoolSize: 16
+          maximumPoolSize: 16
+          keepAliveTime: 0
+          scheduledExecutor: true
+      metrics:
+        namespace: activitypipeline
+        tags:
+          inputGroup: lgdl
+        dc: gccm-1
+      pipeline:
+        enricher: activity
+        checkpoint-store:
+          type: azure-table
+        state-manager:
+          name: multiEventHub
+        subscriber:
+          name: batch
+          type: batch-subscriber
+          scheduler: subscriber
+          batch-params:
+            messagesToHandle: 50
+            innerBatchMessagesParallelism: 16
+        consume:
+          builder: event-hub-msi
+          type: event-hub
+          consumerGroup: $Default
+          unwrap-type: event-hub
+          unwrap-params:
+            enabled: true
+          startFromEarliest: true
+          partition:
+            type: hostname
+          eventHubName: eventhub
+          eventHubNamespace: tp-gccm-usmv-eh-apv2-lg-dl-0.servicebus.usgovcloudapi.net
+        strategy: default
+        error-handling-strategy:
+          type: arbitrator
+          rejector:
+            monitor: fullVerbose
+          failure:
+            type: retryDispatch
+            error-handling-dispatcher: dldispatcher
+      cache:
+        size: 400000
+      dedup:
+        enabled: true
+        cosmos-account: dedupapv2
+        max-transaction-time: PT10S
+      decode:
+        runner: default
+        decoder: activities
+      processors:
+        scheduler: processor
+        runner: sequential
+        list:
+        - name: disabled-tenant-rejector
+        - name: event-time-rejector
+        - name: event-timestamp-rejector
+        - name: future-enrichment-rejector
+        - name: invalid-appid-rejector
+        - name: invalid-event-type-rejector
+        - name: tg-rejector
+        - name: dedup-rejector
+        - name: blocked-rejector
+        - name: apv2-flag
+        - name: event-uid
+        - name: event-uid-rejector
+        - name: aad-tenant
+        - name: unresolved-entities
+        - name: invalid-user
+        - name: user-field
+        - name: org-unit
+        - name: impersonate-event
+        - name: activity-standardization
+        - name: user-identifiers
+        - name: entity-event
+        - name: actor-writer
+        - name: user-tags
+        - name: resolved-actors
+        - name: backport-entity
+        - name: scoped-deployment-rejector
+        - name: obfuscation
+        - name: admin-tag
+        - name: device-event
+        - name: user-agent
+        - name: ip
+        - name: location
+        - name: interflow-risky-ip
+        - name: event-objects-domain
+        - name: created-field
+        - name: big-event-rejector
+      publishers:
+        scheduler: publishers
+        runner: sequential
+        number-to-parallel: 1
+        list:
+        - name: replicator
+          configuration:
+            dispatcherName: consolidatedreplicator
+      security:
+        tokens:
+          geo-token:
+            scopes:
+            - https://tp-gccm-usmv-entra-geo.USGovCloud.onmicrosoft.com/.default
+      secrets:
+        list:
+        - name: dataMongo
+          path: /vault-folder/adallomdbset/dbset-1-mongodb
+          base64: true
+        - name: entitiesMongo
+          path: /vault-folder/adallomdbset/DBset-1-entitiesMongodb
+          base64: true
+        - name: geoclient
+          path: /vault-folder/adallomsecrets/Geo-Client
+          base64: false
+        - name: mgmtMongo
+          path: /vault-folder/adallomdbset/DBset-1-mgmtMongodb
+          base64: true
+      dispatchers:
+        list:
+        - name: dldispatcher
+          type: direct-eventhub
+          scheduler: dispatch
+          dispatchConfigurations:
+            eventhub-namespace: tp-gccm-usmv-eh-apv2-lg-dl-0-alias.servicebus.usgovcloudapi.net
+            eventhub: eventhub
+        - name: consolidatedreplicator
+          type: batching-eventhub
+          scheduler: dispatch
+          dispatchConfigurations:
+            eventhub-namespace: tp-gccm-usmv-eh-activityreplicator-0-alias.servicebus.usgovcloudapi.net
+            eventhub: eventhub
+            parallelism: 1
+    spring:
+      application:
+        name: activitypipeline
+      cloud:
+        discovery:
+          enabled: false
+        service-registry:
+          auto-registration:
+            enabled: false
+    geo-reactive:
+      client:
+        serviceUrl: https://gccm-core-usm-usmv-geo.aa.mda.securitycenter.microsoft.us/api/tp/geo/
+        token: geo-token
+        maxConnections: 30
+  bootstrap.properties: spring.cloud.azure.appconfiguration.stores[0].endpoint=https://tp-gccm-usmv-appconfig-activitypipeline.azconfig.azure.us
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: activity-pipeline-apv2lgdl-0
+    meta.helm.sh/release-namespace: threat-protection
+  creationTimestamp: "2024-11-17T12:17:48Z"
+  labels:
+    ADOOrganizationName: msazure
+    ADOProjectName: MCAS
+    ADORepositoryName: core-main
+    BuildID: "20250824.1"
+    BuildName: ThreatProtection.APv2.Official
+    app.kubernetes.io/component: activitypipeline
+    app.kubernetes.io/instance: activity-pipeline-apv2lgdl-0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: apv2lgdl-0
+    helm.sh/chart: wdatp-service-5.220.0
+    kubernetes.azure.com/managedby: 2fa7ba65-93e0-46c6-98b0-1df0c4e8a74d
+  name: apv2lgdl-0
+  namespace: threat-protection
+  resourceVersion: "3480848224"
+  uid: 158faef5-f37a-4682-8a51-97ea9a09bb06

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -606,6 +606,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 
+	// Validate resource requirements
+	if err := am.Spec.ValidateResources(); err != nil {
+		return fmt.Errorf("invalid resource configuration: %w", err)
+	}
+
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -941,6 +941,33 @@ type CommonPrometheusFields struct {
 	HostUsers *bool `json:"hostUsers,omitempty"`
 }
 
+// ValidateResources validates that resource requests don't exceed limits
+func (c *CommonPrometheusFields) ValidateResources() error {
+	if c.Resources.Limits == nil || c.Resources.Requests == nil {
+		return nil
+	}
+
+	// Validate CPU
+	if cpuLimit, hasLimit := c.Resources.Limits[v1.ResourceCPU]; hasLimit {
+		if cpuRequest, hasRequest := c.Resources.Requests[v1.ResourceCPU]; hasRequest {
+			if cpuRequest.Cmp(cpuLimit) > 0 {
+				return fmt.Errorf("CPU request (%s) exceeds CPU limit (%s)", cpuRequest.String(), cpuLimit.String())
+			}
+		}
+	}
+
+	// Validate Memory
+	if memLimit, hasLimit := c.Resources.Limits[v1.ResourceMemory]; hasLimit {
+		if memRequest, hasRequest := c.Resources.Requests[v1.ResourceMemory]; hasRequest {
+			if memRequest.Cmp(memLimit) > 0 {
+				return fmt.Errorf("Memory request (%s) exceeds Memory limit (%s)", memRequest.String(), memLimit.String())
+			}
+		}
+	}
+
+	return nil
+}
+
 // Specifies the validation scheme for metric and label names.
 //
 // Supported values are:

--- a/pkg/apis/monitoring/v1/resource_validation.go
+++ b/pkg/apis/monitoring/v1/resource_validation.go
@@ -1,0 +1,62 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// ValidateResourceRequirements validates that resource requests do not exceed limits.
+func ValidateResourceRequirements(resources v1.ResourceRequirements) error {
+	return validateResourceRequirements(resources, "")
+}
+
+// validateResourceRequirements validates that resource requests do not exceed limits.
+// The prefix parameter is used to provide context in error messages.
+func validateResourceRequirements(resources v1.ResourceRequirements, prefix string) error {
+	if len(resources.Requests) == 0 || len(resources.Limits) == 0 {
+		return nil // No validation needed if either requests or limits are empty
+	}
+
+	// Check CPU requests vs limits
+	if cpuRequest, hasRequest := resources.Requests[v1.ResourceCPU]; hasRequest {
+		if cpuLimit, hasLimit := resources.Limits[v1.ResourceCPU]; hasLimit {
+			if cpuRequest.Cmp(cpuLimit) > 0 {
+				msg := "CPU requests must not exceed CPU limits"
+				if prefix != "" {
+					msg = fmt.Sprintf("%s: %s", prefix, msg)
+				}
+				return fmt.Errorf("%s (request: %s, limit: %s)", msg, cpuRequest.String(), cpuLimit.String())
+			}
+		}
+	}
+
+	// Check Memory requests vs limits
+	if memRequest, hasRequest := resources.Requests[v1.ResourceMemory]; hasRequest {
+		if memLimit, hasLimit := resources.Limits[v1.ResourceMemory]; hasLimit {
+			if memRequest.Cmp(memLimit) > 0 {
+				msg := "Memory requests must not exceed memory limits"
+				if prefix != "" {
+					msg = fmt.Sprintf("%s: %s", prefix, msg)
+				}
+				return fmt.Errorf("%s (request: %s, limit: %s)", msg, memRequest.String(), memLimit.String())
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/apis/monitoring/v1/validation_test.go
+++ b/pkg/apis/monitoring/v1/validation_test.go
@@ -1,0 +1,195 @@
+// Copyright 2024 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestCommonPrometheusFields_ValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources v1.ResourceRequirements
+		wantErr   bool
+	}{
+		{
+			name: "valid resources",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CPU limit smaller than request",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("200m"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "memory limit smaller than request",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no limits specified",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no requests specified",
+			resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := &CommonPrometheusFields{
+				Resources: tt.resources,
+			}
+			err := fields.ValidateResources()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CommonPrometheusFields.ValidateResources() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerSpec_ValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources v1.ResourceRequirements
+		wantErr   bool
+	}{
+		{
+			name: "valid resources",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CPU limit smaller than request",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("200m"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &AlertmanagerSpec{
+				Resources: tt.resources,
+			}
+			err := spec.ValidateResources()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AlertmanagerSpec.ValidateResources() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestThanosRulerSpec_ValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources v1.ResourceRequirements
+		wantErr   bool
+	}{
+		{
+			name: "valid resources",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100m"),
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "memory limit smaller than request",
+			resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &ThanosRulerSpec{
+				Resources: tt.resources,
+			}
+			err := spec.ValidateResources()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ThanosRulerSpec.ValidateResources() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -630,6 +630,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("feature gate for Prometheus Agent's DaemonSet mode is not enabled")
 	}
 
+	// Validate resource requirements
+	if err := p.Spec.CommonPrometheusFields.ValidateResources(); err != nil {
+		return fmt.Errorf("invalid resource configuration: %w", err)
+	}
+
 	// Generate the configuration data.
 	var (
 		assetStore = assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -824,6 +824,11 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 
+	// Validate resource requirements
+	if err := p.Spec.CommonPrometheusFields.ValidateResources(); err != nil {
+		return fmt.Errorf("invalid resource configuration: %w", err)
+	}
+
 	if p.Spec.Paused {
 		logger.Info("the resource is paused, not reconciling")
 		return nil

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -486,6 +486,11 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 
+	// Validate resource requirements
+	if err := tr.Spec.ValidateResources(); err != nil {
+		return fmt.Errorf("invalid resource configuration: %w", err)
+	}
+
 	ruleConfigMapNames, err := o.createOrUpdateRuleConfigMaps(ctx, tr)
 	if err != nil {
 		return err

--- a/test-invalid-resources.yaml
+++ b/test-invalid-resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: test-invalid-resources
+  namespace: default
+spec:
+  version: v2.45.0
+  replicas: 1
+  serviceAccountName: prometheus
+  resources:
+    requests:
+      cpu: "2000m"     # 2 cores requested
+      memory: "4Gi"    # 4GB requested
+    limits:
+      cpu: "1000m"     # Only 1 core limit - INVALID (less than request)
+      memory: "2Gi"    # Only 2GB limit - INVALID (less than request)

--- a/test-valid-resources.yaml
+++ b/test-valid-resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: test-valid-resources
+  namespace: default
+spec:
+  version: v2.45.0
+  replicas: 1
+  serviceAccountName: prometheus
+  resources:
+    requests:
+      cpu: "500m"      # 0.5 cores requested
+      memory: "2Gi"    # 2GB requested
+    limits:
+      cpu: "1000m"     # 1 core limit - VALID (greater than request)
+      memory: "4Gi"    # 4GB limit - VALID (greater than request)


### PR DESCRIPTION
## Description

This Pull Request introduces basic CR validation to take place at operator deployment time, ensuring that CPU and memory request/limits are valid before admitting the operator. This is useful for avoiding scenarios where the operator deployment succeeds but then fails to create CRs due to the invalid memory definitions, thereby potentially becoming a silent failure where a helm release of prometheus-operator succeeds but subsequently fails to create CRs.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Authored unit tests, tested via company internal CI/CD 

## Changelog entry

```release-note
Add CR validation to ensure valid CPU and memory limits/requests at operator deployment time.
```
