### PR TITLE
pkg/alertmanager: add URL validation for Mattermost receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3306,6 +3306,67 @@ func (mc *mattermostConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 		}
 	}
 
+	if mc.WebhookURL != "" {
+		if _, err := validation.ValidateURL(mc.WebhookURL); err != nil {
+			return fmt.Errorf("invalid 'webhook_url': %w", err)
+		}
+	}
+
+	if mc.IconURL != "" {
+		if err := validation.ValidateTemplateURL(mc.IconURL); err != nil {
+			return fmt.Errorf("invalid 'icon_url': %w", err)
+		}
+	}
+
+	for name, value := range map[string]string{
+		"author_link": mc.AuthorLink,
+		"author_icon": mc.AuthorIcon,
+		"title_link":  mc.TitleLink,
+		"thumb_url":   mc.ThumbURL,
+		"footer_icon": mc.FooterIcon,
+		"image_url":   mc.ImageURL,
+	} {
+		if value == "" {
+			continue
+		}
+		if err := validation.ValidateTemplateURL(value); err != nil {
+			return fmt.Errorf("invalid '%s': %w", name, err)
+		}
+	}
+
+	for i, attachment := range mc.Attachments {
+		if attachment.AuthorLink != "" {
+			if err := validation.ValidateTemplateURL(attachment.AuthorLink); err != nil {
+				return fmt.Errorf("invalid 'author_link' in attachments[%d]: %w", i, err)
+			}
+		}
+		if attachment.AuthorIcon != "" {
+			if err := validation.ValidateTemplateURL(attachment.AuthorIcon); err != nil {
+				return fmt.Errorf("invalid 'author_icon' in attachments[%d]: %w", i, err)
+			}
+		}
+		if attachment.TitleLink != "" {
+			if err := validation.ValidateTemplateURL(attachment.TitleLink); err != nil {
+				return fmt.Errorf("invalid 'title_link' in attachments[%d]: %w", i, err)
+			}
+		}
+		if attachment.ThumbURL != "" {
+			if err := validation.ValidateTemplateURL(attachment.ThumbURL); err != nil {
+				return fmt.Errorf("invalid 'thumb_url' in attachments[%d]: %w", i, err)
+			}
+		}
+		if attachment.FooterIcon != "" {
+			if err := validation.ValidateTemplateURL(attachment.FooterIcon); err != nil {
+				return fmt.Errorf("invalid 'footer_icon' in attachments[%d]: %w", i, err)
+			}
+		}
+		if attachment.ImageURL != "" {
+			if err := validation.ValidateTemplateURL(attachment.ImageURL); err != nil {
+				return fmt.Errorf("invalid 'image_url' in attachments[%d]: %w", i, err)
+			}
+		}
+	}
+
 	return mc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -5692,7 +5692,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								Text:       "test text",
 							},
 						},
@@ -5709,7 +5709,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								Text:       "test text",
 							},
 						},
@@ -5726,7 +5726,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL:     "www.test.com",
+								WebhookURL:     "http://www.test.com",
 								WebhookURLFile: "/test",
 								Text:           "test text",
 							},
@@ -5788,7 +5788,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 							},
 						},
 					},
@@ -5804,7 +5804,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								AuthorName: "test author",
 							},
 						},
@@ -5821,7 +5821,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								AuthorName: "test author",
 							},
 						},
@@ -5838,7 +5838,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								Fields: []mattermostField{
 									{
 										Title: "foo",
@@ -5860,7 +5860,7 @@ func TestSanitizeConfig(t *testing.T) {
 					{
 						MattermostConfigs: []*mattermostConfig{
 							{
-								WebhookURL: "www.test.com",
+								WebhookURL: "http://www.test.com",
 								Fields: []mattermostField{
 									{
 										Title: "foo",
@@ -8080,6 +8080,317 @@ func TestSanitizeRocketChatConfig(t *testing.T) {
 								APIURL:      "http://example.com",
 								TokenID:     new("t123456"),
 								TokenIDFile: "/var/kubernetes/secrets/token-id",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.sanitize(tc.againstVersion, logger)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			amConfigs, err := yaml.Marshal(tc.in)
+			require.NoError(t, err)
+
+			golden.Assert(t, string(amConfigs), tc.golden)
+		})
+	}
+}
+
+func TestSanitizeMattermostConfig(t *testing.T) {
+	logger := newNopLogger(t)
+	versionMattermostAllowed := semver.Version{Major: 0, Minor: 30}
+	for _, tc := range []struct {
+		name           string
+		againstVersion semver.Version
+		in             *alertmanagerConfig
+		golden         string
+		expectErr      bool
+	}{
+		{
+			name:           "mattermost_configs invalid webhook_url returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "not-a-valid-url",
+								Text:       "test",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid icon_url returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								IconURL:    "not-a-valid-url",
+								Text:       "test",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment author_link returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										AuthorLink: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment author_icon returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										AuthorIcon: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment title_link returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										TitleLink: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment thumb_url returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										ThumbURL: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment footer_icon returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										FooterIcon: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs invalid attachment image_url returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										ImageURL: "not-a-valid-url",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs valid urls pass validation",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								IconURL:    "https://example.com/icon.png",
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										AuthorLink: "https://example.com/author",
+										AuthorIcon: "https://example.com/author-icon.png",
+										TitleLink:  "https://example.com/title",
+										ThumbURL:   "https://example.com/thumb.png",
+										FooterIcon: "https://example.com/footer-icon.png",
+										ImageURL:   "https://example.com/image.png",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "mattermost_valid_urls_pass_validation.golden",
+		},
+		{
+			name:           "mattermost_configs templated urls pass validation",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								IconURL:    `{{ .CommonAnnotations.icon }}`,
+								Text:       "test",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										AuthorLink: `{{ .CommonAnnotations.author }}`,
+										AuthorIcon: `{{ .CommonAnnotations.authorIcon }}`,
+										TitleLink:  `{{ .CommonAnnotations.title }}`,
+										ThumbURL:   `{{ .CommonAnnotations.thumb }}`,
+										FooterIcon: `{{ .CommonAnnotations.footerIcon }}`,
+										ImageURL:   `{{ .CommonAnnotations.image }}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "mattermost_templated_urls_pass_validation.golden",
+		},
+		{
+			name:           "mattermost_configs invalid top-level author_link returns error",
+			againstVersion: semver.Version{Major: 0, Minor: 32},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								AuthorLink: "not-a-valid-url",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "mattermost_configs valid and templated top-level urls pass validation",
+			againstVersion: semver.Version{Major: 0, Minor: 32},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								AuthorLink: "https://example.com/author",
+								AuthorIcon: `{{ .CommonAnnotations.authorIcon }}`,
+								TitleLink:  `{{ .CommonAnnotations.title }}`,
+								ThumbURL:   "https://example.com/thumb.png",
+								FooterIcon: `{{ .CommonAnnotations.footerIcon }}`,
+								ImageURL:   "https://example.com/image.png",
+							},
+						},
+					},
+				},
+			},
+			golden: "mattermost_top_level_urls_pass_validation.golden",
+		},
+		{
+			name:           "mattermost_configs invalid template in attachment title_link returns error",
+			againstVersion: versionMattermostAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "http://mattermost.example.com/hooks/xxx",
+								Attachments: []*mattermostAttachmentConfig{
+									{
+										TitleLink: `{{ .CommonAnnotations.title`,
+									},
+								},
 							},
 						},
 					},

--- a/pkg/alertmanager/testdata/mattermost_templated_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/mattermost_templated_urls_pass_validation.golden
@@ -1,0 +1,14 @@
+receivers:
+- name: ""
+  mattermost_configs:
+  - webhook_url: http://mattermost.example.com/hooks/xxx
+    text: test
+    icon_url: '{{ .CommonAnnotations.icon }}'
+    attachments:
+    - author_link: '{{ .CommonAnnotations.author }}'
+      author_icon: '{{ .CommonAnnotations.authorIcon }}'
+      title_link: '{{ .CommonAnnotations.title }}'
+      thumb_url: '{{ .CommonAnnotations.thumb }}'
+      footer_icon: '{{ .CommonAnnotations.footerIcon }}'
+      image_url: '{{ .CommonAnnotations.image }}'
+templates: []

--- a/pkg/alertmanager/testdata/mattermost_top_level_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/mattermost_top_level_urls_pass_validation.golden
@@ -1,0 +1,11 @@
+receivers:
+- name: ""
+  mattermost_configs:
+  - webhook_url: http://mattermost.example.com/hooks/xxx
+    author_link: https://example.com/author
+    author_icon: '{{ .CommonAnnotations.authorIcon }}'
+    title_link: '{{ .CommonAnnotations.title }}'
+    thumb_url: https://example.com/thumb.png
+    footer_icon: '{{ .CommonAnnotations.footerIcon }}'
+    image_url: https://example.com/image.png
+templates: []

--- a/pkg/alertmanager/testdata/mattermost_valid_urls_pass_validation.golden
+++ b/pkg/alertmanager/testdata/mattermost_valid_urls_pass_validation.golden
@@ -1,0 +1,14 @@
+receivers:
+- name: ""
+  mattermost_configs:
+  - webhook_url: http://mattermost.example.com/hooks/xxx
+    text: test
+    icon_url: https://example.com/icon.png
+    attachments:
+    - author_link: https://example.com/author
+      author_icon: https://example.com/author-icon.png
+      title_link: https://example.com/title
+      thumb_url: https://example.com/thumb.png
+      footer_icon: https://example.com/footer-icon.png
+      image_url: https://example.com/image.png
+templates: []

--- a/pkg/alertmanager/testdata/test_config_version_mattermost_allowed.golden
+++ b/pkg/alertmanager/testdata/test_config_version_mattermost_allowed.golden
@@ -1,6 +1,6 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
     text: test text
 templates: []

--- a/pkg/alertmanager/testdata/test_mattermos_text_is_optional.golden
+++ b/pkg/alertmanager/testdata/test_mattermos_text_is_optional.golden
@@ -1,5 +1,5 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
 templates: []

--- a/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_fields_in_supported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_fields_in_supported_version.golden
@@ -1,7 +1,7 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
     fields:
     - title: foo
       value: bar

--- a/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_fields_in_unsupported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_fields_in_unsupported_version.golden
@@ -1,5 +1,5 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
 templates: []

--- a/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_in_supported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_in_supported_version.golden
@@ -1,6 +1,6 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
     author_name: test author
 templates: []

--- a/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_in_unsupported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_top_level_attachment_config_in_unsupported_version.golden
@@ -1,5 +1,5 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
 templates: []

--- a/pkg/alertmanager/testdata/test_webhook_url_takes_precedence_in_mattermost_config.golden
+++ b/pkg/alertmanager/testdata/test_webhook_url_takes_precedence_in_mattermost_config.golden
@@ -1,6 +1,6 @@
 receivers:
 - name: ""
   mattermost_configs:
-  - webhook_url: www.test.com
+  - webhook_url: http://www.test.com
     text: test text
 templates: []


### PR DESCRIPTION
Relates to #8193

## Description

Adds URL validation for Mattermost receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

**Validated fields:**
- `webhook_url`
- `icon_url`
- `attachments[].author_link`
- `attachments[].author_icon`
- `attachments[].title_link`
- `attachments[].thumb_url`
- `attachments[].footer_icon`
- `attachments[].image_url`

## Type of change

- [x] Bug fix

## Verification

- [x] Added test cases for each URL field with invalid URLs
- [x] Added test case for valid URLs
- [x] Fixed existing tests that used invalid URLs (missing scheme)
- [x] All tests pass

## Changelog entry

```release-note
Add URL validation for Mattermost receiver secrets
```