### PR TITLE
api: add listType markers to ScrapeConfig v1alpha1

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -51856,6 +51856,7 @@ spec:
                   - subscriptionID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               basicAuth:
                 description: basicAuth defines information to use on every scrape
                   request.
@@ -52706,6 +52707,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               convertClassicHistogramsToNHCB:
                 description: |-
                   convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
@@ -53330,6 +53332,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dnsSDConfigs:
                 description: dnsSDConfigs defines a list of DNS service discovery
                   configurations.
@@ -53347,6 +53350,7 @@ spec:
                         type: string
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     port:
                       description: |-
                         port defines the port to scrape metrics from. If using the public IP address, this must
@@ -53379,6 +53383,7 @@ spec:
                   - names
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSDConfigs:
                 description: dockerSDConfigs defines a list of Docker service discovery
                   configurations.
@@ -54101,6 +54106,7 @@ spec:
                   - host
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSwarmSDConfigs:
                 description: dockerSwarmSDConfigs defines a list of Dockerswarm service
                   discovery configurations.
@@ -54825,6 +54831,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ec2SDConfigs:
                 description: ec2SDConfigs defines a list of EC2 service discovery
                   configurations.
@@ -55173,6 +55180,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               enableCompression:
                 description: |-
                   enableCompression when false, Prometheus will request uncompressed response from the scraped target.
@@ -55860,6 +55868,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               fallbackScrapeProtocol:
                 description: |-
                   fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
@@ -55903,6 +55912,7 @@ spec:
                   - files
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               gceSDConfigs:
                 description: gceSDConfigs defines a list of GCE service discovery
                   configurations.
@@ -55962,6 +55972,7 @@ spec:
                   - zone
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hetznerSDConfigs:
                 description: hetznerSDConfigs defines a list of Hetzner service discovery
                   configurations.
@@ -56655,6 +56666,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               honorLabels:
                 description: |-
                   honorLabels defines when true the metric's labels when they collide
@@ -57343,6 +57355,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ionosSDConfigs:
                 description: ionosSDConfigs defines a list of IONOS service discovery
                   configurations.
@@ -57969,6 +57982,7 @@ spec:
                   - datacenterID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               jobName:
                 description: |-
                   jobName defines the value of the `job` label assigned to the scraped metrics by default.
@@ -58743,6 +58757,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               kumaSDConfigs:
                 description: kumaSDConfigs defines a list of Kuma service discovery
                   configurations.
@@ -59429,6 +59444,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               labelLimit:
                 description: |-
                   labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
@@ -60188,6 +60204,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               linodeSDConfigs:
                 description: linodeSDConfigs defines a list of Linode service discovery
                   configurations.
@@ -60816,6 +60833,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               metricRelabelings:
                 description: metricRelabelings defines the metricRelabelings to apply
                   to samples before ingestion.
@@ -60906,6 +60924,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               metricsPath:
                 description: metricsPath defines the HTTP path to scrape for metrics.
                   If empty, Prometheus uses the default value (e.g. /metrics).
@@ -61656,6 +61675,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               oauth2:
                 description: oauth2 defines the configuration to use on every scrape
                   request.
@@ -62313,6 +62333,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ovhcloudSDConfigs:
                 description: ovhcloudSDConfigs defines a list of OVHcloud service
                   discovery configurations.
@@ -62406,6 +62427,7 @@ spec:
                   - service
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               params:
                 additionalProperties:
                   items:
@@ -63155,6 +63177,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               relabelings:
                 description: |-
                   relabelings defines how to rewrite the target's labels before scraping.
@@ -63248,6 +63271,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               sampleLimit:
                 description: sampleLimit defines per-scrape limit on number of scraped
                   samples that will be accepted.
@@ -63577,6 +63601,7 @@ spec:
                   - secretKey
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               scheme:
                 description: scheme defines the protocol scheme used for requests.
                 enum:
@@ -63669,6 +63694,7 @@ spec:
                   - targets
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               targetLimit:
                 description: targetLimit defines a limit on the number of scraped
                   targets that will be accepted.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -826,6 +826,7 @@ spec:
                   - subscriptionID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               basicAuth:
                 description: basicAuth defines information to use on every scrape
                   request.
@@ -1676,6 +1677,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               convertClassicHistogramsToNHCB:
                 description: |-
                   convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
@@ -2300,6 +2302,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dnsSDConfigs:
                 description: dnsSDConfigs defines a list of DNS service discovery
                   configurations.
@@ -2317,6 +2320,7 @@ spec:
                         type: string
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     port:
                       description: |-
                         port defines the port to scrape metrics from. If using the public IP address, this must
@@ -2349,6 +2353,7 @@ spec:
                   - names
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSDConfigs:
                 description: dockerSDConfigs defines a list of Docker service discovery
                   configurations.
@@ -3071,6 +3076,7 @@ spec:
                   - host
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSwarmSDConfigs:
                 description: dockerSwarmSDConfigs defines a list of Dockerswarm service
                   discovery configurations.
@@ -3795,6 +3801,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ec2SDConfigs:
                 description: ec2SDConfigs defines a list of EC2 service discovery
                   configurations.
@@ -4143,6 +4150,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               enableCompression:
                 description: |-
                   enableCompression when false, Prometheus will request uncompressed response from the scraped target.
@@ -4830,6 +4838,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               fallbackScrapeProtocol:
                 description: |-
                   fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
@@ -4873,6 +4882,7 @@ spec:
                   - files
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               gceSDConfigs:
                 description: gceSDConfigs defines a list of GCE service discovery
                   configurations.
@@ -4932,6 +4942,7 @@ spec:
                   - zone
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hetznerSDConfigs:
                 description: hetznerSDConfigs defines a list of Hetzner service discovery
                   configurations.
@@ -5625,6 +5636,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               honorLabels:
                 description: |-
                   honorLabels defines when true the metric's labels when they collide
@@ -6313,6 +6325,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ionosSDConfigs:
                 description: ionosSDConfigs defines a list of IONOS service discovery
                   configurations.
@@ -6939,6 +6952,7 @@ spec:
                   - datacenterID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               jobName:
                 description: |-
                   jobName defines the value of the `job` label assigned to the scraped metrics by default.
@@ -7713,6 +7727,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               kumaSDConfigs:
                 description: kumaSDConfigs defines a list of Kuma service discovery
                   configurations.
@@ -8399,6 +8414,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               labelLimit:
                 description: |-
                   labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
@@ -9158,6 +9174,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               linodeSDConfigs:
                 description: linodeSDConfigs defines a list of Linode service discovery
                   configurations.
@@ -9786,6 +9803,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               metricRelabelings:
                 description: metricRelabelings defines the metricRelabelings to apply
                   to samples before ingestion.
@@ -9876,6 +9894,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               metricsPath:
                 description: metricsPath defines the HTTP path to scrape for metrics.
                   If empty, Prometheus uses the default value (e.g. /metrics).
@@ -10626,6 +10645,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               oauth2:
                 description: oauth2 defines the configuration to use on every scrape
                   request.
@@ -11283,6 +11303,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ovhcloudSDConfigs:
                 description: ovhcloudSDConfigs defines a list of OVHcloud service
                   discovery configurations.
@@ -11376,6 +11397,7 @@ spec:
                   - service
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               params:
                 additionalProperties:
                   items:
@@ -12125,6 +12147,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               relabelings:
                 description: |-
                   relabelings defines how to rewrite the target's labels before scraping.
@@ -12218,6 +12241,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               sampleLimit:
                 description: sampleLimit defines per-scrape limit on number of scraped
                   samples that will be accepted.
@@ -12547,6 +12571,7 @@ spec:
                   - secretKey
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               scheme:
                 description: scheme defines the protocol scheme used for requests.
                 enum:
@@ -12639,6 +12664,7 @@ spec:
                   - targets
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               targetLimit:
                 description: targetLimit defines a limit on the number of scraped
                   targets that will be accepted.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -826,6 +826,7 @@ spec:
                   - subscriptionID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               basicAuth:
                 description: basicAuth defines information to use on every scrape
                   request.
@@ -1676,6 +1677,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               convertClassicHistogramsToNHCB:
                 description: |-
                   convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.
@@ -2300,6 +2302,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dnsSDConfigs:
                 description: dnsSDConfigs defines a list of DNS service discovery
                   configurations.
@@ -2317,6 +2320,7 @@ spec:
                         type: string
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     port:
                       description: |-
                         port defines the port to scrape metrics from. If using the public IP address, this must
@@ -2349,6 +2353,7 @@ spec:
                   - names
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSDConfigs:
                 description: dockerSDConfigs defines a list of Docker service discovery
                   configurations.
@@ -3071,6 +3076,7 @@ spec:
                   - host
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               dockerSwarmSDConfigs:
                 description: dockerSwarmSDConfigs defines a list of Dockerswarm service
                   discovery configurations.
@@ -3795,6 +3801,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ec2SDConfigs:
                 description: ec2SDConfigs defines a list of EC2 service discovery
                   configurations.
@@ -4143,6 +4150,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               enableCompression:
                 description: |-
                   enableCompression when false, Prometheus will request uncompressed response from the scraped target.
@@ -4830,6 +4838,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               fallbackScrapeProtocol:
                 description: |-
                   fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
@@ -4873,6 +4882,7 @@ spec:
                   - files
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               gceSDConfigs:
                 description: gceSDConfigs defines a list of GCE service discovery
                   configurations.
@@ -4932,6 +4942,7 @@ spec:
                   - zone
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hetznerSDConfigs:
                 description: hetznerSDConfigs defines a list of Hetzner service discovery
                   configurations.
@@ -5625,6 +5636,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               honorLabels:
                 description: |-
                   honorLabels defines when true the metric's labels when they collide
@@ -6313,6 +6325,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ionosSDConfigs:
                 description: ionosSDConfigs defines a list of IONOS service discovery
                   configurations.
@@ -6939,6 +6952,7 @@ spec:
                   - datacenterID
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               jobName:
                 description: |-
                   jobName defines the value of the `job` label assigned to the scraped metrics by default.
@@ -7713,6 +7727,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               kumaSDConfigs:
                 description: kumaSDConfigs defines a list of Kuma service discovery
                   configurations.
@@ -8399,6 +8414,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               labelLimit:
                 description: |-
                   labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
@@ -9158,6 +9174,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               linodeSDConfigs:
                 description: linodeSDConfigs defines a list of Linode service discovery
                   configurations.
@@ -9786,6 +9803,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               metricRelabelings:
                 description: metricRelabelings defines the metricRelabelings to apply
                   to samples before ingestion.
@@ -9876,6 +9894,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               metricsPath:
                 description: metricsPath defines the HTTP path to scrape for metrics.
                   If empty, Prometheus uses the default value (e.g. /metrics).
@@ -10626,6 +10645,7 @@ spec:
                   - server
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               oauth2:
                 description: oauth2 defines the configuration to use on every scrape
                   request.
@@ -11283,6 +11303,7 @@ spec:
                   - role
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ovhcloudSDConfigs:
                 description: ovhcloudSDConfigs defines a list of OVHcloud service
                   discovery configurations.
@@ -11376,6 +11397,7 @@ spec:
                   - service
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               params:
                 additionalProperties:
                   items:
@@ -12125,6 +12147,7 @@ spec:
                   - url
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               relabelings:
                 description: |-
                   relabelings defines how to rewrite the target's labels before scraping.
@@ -12218,6 +12241,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               sampleLimit:
                 description: sampleLimit defines per-scrape limit on number of scraped
                   samples that will be accepted.
@@ -12547,6 +12571,7 @@ spec:
                   - secretKey
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               scheme:
                 description: scheme defines the protocol scheme used for requests.
                 enum:
@@ -12639,6 +12664,7 @@ spec:
                   - targets
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               targetLimit:
                 description: targetLimit defines a limit on the number of scraped
                   targets that will be accepted.

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -766,7 +766,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "basicAuth": {
                     "description": "basicAuth defines information to use on every scrape request.",
@@ -1550,7 +1551,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "convertClassicHistogramsToNHCB": {
                     "description": "convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native histogram with custom buckets.\nIt requires Prometheus >= v3.0.0.",
@@ -2132,7 +2134,8 @@
                       },
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "dnsSDConfigs": {
                     "description": "dnsSDConfigs defines a list of DNS service discovery configurations.",
@@ -2146,7 +2149,8 @@
                             "type": "string"
                           },
                           "minItems": 1,
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "port": {
                           "description": "port defines the port to scrape metrics from. If using the public IP address, this must\nIgnored for SRV records",
@@ -2177,7 +2181,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "dockerSDConfigs": {
                     "description": "dockerSDConfigs defines a list of Docker service discovery configurations.",
@@ -2858,7 +2863,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "dockerSwarmSDConfigs": {
                     "description": "dockerSwarmSDConfigs defines a list of Dockerswarm service discovery configurations.",
@@ -3539,7 +3545,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "ec2SDConfigs": {
                     "description": "ec2SDConfigs defines a list of EC2 service discovery configurations.",
@@ -3863,7 +3870,8 @@
                       },
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "enableCompression": {
                     "description": "enableCompression when false, Prometheus will request uncompressed response from the scraped target.\n\nIt requires Prometheus >= v2.49.0.\n\nIf unset, Prometheus uses true by default.",
@@ -4502,7 +4510,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "fallbackScrapeProtocol": {
                     "description": "fallbackScrapeProtocol defines the protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.\n\nIt requires Prometheus >= v3.0.0.",
@@ -4542,7 +4551,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "gceSDConfigs": {
                     "description": "gceSDConfigs defines a list of GCE service discovery configurations.",
@@ -4588,7 +4598,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "hetznerSDConfigs": {
                     "description": "hetznerSDConfigs defines a list of Hetzner service discovery configurations.",
@@ -5236,7 +5247,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "honorLabels": {
                     "description": "honorLabels defines when true the metric's labels when they collide\nwith the target's labels.",
@@ -5875,7 +5887,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "ionosSDConfigs": {
                     "description": "ionosSDConfigs defines a list of IONOS service discovery configurations.",
@@ -6462,7 +6475,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "jobName": {
                     "description": "jobName defines the value of the `job` label assigned to the scraped metrics by default.\n\nThe `job_name` field in the rendered scrape configuration is always controlled by the\noperator to prevent duplicate job names, which Prometheus does not allow. Instead the\n`job` label is set by means of relabeling configs.",
@@ -7178,7 +7192,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "kumaSDConfigs": {
                     "description": "kumaSDConfigs defines a list of Kuma service discovery configurations.",
@@ -7819,7 +7834,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "labelLimit": {
                     "description": "labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.\nOnly valid in Prometheus versions 2.27.0 and newer.",
@@ -8528,7 +8544,8 @@
                       },
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "linodeSDConfigs": {
                     "description": "linodeSDConfigs defines a list of Linode service discovery configurations.",
@@ -9116,7 +9133,8 @@
                       },
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "metricRelabelings": {
                     "description": "metricRelabelings defines the metricRelabelings to apply to samples before ingestion.",
@@ -9186,7 +9204,8 @@
                       "type": "object"
                     },
                     "minItems": 1,
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "metricsPath": {
                     "description": "metricsPath defines the HTTP path to scrape for metrics. If empty, Prometheus uses the default value (e.g. /metrics).",
@@ -9882,7 +9901,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "oauth2": {
                     "description": "oauth2 defines the configuration to use on every scrape request.",
@@ -10500,7 +10520,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "ovhcloudSDConfigs": {
                     "description": "ovhcloudSDConfigs defines a list of OVHcloud service discovery configurations.",
@@ -10585,7 +10606,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "params": {
                     "additionalProperties": {
@@ -11284,7 +11306,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "relabelings": {
                     "description": "relabelings defines how to rewrite the target's labels before scraping.\nPrometheus Operator automatically adds relabelings for a few standard Kubernetes fields.\nThe original scrape job's name is available via the `__tmp_prometheus_job_name` label.\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
@@ -11354,7 +11377,8 @@
                       "type": "object"
                     },
                     "minItems": 1,
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "sampleLimit": {
                     "description": "sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
@@ -11667,7 +11691,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "scheme": {
                     "description": "scheme defines the protocol scheme used for requests.",
@@ -11749,7 +11774,8 @@
                       ],
                       "type": "object"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "targetLimit": {
                     "description": "targetLimit defines a limit on the number of scraped targets that will be accepted.",

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -176,78 +176,102 @@ type ScrapeConfigSpec struct {
 	// +optional
 	JobName *string `json:"jobName,omitempty"`
 	// staticConfigs defines a list of static targets with a common label set.
+	// +listType=atomic
 	// +optional
 	StaticConfigs []StaticConfig `json:"staticConfigs,omitempty"`
 	// fileSDConfigs defines a list of file service discovery configurations.
+	// +listType=atomic
 	// +optional
 	FileSDConfigs []FileSDConfig `json:"fileSDConfigs,omitempty"`
 	// httpSDConfigs defines a list of HTTP service discovery configurations.
+	// +listType=atomic
 	// +optional
 	HTTPSDConfigs []HTTPSDConfig `json:"httpSDConfigs,omitempty"`
 	// kubernetesSDConfigs defines a list of Kubernetes service discovery configurations.
+	// +listType=atomic
 	// +optional
 	KubernetesSDConfigs []KubernetesSDConfig `json:"kubernetesSDConfigs,omitempty"`
 	// consulSDConfigs defines a list of Consul service discovery configurations.
+	// +listType=atomic
 	// +optional
 	ConsulSDConfigs []ConsulSDConfig `json:"consulSDConfigs,omitempty"`
 	// dnsSDConfigs defines a list of DNS service discovery configurations.
+	// +listType=atomic
 	// +optional
 	DNSSDConfigs []DNSSDConfig `json:"dnsSDConfigs,omitempty"`
 	// ec2SDConfigs defines a list of EC2 service discovery configurations.
+	// +listType=atomic
 	// +optional
 	EC2SDConfigs []EC2SDConfig `json:"ec2SDConfigs,omitempty"`
 	// azureSDConfigs defines a list of Azure service discovery configurations.
+	// +listType=atomic
 	// +optional
 	AzureSDConfigs []AzureSDConfig `json:"azureSDConfigs,omitempty"`
 	// gceSDConfigs defines a list of GCE service discovery configurations.
+	// +listType=atomic
 	// +optional
 	GCESDConfigs []GCESDConfig `json:"gceSDConfigs,omitempty"`
 	// openstackSDConfigs defines a list of OpenStack service discovery configurations.
+	// +listType=atomic
 	// +optional
 	OpenStackSDConfigs []OpenStackSDConfig `json:"openstackSDConfigs,omitempty"`
 	// digitalOceanSDConfigs defines a list of DigitalOcean service discovery configurations.
+	// +listType=atomic
 	// +optional
 	DigitalOceanSDConfigs []DigitalOceanSDConfig `json:"digitalOceanSDConfigs,omitempty"`
 	// kumaSDConfigs defines a list of Kuma service discovery configurations.
+	// +listType=atomic
 	// +optional
 	KumaSDConfigs []KumaSDConfig `json:"kumaSDConfigs,omitempty"`
 	// eurekaSDConfigs defines a list of Eureka service discovery configurations.
+	// +listType=atomic
 	// +optional
 	EurekaSDConfigs []EurekaSDConfig `json:"eurekaSDConfigs,omitempty"`
 	// dockerSDConfigs defines a list of Docker service discovery configurations.
+	// +listType=atomic
 	// +optional
 	DockerSDConfigs []DockerSDConfig `json:"dockerSDConfigs,omitempty"`
 	// linodeSDConfigs defines a list of Linode service discovery configurations.
+	// +listType=atomic
 	// +optional
 	LinodeSDConfigs []LinodeSDConfig `json:"linodeSDConfigs,omitempty"`
 	// hetznerSDConfigs defines a list of Hetzner service discovery configurations.
+	// +listType=atomic
 	// +optional
 	HetznerSDConfigs []HetznerSDConfig `json:"hetznerSDConfigs,omitempty"`
 	// nomadSDConfigs defines a list of Nomad service discovery configurations.
+	// +listType=atomic
 	// +optional
 	NomadSDConfigs []NomadSDConfig `json:"nomadSDConfigs,omitempty"`
 	// dockerSwarmSDConfigs defines a list of Dockerswarm service discovery configurations.
+	// +listType=atomic
 	// +optional
 	DockerSwarmSDConfigs []DockerSwarmSDConfig `json:"dockerSwarmSDConfigs,omitempty"`
 	// puppetDBSDConfigs defines a list of PuppetDB service discovery configurations.
+	// +listType=atomic
 	// +optional
 	PuppetDBSDConfigs []PuppetDBSDConfig `json:"puppetDBSDConfigs,omitempty"`
 	// lightSailSDConfigs defines a list of Lightsail service discovery configurations.
+	// +listType=atomic
 	// +optional
 	LightSailSDConfigs []LightSailSDConfig `json:"lightSailSDConfigs,omitempty"`
 	// ovhcloudSDConfigs defines a list of OVHcloud service discovery configurations.
+	// +listType=atomic
 	// +optional
 	OVHCloudSDConfigs []OVHCloudSDConfig `json:"ovhcloudSDConfigs,omitempty"`
 	// scalewaySDConfigs defines a list of Scaleway instances and baremetal service discovery configurations.
+	// +listType=atomic
 	// +optional
 	ScalewaySDConfigs []ScalewaySDConfig `json:"scalewaySDConfigs,omitempty"`
 	// ionosSDConfigs defines a list of IONOS service discovery configurations.
+	// +listType=atomic
 	// +optional
 	IonosSDConfigs []IonosSDConfig `json:"ionosSDConfigs,omitempty"`
 	// relabelings defines how to rewrite the target's labels before scraping.
 	// Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields.
 	// The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
 	// More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +optional
 	RelabelConfigs []v1.RelabelConfig `json:"relabelings,omitempty"`
@@ -269,6 +293,7 @@ type ScrapeConfigSpec struct {
 	//
 	// It requires Prometheus >= v2.49.0.
 	//
+	//nolint:kubeapilinter
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1
 	// +optional
@@ -365,6 +390,7 @@ type ScrapeConfigSpec struct {
 	// +optional
 	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// metricRelabelings defines the metricRelabelings to apply to samples before ingestion.
+	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +optional
 	MetricRelabelConfigs []v1.RelabelConfig `json:"metricRelabelings,omitempty"`
@@ -629,6 +655,7 @@ const (
 // +k8s:openapi-gen=true
 type DNSSDConfig struct {
 	// names defines a list of DNS domain names to be queried.
+	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:items:MinLength=1
 	// +required


### PR DESCRIPTION
## Description

Add SSA (Server-Side Apply) listType markers to all slice fields in `v1alpha1/scrapeconfig_types.go` to satisfy the KAL ssatags linter.

- Use `listType=atomic` for all SD config lists, RelabelConfigs, MetricRelabelConfigs, and DNSSDConfig.Names

Related to: #8131

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Ran the linter locally, no violations left in this file

## Changelog entry

```release-note
NONE
```