### PR TITLE
feat: add new NoSelectedResources reason

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -59,12 +59,14 @@ var (
 )
 
 type ReconciliationStatus struct {
-	err error
+	err     error
+	reason  string
+	message string
 }
 
 func (rs ReconciliationStatus) Reason() string {
 	if rs.Ok() {
-		return ""
+		return rs.reason
 	}
 
 	return "ReconciliationFailed"
@@ -72,7 +74,7 @@ func (rs ReconciliationStatus) Reason() string {
 
 func (rs ReconciliationStatus) Message() string {
 	if rs.Ok() {
-		return ""
+		return rs.message
 	}
 
 	return rs.err.Error()
@@ -131,13 +133,37 @@ func (rt *ReconciliationTracker) UpdateReferenceTracker(key string, refTracker R
 	rt.refTracker[key] = refTracker
 }
 
+// ResetStatus resets the reconciliation status for the object identified by key.
+func (rt *ReconciliationTracker) ResetStatus(key string) {
+	rt.init()
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
+
+	rt.statusByObject[key] = ReconciliationStatus{}
+}
+
 // SetStatus updates the last reconciliation status for the object identified by key.
 func (rt *ReconciliationTracker) SetStatus(key string, err error) {
 	rt.init()
 	rt.mtx.Lock()
 	defer rt.mtx.Unlock()
 
-	rt.statusByObject[key] = ReconciliationStatus{err: err}
+	rs := rt.statusByObject[key]
+	rs.err = err
+	rt.statusByObject[key] = rs
+}
+
+// SetReasonAndMessage updates the reason and message for the object identified by key.
+// The reason and message are only used when the reconciliation returned no error.
+func (rt *ReconciliationTracker) SetReasonAndMessage(key string, reason, message string) {
+	rt.init()
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
+
+	rs := rt.statusByObject[key]
+	rs.reason = reason
+	rs.message = message
+	rt.statusByObject[key] = rs
 }
 
 // GetStatus returns the last reconciliation status for the given object.

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -295,7 +294,7 @@ func NewResourceReconciler(
 func (rr *ResourceReconciler) DeletionInProgress(o metav1.Object) bool {
 	if o.GetDeletionTimestamp() != nil {
 		rr.logger.Debug("object deletion in progress",
-			"object", fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName()),
+			"object", KeyForObject(o),
 		)
 		return true
 	}
@@ -308,7 +307,7 @@ func (rr *ResourceReconciler) hasObjectChanged(old, cur metav1.Object) bool {
 		rr.logger.Debug("different resource versions",
 			"current", cur.GetResourceVersion(),
 			"old", old.GetResourceVersion(),
-			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+			"object", KeyForObject(cur),
 		)
 		return true
 	}
@@ -325,7 +324,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 		rr.logger.Debug("different generations",
 			"current", cur.GetGeneration(),
 			"old", old.GetGeneration(),
-			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+			"object", KeyForObject(cur),
 		)
 		return true
 	}
@@ -334,7 +333,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 		rr.logger.Debug("different labels",
 			"current", fmt.Sprintf("%v", cur.GetLabels()),
 			"old", fmt.Sprintf("%v", old.GetLabels()),
-			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+			"object", KeyForObject(cur),
 		)
 		return true
 
@@ -343,7 +342,7 @@ func (rr *ResourceReconciler) hasStateChanged(old, cur metav1.Object) bool {
 		rr.logger.Debug("different annotations",
 			"current", fmt.Sprintf("%v", cur.GetAnnotations()),
 			"old", fmt.Sprintf("%v", old.GetAnnotations()),
-			"object", fmt.Sprintf("%s/%s", cur.GetNamespace(), cur.GetName()),
+			"object", KeyForObject(cur),
 		)
 		return true
 	}
@@ -373,7 +372,7 @@ func (rr *ResourceReconciler) resolve(obj metav1.Object) metav1.Object {
 			continue
 		}
 
-		owner, err := rr.getter.Get(types.NamespacedName{Namespace: obj.GetNamespace(), Name: or.Name}.String())
+		owner, err := rr.getter.Get(KeyForObject(&metav1.ObjectMeta{Name: or.Name, Namespace: obj.GetNamespace()}))
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				rr.logger.Error("failed to resolve controller owner", "err", err, "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", rr.resourceKind)
@@ -613,7 +612,7 @@ func (rr *ResourceReconciler) EnqueueForReconciliation(obj metav1.Object) {
 		return
 	}
 
-	rr.reconcileQ.Add(obj.GetNamespace() + "/" + obj.GetName())
+	rr.reconcileQ.Add(KeyForObject(obj))
 }
 
 // EnqueueForStatus asks for updating the status of the object.
@@ -622,7 +621,7 @@ func (rr *ResourceReconciler) EnqueueForStatus(obj metav1.Object) {
 		return
 	}
 
-	rr.statusQ.Add(obj.GetNamespace() + "/" + obj.GetName())
+	rr.statusQ.Add(KeyForObject(obj))
 }
 
 // Run the goroutines responsible for processing the reconciliation and status
@@ -714,9 +713,20 @@ func (rr *ResourceReconciler) isManagedByController(obj metav1.Object) bool {
 	}
 
 	if controllerID != rr.controllerID {
-		rr.logger.Debug("skipping object not managed by the controller", "object", fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()), "object_id", controllerID, "controller_id", rr.controllerID)
+		rr.logger.Debug("skipping object not managed by the controller", "object", KeyForObject(obj), "object_id", controllerID, "controller_id", rr.controllerID)
 		return false
 	}
 
 	return true
+}
+
+// KeyForObject returns a string key identifying the given object.
+// For cluster-scoped resources, the key is `<name>`.
+// For namespace-scoped resources, the key is `<namespace>/<name>`.
+func KeyForObject(o metav1.Object) string {
+	if o.GetNamespace() == "" {
+		return o.GetName()
+	}
+
+	return o.GetNamespace() + "/" + o.GetName()
 }

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -23,6 +23,12 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
+const (
+	// NoSelectedResourcesReason is used in status conditions to indicate that
+	// a workload resource selected no configuration resources.
+	NoSelectedResourcesReason = "NoSelectedResources"
+)
+
 type StatusReconciler interface {
 	Iterate(func(metav1.Object, []monitoringv1.Condition))
 	RefreshStatusFor(metav1.Object)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -50,6 +50,8 @@ const (
 	resyncPeriod              = 5 * time.Minute
 	controllerName            = "prometheusagent-controller"
 	applicationNameLabelValue = "prometheus-agent"
+
+	noSelectedResourcesMessage = "No ServiceMonitor, PodMonitor, Probe, and ScrapeConfig have been selected."
 )
 
 // Operator manages life cycle of Prometheus agent deployments and
@@ -934,6 +936,10 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, logger
 		if err != nil {
 			return fmt.Errorf("selecting ScrapeConfigs failed: %w", err)
 		}
+	}
+
+	if len(smons)+len(pmons)+len(bmons)+len(scrapeConfigs) == 0 {
+		c.reconciliations.SetReasonAndMessage(operator.KeyForObject(p), operator.NoSelectedResourcesReason, noSelectedResourcesMessage)
 	}
 
 	if err := cg.AddRemoteWriteToStore(ctx, store, p.GetNamespace(), p.Spec.RemoteWrite); err != nil {

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -54,11 +54,13 @@ const (
 	controllerName            = "prometheus-controller"
 	applicationNameLabelValue = "prometheus"
 
-	unmanagedConfigurationReason         = "ConfigurationUnmanaged"
-	unmanagedConfigurationMessage string = "the operator doesn't manage the Prometheus configuration secret because neither serviceMonitorSelector nor podMonitorSelector, nor probeSelector is specified. Unmanaged Prometheus configuration is deprecated, use additionalScrapeConfigs or the ScrapeConfig instead."
+	noSelectedResourcesMessage = "No ServiceMonitor, PodMonitor, Probe, ScrapeConfig, and PrometheusRule have been selected."
+
+	unmanagedConfigurationReason  = "ConfigurationUnmanaged"
+	unmanagedConfigurationMessage = "the operator doesn't manage the Prometheus configuration secret because neither serviceMonitorSelector nor podMonitorSelector, nor probeSelector, nor scrapeConfigSelector is specified. Unmanaged Prometheus configuration is deprecated, use additionalScrapeConfigs or the ScrapeConfig Custom Resource Definition instead."
 )
 
-// Operator manages life cycle of Prometheus deployments and
+// Operator manages the life cycle of Prometheus deployments and
 // monitoring configurations.
 type Operator struct {
 	kclient  kubernetes.Interface
@@ -112,6 +114,14 @@ type selectedConfigResources struct {
 	bMons         operator.TypedResourcesSelection[*monitoringv1.Probe]
 	scrapeConfigs operator.TypedResourcesSelection[*monitoringv1alpha1.ScrapeConfig]
 	rules         operator.PrometheusRuleSelection
+}
+
+func (s *selectedConfigResources) Len() int {
+	return len(s.sMons) +
+		len(s.pMons) +
+		len(s.bMons) +
+		len(s.scrapeConfigs) +
+		s.rules.SelectedLen()
 }
 
 // WithEndpointSlice tells that the Kubernetes API supports the Endpointslice resource.
@@ -801,6 +811,7 @@ func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
 
 // Sync implements the operator.Syncer interface.
 func (c *Operator) Sync(ctx context.Context, key string) error {
+	c.reconciliations.ResetStatus(key)
 	err := c.sync(ctx, key)
 	c.reconciliations.SetStatus(key, err)
 
@@ -868,6 +879,10 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	resources, err := c.getSelectedConfigResources(ctx, logger, p, assetStore)
 	if err != nil {
 		return err
+	}
+
+	if resources.Len() == 0 {
+		c.reconciliations.SetReasonAndMessage(key, operator.NoSelectedResourcesReason, noSelectedResourcesMessage)
 	}
 
 	ruleConfigMapNames, err := c.createOrUpdateRuleConfigMaps(ctx, p, resources.rules, logger)
@@ -1207,16 +1222,6 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to get prometheus status: %w", err)
 	}
 
-	if c.unmanagedPrometheusConfiguration(p) {
-		for i, condition := range pStatus.Conditions {
-			if condition.Type == monitoringv1.Reconciled && condition.Status == monitoringv1.ConditionTrue {
-				condition.Reason = unmanagedConfigurationReason
-				condition.Message = unmanagedConfigurationMessage
-				pStatus.Conditions[i] = condition
-			}
-		}
-	}
-
 	p.Status = *pStatus
 	selectorLabels := makeSelectorLabels(p.Name)
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: selectorLabels})
@@ -1375,6 +1380,8 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, logger
 	// wants to manage configuration themselves. Let's create an empty Secret
 	// if it doesn't exist.
 	if c.unmanagedPrometheusConfiguration(p) {
+		c.reconciliations.SetReasonAndMessage(operator.KeyForObject(p), unmanagedConfigurationReason, unmanagedConfigurationMessage)
+
 		s, err := prompkg.MakeConfigurationSecret(p, c.config, nil)
 		if err != nil {
 			return fmt.Errorf("failed to generate empty configuration secret: %w", err)

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -55,6 +55,8 @@ const (
 	applicationNameLabelValue = "thanos-ruler"
 	controllerName            = "thanos-controller"
 	rwConfigFile              = "remote-write.yaml"
+
+	noSelectedResourcesMessage = "No PrometheusRule have been selected."
 )
 
 var minRemoteWriteVersion = semver.MustParse("0.24.0")
@@ -527,6 +529,10 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	selectedRules, err := o.selectPrometheusRules(tr, logger)
 	if err != nil {
 		return err
+	}
+
+	if selectedRules.SelectedLen() == 0 {
+		o.reconciliations.SetReasonAndMessage(key, operator.NoSelectedResourcesReason, noSelectedResourcesMessage)
 	}
 
 	ruleConfigMapNames, err := o.createOrUpdateRuleConfigMaps(ctx, tr, selectedRules, logger)

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -310,7 +310,8 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
 
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(_ context.Context) (bool, error) {
+		ctx := context.Background()
 		dms, err = framework.KubeClient.AppsV1().DaemonSets(ns).Get(ctx, dmsName, metav1.GetOptions{})
 		if err != nil {
 			pollErr = fmt.Errorf("failed to get Prometheus Agent DaemonSet: %w", err)

--- a/test/framework/status.go
+++ b/test/framework/status.go
@@ -52,8 +52,11 @@ func (f *Framework) AssertCondition(conds []monitoringv1.Condition, expectedType
 // If the resource isn't available within the given timeout, it returns an error.
 func (f *Framework) WaitForResourceAvailable(ctx context.Context, getResourceStatus func(context.Context) (resourceStatus, error), timeout time.Duration) error {
 	var pollErr error
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
-		var status resourceStatus
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		var (
+			ctx    = context.Background()
+			status resourceStatus
+		)
 		status, pollErr = getResourceStatus(ctx)
 		if pollErr != nil {
 			return false, nil


### PR DESCRIPTION
## Description

This commit introduces the `NoSelectedResources` reason for the `Reconciled` condition when a workload object selects no resources (valid or invalid). It should make it easier to detect when resource selectors are null or match no resource.

The `Alertmanager` resource is the exception because the configuration may be provided only via a reference to a Secret key.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
