### PR TITLE
pkg/alertmanager: add URL validation for Discord receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3185,6 +3185,18 @@ func (dc *discordConfig) sanitize(amVersion semver.Version, logger *slog.Logger)
 		dc.AvatarURL = ""
 	}
 
+	if dc.WebhookURL != "" {
+		if _, err := validation.ValidateURL(dc.WebhookURL); err != nil {
+			return fmt.Errorf("invalid 'webhook_url': %w", err)
+		}
+	}
+
+	if dc.AvatarURL != "" {
+		if _, err := validation.ValidateURL(dc.AvatarURL); err != nil {
+			return fmt.Errorf("invalid 'avatar_url': %w", err)
+		}
+	}
+
 	return dc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -7861,6 +7861,7 @@ func TestSanitizeDiscordConfig(t *testing.T) {
 		againstVersion semver.Version
 		in             *alertmanagerConfig
 		golden         string
+		expectErr      bool
 	}{
 		{
 			name:           "Test Username field is dropped in discord config for unsupported versions",
@@ -7928,7 +7929,7 @@ func TestSanitizeDiscordConfig(t *testing.T) {
 						Name: "discord",
 						DiscordConfigs: []*discordConfig{
 							{
-								AvatarURL:  "content",
+								AvatarURL:  "http://example.com/avatar.png",
 								WebhookURL: "http://example.com",
 								Message:    "test message",
 							},
@@ -7976,9 +7977,66 @@ func TestSanitizeDiscordConfig(t *testing.T) {
 			},
 			golden: "Discord_content_add_in_supported_versions_config.golden",
 		},
+		{
+			name:           "Test invalid webhook_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 28},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "discord",
+						DiscordConfigs: []*discordConfig{
+							{
+								WebhookURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid avatar_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 28},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "discord",
+						DiscordConfigs: []*discordConfig{
+							{
+								WebhookURL: "http://example.com",
+								AvatarURL:  "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test valid urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 28},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						Name: "discord",
+						DiscordConfigs: []*discordConfig{
+							{
+								WebhookURL: "https://discord.com/api/webhooks/123/abc",
+								AvatarURL:  "https://example.com/avatar.png",
+							},
+						},
+					},
+				},
+			},
+			golden: "Discord_valid_urls_pass_validation.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			amConfigs, err := yaml.Marshal(tc.in)

--- a/pkg/alertmanager/testdata/Discord_avatarURL_add_in_supported_versions_config.golden
+++ b/pkg/alertmanager/testdata/Discord_avatarURL_add_in_supported_versions_config.golden
@@ -3,5 +3,5 @@ receivers:
   discord_configs:
   - webhook_url: http://example.com
     message: test message
-    avatar_url: content
+    avatar_url: http://example.com/avatar.png
 templates: []

--- a/pkg/alertmanager/testdata/Discord_valid_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/Discord_valid_urls_pass_validation.golden
@@ -1,0 +1,6 @@
+receivers:
+- name: discord
+  discord_configs:
+  - webhook_url: https://discord.com/api/webhooks/123/abc
+    avatar_url: https://example.com/avatar.png
+templates: []


### PR DESCRIPTION
Realtes to #8193 
## Description

Add URL validation for Discord receiver configurations loaded from Alertmanager secrets.

Currently, sanitize methods check Alertmanager secrets for mutually exclusive values and version support, but URLs are only validated at the CR level during conversion. This creates an inconsistency where invalid URLs in secret-based configurations may pass through without proper validation.

This PR adds URL validation to the `discordConfig.sanitize()` method for:
- `webhook_url` - Discord webhook URL
- `avatar_url` - Avatar image URL

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Added unit tests for invalid URL validation (webhook_url, avatar_url)
- Added unit test for valid URLs passing validation
- All existing tests continue to pass
- Ran `go test ./pkg/alertmanager/...` successfully

## Changelog entry

```release-note
Add URL validation for Discord receiver configurations in Alertmanager secrets.
```