### PR TITLE
Add validating webhook for Alertmanager ConfigSecret

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -69,6 +69,15 @@ func alertmanagerConfigFromBytes(b []byte) (*alertmanagerConfig, error) {
 	return cfg, nil
 }
 
+// ValidateConfigSecret validates raw Alertmanager configuration bytes.
+// It is used by the admission webhook to validate Secrets containing
+// Alertmanager configurations (referenced via am.Spec.ConfigSecret).
+// It returns an error if the configuration is invalid.
+func ValidateConfigSecret(configData []byte) error {
+	_, err := alertmanagerConfigFromBytes(configData)
+	return err
+}
+
 func checkAlertmanagerConfigRootRoute(rootRoute *route) error {
 	if rootRoute == nil {
 		return errors.New("root route must exist")

--- a/test/framework/resources/alertmanager-secret-validating-webhook.yaml
+++ b/test/framework/resources/alertmanager-secret-validating-webhook.yaml
@@ -1,0 +1,32 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: prometheus-operator-alertmanager-secret-validation
+webhooks:
+  - clientConfig:
+      service:
+        name: prometheus-operator-admission-webhook
+        namespace: default
+        path: /admission-alertmanager-secrets/validate
+    failurePolicy: Fail
+    name: alertmanager-secrets-validate.monitoring.coreos.com
+    namespaceSelector:
+      matchExpressions:
+      - key: excludeFromWebhook
+        operator: NotIn
+        values: ["true"]
+    # Only trigger for Secrets with the alertmanager.yaml key
+    # Users can also filter by labels using objectSelector if needed
+    rules:
+      - apiGroups:
+          - ""  # Core API group (Secrets are core resources)
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+    admissionReviewVersions:
+      - v1


### PR DESCRIPTION
## Description

Added a validating webhook for `Alertmanager` configuration secrets. currently, users can create secrets with invalid Alertmanager configurations (referenced via `am.Spec.ConfigSecret`) and errors are only discovered at `Alertmanager` startup. this pr adds admission validation to catch configuration errors early when the secret is created or updated.
the webhook validates secrets that contain an `alertmanager.yaml` key by reusing the existing `alertmanagerConfigFromBytes` validation logic.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #7472 

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
- Added unit tests covering valid config, invalid config (missing receiver, malformed YAML, empty config), and secrets without [alertmanager.yaml]


## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add validating webhook for Alertmanager ConfigSecret to catch configuration errors early.
```
