### PR TITLE
docs: update proposal links to reflect current directory structure

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -15405,7 +15405,7 @@ ShardRetentionPolicy
 <em>(Optional)</em>
 <p>shardRetentionPolicy defines the retention policy for the Prometheus shards.
 (Alpha) Using this field requires the &lsquo;PrometheusShardRetentionPolicy&rsquo; feature gate to be enabled.</p>
-<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling\.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling\.md#graceful-scale-down-of-prometheus-servers</a>,
+<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers</a>,
 however, the feature is not yet fully implemented in this PR. The limitation being:
 * Retention duration is not settable, for now, shards are retained forever.</p>
 </td>

--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -3609,7 +3609,7 @@ ShardRetentionPolicy
 <em>(Optional)</em>
 <p>shardRetentionPolicy defines the retention policy for the Prometheus shards.
 (Alpha) Using this field requires the &lsquo;PrometheusShardRetentionPolicy&rsquo; feature gate to be enabled.</p>
-<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers</a>,
+<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers</a>,
 however, the feature is not yet fully implemented in this PR. The limitation being:
 * Retention duration is not settable, for now, shards are retained forever.</p>
 </td>
@@ -15405,7 +15405,7 @@ ShardRetentionPolicy
 <em>(Optional)</em>
 <p>shardRetentionPolicy defines the retention policy for the Prometheus shards.
 (Alpha) Using this field requires the &lsquo;PrometheusShardRetentionPolicy&rsquo; feature gate to be enabled.</p>
-<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers</a>,
+<p>The final goals for this feature can be seen at <a href="https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling\.md#graceful-scale-down-of-prometheus-servers">https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling\.md#graceful-scale-down-of-prometheus-servers</a>,
 however, the feature is not yet fully implemented in this PR. The limitation being:
 * Retention duration is not settable, for now, shards are retained forever.</p>
 </td>

--- a/Documentation/getting-started/design.md
+++ b/Documentation/getting-started/design.md
@@ -47,7 +47,7 @@ The `ThanosRuler` CRD sets up a [Thanos Ruler](https://github.com/thanos-io/than
 
 #### Prometheus Agent
 
-The `Prometheus Agent` CRD sets up a [Prometheus Agent](https://prometheus.io/blog/2021/11/16/agent/) instance in a Kubernetes cluster. While similar to the `Prometheus` CR, the `Prometheus Agent` has several configuration options redacted, including alerting, PrometheusRules selectors, remote-read, storage, and Thanos sidecars. To understand why Agent support was introduced, read the [proposal here](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202201-prometheus-agent.md).
+The `Prometheus Agent` CRD sets up a [Prometheus Agent](https://prometheus.io/blog/2021/11/16/agent/) instance in a Kubernetes cluster. While similar to the `Prometheus` CR, the `Prometheus Agent` has several configuration options redacted, including alerting, PrometheusRules selectors, remote-read, storage, and Thanos sidecars. To understand why Agent support was introduced, read the [proposal here](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/implemented/202201-prometheus-agent.md).
 
 ### Config-Based Resources
 

--- a/Documentation/proposals/accepted/202405-scrapeconfig-graduation.md
+++ b/Documentation/proposals/accepted/202405-scrapeconfig-graduation.md
@@ -17,7 +17,7 @@ draft: false
 * Related Tickets:
   * [Graduate The `ScrapeConfig` CRD To `v1beta1`](https://github.com/prometheus-operator/prometheus-operator/issues/6697)
 * Other docs:
-  * [ScrapeConfig Design Proposal](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202212-scrape-config.md)
+  * [ScrapeConfig Design Proposal](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/implemented/202212-scrape-config.md)
   * [Kubernetes API versioning](https://kubernetes.io/docs/reference/using-api/#api-versioning)
 
 ## Why

--- a/Documentation/proposals/accepted/202411-zone-aware-sharding.md
+++ b/Documentation/proposals/accepted/202411-zone-aware-sharding.md
@@ -20,7 +20,7 @@ draft: false
   * [Well known kubernetes labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone)
   * [AWS zone names](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-availability-zones)
   * [GCP zone names](https://cloud.google.com/compute/docs/regions-zones#available)
-  * [Shard Autoscaling](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md) design proposal.
+  * [Shard Autoscaling](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md) design proposal.
 
 This proposal describes how we can implement zone-aware sharding by adding
 support for custom labels and zone configuration options to the existing

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1151,7 +1151,7 @@ type PrometheusSpec struct {
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
 	// (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
 	//
-	// The final goals for this feature can be seen at https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers,
+	// The final goals for this feature can be seen at https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/proposals/accepted/202310-shard-autoscaling.md#graceful-scale-down-of-prometheus-servers,
 	// however, the feature is not yet fully implemented in this PR. The limitation being:
 	// * Retention duration is not settable, for now, shards are retained forever.
 	//


### PR DESCRIPTION
## Description

This PR updates documentation links to point to the correct paths for design proposals that have been moved to the `accepted/` and `implemented/` directories. The changes include updating links in API documentation, design documentation, and proposal files to reflect the new directory structure.

## Type of change

- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, **docs**, etc.)

## Verification

No verification needed as this is a documentation-only change. All links have been manually verified to point to the correct locations.

## Changelog entry

```release-note
Update documentation links to point to correct proposal directories
```