### PR TITLE
chore: inject related object into all events

### DIFF
--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1368,11 +1368,12 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			c := fake.NewSimpleClientset(tc.objects...)
 
 			o := &Operator{
-				kclient:    c,
-				mclient:    monitoringfake.NewSimpleClientset(),
-				ssarClient: &alwaysAllowed{},
-				logger:     slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
-				metrics:    operator.NewMetrics(prometheus.NewRegistry()),
+				kclient:          c,
+				mclient:          monitoringfake.NewSimpleClientset(),
+				ssarClient:       &alwaysAllowed{},
+				logger:           slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
+				metrics:          operator.NewMetrics(prometheus.NewRegistry()),
+				newEventRecorder: func(related runtime.Object) *operator.EventRecorder { return operator.NewFakeRecorder(1, related) },
 			}
 
 			err := o.bootstrap(

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
@@ -48,17 +47,20 @@ func init() {
 type RuleConfigurationFormat int
 
 const (
+	// PrometheusFormat indicates that the rule configuration should comply with the Prometheus format.
 	PrometheusFormat RuleConfigurationFormat = iota
+	// ThanosFormat indicates that the rule configuration should comply with the Thanos format.
 	ThanosFormat
+)
 
+const (
 	selectingPrometheusRuleResourcesAction = "SelectingPrometheusRuleResources"
 )
 
-// The maximum `Data` size of a ConfigMap seems to differ between
-// environments. This is probably due to different meta data sizes which count
-// into the overall maximum size of a ConfigMap. Thereby lets leave a
-// large buffer.
-// nolint:godoclint
+// MaxConfigMapDataSize represents the maximum size for ConfigMap's data.  The
+// maximum `Data` size of a ConfigMap seems to differ between environments.
+// This is probably due to different meta data sizes which count into the
+// overall maximum size of a ConfigMap. Thereby lets leave a large buffer.
 var MaxConfigMapDataSize = int(float64(v1.MaxSecretSize) * 0.5)
 
 type PrometheusRuleSelector struct {
@@ -68,12 +70,12 @@ type PrometheusRuleSelector struct {
 	nsLabeler    *namespacelabeler.Labeler
 	ruleInformer *informers.ForResource
 
-	eventRecorder events.EventRecorder
+	eventRecorder *EventRecorder
 
 	logger *slog.Logger
 }
 
-func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder events.EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
+func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder *EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
 	componentVersion, err := semver.ParseTolerant(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)
@@ -241,7 +243,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (map[string]strin
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, nil, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			continue
 		}
 

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -71,7 +70,7 @@ type ResourceSelector struct {
 	metrics            *operator.Metrics
 	accessor           *operator.Accessor
 
-	eventRecorder events.EventRecorder
+	eventRecorder *operator.EventRecorder
 }
 
 // TypedConfigurationResource is a generic type that holds a configuration resource with its validation status.
@@ -127,7 +126,7 @@ func NewResourceSelector(
 	store *assets.StoreBuilder,
 	namespaceInformers cache.SharedIndexInformer,
 	metrics *operator.Metrics,
-	eventRecorder events.EventRecorder,
+	eventRecorder *operator.EventRecorder,
 ) (*ResourceSelector, error) {
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 	version, err := semver.ParseTolerant(promVersion)
@@ -219,7 +218,7 @@ func selectObjects[T ConfigurationResource](
 			rejected++
 			reason = invalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, nil, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -756,23 +755,24 @@ func TestSelectProbes(t *testing.T) {
 				},
 			)
 
-			rs, err := NewResourceSelector(
-				newLogger(),
-				&monitoringv1.Prometheus{
-					Spec: monitoringv1.PrometheusSpec{
-						CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-							ScrapeClasses: []monitoringv1.ScrapeClass{
-								{
-									Name: "existent",
-								},
+			p := &monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeClasses: []monitoringv1.ScrapeClass{
+							{
+								Name: "existent",
 							},
 						},
 					},
 				},
+			}
+			rs, err := NewResourceSelector(
+				newLogger(),
+				p,
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				events.NewFakeRecorder(1),
+				operator.NewFakeRecorder(1, p),
 			)
 			require.NoError(t, err)
 
@@ -1342,23 +1342,24 @@ func TestSelectServiceMonitors(t *testing.T) {
 				},
 			)
 
-			rs, err := NewResourceSelector(
-				newLogger(),
-				&monitoringv1.Prometheus{
-					Spec: monitoringv1.PrometheusSpec{
-						CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-							ScrapeClasses: []monitoringv1.ScrapeClass{
-								{
-									Name: "existent",
-								},
+			p := &monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeClasses: []monitoringv1.ScrapeClass{
+							{
+								Name: "existent",
 							},
 						},
 					},
 				},
+			}
+			rs, err := NewResourceSelector(
+				newLogger(),
+				p,
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				events.NewFakeRecorder(1),
+				operator.NewFakeRecorder(1, p),
 			)
 			require.NoError(t, err)
 
@@ -1645,23 +1646,25 @@ func TestSelectPodMonitors(t *testing.T) {
 					},
 				},
 			)
-			rs, err := NewResourceSelector(
-				newLogger(),
-				&monitoringv1.Prometheus{
-					Spec: monitoringv1.PrometheusSpec{
-						CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-							ScrapeClasses: []monitoringv1.ScrapeClass{
-								{
-									Name: "existent",
-								},
+
+			p := &monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						ScrapeClasses: []monitoringv1.ScrapeClass{
+							{
+								Name: "existent",
 							},
 						},
 					},
 				},
+			}
+			rs, err := NewResourceSelector(
+				newLogger(),
+				p,
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				events.NewFakeRecorder(1),
+				operator.NewFakeRecorder(1, p),
 			)
 			require.NoError(t, err)
 
@@ -4616,28 +4619,29 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				},
 			)
 
-			rs, err := NewResourceSelector(
-				newLogger(),
-				&monitoringv1.Prometheus{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: monitoringv1.PrometheusSpec{
-						CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-							Version: tc.promVersion,
-							ScrapeClasses: []monitoringv1.ScrapeClass{
-								{
-									Name: "existent",
-								},
+			p := &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Version: tc.promVersion,
+						ScrapeClasses: []monitoringv1.ScrapeClass{
+							{
+								Name: "existent",
 							},
 						},
 					},
 				},
+			}
+			rs, err := NewResourceSelector(
+				newLogger(),
+				p,
 				assets.NewStoreBuilder(cs.CoreV1(), cs.CoreV1()),
 				nil,
 				operator.NewMetrics(prometheus.NewPedanticRegistry()),
-				events.NewFakeRecorder(1),
+				operator.NewFakeRecorder(1, p),
 			)
 			require.NoError(t, err)
 

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -60,7 +60,7 @@ func (c *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, p *monitori
 	logger := c.logger.With("prometheus", p.Name, "namespace", p.Namespace)
 	promVersion := operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
 
-	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.PrometheusFormat, promVersion, p.Spec.RuleSelector, nsLabeler, c.ruleInfs, c.eventRecorder, logger)
+	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.PrometheusFormat, promVersion, p.Spec.RuleSelector, nsLabeler, c.ruleInfs, c.newEventRecorder(p), logger)
 	if err != nil {
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -85,7 +84,7 @@ type Operator struct {
 	reconciliations     *operator.ReconciliationTracker
 	canReadStorageClass bool
 
-	eventRecorder events.EventRecorder
+	newEventRecorder operator.NewEventRecorderFunc
 
 	config Config
 
@@ -136,15 +135,15 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "thanos"}, r)
 
 	o := &Operator{
-		kclient:         client,
-		mdClient:        mdClient,
-		mclient:         mclient,
-		logger:          logger,
-		accessor:        operator.NewAccessor(logger),
-		metrics:         operator.NewMetrics(r),
-		eventRecorder:   c.EventRecorderFactory(client, controllerName),
-		reconciliations: &operator.ReconciliationTracker{},
-		controllerID:    c.ControllerID,
+		kclient:          client,
+		mdClient:         mdClient,
+		mclient:          mclient,
+		logger:           logger,
+		accessor:         operator.NewAccessor(logger),
+		metrics:          operator.NewMetrics(r),
+		newEventRecorder: c.EventRecorderFactory(client, controllerName),
+		reconciliations:  &operator.ReconciliationTracker{},
+		controllerID:     c.ControllerID,
 		config: Config{
 			ReloaderConfig:         c.ReloaderConfig,
 			ThanosDefaultBaseImage: c.ThanosDefaultBaseImage,

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -62,7 +62,7 @@ func (o *Operator) createOrUpdateRuleConfigMaps(ctx context.Context, t *monitori
 	logger := o.logger.With("thanos", t.Name, "namespace", t.Namespace)
 	thanosVersion := operator.StringValOrDefault(ptr.Deref(t.Spec.Version, ""), operator.DefaultThanosVersion)
 
-	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, o.eventRecorder, logger)
+	promRuleSelector, err := operator.NewPrometheusRuleSelector(operator.ThanosFormat, thanosVersion, t.Spec.RuleSelector, nsLabeler, o.ruleInfs, o.newEventRecorder(t), logger)
 	if err != nil {
 		return nil, fmt.Errorf("initializing PrometheusRules failed: %w", err)
 	}


### PR DESCRIPTION
## Description

This is a follow-up of #7867 which refactors the event handling to always inject the related object.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
