### PR TITLE
pkg/alertmanager: add URL validation for PagerDuty receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2792,6 +2792,39 @@ func (pdc *pagerdutyConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 		}
 	}
 
+	if pdc.URL != "" {
+		if _, err := validation.ValidateURL(pdc.URL); err != nil {
+			return fmt.Errorf("invalid 'url': %w", err)
+		}
+	}
+
+	if pdc.ClientURL != "" {
+		if err := validation.ValidateTemplateURL(pdc.ClientURL); err != nil {
+			return fmt.Errorf("invalid 'client_url': %w", err)
+		}
+	}
+
+	for i, image := range pdc.Images {
+		if image.Src != "" {
+			if err := validation.ValidateTemplateURL(image.Src); err != nil {
+				return fmt.Errorf("invalid 'src' in images[%d]: %w", i, err)
+			}
+		}
+		if image.Href != "" {
+			if err := validation.ValidateTemplateURL(image.Href); err != nil {
+				return fmt.Errorf("invalid 'href' in images[%d]: %w", i, err)
+			}
+		}
+	}
+
+	for i, link := range pdc.Links {
+		if link.Href != "" {
+			if err := validation.ValidateTemplateURL(link.Href); err != nil {
+				return fmt.Errorf("invalid 'href' in links[%d]: %w", i, err)
+			}
+		}
+	}
+
 	return pdc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -7660,6 +7660,159 @@ func TestSanitizePagerDutyConfig(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:           "Test invalid url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								URL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid client_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								ClientURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid image src returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								Images: []pagerdutyImage{
+									{Src: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid image href returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								Images: []pagerdutyImage{
+									{Href: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid link href returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								Links: []pagerdutyLink{
+									{Href: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test valid urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								URL:       "https://events.pagerduty.com/v2/enqueue",
+								ClientURL: "https://example.com/client",
+								Images: []pagerdutyImage{
+									{
+										Src:  "https://example.com/image.png",
+										Href: "https://example.com/link",
+									},
+								},
+								Links: []pagerdutyLink{
+									{Href: "https://example.com/docs"},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "test_valid_urls_pass_validation_in_pagerduty_config.golden",
+		},
+		{
+			name:           "Test templated urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								ClientURL: `{{ .CommonAnnotations.client }}`,
+								Images: []pagerdutyImage{
+									{
+										Src:  `{{ .CommonAnnotations.image }}`,
+										Href: `{{ .CommonAnnotations.link }}`,
+									},
+								},
+								Links: []pagerdutyLink{
+									{Href: `{{ .CommonAnnotations.docs }}`},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "test_templated_urls_pass_validation_in_pagerduty_config.golden",
+		},
+		{
+			name:           "Test invalid template in client_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 25},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						PagerdutyConfigs: []*pagerdutyConfig{
+							{
+								ClientURL: `{{ .CommonAnnotations.client`,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)

--- a/pkg/alertmanager/testdata/test_templated_urls_pass_validation_in_pagerduty_config.golden
+++ b/pkg/alertmanager/testdata/test_templated_urls_pass_validation_in_pagerduty_config.golden
@@ -1,0 +1,10 @@
+receivers:
+- name: ""
+  pagerduty_configs:
+  - client_url: '{{ .CommonAnnotations.client }}'
+    images:
+    - src: '{{ .CommonAnnotations.image }}'
+      href: '{{ .CommonAnnotations.link }}'
+    links:
+    - href: '{{ .CommonAnnotations.docs }}'
+templates: []

--- a/pkg/alertmanager/testdata/test_valid_urls_pass_validation_in_pagerduty_config.golden
+++ b/pkg/alertmanager/testdata/test_valid_urls_pass_validation_in_pagerduty_config.golden
@@ -1,0 +1,11 @@
+receivers:
+- name: ""
+  pagerduty_configs:
+  - url: https://events.pagerduty.com/v2/enqueue
+    client_url: https://example.com/client
+    images:
+    - src: https://example.com/image.png
+      href: https://example.com/link
+    links:
+    - href: https://example.com/docs
+templates: []


### PR DESCRIPTION
Relates to #8193 
## Description

Added URL validation for PagerDuty receiver configurations loaded from Alertmanager secrets.

Currently, sanitize methods check Alertmanager secrets for mutually exclusive values and version support, but URLs are only validated at the CR level during conversion. This creates an inconsistency where invalid URLs in secret-based configurations may pass through without proper validation.

This PR adds URL validation to the `pagerdutyConfig.sanitize()` method for:
- `url` - PagerDuty API endpoint
- `client_url` - PagerDuty client URL
- `images[*].src` - Image source URLs
- `images[*].href` - Image link URLs
- `links[*].href` - Link URLs

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Added unit tests for invalid URL validation (url, client_url, image src/href, link href)
- Added unit test for valid URLs passing validation
- All existing tests continue to pass
- Ran `go test ./pkg/alertmanager/...` successfully

## Changelog entry

```release-note
Add URL validation for PagerDuty receiver configurations in Alertmanager secrets.
```