### PR TITLE
pkg/alertmanager: add URL validation for Slack receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2924,10 +2924,6 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		return fmt.Errorf("at most one of app_token/app_token_file & api_url/api_url_file must be configured")
 	}
 
-	if sc.APIURLFile == "" {
-		return nil
-	}
-
 	// We need to sanitize the config for slack receivers
 	// As of v0.22.0 Alertmanager config supports passing URL via file name
 	if sc.APIURLFile != "" && amVersion.LT(semver.MustParse("0.22.0")) {
@@ -2940,6 +2936,50 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		msg := "'api_url' and 'api_url_file' are mutually exclusive for slack receiver config - 'api_url' has taken precedence"
 		logger.Warn(msg)
 		sc.APIURLFile = ""
+	}
+
+	if sc.APIURL != "" {
+		if _, err := validation.ValidateURL(sc.APIURL); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
+
+	if sc.AppURL != "" {
+		if _, err := validation.ValidateURL(sc.AppURL); err != nil {
+			return fmt.Errorf("invalid 'app_url': %w", err)
+		}
+	}
+
+	if sc.TitleLink != "" {
+		if err := validation.ValidateTemplateURL(sc.TitleLink); err != nil {
+			return fmt.Errorf("invalid 'title_link': %w", err)
+		}
+	}
+
+	if sc.IconURL != "" {
+		if err := validation.ValidateTemplateURL(sc.IconURL); err != nil {
+			return fmt.Errorf("invalid 'icon_url': %w", err)
+		}
+	}
+
+	if sc.ImageURL != "" {
+		if err := validation.ValidateTemplateURL(sc.ImageURL); err != nil {
+			return fmt.Errorf("invalid 'image_url': %w", err)
+		}
+	}
+
+	if sc.ThumbURL != "" {
+		if err := validation.ValidateTemplateURL(sc.ThumbURL); err != nil {
+			return fmt.Errorf("invalid 'thumb_url': %w", err)
+		}
+	}
+
+	for i, action := range sc.Actions {
+		if action.URL != "" {
+			if err := validation.ValidateTemplateURL(action.URL); err != nil {
+				return fmt.Errorf("invalid 'url' in actions[%d]: %w", i, err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -9521,7 +9521,7 @@ func TestSanitizeSlackConfig(t *testing.T) {
 					{
 						SlackConfigs: []*slackConfig{
 							{
-								APIURL:     "www.test.com",
+								APIURL:     "http://www.test.com",
 								APIURLFile: "/test",
 							},
 						},
@@ -9652,6 +9652,182 @@ func TestSanitizeSlackConfig(t *testing.T) {
 							{
 								APIURL:        "https://api.url",
 								UpdateMessage: new(true),
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid api_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								APIURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid app_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 30},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								AppURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid title_link returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								APIURL:    "http://example.com",
+								TitleLink: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid icon_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								IconURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid image_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								ImageURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid thumb_url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								ThumbURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test invalid action url returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								Actions: []slackAction{
+									{URL: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "Test valid urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								APIURL:    "https://hooks.slack.com/services/xxx",
+								TitleLink: "https://example.com/title",
+								IconURL:   "https://example.com/icon.png",
+								ImageURL:  "https://example.com/image.png",
+								ThumbURL:  "https://example.com/thumb.png",
+								Actions: []slackAction{
+									{URL: "https://example.com/action"},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "slack_valid_urls_pass_validation.golden",
+		},
+		{
+			name:           "Test templated urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								TitleLink: `{{ .CommonAnnotations.link }}`,
+								IconURL:   `{{ .CommonAnnotations.icon }}`,
+								ImageURL:  `{{ .CommonAnnotations.image }}`,
+								ThumbURL:  `{{ .CommonAnnotations.thumb }}`,
+								Actions: []slackAction{
+									{URL: `{{ .CommonAnnotations.action }}`},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "slack_templated_urls_pass_validation.golden",
+		},
+		{
+			name:           "Test invalid template in title_link returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 22},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						SlackConfigs: []*slackConfig{
+							{
+								TitleLink: `{{ .CommonAnnotations.link`,
 							},
 						},
 					},

--- a/pkg/alertmanager/testdata/slack_templated_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/slack_templated_urls_pass_validation.golden
@@ -1,0 +1,10 @@
+receivers:
+- name: ""
+  slack_configs:
+  - title_link: '{{ .CommonAnnotations.link }}'
+    icon_url: '{{ .CommonAnnotations.icon }}'
+    image_url: '{{ .CommonAnnotations.image }}'
+    thumb_url: '{{ .CommonAnnotations.thumb }}'
+    actions:
+    - url: '{{ .CommonAnnotations.action }}'
+templates: []

--- a/pkg/alertmanager/testdata/slack_valid_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/slack_valid_urls_pass_validation.golden
@@ -1,0 +1,11 @@
+receivers:
+- name: ""
+  slack_configs:
+  - api_url: https://hooks.slack.com/services/xxx
+    title_link: https://example.com/title
+    icon_url: https://example.com/icon.png
+    image_url: https://example.com/image.png
+    thumb_url: https://example.com/thumb.png
+    actions:
+    - url: https://example.com/action
+templates: []

--- a/pkg/alertmanager/testdata/test_api_url_takes_precedence_in_slack_config.golden
+++ b/pkg/alertmanager/testdata/test_api_url_takes_precedence_in_slack_config.golden
@@ -1,5 +1,5 @@
 receivers:
 - name: ""
   slack_configs:
-  - api_url: www.test.com
+  - api_url: http://www.test.com
 templates: []


### PR DESCRIPTION
Relates to #8193 
## Description

Add URL validation for Slack receiver configurations loaded from Alertmanager secrets.

Currently, sanitize methods check Alertmanager secrets for mutually exclusive values and version support, but URLs are only validated at the CR level during conversion. This creates an inconsistency where invalid URLs in secret-based configurations may pass through without proper validation.

This PR adds URL validation to the `slackConfig.sanitize()` method for:
- `api_url` - Slack API URL
- `title_link` - Title link URL
- `icon_url` - Icon URL
- `image_url` - Image URL
- `thumb_url` - Thumbnail URL
- `actions[*].url` - Action button URLs

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Added unit tests for invalid URL validation (api_url, title_link, icon_url, image_url, thumb_url, actions[*].url)
- Added unit test for valid URLs passing validation
- All existing tests continue to pass
- Ran `go test ./pkg/alertmanager/...` successfully

## Changelog entry

```release-note
Add URL validation for Slack receiver configurations in Alertmanager secrets.
```