### PR TITLE
docs: update AlertmanagerConfig API docs to include AlertmanagerConfigMatcherStrategyType

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -37196,9 +37196,9 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>route defines the Alertmanager route definition for alerts matching the resource&rsquo;s
-namespace. If present, it will be added to the generated Alertmanager
-configuration as a first-level route.</p>
+<p>route defines the Alertmanager route definition for incoming alerts. It will be added to the
+generated Alertmanager configuration as a first-level route. The matching behavior of the
+route depends on the Alertmanager&rsquo;s AlertmanagerConfigMatcherStrategyType.</p>
 </td>
 </tr>
 <tr>
@@ -37296,9 +37296,9 @@ Route
 </td>
 <td>
 <em>(Optional)</em>
-<p>route defines the Alertmanager route definition for alerts matching the resource&rsquo;s
-namespace. If present, it will be added to the generated Alertmanager
-configuration as a first-level route.</p>
+<p>route defines the Alertmanager route definition for incoming alerts. It will be added to the
+generated Alertmanager configuration as a first-level route. The matching behavior of the
+route depends on the Alertmanager&rsquo;s AlertmanagerConfigMatcherStrategyType.</p>
 </td>
 </tr>
 <tr>
@@ -40005,8 +40005,8 @@ Example: &ldquo;4h&rdquo;</p>
 <em>(Optional)</em>
 <p>matchers defines the list of matchers that the alert&rsquo;s labels should match. For the first
 level route, the operator removes any existing equality and regexp
-matcher on the <code>namespace</code> label and adds a <code>namespace: &lt;object
-namespace&gt;</code> matcher.</p>
+matcher on the <code>namespace</code> label and adds a <code>namespace: &lt;object namespace&gt;</code> matcher,
+unless configured otherwise in Alertmanager&rsquo;s AlertmanagerConfigMatcherStrategyType.</p>
 </td>
 </tr>
 <tr>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -24111,9 +24111,9 @@ spec:
                 type: array
               route:
                 description: |-
-                  route defines the Alertmanager route definition for alerts matching the resource's
-                  namespace. If present, it will be added to the generated Alertmanager
-                  configuration as a first-level route.
+                  route defines the Alertmanager route definition for incoming alerts. It will be added to the
+                  generated Alertmanager configuration as a first-level route. The matching behavior of the
+                  route depends on the Alertmanager's AlertmanagerConfigMatcherStrategyType.
                 properties:
                   activeTimeIntervals:
                     description: activeTimeIntervals is a list of TimeInterval names
@@ -24154,8 +24154,8 @@ spec:
                     description: |-
                       matchers defines the list of matchers that the alert's labels should match. For the first
                       level route, the operator removes any existing equality and regexp
-                      matcher on the `namespace` label and adds a `namespace: <object
-                      namespace>` matcher.
+                      matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher,
+                      unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
                     items:
                       description: Matcher defines how to match on alert's labels.
                       properties:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -10769,7 +10769,7 @@
                 type: 'array',
               },
               route: {
-                description: "route defines the Alertmanager route definition for alerts matching the resource's\nnamespace. If present, it will be added to the generated Alertmanager\nconfiguration as a first-level route.",
+                description: "route defines the Alertmanager route definition for incoming alerts. It will be added to the\ngenerated Alertmanager configuration as a first-level route. The matching behavior of the\nroute depends on the Alertmanager's AlertmanagerConfigMatcherStrategyType.",
                 properties: {
                   activeTimeIntervals: {
                     description: 'activeTimeIntervals is a list of TimeInterval names when this route should be active.',
@@ -10802,7 +10802,7 @@
                     type: 'string',
                   },
                   matchers: {
-                    description: "matchers defines the list of matchers that the alert's labels should match. For the first\nlevel route, the operator removes any existing equality and regexp\nmatcher on the `namespace` label and adds a `namespace: <object\nnamespace>` matcher.",
+                    description: "matchers defines the list of matchers that the alert's labels should match. For the first\nlevel route, the operator removes any existing equality and regexp\nmatcher on the `namespace` label and adds a `namespace: <object namespace>` matcher,\nunless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.",
                     items: {
                       description: "Matcher defines how to match on alert's labels.",
                       properties: {

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -79,9 +79,9 @@ type AlertmanagerConfigList struct {
 // By definition, the Alertmanager configuration only applies to alerts for which
 // the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.
 type AlertmanagerConfigSpec struct {
-	// route defines the Alertmanager route definition for alerts matching the resource's
-	// namespace. If present, it will be added to the generated Alertmanager
-	// configuration as a first-level route.
+	// route defines the Alertmanager route definition for incoming alerts. It will be added to the
+	// generated Alertmanager configuration as a first-level route. The matching behavior of the
+	// route depends on the Alertmanager's AlertmanagerConfigMatcherStrategyType.
 	// +optional
 	Route *Route `json:"route"`
 	// receivers defines the list of receivers.
@@ -123,8 +123,8 @@ type Route struct {
 	RepeatInterval *monitoringv1.NonEmptyDuration `json:"repeatInterval,omitempty"`
 	// matchers defines the list of matchers that the alert's labels should match. For the first
 	// level route, the operator removes any existing equality and regexp
-	// matcher on the `namespace` label and adds a `namespace: <object
-	// namespace>` matcher.
+	// matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher,
+	// unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// continue defines the boolean indicating whether an alert should continue matching subsequent

--- a/pkg/client/applyconfiguration/monitoring/v1beta1/alertmanagerconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1beta1/alertmanagerconfigspec.go
@@ -23,9 +23,9 @@ package v1beta1
 // By definition, the Alertmanager configuration only applies to alerts for which
 // the `namespace` label is equal to the namespace of the AlertmanagerConfig resource.
 type AlertmanagerConfigSpecApplyConfiguration struct {
-	// route defines the Alertmanager route definition for alerts matching the resource's
-	// namespace. If present, it will be added to the generated Alertmanager
-	// configuration as a first-level route.
+	// route defines the Alertmanager route definition for incoming alerts. It will be added to the
+	// generated Alertmanager configuration as a first-level route. The matching behavior of the
+	// route depends on the Alertmanager's AlertmanagerConfigMatcherStrategyType.
 	Route *RouteApplyConfiguration `json:"route,omitempty"`
 	// receivers defines the list of receivers.
 	Receivers []ReceiverApplyConfiguration `json:"receivers,omitempty"`

--- a/pkg/client/applyconfiguration/monitoring/v1beta1/route.go
+++ b/pkg/client/applyconfiguration/monitoring/v1beta1/route.go
@@ -46,8 +46,8 @@ type RouteApplyConfiguration struct {
 	RepeatInterval *v1.NonEmptyDuration `json:"repeatInterval,omitempty"`
 	// matchers defines the list of matchers that the alert's labels should match. For the first
 	// level route, the operator removes any existing equality and regexp
-	// matcher on the `namespace` label and adds a `namespace: <object
-	// namespace>` matcher.
+	// matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher,
+	// unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
 	Matchers []MatcherApplyConfiguration `json:"matchers,omitempty"`
 	// continue defines the boolean indicating whether an alert should continue matching subsequent
 	// sibling nodes. It will always be overridden to true for the first-level


### PR DESCRIPTION
## Description

This PR updates the documentation of AlertmanagerConfig to include a reference to `AlertmanagerConfigMatcherStrategyType` where applicable.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

No testing required

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update documentation for AlertmanagerConfig to include AlertmanagerConfigMatcherStrategyType
```
