### PR TITLE
pkg/operator: prune orphaned bindings for configuration resources

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/metadata"
@@ -82,6 +83,7 @@ type Operator struct {
 	kclient    kubernetes.Interface
 	mdClient   metadata.Interface
 	mclient    monitoringclient.Interface
+	dclient    dynamic.Interface
 	ssarClient authv1.SelfSubjectAccessReviewInterface
 
 	controllerID string
@@ -149,6 +151,11 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		return nil, fmt.Errorf("instantiating monitoring client failed: %w", err)
 	}
 
+	dclient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating dynamic client failed: %w", err)
+	}
+
 	// All the metrics exposed by the controller get the controller="alertmanager" label.
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "alertmanager"}, r)
 
@@ -156,6 +163,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		kclient:    client,
 		mdClient:   mdClient,
 		mclient:    mclient,
+		dclient:    dclient,
 		ssarClient: client.AuthorizationV1().SelfSubjectAccessReviews(),
 
 		logger:   logger,
@@ -500,6 +508,8 @@ func (c *Operator) Run(ctx context.Context) error {
 	// TODO(simonpasquier): watch for Alertmanager pods instead of polling.
 	go operator.StatusPoller(ctx, c)
 
+	go c.pruneOrphanedBindings(ctx)
+
 	c.metrics.Ready().Set(1)
 	<-ctx.Done()
 	return nil
@@ -783,6 +793,46 @@ func labelSelectorForStatefulSets() string {
 		operator.ManagedByLabelKey, operator.ManagedByLabelValue,
 		operator.ApplicationNameLabelKey, applicationNameLabelValue,
 	)
+}
+
+// pruneOrphanedBindings prunes orphaned bindings for Alertmanager configs.
+func (c *Operator) pruneOrphanedBindings(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	workloadGVR := monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.AlertmanagerName)
+	workloadChecker := c.workloadChecker
+	configResourceSyncerFactory := func(workload operator.RuntimeObject) operator.BindingRemover {
+		return operator.NewConfigResourceSyncer(workload, c.dclient, c.accessor)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := operator.PruneOrphanedBindings[*monitoringv1alpha1.AlertmanagerConfig](
+				ctx,
+				c.alrtCfgInfs.ListAll,
+				workloadGVR,
+				workloadChecker,
+				configResourceSyncerFactory,
+			); err != nil {
+				c.logger.Error("failed to prune orphaned bindings from AlertmanagerConfigs", "err", err)
+			}
+		}
+	}
+}
+
+func (c *Operator) workloadChecker(ns, name string) (bool, error) {
+	_, err := c.alrtInfs.Get(ns + "/" + name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *operator.ShardedSecret, s appsv1.StatefulSetSpec) (string, error) {

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -67,6 +67,10 @@ type AlertmanagerConfig struct {
 	Status monitoringv1.ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
+func (l *AlertmanagerConfig) Bindings() []monitoringv1.WorkloadBinding {
+	return l.Status.Bindings
+}
+
 // AlertmanagerConfigList is a list of AlertmanagerConfig.
 // +k8s:openapi-gen=true
 type AlertmanagerConfigList struct {

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -397,6 +397,8 @@ func (o *Operator) Run(ctx context.Context) error {
 	// TODO(simonpasquier): watch for ThanosRuler pods instead of polling.
 	go operator.StatusPoller(ctx, o)
 
+	go o.pruneOrphanedBindings(ctx)
+
 	o.metrics.Ready().Set(1)
 	<-ctx.Done()
 	return nil
@@ -771,7 +773,6 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 	ns := nsObject.(*v1.Namespace)
 
 	err = o.thanosRulerInfs.ListAll(labels.Everything(), func(obj any) {
-		// Check for ThanosRuler instances in the namespace.
 		tr := obj.(*monitoringv1.ThanosRuler)
 		if tr.Namespace == nsName {
 			o.rr.EnqueueForReconciliation(tr)
@@ -782,11 +783,9 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		// the namespace.
 		ruleNSSelector, err := metav1.LabelSelectorAsSelector(tr.Spec.RuleNamespaceSelector)
 		if err != nil {
-			o.logger.Error("",
-				"err", fmt.Errorf("failed to convert RuleNamespaceSelector: %w", err),
-				"name", tr.Name,
-				"namespace", tr.Namespace,
-				"selector", tr.Spec.RuleNamespaceSelector,
+			o.logger.Error(
+				fmt.Sprintf("failed to convert RuleNamespaceSelector of %q to selector", tr.Name),
+				"err", err,
 			)
 			return
 		}
@@ -797,10 +796,51 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		}
 	})
 	if err != nil {
-		o.logger.Error("listing all ThanosRuler instances from cache failed",
+		o.logger.Error(
+			"listing all ThanosRuler instances from cache failed",
 			"err", err,
 		)
 	}
+}
+
+func (o *Operator) pruneOrphanedBindings(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	workloadGVR := monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ThanosRulerName)
+	workloadChecker := o.workloadChecker
+	configResourceSyncerFactory := func(workload operator.RuntimeObject) operator.BindingRemover {
+		return operator.NewConfigResourceSyncer(workload, o.dclient, o.accessor)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// prune bindings here
+			if err := operator.PruneOrphanedBindings[*monitoringv1.PrometheusRule](
+				ctx,
+				o.ruleInfs.ListAll,
+				workloadGVR,
+				workloadChecker,
+				configResourceSyncerFactory,
+			); err != nil {
+				o.logger.Error("failed to prune orphaned bindings from PrometheusRules", "err", err)
+			}
+		}
+	}
+}
+
+func (o *Operator) workloadChecker(ns, name string) (bool, error) {
+	_, err := o.thanosRulerInfs.Get(ns + "/" + name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (o *Operator) createOrUpdateWebConfigSecret(ctx context.Context, tr *monitoringv1.ThanosRuler) error {


### PR DESCRIPTION
## Description

This change implements a periodic pruning mechanism to remove non-existing workloads from the status subresources of configuration resources (ServiceMonitor, PodMonitor, PrometheusRule, etc.). This fixes the issue where bindings would persist even after the workload (like prometheus instance) was deleted.

Pruning logic is generic and has been integrated into the loop of Prometheus, Agent, Alertmanager, and Thanos Ruler operators, executing every minute. It checks the bindings in the configuration resource status against the actual workloads in the cluster and removes any that no longer exist.

Unit tests have been added to verify the pruning behavior.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #8082

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

- Added new unit tests in `pkg/operator` (`TestPruneOrphanedBindings`) covering various scenarios including orphaned, existing, and unrelated bindings.
- Verified that all unit tests pass with `go test ./pkg/operator/...`.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add pruning mechanism to clean up non-existing workloads from configuration resource status.