### PR TITLE
Feat: add support UnderscoreEscapingWithoutSuffixes for TranslationStrategyOption

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -20397,6 +20397,7 @@ AdditionalLabelSelectors
 Supported values are:
 * <code>NoUTF8EscapingWithSuffixes</code>
 * <code>UnderscoreEscapingWithSuffixes</code>
+* <code>UnderscoreEscapingWithoutSuffixes</code>
 * <code>NoTranslation</code></p>
 </div>
 <table>
@@ -20412,6 +20413,8 @@ Supported values are:
 </tr><tr><td><p>&#34;NoUTF8EscapingWithSuffixes&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;UnderscoreEscapingWithSuffixes&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;UnderscoreEscapingWithoutSuffixes&#34;</p></td>
 <td></td>
 </tr></tbody>
 </table>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5083,6 +5083,7 @@ spec:
                     enum:
                     - NoUTF8EscapingWithSuffixes
                     - UnderscoreEscapingWithSuffixes
+                    - UnderscoreEscapingWithoutSuffixes
                     - NoTranslation
                     type: string
                 type: object

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -5855,6 +5855,7 @@ spec:
                     enum:
                     - NoUTF8EscapingWithSuffixes
                     - UnderscoreEscapingWithSuffixes
+                    - UnderscoreEscapingWithoutSuffixes
                     - NoTranslation
                     type: string
                 type: object

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5084,6 +5084,7 @@ spec:
                     enum:
                     - NoUTF8EscapingWithSuffixes
                     - UnderscoreEscapingWithSuffixes
+                    - UnderscoreEscapingWithoutSuffixes
                     - NoTranslation
                     type: string
                 type: object

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -5856,6 +5856,7 @@ spec:
                     enum:
                     - NoUTF8EscapingWithSuffixes
                     - UnderscoreEscapingWithSuffixes
+                    - UnderscoreEscapingWithoutSuffixes
                     - NoTranslation
                     type: string
                 type: object

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4292,6 +4292,7 @@
                         "enum": [
                           "NoUTF8EscapingWithSuffixes",
                           "UnderscoreEscapingWithSuffixes",
+                          "UnderscoreEscapingWithoutSuffixes",
                           "NoTranslation"
                         ],
                         "type": "string"

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -4943,6 +4943,7 @@
                         "enum": [
                           "NoUTF8EscapingWithSuffixes",
                           "UnderscoreEscapingWithSuffixes",
+                          "UnderscoreEscapingWithoutSuffixes",
                           "NoTranslation"
                         ],
                         "type": "string"

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -2469,13 +2469,15 @@ type ScrapeClass struct {
 // Supported values are:
 // * `NoUTF8EscapingWithSuffixes`
 // * `UnderscoreEscapingWithSuffixes`
+// * `UnderscoreEscapingWithoutSuffixes`
 // * `NoTranslation`
-// +kubebuilder:validation:Enum=NoUTF8EscapingWithSuffixes;UnderscoreEscapingWithSuffixes;NoTranslation
+// +kubebuilder:validation:Enum=NoUTF8EscapingWithSuffixes;UnderscoreEscapingWithSuffixes;UnderscoreEscapingWithoutSuffixes;NoTranslation
 type TranslationStrategyOption string
 
 const (
-	NoUTF8EscapingWithSuffixes     TranslationStrategyOption = "NoUTF8EscapingWithSuffixes"
-	UnderscoreEscapingWithSuffixes TranslationStrategyOption = "UnderscoreEscapingWithSuffixes"
+	NoUTF8EscapingWithSuffixes        TranslationStrategyOption = "NoUTF8EscapingWithSuffixes"
+	UnderscoreEscapingWithSuffixes    TranslationStrategyOption = "UnderscoreEscapingWithSuffixes"
+	UnderscoreEscapingWithoutSuffixes TranslationStrategyOption = "UnderscoreEscapingWithoutSuffixes"
 	// It requires Prometheus >= v3.4.0.
 	NoTranslation TranslationStrategyOption = "NoTranslation"
 )


### PR DESCRIPTION
## Description

This PR adds UnderscoreEscapingWithoutSuffixes for TranslationStrategyOption as it supports on Prometheus 3.6.0

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
- Add support UnderscoreEscapingWithoutSuffixes for TranslationStrategyOption
```
