### PR TITLE
feat/change: fail reconciliation if invalid external labels are provided

### DIFF
--- a/pkg/prometheus/testdata/external_label_names_utf8_prometheus3.golden
+++ b/pkg/prometheus/testdata/external_label_names_utf8_prometheus3.golden
@@ -1,8 +1,7 @@
 global:
   scrape_interval: 30s
   external_labels:
-    prometheus: test/example
-    prometheus_replica: $(POD_NAME)
-    some-other-key: some-value
+    测试_prometheus: test/example
+    测试_replica: $(POD_NAME)
   evaluation_interval: 30s
 scrape_configs: []

--- a/pkg/prometheus/testdata/external_labels_utf8_prometheus3.golden
+++ b/pkg/prometheus/testdata/external_labels_utf8_prometheus3.golden
@@ -1,9 +1,10 @@
 global:
   scrape_interval: 30s
   external_labels:
-    key1: value1
-    key2: value2
     prometheus: test/example
     prometheus_replica: $(POD_NAME)
+    unicode_测试: prometheus
+    valid_label: test
+    环境: production
   evaluation_interval: 30s
 scrape_configs: []

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -322,6 +322,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PrometheusReconciliationOnSecretChanges":   testPrometheusReconciliationOnSecretChanges,
 		"PrometheusUTF8MetricsSupport":              testPrometheusUTF8MetricsSupport,
 		"PrometheusUTF8LabelSupport":                testPrometheusUTF8LabelSupport,
+		"PrometheusExternalLabelsValidation":        testPrometheusExternalLabelsValidation,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
This commit might break existing configs
which uses invalid label names which was not
validated by operator before.

Related-to: #7362


## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

_If it fixes an existing issue (bug or feature), use the following keyword:_

_Closes: #ISSUE-NUMBER_

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat/change: UTF-8 support for external labels
```
