### PR TITLE
feat: Added forbidden markers checks

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -34,6 +34,7 @@ linters:
               - "statusoptional"
               - "nophase"
               - "nonullable"
+              - "forbiddenmarkers"
             disable:
               - "*"
           lintersConfig:
@@ -44,7 +45,14 @@ linters:
                   - ["default", "kubebuilder:default"]
                   - ["required", "kubebuilder:validation:Required", "k8s:required"]
                 description: "A field with a default value cannot be required"
-
+            forbiddenmarkers:
+              markers:
+                - identifier: "+kubebuilder:pruning:PreserveUnknownFields"
+                - identifier: "+kubebuilder:validation:XPreserveUnknownFields"
+                - identifier: "+kubebuilder:validation:items:XPreserveUnknownFields"
+                - identifier: "+kubebuilder:validation:EmbeddedResource"
+                - identifier: "+kubebuilder:validation:XEmbeddedResource"
+                - identifier: "+kubebuilder:validation:items:XEmbeddedResource"
   exclusions:
     generated: strict
     paths:


### PR DESCRIPTION
## Description

Added forbidden markers checks by configuring it in `.golangci-kal.yml` and the markers are:

  - `+kubebuilder:pruning:PreserveUnknownFields`

  - `+kubebuilder:validation:XPreserveUnknownFields`

  - `+kubebuilder:validation:items:XPreserveUnknownFields`

  - `+kubebuilder:validation:EmbeddedResource`

  - `+kubebuilder:validation:XEmbeddedResource`

  - `+kubebuilder:validation:items:XEmbeddedResource`


Closes: #8129 

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
