### PR TITLE
Chore: add WeChat global config secret validation in Alertmanager

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -281,7 +281,7 @@ func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 		return err
 	}
 
-	if err := checkAlertmanagerGlobalConfigResource(globalConfig); err != nil {
+	if err := checkAlertmanagerGlobalConfigResource(ctx, globalConfig, crKey.Namespace, cb.store); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

This PR adds global config validation for WeChat in Alertmanager.

The validation checks the secret is presented.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Test

## Changelog entry

```release-note
- Add secret validation for WeChat global config in Alertmanager
```
