### PR TITLE
feat: add "managed by" label to all managed resources

### DIFF
--- a/pkg/operator/factory.go
+++ b/pkg/operator/factory.go
@@ -163,12 +163,13 @@ func WithoutKubectlAnnotations() ObjectOption {
 	}
 }
 
-// UpdateObject updates the object's metadata with the provided options.
-// It automatically injects the "managed-by" label which identifies the
-// operator as the managing entity.
+// UpdateObject updates the object's metadata with the provided options. It
+// automatically injects the "managed-by" and "app.kubernetes.io/managed-by"
+// labels which identifies the operator as the managing entity.
 func UpdateObject(o metav1.Object, opts ...ObjectOption) {
 	WithLabels(map[string]string{
 		managedByOperatorLabel: ManagedByLabelValue,
+		ManagedByLabelKey:      ManagedByLabelValue,
 	})(o)
 
 	for _, opt := range opts {

--- a/pkg/operator/factory_test.go
+++ b/pkg/operator/factory_test.go
@@ -41,7 +41,10 @@ func TestUpdateObject(t *testing.T) {
 			o: &v1.Secret{},
 			exp: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"managed-by": "prometheus-operator"},
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "prometheus-operator",
+						"managed-by":                   "prometheus-operator",
+					},
 				},
 			},
 		},
@@ -85,10 +88,11 @@ func TestUpdateObject(t *testing.T) {
 						"annotation2": "val2",
 					},
 					Labels: map[string]string{
-						"label1":     "val1",
-						"label2":     "val2",
-						"label3":     "val3",
-						"managed-by": "prometheus-operator",
+						"label1":                       "val1",
+						"label2":                       "val2",
+						"label3":                       "val3",
+						"managed-by":                   "prometheus-operator",
+						"app.kubernetes.io/managed-by": "prometheus-operator",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{


### PR DESCRIPTION
## Description

This is a follow-up of #7786 which was only targeting workload resources such as statefulsets, daemonsets and pods. With this commit, all resources managed by the operator will be labelled with the `app.kubernetes.io/managed-by: prometheus-operator` label.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
