### PR TITLE
Feat: Add URL Validation for PagerdutyURL in Alertmanager Globalconfig

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -6197,7 +6197,9 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <code>pagerdutyUrl</code><br/>
 <em>
-string
+<a href="#monitoring.coreos.com/v1.URL">
+URL
+</a>
 </em>
 </td>
 <td>
@@ -20418,7 +20420,7 @@ Supported values are:
 <h3 id="monitoring.coreos.com/v1.URL">URL
 (<code>string</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.GlobalJiraConfig">GlobalJiraConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalRocketChatConfig">GlobalRocketChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalTelegramConfig">GlobalTelegramConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalVictorOpsConfig">GlobalVictorOpsConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWeChatConfig">GlobalWeChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWebexConfig">GlobalWebexConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.AlertmanagerGlobalConfig">AlertmanagerGlobalConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalJiraConfig">GlobalJiraConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalRocketChatConfig">GlobalRocketChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalTelegramConfig">GlobalTelegramConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalVictorOpsConfig">GlobalVictorOpsConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWeChatConfig">GlobalWeChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWebexConfig">GlobalWebexConfig</a>)
 </p>
 <div>
 <p>URL represents a valid URL</p>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1895,6 +1895,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       pagerdutyUrl:
                         description: pagerdutyUrl defines the default Pagerduty URL.
+                        pattern: ^(http|https)://.+$
                         type: string
                       resolveTimeout:
                         description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1896,6 +1896,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       pagerdutyUrl:
                         description: pagerdutyUrl defines the default Pagerduty URL.
+                        pattern: ^(http|https)://.+$
                         type: string
                       resolveTimeout:
                         description: |-

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1674,6 +1674,7 @@
                           },
                           "pagerdutyUrl": {
                             "description": "pagerdutyUrl defines the default Pagerduty URL.",
+                            "pattern": "^(http|https)://.+$",
                             "type": "string"
                           },
                           "resolveTimeout": {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -487,7 +487,7 @@ func (cb *ConfigBuilder) convertGlobalConfig(ctx context.Context, in *monitoring
 	}
 
 	if in.PagerdutyURL != nil {
-		u, err := url.Parse(*in.PagerdutyURL)
+		u, err := url.Parse(string(*in.PagerdutyURL))
 		if err != nil {
 			return nil, fmt.Errorf("parse Pagerduty URL: %w", err)
 		}

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -500,7 +500,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 		{
 			name: "valid global config with Pagerduty URL",
 			globalConfig: &monitoringv1.AlertmanagerGlobalConfig{
-				PagerdutyURL: &pagerdutyURL,
+				PagerdutyURL: ptr.To(monitoringv1.URL(pagerdutyURL)),
 			},
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -534,7 +534,7 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 		{
 			name: "global config with invalid Pagerduty URL",
 			globalConfig: &monitoringv1.AlertmanagerGlobalConfig{
-				PagerdutyURL: &invalidPagerdutyURL,
+				PagerdutyURL: ptr.To(monitoringv1.URL(invalidPagerdutyURL)),
 			},
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -468,7 +468,7 @@ type AlertmanagerGlobalConfig struct {
 
 	// pagerdutyUrl defines the default Pagerduty URL.
 	// +optional
-	PagerdutyURL *string `json:"pagerdutyUrl,omitempty"`
+	PagerdutyURL *URL `json:"pagerdutyUrl,omitempty"`
 
 	// telegram defines the default Telegram config
 	// +optional

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -240,7 +240,7 @@ func (in *AlertmanagerGlobalConfig) DeepCopyInto(out *AlertmanagerGlobalConfig) 
 	}
 	if in.PagerdutyURL != nil {
 		in, out := &in.PagerdutyURL, &out.PagerdutyURL
-		*out = new(string)
+		*out = new(URL)
 		**out = **in
 	}
 	if in.TelegramConfig != nil {

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerglobalconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerglobalconfig.go
@@ -30,7 +30,7 @@ type AlertmanagerGlobalConfigApplyConfiguration struct {
 	SlackAPIURL      *corev1.SecretKeySelector                 `json:"slackApiUrl,omitempty"`
 	OpsGenieAPIURL   *corev1.SecretKeySelector                 `json:"opsGenieApiUrl,omitempty"`
 	OpsGenieAPIKey   *corev1.SecretKeySelector                 `json:"opsGenieApiKey,omitempty"`
-	PagerdutyURL     *string                                   `json:"pagerdutyUrl,omitempty"`
+	PagerdutyURL     *monitoringv1.URL                         `json:"pagerdutyUrl,omitempty"`
 	TelegramConfig   *GlobalTelegramConfigApplyConfiguration   `json:"telegram,omitempty"`
 	JiraConfig       *GlobalJiraConfigApplyConfiguration       `json:"jira,omitempty"`
 	VictorOpsConfig  *GlobalVictorOpsConfigApplyConfiguration  `json:"victorops,omitempty"`
@@ -96,7 +96,7 @@ func (b *AlertmanagerGlobalConfigApplyConfiguration) WithOpsGenieAPIKey(value co
 // WithPagerdutyURL sets the PagerdutyURL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PagerdutyURL field is set to the value of the last call.
-func (b *AlertmanagerGlobalConfigApplyConfiguration) WithPagerdutyURL(value string) *AlertmanagerGlobalConfigApplyConfiguration {
+func (b *AlertmanagerGlobalConfigApplyConfiguration) WithPagerdutyURL(value monitoringv1.URL) *AlertmanagerGlobalConfigApplyConfiguration {
 	b.PagerdutyURL = &value
 	return b
 }


### PR DESCRIPTION
## Description

Change PagerdutyURL's type from string to URL to add kube validation for the URL type in Alertmanager Globalconfig

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Use unit testing

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Change type for PagerdutyURL in Alertmanager Globalconfig from string to URL to inject kube validation
```
