### PR TITLE
pkg/alertmanager: add URL validation for MSTeams receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2743,6 +2743,10 @@ func (tc *msTeamsConfig) sanitize(amVersion semver.Version, logger *slog.Logger)
 		return fmt.Errorf("mandatory field %q is empty", "webhook_url")
 	}
 
+	if _, err := validation.ValidateURL(tc.WebhookURL); err != nil {
+		return fmt.Errorf("invalid 'webhook_url': %w", err)
+	}
+
 	if tc.Summary != "" && amVersion.LT(semver.MustParse("0.27.0")) {
 		msg := "'summary' supported in Alertmanager >= 0.27.0 only - dropping field `summary` from msteams config"
 		logger.Warn(msg, "current_version", amVersion.String())

--- a/pkg/alertmanager/testdata/msteams_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/msteams_valid_url_passes.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  msteams_configs:
+  - webhook_url: http://example.com/webhook
+templates: []


### PR DESCRIPTION
## Description

Adds URL validation for MSTeams receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

Validated fields:
- `webhook_url`

Relates to #8193

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->

- Added test case for invalid Webhook URL (`msteams invalid webhook_url returns error`)
- Added test case for valid Webhook URL (`msteams valid webhook_url passes validation`) with golden file
- All tests pass

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add URL validation for MSTeams receiver secrets
```
