### PR TITLE
prometheus: generate TLS ServerName from ServiceName

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -18458,6 +18458,18 @@ string
 </tr>
 <tr>
 <td>
+<code>serviceName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>serviceName is the service name of the target.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>insecureSkipVerify</code><br/>
 <em>
 bool
@@ -19524,6 +19536,18 @@ string
 <td>
 <em>(Optional)</em>
 <p>serverName is used to verify the hostname for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>serviceName is the service name of the target.</p>
 </td>
 </tr>
 <tr>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -755,6 +755,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -986,6 +990,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -1306,6 +1314,10 @@ spec:
                               serverName:
                                 description: serverName is used to verify the hostname
                                   for the targets.
+                                type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
                                 type: string
                             type: object
                           to:
@@ -1797,6 +1809,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -2028,6 +2044,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -2564,6 +2584,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -2795,6 +2819,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -3399,6 +3427,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -3630,6 +3662,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -4234,6 +4270,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -4465,6 +4505,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -5087,6 +5131,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -5318,6 +5366,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -6009,6 +6061,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -6240,6 +6296,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -6988,6 +7048,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -7219,6 +7283,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -7781,6 +7849,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -8012,6 +8084,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -8653,6 +8729,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -8884,6 +8964,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -9459,6 +9543,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -9690,6 +9778,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -10203,6 +10295,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -10434,6 +10530,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -10933,6 +11033,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -11164,6 +11268,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -11744,6 +11852,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -11975,6 +12087,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -12862,6 +12978,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -13093,6 +13213,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -13397,6 +13521,10 @@ spec:
                               serverName:
                                 description: serverName is used to verify the hostname
                                   for the targets.
+                                type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
                                 type: string
                             type: object
                           to:
@@ -13880,6 +14008,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -14111,6 +14243,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -14639,6 +14775,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -14870,6 +15010,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -15458,6 +15602,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -15689,6 +15837,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -16278,6 +16430,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -16509,6 +16665,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -17107,6 +17267,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -17338,6 +17502,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -18005,6 +18173,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -18236,6 +18408,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -18967,6 +19143,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -19198,6 +19378,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -19751,6 +19935,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -19982,6 +20170,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -20608,6 +20800,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -20839,6 +21035,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -21398,6 +21598,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -21629,6 +21833,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -22136,6 +22344,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -22367,6 +22579,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -22858,6 +23074,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -23089,6 +23309,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -23647,6 +23871,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -23878,6 +24106,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1623,6 +1623,10 @@ spec:
                                     description: serverName is used to verify the
                                       hostname for the targets.
                                     type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
+                                    type: string
                                 type: object
                               tokenUrl:
                                 description: tokenUrl defines the URL to fetch the
@@ -1846,6 +1850,10 @@ spec:
                               serverName:
                                 description: serverName is used to verify the hostname
                                   for the targets.
+                                type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
                                 type: string
                             type: object
                         type: object
@@ -2269,6 +2277,10 @@ spec:
                                 description: serverName is used to verify the hostname
                                   for the targets.
                                 type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
+                                type: string
                             type: object
                         type: object
                       telegram:
@@ -2641,6 +2653,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                   server:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -763,6 +763,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1150,6 +1154,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     trackTimestampsStaleness:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -676,6 +676,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
@@ -1299,6 +1302,9 @@ spec:
                   serverName:
                     description: serverName is used to verify the hostname for the
                       targets.
+                    type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
                     type: string
                 type: object
             type: object

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -1411,6 +1411,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                 required:
                 - host
@@ -6054,6 +6057,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6450,6 +6457,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -7132,6 +7142,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8904,6 +8917,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1781,6 +1781,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                       required:
                       - name
@@ -2158,6 +2162,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:
@@ -6768,6 +6775,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -7017,6 +7028,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -7644,6 +7658,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -8040,6 +8058,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -8867,6 +8888,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -10474,6 +10498,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   httpListenLocal:
                     description: |-
@@ -11201,6 +11228,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -567,6 +567,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -818,6 +822,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -1353,6 +1360,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1627,6 +1638,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     tokenRef:
@@ -2044,6 +2058,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -2278,6 +2296,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -2811,6 +2832,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -3045,6 +3070,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -3524,6 +3552,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -3767,6 +3799,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -4117,6 +4152,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -4570,6 +4608,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -4803,6 +4845,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -5355,6 +5400,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -5598,6 +5647,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -6054,6 +6106,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6281,6 +6337,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -6678,6 +6737,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6912,6 +6975,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -7415,6 +7481,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -7686,6 +7756,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8140,6 +8213,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -8372,6 +8449,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8863,6 +8943,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -9129,6 +9213,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -9514,6 +9601,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -9757,6 +9848,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -10347,6 +10441,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -10590,6 +10688,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -10914,6 +11015,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
@@ -11233,6 +11337,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     userid:
@@ -11842,6 +11949,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -12082,6 +12193,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -12499,6 +12613,9 @@ spec:
                           description: serverName is used to verify the hostname for
                             the targets.
                           type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
+                          type: string
                       type: object
                     zone:
                       description: zone defines the availability zone of your targets
@@ -12775,6 +12892,9 @@ spec:
                   serverName:
                     description: serverName is used to verify the hostname for the
                       targets.
+                    type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
                     type: string
                 type: object
               trackTimestampsStaleness:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -684,6 +684,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1057,6 +1061,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     trackTimestampsStaleness:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -2959,6 +2959,9 @@ spec:
                     description: serverName is used to verify the hostname for the
                       targets.
                     type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
+                    type: string
                 type: object
               hostAliases:
                 description: hostAliases defines pods' hostAliases configuration
@@ -5397,6 +5400,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -5793,6 +5800,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -756,6 +756,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -987,6 +991,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -1307,6 +1315,10 @@ spec:
                               serverName:
                                 description: serverName is used to verify the hostname
                                   for the targets.
+                                type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
                                 type: string
                             type: object
                           to:
@@ -1798,6 +1810,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -2029,6 +2045,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -2565,6 +2585,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -2796,6 +2820,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -3400,6 +3428,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -3631,6 +3663,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -4235,6 +4271,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -4466,6 +4506,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -5088,6 +5132,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -5319,6 +5367,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -6010,6 +6062,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -6241,6 +6297,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -6989,6 +7049,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -7220,6 +7284,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -7782,6 +7850,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -8013,6 +8085,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -8654,6 +8730,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -8885,6 +8965,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -9460,6 +9544,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -9691,6 +9779,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -10204,6 +10296,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -10435,6 +10531,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -10934,6 +11034,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -11165,6 +11269,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object
@@ -11745,6 +11853,10 @@ spec:
                                         description: serverName is used to verify
                                           the hostname for the targets.
                                         type: string
+                                      serviceName:
+                                        description: serviceName is the service name
+                                          of the target.
+                                        type: string
                                     type: object
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
@@ -11976,6 +12088,10 @@ spec:
                                   serverName:
                                     description: serverName is used to verify the
                                       hostname for the targets.
+                                    type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
                                     type: string
                                 type: object
                             type: object

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1624,6 +1624,10 @@ spec:
                                     description: serverName is used to verify the
                                       hostname for the targets.
                                     type: string
+                                  serviceName:
+                                    description: serviceName is the service name of
+                                      the target.
+                                    type: string
                                 type: object
                               tokenUrl:
                                 description: tokenUrl defines the URL to fetch the
@@ -1847,6 +1851,10 @@ spec:
                               serverName:
                                 description: serverName is used to verify the hostname
                                   for the targets.
+                                type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
                                 type: string
                             type: object
                         type: object
@@ -2270,6 +2278,10 @@ spec:
                                 description: serverName is used to verify the hostname
                                   for the targets.
                                 type: string
+                              serviceName:
+                                description: serviceName is the service name of the
+                                  target.
+                                type: string
                             type: object
                         type: object
                       telegram:
@@ -2642,6 +2654,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                   server:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -764,6 +764,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1151,6 +1155,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     trackTimestampsStaleness:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -677,6 +677,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
@@ -1300,6 +1303,9 @@ spec:
                   serverName:
                     description: serverName is used to verify the hostname for the
                       targets.
+                    type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
                     type: string
                 type: object
             type: object

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -1412,6 +1412,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                 required:
                 - host
@@ -6055,6 +6058,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6451,6 +6458,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -7133,6 +7143,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8905,6 +8918,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1782,6 +1782,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                       required:
                       - name
@@ -2159,6 +2163,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:
@@ -6769,6 +6776,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -7018,6 +7029,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -7645,6 +7659,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -8041,6 +8059,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -8868,6 +8889,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -10475,6 +10499,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   httpListenLocal:
                     description: |-
@@ -11202,6 +11229,9 @@ spec:
                       serverName:
                         description: serverName is used to verify the hostname for
                           the targets.
+                        type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
                         type: string
                     type: object
                 required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -568,6 +568,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -819,6 +823,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -1354,6 +1361,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1628,6 +1639,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     tokenRef:
@@ -2045,6 +2059,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -2279,6 +2297,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -2812,6 +2833,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -3046,6 +3071,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -3525,6 +3553,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -3768,6 +3800,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -4118,6 +4153,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -4571,6 +4609,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -4804,6 +4846,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -5356,6 +5401,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -5599,6 +5648,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -6055,6 +6107,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6282,6 +6338,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -6679,6 +6738,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -6913,6 +6976,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -7416,6 +7482,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -7687,6 +7757,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8141,6 +8214,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -8373,6 +8450,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -8864,6 +8944,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -9130,6 +9214,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -9515,6 +9602,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -9758,6 +9849,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   type: object
@@ -10348,6 +10442,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -10591,6 +10689,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                   required:
@@ -10915,6 +11016,9 @@ spec:
                         description: serverName is used to verify the hostname for
                           the targets.
                         type: string
+                      serviceName:
+                        description: serviceName is the service name of the target.
+                        type: string
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
@@ -11234,6 +11338,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     userid:
@@ -11843,6 +11950,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -12083,6 +12194,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:
@@ -12500,6 +12614,9 @@ spec:
                           description: serverName is used to verify the hostname for
                             the targets.
                           type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
+                          type: string
                       type: object
                     zone:
                       description: zone defines the availability zone of your targets
@@ -12776,6 +12893,9 @@ spec:
                   serverName:
                     description: serverName is used to verify the hostname for the
                       targets.
+                    type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
                     type: string
                 type: object
               trackTimestampsStaleness:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -685,6 +685,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -1058,6 +1062,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     trackTimestampsStaleness:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -2960,6 +2960,9 @@ spec:
                     description: serverName is used to verify the hostname for the
                       targets.
                     type: string
+                  serviceName:
+                    description: serviceName is the service name of the target.
+                    type: string
                 type: object
               hostAliases:
                 description: hostAliases defines pods' hostAliases configuration
@@ -5398,6 +5401,10 @@ spec:
                               description: serverName is used to verify the hostname
                                 for the targets.
                               type: string
+                            serviceName:
+                              description: serviceName is the service name of the
+                                target.
+                              type: string
                           type: object
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
@@ -5794,6 +5801,9 @@ spec:
                         serverName:
                           description: serverName is used to verify the hostname for
                             the targets.
+                          type: string
+                        serviceName:
+                          description: serviceName is the service name of the target.
                           type: string
                       type: object
                     url:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -699,6 +699,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -916,6 +920,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -1217,6 +1225,10 @@
                                   },
                                   "serverName": {
                                     "description": "serverName is used to verify the hostname for the targets.",
+                                    "type": "string"
+                                  },
+                                  "serviceName": {
+                                    "description": "serviceName is the service name of the target.",
                                     "type": "string"
                                   }
                                 },
@@ -1653,6 +1665,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -1870,6 +1886,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -2347,6 +2367,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -2564,6 +2588,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -3105,6 +3133,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -3322,6 +3354,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -3871,6 +3907,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -4088,6 +4128,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -4645,6 +4689,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -4862,6 +4910,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -5466,6 +5518,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -5683,6 +5739,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -6349,6 +6409,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -6566,6 +6630,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -7073,6 +7141,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -7290,6 +7362,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -7858,6 +7934,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -8075,6 +8155,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -8590,6 +8674,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -8807,6 +8895,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -9267,6 +9359,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -9484,6 +9580,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -9935,6 +10035,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -10152,6 +10256,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },
@@ -10666,6 +10774,10 @@
                                           "serverName": {
                                             "description": "serverName is used to verify the hostname for the targets.",
                                             "type": "string"
+                                          },
+                                          "serviceName": {
+                                            "description": "serviceName is the service name of the target.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object"
@@ -10883,6 +10995,10 @@
                                       },
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
+                                        "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
                                         "type": "string"
                                       }
                                     },

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -558,6 +558,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -774,6 +778,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -1067,6 +1075,10 @@
                               },
                               serverName: {
                                 description: 'serverName is used to verify the hostname for the targets.',
+                                type: 'string',
+                              },
+                              serviceName: {
+                                description: 'serviceName is the service name of the target.',
                                 type: 'string',
                               },
                             },
@@ -1500,6 +1512,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -1716,6 +1732,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -2190,6 +2210,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -2406,6 +2430,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -2940,6 +2968,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -3156,6 +3188,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -3696,6 +3732,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -3912,6 +3952,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -4458,6 +4502,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -4674,6 +4722,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -5267,6 +5319,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -5483,6 +5539,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -6141,6 +6201,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -6357,6 +6421,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -6860,6 +6928,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -7076,6 +7148,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -7638,6 +7714,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -7854,6 +7934,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -8362,6 +8446,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -8578,6 +8666,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -9035,6 +9127,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -9251,6 +9347,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -9699,6 +9799,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -9915,6 +10019,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },
@@ -10420,6 +10528,10 @@
                                         description: 'serverName is used to verify the hostname for the targets.',
                                         type: 'string',
                                       },
+                                      serviceName: {
+                                        description: 'serviceName is the service name of the target.',
+                                        type: 'string',
+                                      },
                                     },
                                     type: 'object',
                                   },
@@ -10636,6 +10748,10 @@
                                   },
                                   serverName: {
                                     description: 'serverName is used to verify the hostname for the targets.',
+                                    type: 'string',
+                                  },
+                                  serviceName: {
+                                    description: 'serviceName is the service name of the target.',
                                     type: 'string',
                                   },
                                 },

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1398,6 +1398,10 @@
                                       "serverName": {
                                         "description": "serverName is used to verify the hostname for the targets.",
                                         "type": "string"
+                                      },
+                                      "serviceName": {
+                                        "description": "serviceName is the service name of the target.",
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object"
@@ -1611,6 +1615,10 @@
                                   },
                                   "serverName": {
                                     "description": "serverName is used to verify the hostname for the targets.",
+                                    "type": "string"
+                                  },
+                                  "serviceName": {
+                                    "description": "serviceName is the service name of the target.",
                                     "type": "string"
                                   }
                                 },
@@ -2012,6 +2020,10 @@
                                   "serverName": {
                                     "description": "serverName is used to verify the hostname for the targets.",
                                     "type": "string"
+                                  },
+                                  "serviceName": {
+                                    "description": "serviceName is the service name of the target.",
+                                    "type": "string"
                                   }
                                 },
                                 "type": "object"
@@ -2371,6 +2383,10 @@
                           },
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
                             "type": "string"
                           }
                         },

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -636,6 +636,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -969,6 +973,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -587,6 +587,10 @@
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
                             "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
+                            "type": "string"
                           }
                         },
                         "type": "object"
@@ -1139,6 +1143,10 @@
                       },
                       "serverName": {
                         "description": "serverName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      },
+                      "serviceName": {
+                        "description": "serviceName is the service name of the target.",
                         "type": "string"
                       }
                     },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -1203,6 +1203,10 @@
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
                             "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
+                            "type": "string"
                           }
                         },
                         "type": "object"
@@ -5099,6 +5103,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -5459,6 +5467,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -6026,6 +6038,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -7344,6 +7360,10 @@
                           },
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
                             "type": "string"
                           }
                         },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -1502,6 +1502,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -1841,6 +1845,10 @@
                           },
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
                             "type": "string"
                           }
                         },
@@ -5700,6 +5708,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -5941,6 +5953,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -6487,6 +6503,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -6847,6 +6867,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -7543,6 +7567,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -8760,6 +8788,10 @@
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
                             "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
+                            "type": "string"
                           }
                         },
                         "type": "object"
@@ -9334,6 +9366,10 @@
                           },
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
+                            "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
                             "type": "string"
                           }
                         },

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -514,6 +514,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -754,6 +758,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -1241,6 +1249,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -1505,6 +1517,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -1888,6 +1904,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -2113,6 +2133,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -2609,6 +2633,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -2834,6 +2862,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -3279,6 +3311,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -3513,6 +3549,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -3840,6 +3880,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -4253,6 +4297,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -4477,6 +4525,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -4976,6 +5028,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -5211,6 +5267,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -5627,6 +5687,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -5845,6 +5909,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -6212,6 +6280,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -6437,6 +6509,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -6889,6 +6965,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -7153,6 +7233,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -7571,6 +7655,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -7794,6 +7882,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -8245,6 +8337,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -8502,6 +8598,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -8855,6 +8955,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -9090,6 +9194,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -9617,6 +9725,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -9848,6 +9960,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -10154,6 +10270,10 @@
                           "serverName": {
                             "description": "serverName is used to verify the hostname for the targets.",
                             "type": "string"
+                          },
+                          "serviceName": {
+                            "description": "serviceName is the service name of the target.",
+                            "type": "string"
                           }
                         },
                         "type": "object"
@@ -10454,6 +10574,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -11013,6 +11137,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -11243,6 +11371,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },
@@ -11624,6 +11756,10 @@
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
                               "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
+                              "type": "string"
                             }
                           },
                           "type": "object"
@@ -11886,6 +12022,10 @@
                       },
                       "serverName": {
                         "description": "serverName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      },
+                      "serviceName": {
+                        "description": "serviceName is the service name of the target.",
                         "type": "string"
                       }
                     },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -570,6 +570,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -908,6 +912,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -2567,6 +2567,10 @@
                       "serverName": {
                         "description": "serverName is used to verify the hostname for the targets.",
                         "type": "string"
+                      },
+                      "serviceName": {
+                        "description": "serviceName is the service name of the target.",
+                        "type": "string"
                       }
                     },
                     "type": "object"
@@ -4669,6 +4673,10 @@
                                 "serverName": {
                                   "description": "serverName is used to verify the hostname for the targets.",
                                   "type": "string"
+                                },
+                                "serviceName": {
+                                  "description": "serviceName is the service name of the target.",
+                                  "type": "string"
                                 }
                               },
                               "type": "object"
@@ -5029,6 +5037,10 @@
                             },
                             "serverName": {
                               "description": "serverName is used to verify the hostname for the targets.",
+                              "type": "string"
+                            },
+                            "serviceName": {
+                              "description": "serviceName is the service name of the target.",
                               "type": "string"
                             }
                           },

--- a/pkg/apis/monitoring/v1/tls_types.go
+++ b/pkg/apis/monitoring/v1/tls_types.go
@@ -106,6 +106,10 @@ type SafeTLSConfig struct {
 	// +optional
 	ServerName *string `json:"serverName,omitempty"`
 
+	// serviceName is the service name of the target.
+	// +optional
+	ServiceName *string `json:"serviceName,omitempty"`
+
 	// insecureSkipVerify defines how to disable target certificate validation.
 	// +optional
 	InsecureSkipVerify *bool `json:"insecureSkipVerify,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -3288,6 +3288,11 @@ func (in *SafeTLSConfig) DeepCopyInto(out *SafeTLSConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceName != nil {
+		in, out := &in.ServiceName, &out.ServiceName
+		*out = new(string)
+		**out = **in
+	}
 	if in.InsecureSkipVerify != nil {
 		in, out := &in.InsecureSkipVerify, &out.InsecureSkipVerify
 		*out = new(bool)

--- a/pkg/client/applyconfiguration/monitoring/v1/safetlsconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/safetlsconfig.go
@@ -28,6 +28,7 @@ type SafeTLSConfigApplyConfiguration struct {
 	Cert               *SecretOrConfigMapApplyConfiguration `json:"cert,omitempty"`
 	KeySecret          *corev1.SecretKeySelector            `json:"keySecret,omitempty"`
 	ServerName         *string                              `json:"serverName,omitempty"`
+	ServiceName        *string                              `json:"serviceName,omitempty"`
 	InsecureSkipVerify *bool                                `json:"insecureSkipVerify,omitempty"`
 	MinVersion         *monitoringv1.TLSVersion             `json:"minVersion,omitempty"`
 	MaxVersion         *monitoringv1.TLSVersion             `json:"maxVersion,omitempty"`
@@ -68,6 +69,14 @@ func (b *SafeTLSConfigApplyConfiguration) WithKeySecret(value corev1.SecretKeySe
 // If called multiple times, the ServerName field is set to the value of the last call.
 func (b *SafeTLSConfigApplyConfiguration) WithServerName(value string) *SafeTLSConfigApplyConfiguration {
 	b.ServerName = &value
+	return b
+}
+
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *SafeTLSConfigApplyConfiguration) WithServiceName(value string) *SafeTLSConfigApplyConfiguration {
+	b.ServiceName = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/tlsconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/tlsconfig.go
@@ -66,6 +66,14 @@ func (b *TLSConfigApplyConfiguration) WithServerName(value string) *TLSConfigApp
 	return b
 }
 
+// WithServiceName sets the ServiceName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceName field is set to the value of the last call.
+func (b *TLSConfigApplyConfiguration) WithServiceName(value string) *TLSConfigApplyConfiguration {
+	b.SafeTLSConfigApplyConfiguration.ServiceName = &value
+	return b
+}
+
 // WithInsecureSkipVerify sets the InsecureSkipVerify field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the InsecureSkipVerify field is set to the value of the last call.

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -802,6 +802,7 @@ func (cg *ConfigGenerator) addProxyConfigtoYaml(
 
 func (cg *ConfigGenerator) addSafeTLStoYaml(
 	cfg yaml.MapSlice,
+	namespace string,
 	store assets.StoreGetter,
 	safetls *monitoringv1.SafeTLSConfig,
 ) yaml.MapSlice {
@@ -857,6 +858,8 @@ func (cg *ConfigGenerator) addSafeTLStoYaml(
 
 	if ptr.Deref(safetls.ServerName, "") != "" {
 		safetlsConfig = append(safetlsConfig, yaml.MapItem{Key: "server_name", Value: *safetls.ServerName})
+	} else if ptr.Deref(safetls.ServiceName, "") != "" && namespace != "" {
+		safetlsConfig = append(safetlsConfig, yaml.MapItem{Key: "server_name", Value: fmt.Sprintf("%s.%s.svc", *safetls.ServiceName, namespace)})
 	}
 
 	if safetls.MinVersion != nil {
@@ -872,6 +875,7 @@ func (cg *ConfigGenerator) addSafeTLStoYaml(
 
 func (cg *ConfigGenerator) addHTTPConfigToYAML(
 	cfg yaml.MapSlice,
+	namespace string,
 	store assets.StoreGetter,
 	httpConfig *monitoringv1.HTTPConfig,
 	scrapeClass monitoringv1.ScrapeClass,
@@ -889,11 +893,12 @@ func (cg *ConfigGenerator) addHTTPConfigToYAML(
 		cfg = cg.WithMinimumVersion("2.35.0").AppendMapItem(cfg, "enable_http2", *httpConfig.EnableHTTP2)
 	}
 
-	return cg.addTLStoYaml(cfg, store, mergeSafeTLSConfigWithScrapeClass(httpConfig.TLSConfig, scrapeClass))
+	return cg.addTLStoYaml(cfg, namespace, store, mergeSafeTLSConfigWithScrapeClass(httpConfig.TLSConfig, scrapeClass))
 }
 
 func (cg *ConfigGenerator) addTLStoYaml(
 	cfg yaml.MapSlice,
+	namespace string,
 	store assets.StoreGetter,
 	tls *monitoringv1.TLSConfig,
 ) yaml.MapSlice {
@@ -901,7 +906,7 @@ func (cg *ConfigGenerator) addTLStoYaml(
 		return cfg
 	}
 
-	tlsConfig := cg.addSafeTLStoYaml(yaml.MapSlice{}, store, &tls.SafeTLSConfig)[0].Value.(yaml.MapSlice)
+	tlsConfig := cg.addSafeTLStoYaml(yaml.MapSlice{}, namespace, store, &tls.SafeTLSConfig)[0].Value.(yaml.MapSlice)
 
 	if tls.CAFile != "" {
 		tlsConfig = append(tlsConfig, yaml.MapItem{Key: "ca_file", Value: tls.CAFile})
@@ -1015,12 +1020,12 @@ func (cg *ConfigGenerator) GenerateServerConfiguration(
 
 	// Remote write config
 	if len(cpf.RemoteWrite) > 0 {
-		cfg = append(cfg, cg.GenerateRemoteWriteConfig(cpf.RemoteWrite, s))
+		cfg = append(cfg, cg.GenerateRemoteWriteConfig(cpf.RemoteWrite, cg.prom.GetObjectMeta().GetNamespace(), s))
 	}
 
 	// Remote read config
 	if len(p.Spec.RemoteRead) > 0 {
-		cfg = append(cfg, cg.generateRemoteReadConfig(p.Spec.RemoteRead, s))
+		cfg = append(cfg, cg.generateRemoteReadConfig(p.Spec.RemoteRead, cg.prom.GetObjectMeta().GetNamespace(), s))
 	}
 
 	// OTLP config
@@ -1383,7 +1388,7 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 		cfg = append(cfg, yaml.MapItem{Key: "scheme", Value: ep.Scheme.String()})
 	}
 
-	cfg = cg.addHTTPConfigToYAML(cfg, s, &ep.HTTPConfig, scrapeClass)
+	cfg = cg.addHTTPConfigToYAML(cfg, m.Namespace, s, &ep.HTTPConfig, scrapeClass)
 
 	//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 	if ep.BearerTokenSecret != nil && ep.BearerTokenSecret.Name != "" {
@@ -1398,7 +1403,7 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 	}
 
 	cfg = cg.addBasicAuthToYaml(cfg, s, ep.BasicAuth)
-	cfg = cg.addOAuth2ToYaml(cfg, s, ep.OAuth2)
+	cfg = cg.addOAuth2ToYaml(cfg, m.Namespace, s, ep.OAuth2)
 
 	cfg = cg.addProxyConfigtoYaml(cfg, s, ep.ProxyConfig)
 
@@ -1807,7 +1812,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 	relabelings = appendShardingRelabelingForProbes(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
-	cfg = cg.addTLStoYaml(cfg, s, mergeSafeTLSConfigWithScrapeClass(m.Spec.TLSConfig, scrapeClass))
+	cfg = cg.addTLStoYaml(cfg, m.Namespace, s, mergeSafeTLSConfigWithScrapeClass(m.Spec.TLSConfig, scrapeClass))
 
 	if m.Spec.BearerTokenSecret != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		b, err := s.GetSecretKey(*m.Spec.BearerTokenSecret) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
@@ -1819,7 +1824,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 	}
 
 	cfg = cg.addBasicAuthToYaml(cfg, s, m.Spec.BasicAuth)
-	cfg = cg.addOAuth2ToYaml(cfg, s, m.Spec.OAuth2)
+	cfg = cg.addOAuth2ToYaml(cfg, m.Namespace, s, m.Spec.OAuth2)
 
 	cfg = cg.addAuthorizationToYaml(cfg, s, mergeSafeAuthorizationWithScrapeClass(m.Spec.Authorization, scrapeClass))
 
@@ -1898,9 +1903,9 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 
 	cfg = cg.addProxyConfigtoYaml(cfg, s, ep.ProxyConfig)
 
-	cfg = cg.addOAuth2ToYaml(cfg, s, ep.OAuth2)
+	cfg = cg.addOAuth2ToYaml(cfg, m.Namespace, s, ep.OAuth2)
 
-	cfg = cg.addTLStoYaml(cfg, s, mergeTLSConfigWithScrapeClass(ep.TLSConfig, scrapeClass))
+	cfg = cg.addTLStoYaml(cfg, m.Namespace, s, mergeTLSConfigWithScrapeClass(ep.TLSConfig, scrapeClass))
 
 	if ep.BearerTokenFile != "" { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		cg.logger.Debug("'bearerTokenFile' is deprecated, use 'authorization' instead.")
@@ -2321,7 +2326,7 @@ func (cg *ConfigGenerator) generateK8SSDConfig(
 
 		k8sSDConfig = cg.addAuthorizationToYaml(k8sSDConfig, store, apiserverConfig.Authorization)
 
-		k8sSDConfig = cg.addTLStoYaml(k8sSDConfig, store, apiserverConfig.TLSConfig)
+		k8sSDConfig = cg.addTLStoYaml(k8sSDConfig, namespace, store, apiserverConfig.TLSConfig)
 
 		k8sSDConfig = cg.addProxyConfigtoYaml(k8sSDConfig, store, apiserverConfig.ProxyConfig)
 	}
@@ -2413,11 +2418,11 @@ func (cg *ConfigGenerator) generateAlertmanagerConfig(alerting *monitoringv1.Ale
 			cfg = cg.WithMinimumVersion("2.35.0").AppendMapItem(cfg, "enable_http2", *am.EnableHttp2)
 		}
 
-		cfg = cg.addTLStoYaml(cfg, store, am.TLSConfig)
+		ns := ptr.Deref(am.Namespace, cg.prom.GetObjectMeta().GetNamespace())
+		cfg = cg.addTLStoYaml(cfg, ns, store, am.TLSConfig)
 
 		cfg = cg.addProxyConfigtoYaml(cfg, store, am.ProxyConfig)
 
-		ns := ptr.Deref(am.Namespace, cg.prom.GetObjectMeta().GetNamespace())
 		cfg = append(cfg, cg.generateK8SSDConfig(monitoringv1.NamespaceSelector{}, ns, apiserverConfig, store, cg.defaultEndpointRoleFlavor(), nil))
 
 		//nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
@@ -2536,7 +2541,7 @@ func (cg *ConfigGenerator) generateAdditionalScrapeConfigs(
 	return addlScrapeConfigs, nil
 }
 
-func (cg *ConfigGenerator) generateRemoteReadConfig(remoteRead []monitoringv1.RemoteReadSpec, s assets.StoreGetter) yaml.MapItem {
+func (cg *ConfigGenerator) generateRemoteReadConfig(remoteRead []monitoringv1.RemoteReadSpec, namespace string, s assets.StoreGetter) yaml.MapItem {
 	cfgs := []yaml.MapSlice{}
 
 	for _, spec := range remoteRead {
@@ -2578,9 +2583,9 @@ func (cg *ConfigGenerator) generateRemoteReadConfig(remoteRead []monitoringv1.Re
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: spec.BearerTokenFile})
 		}
 
-		cfg = cg.addOAuth2ToYaml(cfg, s, spec.OAuth2)
+		cfg = cg.addOAuth2ToYaml(cfg, namespace, s, spec.OAuth2)
 
-		cfg = cg.addTLStoYaml(cfg, s, spec.TLSConfig)
+		cfg = cg.addTLStoYaml(cfg, namespace, s, spec.TLSConfig)
 
 		cfg = cg.addAuthorizationToYaml(cfg, s, spec.Authorization)
 
@@ -2605,6 +2610,7 @@ func (cg *ConfigGenerator) generateRemoteReadConfig(remoteRead []monitoringv1.Re
 
 func (cg *ConfigGenerator) addOAuth2ToYaml(
 	cfg yaml.MapSlice,
+	namespace string,
 	store assets.StoreGetter,
 	oauth2 *monitoringv1.OAuth2,
 ) yaml.MapSlice {
@@ -2640,7 +2646,7 @@ func (cg *ConfigGenerator) addOAuth2ToYaml(
 	}
 
 	oauth2Cfg = cg.WithMinimumVersion("2.43.0").addProxyConfigtoYaml(oauth2Cfg, store, oauth2.ProxyConfig)
-	oauth2Cfg = cg.WithMinimumVersion("2.43.0").addSafeTLStoYaml(oauth2Cfg, store, oauth2.TLSConfig)
+	oauth2Cfg = cg.WithMinimumVersion("2.43.0").addSafeTLStoYaml(oauth2Cfg, namespace, store, oauth2.TLSConfig)
 
 	return cg.WithMinimumVersion("2.27.0").AppendMapItem(cfg, "oauth2", oauth2Cfg)
 }
@@ -2675,7 +2681,7 @@ func (cg *ConfigGenerator) AddRemoteWriteToStore(ctx context.Context, store *ass
 	return nil
 }
 
-func (cg *ConfigGenerator) GenerateRemoteWriteConfig(rws []monitoringv1.RemoteWriteSpec, s assets.StoreGetter) yaml.MapItem {
+func (cg *ConfigGenerator) GenerateRemoteWriteConfig(rws []monitoringv1.RemoteWriteSpec, namespace string, s assets.StoreGetter) yaml.MapItem {
 	var cfgs []yaml.MapSlice
 
 	for i, spec := range rws {
@@ -2760,9 +2766,9 @@ func (cg *ConfigGenerator) GenerateRemoteWriteConfig(rws []monitoringv1.RemoteWr
 			cfg = append(cfg, yaml.MapItem{Key: "bearer_token_file", Value: spec.BearerTokenFile})
 		}
 
-		cfg = cg.addOAuth2ToYaml(cfg, s, spec.OAuth2)
+		cfg = cg.addOAuth2ToYaml(cfg, namespace, s, spec.OAuth2)
 
-		cfg = cg.addTLStoYaml(cfg, s, spec.TLSConfig)
+		cfg = cg.addTLStoYaml(cfg, namespace, s, spec.TLSConfig)
 
 		cfg = cg.addAuthorizationToYaml(cfg, s, spec.Authorization)
 
@@ -3152,7 +3158,7 @@ func (cg *ConfigGenerator) GenerateAgentConfiguration(
 	// Remote write config
 	s := store.ForNamespace(cg.prom.GetObjectMeta().GetNamespace())
 	if len(cpf.RemoteWrite) > 0 {
-		cfg = append(cfg, cg.GenerateRemoteWriteConfig(cpf.RemoteWrite, s))
+		cfg = append(cfg, cg.GenerateRemoteWriteConfig(cpf.RemoteWrite, cg.prom.GetObjectMeta().GetNamespace(), s))
 	}
 
 	// OTLP config
@@ -3268,9 +3274,9 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 	cfg = cg.addAuthorizationToYaml(cfg, s, mergeSafeAuthorizationWithScrapeClass(sc.Spec.Authorization, scrapeClass))
 
-	cfg = cg.addOAuth2ToYaml(cfg, s, sc.Spec.OAuth2)
+	cfg = cg.addOAuth2ToYaml(cfg, sc.Namespace, s, sc.Spec.OAuth2)
 
-	cfg = cg.addTLStoYaml(cfg, s, mergeSafeTLSConfigWithScrapeClass(sc.Spec.TLSConfig, scrapeClass))
+	cfg = cg.addTLStoYaml(cfg, sc.Namespace, s, mergeSafeTLSConfigWithScrapeClass(sc.Spec.TLSConfig, scrapeClass))
 
 	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, sc.Spec.SampleLimit, cpf.EnforcedSampleLimit)
 	cfg = cg.AddLimitsToYAML(cfg, targetLimitKey, sc.Spec.TargetLimit, cpf.EnforcedTargetLimit)
@@ -3335,9 +3341,9 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.HTTPSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 
 			configs[i] = append(configs[i], yaml.MapItem{
 				Key:   "url",
@@ -3393,7 +3399,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			if config.FollowRedirects != nil {
@@ -3410,7 +3416,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.Namespaces != nil {
 				namespaces := []yaml.MapItem{
@@ -3473,10 +3479,10 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.ConsulSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
 				Key:   "server",
@@ -3715,7 +3721,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			}
 
 			if config.TLSConfig != nil {
-				configs[i] = cgForHTTPClientConfig.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+				configs[i] = cgForHTTPClientConfig.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 			}
 		}
 		cfg = append(cfg, yaml.MapItem{
@@ -3985,7 +3991,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 		}
 		cfg = append(cfg, yaml.MapItem{
 			Key:   "openstack_sd_configs",
@@ -3998,7 +4004,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		configs := make([][]yaml.MapItem, len(sc.Spec.DigitalOceanSDConfigs))
 		for i, config := range sc.Spec.DigitalOceanSDConfigs {
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			if config.FollowRedirects != nil {
@@ -4015,7 +4021,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.Port != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4043,7 +4049,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.KumaSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
@@ -4065,7 +4071,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.RefreshInterval != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4100,7 +4106,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.EurekaSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			if config.FollowRedirects != nil {
@@ -4117,7 +4123,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.RefreshInterval != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4145,7 +4151,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 		for i, config := range sc.Spec.DockerSDConfigs {
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addFiltersToYaml(configs[i], config.Filters)
@@ -4155,7 +4161,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				Value: config.Host,
 			})
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.Port != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4211,10 +4217,10 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 		for i, config := range sc.Spec.LinodeSDConfigs {
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.Port != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4273,7 +4279,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.HetznerSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
@@ -4295,7 +4301,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.Port != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4329,7 +4335,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.NomadSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
@@ -4386,7 +4392,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 		}
 		cfg = append(cfg, yaml.MapItem{
 			Key:   "nomad_sd_configs",
@@ -4400,7 +4406,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.DockerSwarmSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 			configs[i] = cg.addFiltersToYaml(configs[i], config.Filters)
 
@@ -4409,7 +4415,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				Value: config.Host,
 			})
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
 				Key:   "role",
@@ -4457,7 +4463,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.PuppetDBSDConfigs {
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
@@ -4498,7 +4504,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.EnableHTTP2 != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4520,7 +4526,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
-			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], sc.Namespace, s, config.OAuth2)
 
 			if config.Region != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4580,7 +4586,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 				})
 			}
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.FollowRedirects != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4722,7 +4728,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
 
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			if config.FollowRedirects != nil {
 				configs[i] = append(configs[i], yaml.MapItem{
@@ -4751,7 +4757,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		for i, config := range sc.Spec.IonosSDConfigs {
 			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, &config.Authorization)
 			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
-			configs[i] = cg.addSafeTLStoYaml(configs[i], s, config.TLSConfig)
+			configs[i] = cg.addSafeTLStoYaml(configs[i], sc.Namespace, s, config.TLSConfig)
 
 			configs[i] = append(configs[i], yaml.MapItem{
 				Key:   "datacenter_id",
@@ -4968,7 +4974,7 @@ func (cg *ConfigGenerator) appendTracingConfig(cfg yaml.MapSlice, s assets.Store
 		})
 	}
 
-	tracing = cg.addTLStoYaml(tracing, s, tracingConfig.TLSConfig)
+	tracing = cg.addTLStoYaml(tracing, cg.prom.GetObjectMeta().GetNamespace(), s, tracingConfig.TLSConfig)
 
 	return append(
 		cfg,

--- a/pkg/prometheus/promcfg_servicename_test.go
+++ b/pkg/prometheus/promcfg_servicename_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestGenerateServiceMonitorConfigWithServiceName(t *testing.T) {
+	cg := &ConfigGenerator{
+		logger:  nil,
+		version: semver.MustParse("2.45.0"),
+	}
+
+	serviceName := "my-service"
+	namespace := "my-namespace"
+
+	// Test addSafeTLStoYaml
+	tlsConfig := &monitoringv1.SafeTLSConfig{
+		ServiceName: &serviceName,
+	}
+
+	store := &MockStore{}
+
+	// Call addSafeTLStoYaml
+	cfg := yaml.MapSlice{}
+	cfg = cg.addSafeTLStoYaml(cfg, namespace, store, tlsConfig)
+
+	// Verify "server_name" inside "tls_config"
+	var tlsMap yaml.MapSlice
+	foundTLS := false
+	for _, item := range cfg {
+		if item.Key == "tls_config" {
+			tlsMap = item.Value.(yaml.MapSlice)
+			foundTLS = true
+			break
+		}
+	}
+	require.True(t, foundTLS, "tls_config not found in generated config")
+
+	foundServerName := false
+	for _, item := range tlsMap {
+		if item.Key == "server_name" {
+			foundServerName = true
+			require.Equal(t, serviceName+"."+namespace+".svc", item.Value)
+		}
+	}
+	require.True(t, foundServerName, "server_name not found in nested tls_config")
+}
+
+// Minimal mock for StoreGetter.
+type MockStore struct{}
+
+func (s *MockStore) GetSecretKey(key v1.SecretKeySelector) ([]byte, error) {
+	return []byte("secret"), nil
+}
+
+func (s *MockStore) GetSecretOrConfigMapKey(key monitoringv1.SecretOrConfigMap) (string, error) {
+	return "secret", nil
+}
+
+func (s *MockStore) GetConfigMapKey(key v1.ConfigMapKeySelector) (string, error) {
+	return "config", nil
+}
+
+func (s *MockStore) TLSAsset(key any) string {
+	return ""
+}

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -1036,7 +1036,7 @@ func (o *Operator) createOrUpdateRulerConfigSecret(ctx context.Context, store *a
 
 	rwConfig, err := yaml.Marshal(
 		yaml.MapSlice{
-			cg.GenerateRemoteWriteConfig(tr.Spec.RemoteWrite, store.ForNamespace(tr.Namespace)),
+			cg.GenerateRemoteWriteConfig(tr.Spec.RemoteWrite, tr.Namespace, store.ForNamespace(tr.Namespace)),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

Currently users manually specify the full TLS ServerName even when it follows the standard kubernetes dns format; redundant, prone to errors.

This change adds an optional ServiceName field to the SafeTLSConfig. If ServerName is not provided, the operator will now automatically generate it using the format `<ServiceName>.<Namespace>.svc`. This simplifies TLS config for ServiceMonitors, PodMonitors, Probes.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #7625

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
I've addded a new test `TestGenerateServiceMonitorConfigWithServiceName` in `pkg/prometheus/promcfg_servicename_test.go` - verify that server_name is correctly generated as `<service>.<namespace>.svc` when serviceName is provided.
- successful `go test ./pkg/prometheus/....`

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add `serviceName` field to TLS configuration to automatically generate the `serverName` based on the Service name and namespace.
```
