### PR TITLE
pkg/alertmanager: add URL validation for RocketChat receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3254,6 +3254,49 @@ func (rc *rocketChatConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 		return fmt.Errorf("at most one of token_id & token_id_file must be configured")
 	}
 
+	if rc.APIURL != "" {
+		if _, err := validation.ValidateURL(rc.APIURL); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
+
+	if rc.TitleLink != "" {
+		if err := validation.ValidateTemplateURL(rc.TitleLink); err != nil {
+			return fmt.Errorf("invalid 'title_link': %w", err)
+		}
+	}
+
+	if rc.IconURL != "" {
+		if err := validation.ValidateTemplateURL(rc.IconURL); err != nil {
+			return fmt.Errorf("invalid 'icon_url': %w", err)
+		}
+	}
+
+	if rc.ImageURL != "" {
+		if err := validation.ValidateTemplateURL(rc.ImageURL); err != nil {
+			return fmt.Errorf("invalid 'image_url': %w", err)
+		}
+	}
+
+	if rc.ThumbURL != "" {
+		if err := validation.ValidateTemplateURL(rc.ThumbURL); err != nil {
+			return fmt.Errorf("invalid 'thumb_url': %w", err)
+		}
+	}
+
+	for i, action := range rc.Actions {
+		if action.URL != "" {
+			if err := validation.ValidateTemplateURL(action.URL); err != nil {
+				return fmt.Errorf("invalid 'url' in actions[%d]: %w", i, err)
+			}
+		}
+		if action.ImageURL != "" {
+			if err := validation.ValidateTemplateURL(action.ImageURL); err != nil {
+				return fmt.Errorf("invalid 'image_url' in actions[%d]: %w", i, err)
+			}
+		}
+	}
+
 	return rc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -8087,6 +8087,195 @@ func TestSanitizeRocketChatConfig(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:           "rocketchat_configs invalid api_url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid title_link returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL:    "http://example.com",
+								TitleLink: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid icon_url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL:  "http://example.com",
+								IconURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid image_url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL:   "http://example.com",
+								ImageURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid thumb_url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL:   "http://example.com",
+								ThumbURL: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid action url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL: "http://example.com",
+								Actions: []*rocketchatAttachmentAction{
+									{URL: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs invalid action image_url returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL: "http://example.com",
+								Actions: []*rocketchatAttachmentAction{
+									{ImageURL: "not-a-valid-url"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "rocketchat_configs valid urls pass validation",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								APIURL:    "https://rocket.example.com/hooks/xxx",
+								TitleLink: "https://example.com/title",
+								IconURL:   "https://example.com/icon.png",
+								ImageURL:  "https://example.com/image.png",
+								ThumbURL:  "https://example.com/thumb.png",
+								Actions: []*rocketchatAttachmentAction{
+									{
+										URL:      "https://example.com/action",
+										ImageURL: "https://example.com/action-image.png",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "rocketchat_valid_urls_pass_validation.golden",
+		},
+		{
+			name:           "rocketchat_configs templated urls pass validation",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								TitleLink: `{{ .CommonAnnotations.link }}`,
+								IconURL:   `{{ .CommonAnnotations.icon }}`,
+								ImageURL:  `{{ .CommonAnnotations.image }}`,
+								ThumbURL:  `{{ .CommonAnnotations.thumb }}`,
+								Actions: []*rocketchatAttachmentAction{
+									{
+										URL:      `{{ .CommonAnnotations.action }}`,
+										ImageURL: `{{ .CommonAnnotations.actionImage }}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "rocketchat_templated_urls_pass_validation.golden",
+		},
+		{
+			name:           "rocketchat_configs invalid template in title_link returns error",
+			againstVersion: versionRocketChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						RocketChatConfigs: []*rocketChatConfig{
+							{
+								TitleLink: `{{ .CommonAnnotations.link`,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)

--- a/pkg/alertmanager/testdata/rocketchat_templated_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/rocketchat_templated_urls_pass_validation.golden
@@ -1,0 +1,15 @@
+receivers:
+- name: ""
+  rocketchat_configs:
+  - title_link: '{{ .CommonAnnotations.link }}'
+    short_fields: false
+    icon_url: '{{ .CommonAnnotations.icon }}'
+    image_url: '{{ .CommonAnnotations.image }}'
+    thumb_url: '{{ .CommonAnnotations.thumb }}'
+    link_names: false
+    actions:
+    - url: '{{ .CommonAnnotations.action }}'
+      image_url: '{{ .CommonAnnotations.actionImage }}'
+      is_webview: false
+      msg_in_chat_window: false
+templates: []

--- a/pkg/alertmanager/testdata/rocketchat_valid_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/rocketchat_valid_urls_pass_validation.golden
@@ -1,0 +1,16 @@
+receivers:
+- name: ""
+  rocketchat_configs:
+  - api_url: https://rocket.example.com/hooks/xxx
+    title_link: https://example.com/title
+    short_fields: false
+    icon_url: https://example.com/icon.png
+    image_url: https://example.com/image.png
+    thumb_url: https://example.com/thumb.png
+    link_names: false
+    actions:
+    - url: https://example.com/action
+      image_url: https://example.com/action-image.png
+      is_webview: false
+      msg_in_chat_window: false
+templates: []


### PR DESCRIPTION
Relates to #8193

## Description

Adds URL validation for RocketChat receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

**Validated fields:**
- `api_url`
- `title_link`
- `icon_url`
- `image_url`
- `thumb_url`
- `actions[].url`
- `actions[].image_url`

## Type of change

- [x] Bug fix

## Verification

- [x] Added test cases for each URL field with invalid URLs
- [x] Added test case for valid URLs
- [x] All tests pass

## Changelog entry

```release-note
Add URL validation for RocketChat receiver secrets
```