### PR TITLE
ScrapeConfig Status Subresource Removal from prometheus

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1121,6 +1121,11 @@ func (c *Operator) configResStatusCleanup(ctx context.Context, p *monitoringv1.P
 	if err := prompkg.CleanupBindings(ctx, c.pmonInfs.ListAll, prompkg.TypedResourcesSelection[*monitoringv1.PodMonitor]{}, configResourceSyncer); err != nil {
 		return fmt.Errorf("failed to remove bindings for pod monitors: %w", err)
 	}
+
+	// Remove bindings from all scrapeConfigs which reference the workload.
+	if err := prompkg.CleanupBindings(ctx, c.pmonInfs.ListAll, prompkg.TypedResourcesSelection[*monitoringv1.PodMonitor]{}, configResourceSyncer); err != nil {
+		return fmt.Errorf("failed to remove bindings for pod monitors: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1123,7 +1123,7 @@ func (c *Operator) configResStatusCleanup(ctx context.Context, p *monitoringv1.P
 	}
 
 	// Remove bindings from all scrapeConfigs which reference the workload.
-	if err := prompkg.CleanupBindings(ctx, c.pmonInfs.ListAll, prompkg.TypedResourcesSelection[*monitoringv1.PodMonitor]{}, configResourceSyncer); err != nil {
+	if err := prompkg.CleanupBindings(ctx, c.sconInfs.ListAll, prompkg.TypedResourcesSelection[*monitoringv1alpha1.ScrapeConfig]{}, configResourceSyncer); err != nil {
 		return fmt.Errorf("failed to remove bindings for pod monitors: %w", err)
 	}
 	return nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1095,6 +1095,12 @@ func (c *Operator) updateConfigResourcesStatus(ctx context.Context, p *monitorin
 	if err := prompkg.CleanupBindings(ctx, c.pmonInfs.ListAll, resources.pMons, configResourceSyncer); err != nil {
 		return fmt.Errorf("failed to remove bindings for pod monitors: %w", err)
 	}
+
+	// Remove bindings from scrapeConfigs which reference the
+	// workload but aren't selected anymore.
+	if err := prompkg.CleanupBindings(ctx, c.sconInfs.ListAll, resources.scrapeConfigs, configResourceSyncer); err != nil {
+		return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
+	}
 	return nil
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -443,6 +443,8 @@ func TestGatedFeatures(t *testing.T) {
 		"GarbageCollectionOfPodMonitorBinding":               testGarbageCollectionOfPodMonitorBinding,
 		"RmPodMonitorBindingDuringWorkloadDelete":            testRmPodMonitorBindingDuringWorkloadDelete,
 		"ScrapeConfigStatusSubresource":                      testScrapeConfigStatusSubresource,
+		"GarbageCollectionOfScrapeConfigBinding":             testGarbageCollectionOfScrapeConfigBinding,
+		"RmScrapeConfigBindingDuringWorkloadDelete":          testRmScrapeConfigBindingDuringWorkloadDelete,
 		"FinalizerForPromAgentWhenStatusForConfigResEnabled": testFinalizerForPromAgentWhenStatusForConfigResEnabled,
 	}
 

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -639,6 +639,8 @@ func testGarbageCollectionOfScrapeConfigBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	sc := framework.MakeBasicScrapeConfig(ns, name)
+	sc.Labels["group"] = name
+
 	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, v1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -682,9 +684,11 @@ func testRmScrapeConfigBindingDuringWorkloadDelete(t *testing.T) {
 
 	_, err = framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
 	require.NoError(t, err, "failed to create Prometheus")
-	scfg := framework.MakeBasicScrapeConfig(ns, name)
 
-	sc, err := framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, scfg, v1.CreateOptions{})
+	sc := framework.MakeBasicScrapeConfig(ns, name)
+	sc.Labels["group"] = name
+
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, v1.CreateOptions{})
 	require.NoError(t, err)
 
 	sc, err = framework.WaitForScrapeConfigCondition(ctx, sc, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -608,6 +608,95 @@ func testScrapeConfigStatusSubresource(t *testing.T) {
 	require.Equal(t, ts, cond.LastTransitionTime.String())
 }
 
+// testGarbageCollectionOfScrapeConfigBinding validates that the operator removes the reference to the Prometheus resource when the ScrapeConfig isn't selected anymore by the workload.
+func testGarbageCollectionOfScrapeConfigBinding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.StatusForConfigurationResourcesFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "scfg-status-binding-cleanup-test"
+
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
+	p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"group": name,
+		},
+	}
+
+	_, err = framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	require.NoError(t, err)
+
+	sc := framework.MakeBasicScrapeConfig(ns, name)
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	sc, err = framework.WaitForScrapeConfigCondition(ctx, sc, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	// Update the ScrapeConfig's labels, Prometheus doesn't select the resource anymore.
+	sc.Labels = map[string]string{}
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = framework.WaitForScrapeConfigWorkloadBindingCleanup(ctx, sc, p, monitoringv1.PrometheusName, 1*time.Minute)
+	require.NoError(t, err)
+}
+
+// testRmScrapeConfigBindingDuringWorkloadDelete validates that the operator removes the reference to the Prometheus resource when workload is deleted.
+func testRmScrapeConfigBindingDuringWorkloadDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.StatusForConfigurationResourcesFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "workload-del-scfg-test"
+	p := framework.MakeBasicPrometheus(ns, name, name, 1)
+	p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"group": name,
+		},
+	}
+
+	_, err = framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+	require.NoError(t, err, "failed to create Prometheus")
+	scfg := framework.MakeBasicScrapeConfig(ns, name)
+
+	sc, err := framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, scfg, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	sc, err = framework.WaitForScrapeConfigCondition(ctx, sc, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	err = framework.DeletePrometheusAndWaitUntilGone(ctx, ns, name)
+	require.NoError(t, err)
+
+	_, err = framework.WaitForScrapeConfigWorkloadBindingCleanup(ctx, sc, p, monitoringv1.PrometheusName, 1*time.Minute)
+	require.NoError(t, err)
+}
+
 // testFinalizerForPromAgentWhenStatusForConfigResEnabled tests the adding/removing of status-cleanup finalizer for PrometheusAgent when StatusForConfigurationResourcesFeature is enabled.
 func testFinalizerForPromAgentWhenStatusForConfigResEnabled(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Description

ScrapeConfig Status Subresource Removal from prometheus

Closes: #7961

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
