### PR TITLE
docs: add missing metadata tags into manifests

### DIFF
--- a/Documentation/platform/troubleshooting.md
+++ b/Documentation/platform/troubleshooting.md
@@ -53,6 +53,7 @@ Example of Role definition required by the Prometheus operator's Service Account
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
+metadata:
   name: prometheus-operator-kubelet
 rules:
 - apiGroups:
@@ -72,6 +73,7 @@ Example of Role definition required by the Prometheus's Service Account to disco
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
+metadata:
   name: prometheus-kubelet
 rules:
 - apiGroups:


### PR DESCRIPTION
This change adds missing `metadata` keys into Role manifests describing `v1 Endpoiints is deprecated...` warning on troubleshooting page

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
