### PR TITLE
pkg/alertmanager: add URL validation checks for Incident.io receiver

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -6237,6 +6237,23 @@ func TestSanitizeIncidentioConfig(t *testing.T) {
 			golden: "incidentio_configs_for_supported_versions.golden",
 		},
 		{
+			name:           "incidentio_configs invalid url returns error",
+			againstVersion: versionIncidentioAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						IncidentioConfigs: []*incidentioConfig{
+							{
+								URL:              "not-a-valid-url",
+								AlertSourceToken: "token123",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
 			name:           "incidentio_configs both url and url_file set",
 			againstVersion: versionIncidentioAllowed,
 			in: &alertmanagerConfig{


### PR DESCRIPTION
## Description

This PR adds test coverage to verify URL validation logic for the Incidentio receiver in Alertmanager configuration. The validation ensures that the url field, when provided, is a well-formed URL.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->
Relates to #8193

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->

- Ran tests: `go test ./pkg/alertmanager -run TestSanitizeIncidentioConfig`
- Verified that invalid URLs return an appropriate error.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add URL validation for Incident.io receiver secrets
```
