### PR TITLE
pkg/alertmanager: add URL validation for Jira receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2887,6 +2887,11 @@ func (jc *jiraConfig) sanitize(amVersion semver.Version, logger *slog.Logger) er
 			}
 		}
 	}
+	if jc.APIURL != "" {
+		if _, err := validation.ValidateURL(jc.APIURL); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
 
 	return jc.HTTPConfig.sanitize(amVersion, logger)
 }

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -6070,6 +6070,24 @@ func TestSanitizeJiraConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:           "jira_configs invalid api_url returns error",
+			againstVersion: versionJiraAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "not-a-valid-url",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
 			name:           "jira_configs allows for supported versions",
 			againstVersion: versionJiraAllowed,
 			in: &alertmanagerConfig{


### PR DESCRIPTION
## Description

Adds URL validation for Jira receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.


Validated fields:
- `api_url`

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to #8193


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
- Added test case for invalid API URL (`jira_configs invalid api_url returns error`)
- Verified existing test cases using valid URLs pass
- All tests pass

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add URL validation for Jira receiver secrets
```
