### PR TITLE
Update AlertmanagerConfig's status subresource on Alertmanager reconciliations

### DIFF
--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -14,6 +14,7 @@ rules:
   - alertmanagers/finalizers
   - alertmanagers/status
   - alertmanagerconfigs
+  - alertmanagerconfigs/status
   - prometheuses
   - prometheuses/finalizers
   - prometheuses/status

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -85,6 +85,7 @@ function(params) {
                  'alertmanagers/finalizers',
                  'alertmanagers/status',
                  'alertmanagerconfigs',
+                 'alertmanagerconfigs/status',
                  'prometheuses',
                  'prometheuses/finalizers',
                  'prometheuses/status',

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -746,9 +746,11 @@ func (c *Operator) updateConfigResourcesStatus(ctx context.Context, am *monitori
 		return nil
 	}
 
+	fmt.Println("update status ke andar")
 	var configResourceSyncer = operator.NewConfigResourceSyncer(am, c.dclient, c.accessor)
 
 	for key, configResource := range amConfigs {
+		fmt.Println("observed generation: ", configResource.Resource().GetGeneration())
 		if err := configResourceSyncer.UpdateBinding(ctx, configResource.Resource(), configResource.Conditions()); err != nil {
 			return fmt.Errorf("failed to update AlertmanagerConfig %s status: %w", key, err)
 		}

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1111,7 +1111,8 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 	eventRecorder := c.newEventRecorder(am)
 	for namespaceAndName, amc := range amConfigs {
 		var reason string
-		if err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store); err != nil {
+		err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store)
+		if err != nil {
 			rejected++
 			reason = operator.InvalidConfiguration
 			c.logger.Warn(

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1081,6 +1081,11 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				return
 			}
 
+			if err := k8sutil.AddTypeInformationToObject(amConfig); err != nil {
+				c.logger.Error("skipping alertmanagerconfig due to missing type information", "alertmanagerconfig", k, "namespace", am.Namespace, "alertmanager", am.Name, "err", err)
+				return
+			}
+
 			amConfigs[k] = amConfig
 		})
 		if err != nil {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -619,7 +619,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
-	amVersion, err := c.getAlertmanagerVersion(am)
+	amVersion, err := getAlertmanagerVersion(am)
 	if err != nil {
 		return err
 	}
@@ -910,7 +910,7 @@ func (c *Operator) loadConfigurationFromSecret(ctx context.Context, am *monitori
 	return rawAlertmanagerConfig, secret.Data, nil
 }
 
-func (c *Operator) getAlertmanagerVersion(am *monitoringv1.Alertmanager) (semver.Version, error) {
+func getAlertmanagerVersion(am *monitoringv1.Alertmanager) (semver.Version, error) {
 	amVersion := operator.StringValOrDefault(am.Spec.Version, operator.DefaultAlertmanagerVersion)
 	version, err := semver.ParseTolerant(amVersion)
 	if err != nil {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1108,7 +1108,6 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"alertmanager", am.Name,
 			)
 			eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
-			continue
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1393,21 +1393,9 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
-			amVersion, err := o.getAlertmanagerVersion(tc.am)
-			if !tc.ok {
-				require.Error(t, err)
-				return
-			}
+			amVersion, _ := o.getAlertmanagerVersion(tc.am)
 
-			require.NoError(t, err)
-
-			amConfigs, err := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
-			if !tc.ok {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
+			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
 
 			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
 			if !tc.ok {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1394,11 +1394,22 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 			amVersion, err := o.getAlertmanagerVersion(tc.am)
+			if !tc.ok {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 
 			amConfigs, err := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
+			if !tc.ok {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 
 			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
-
 			if !tc.ok {
 				require.Error(t, err)
 				return

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1393,7 +1393,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
-			amVersion, _ := o.getAlertmanagerVersion(tc.am)
+			amVersion, _ := getAlertmanagerVersion(tc.am)
 
 			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
 

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1392,7 +1392,12 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			require.NoError(t, err)
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
-			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store)
+
+			amVersion, err := o.getAlertmanagerVersion(tc.am)
+
+			amConfigs, err := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
+
+			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
 
 			if !tc.ok {
 				require.Error(t, err)

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -66,6 +66,10 @@ type AlertmanagerConfig struct {
 	Status monitoringv1.ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
+func (l *AlertmanagerConfig) Bindings() []monitoringv1.WorkloadBinding {
+	return l.Status.Bindings
+}
+
 // AlertmanagerConfigList is a list of AlertmanagerConfig.
 // +k8s:openapi-gen=true
 type AlertmanagerConfigList struct {

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -66,6 +66,10 @@ type AlertmanagerConfig struct {
 	Status monitoringv1.ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
+func (l *AlertmanagerConfig) Bindings() []monitoringv1.WorkloadBinding {
+	return l.Status.Bindings
+}
+
 // AlertmanagerConfigList is a list of AlertmanagerConfig.
 // +k8s:openapi-gen=true
 type AlertmanagerConfigList struct {

--- a/pkg/operator/config_resource.go
+++ b/pkg/operator/config_resource.go
@@ -46,7 +46,7 @@ const (
 // ConfigurationResource is a type constraint that permits only the specific pointer types for configuration resources
 // selectable by Prometheus, PrometheusAgent, Alertmanager or ThanosRuler.
 type ConfigurationResource interface {
-	*monitoringv1.ServiceMonitor | *monitoringv1.PodMonitor | *monitoringv1.Probe | *monitoringv1alpha1.ScrapeConfig | *monitoringv1.PrometheusRule
+	*monitoringv1.ServiceMonitor | *monitoringv1.PodMonitor | *monitoringv1.Probe | *monitoringv1alpha1.ScrapeConfig | *monitoringv1.PrometheusRule | *monitoringv1alpha1.AlertmanagerConfig
 }
 
 // TypedConfigurationResource is a generic type that holds a configuration resource with its validation status.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -456,6 +456,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PrometheusRuleStatusSubresourceForThanosRuler":        testPrometheusRuleStatusSubresourceForThanosRuler,
 		"GarbageCollectionOfPromRuleBindingForThanosRuler":     testGarbageCollectionOfPromRuleBindingForThanosRuler,
 		"RmPromeRuleBindingDuringWorkloadDeleteForThanosRuler": testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler,
+		"AlertmanagerConfigStatusSubresource":                  testAlertmanagerConfigStatusSubresource,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1343,6 +1343,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "amcfg1",
 			Namespace: ns,
+			Labels:    map[string]string{},
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -1380,6 +1381,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "amcfg2",
 			Namespace: ns,
+			Labels:    map[string]string{},
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -25,8 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -1304,4 +1306,126 @@ func testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler(t *testing.T) {
 
 	_, err = framework.WaitForRuleWorkloadBindingCleanup(ctx, pr, tr, monitoringv1.ThanosRulerName, 1*time.Minute)
 	require.NoError(t, err)
+}
+
+// testAlertmanagerConfigStatusSubresource validates AlertmanagerConfig status updates upon Alertmanager selection.
+func testAlertmanagerConfigStatusSubresource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.StatusForConfigurationResourcesFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "am-cfg-status-subresource-test"
+
+	am := framework.MakeBasicAlertmanager(ns, name, 1)
+	am.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"group": name,
+		},
+	}
+
+	_, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, am)
+	require.NoError(t, err)
+
+	// Create a first AlertmanagerConfig to check that the operator only updates the binding when needed.
+	alc1 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg1",
+			Namespace: ns,
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: ptr.To("http://example.com/webhook"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc1.Labels["group"] = name
+
+	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc1, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Record the lastTransitionTime value.
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	require.NoError(t, err)
+	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	ts := cond.LastTransitionTime.String()
+	require.NotEqual(t, "", ts)
+
+	// Create a second AlertmanagerConfig to check that the operator updates the binding when the condition changes.
+	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg2",
+			Namespace: ns,
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: ptr.To("http://example.com/webhook"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc2.Labels["group"] = name
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	// Update the labels of the first AlertmanagerConfig. A label update doesn't
+	// change the status of the AlertmanagerConfig and the observed timestamp
+	// should be the same as before.
+	alc1.Labels["test"] = "test"
+	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc1, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Update the second AlertmanagerConfig to have an invalid rule expression.
+	alc2.Spec.Receivers[0].WebhookConfigs[0].URL = ptr.To("://invalid-url")
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The second AlertmanagerConfig should change to Accepted=False.
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	require.NoError(t, err)
+
+	// The first AlertmanagerConfig should remain unchanged.
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	require.NoError(t, err)
+	cond, err = framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	require.Equal(t, ts, cond.LastTransitionTime.String())
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1354,7 +1353,9 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 					Name: "default",
 					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 						{
-							URL: ptr.To("http://example.com/webhook"),
+							URL: func(s string) *string {
+								return &s
+							}("http://test.url"),
 						},
 					},
 				},
@@ -1392,7 +1393,9 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 					Name: "default",
 					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 						{
-							URL: ptr.To("http://example.com/webhook"),
+							URL: func(s string) *string {
+								return &s
+							}("http://test.url"),
 						},
 					},
 				},
@@ -1414,7 +1417,9 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update the second AlertmanagerConfig to have an invalid rule expression.
-	alc2.Spec.Receivers[0].WebhookConfigs[0].URL = ptr.To("://invalid-url")
+	alc2.Spec.Receivers[0].WebhookConfigs[0].URL = func(s string) *string {
+		return &s
+	}("//invalid-url")
 	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
 	require.NoError(t, err)
 

--- a/test/framework/alertmanager_config.go
+++ b/test/framework/alertmanager_config.go
@@ -25,14 +25,14 @@ import (
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 )
 
-func (f *Framework) WaitForAlertmanagerConfigCondition(ctx context.Context, pm *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, conditionType monitoringv1.ConditionType, conditionStatus monitoringv1.ConditionStatus, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+func (f *Framework) WaitForAlertmanagerConfigCondition(ctx context.Context, alc *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, conditionType monitoringv1.ConditionType, conditionStatus monitoringv1.ConditionStatus, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	var current *monitoringv1alpha1.AlertmanagerConfig
 
 	if err := f.WaitForConfigResourceCondition(
 		ctx,
 		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
 			var err error
-			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(pm.Namespace).Get(ctx, pm.Name, metav1.GetOptions{})
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(alc.Namespace).Get(ctx, alc.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -44,19 +44,19 @@ func (f *Framework) WaitForAlertmanagerConfigCondition(ctx context.Context, pm *
 		conditionStatus,
 		timeout,
 	); err != nil {
-		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", pm.Namespace, pm.Name, err)
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", alc.Namespace, alc.Name, err)
 	}
 	return current, nil
 }
 
-func (f *Framework) WaitForAlertmanagerConfigWorkloadBindingCleanup(ctx context.Context, pm *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+func (f *Framework) WaitForAlertmanagerConfigWorkloadBindingCleanup(ctx context.Context, alc *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	var current *monitoringv1alpha1.AlertmanagerConfig
 
 	if err := f.WaitForConfigResWorkloadBindingCleanup(
 		ctx,
 		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
 			var err error
-			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(pm.Namespace).Get(ctx, pm.Name, metav1.GetOptions{})
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(alc.Namespace).Get(ctx, alc.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -66,7 +66,7 @@ func (f *Framework) WaitForAlertmanagerConfigWorkloadBindingCleanup(ctx context.
 		resource,
 		timeout,
 	); err != nil {
-		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", pm.Namespace, pm.Name, err)
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", alc.Namespace, alc.Name, err)
 	}
 	return current, nil
 }

--- a/test/framework/alertmanager_config.go
+++ b/test/framework/alertmanager_config.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+)
+
+func (f *Framework) WaitForAlertmanagerConfigCondition(ctx context.Context, pm *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, conditionType monitoringv1.ConditionType, conditionStatus monitoringv1.ConditionStatus, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	var current *monitoringv1alpha1.AlertmanagerConfig
+
+	if err := f.WaitForConfigResourceCondition(
+		ctx,
+		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
+			var err error
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(pm.Namespace).Get(ctx, pm.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return current.Status.Bindings, nil
+		},
+		workload,
+		resource,
+		conditionType,
+		conditionStatus,
+		timeout,
+	); err != nil {
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", pm.Namespace, pm.Name, err)
+	}
+	return current, nil
+}
+
+func (f *Framework) WaitForAlertmanagerConfigWorkloadBindingCleanup(ctx context.Context, pm *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	var current *monitoringv1alpha1.AlertmanagerConfig
+
+	if err := f.WaitForConfigResWorkloadBindingCleanup(
+		ctx,
+		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
+			var err error
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(pm.Namespace).Get(ctx, pm.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return current.Status.Bindings, nil
+		},
+		workload,
+		resource,
+		timeout,
+	); err != nil {
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", pm.Namespace, pm.Name, err)
+	}
+	return current, nil
+}


### PR DESCRIPTION
## Description

Closes: #7996 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
