### PR TITLE
pkg/alertmanager: add URL validation for Pushover receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2553,6 +2553,12 @@ func (poc *pushoverConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 		return errors.New("either monospace or html must be configured")
 	}
 
+	if poc.URL != "" {
+		if _, err := validation.ValidateURL(poc.URL); err != nil {
+			return fmt.Errorf("invalid 'url': %w", err)
+		}
+	}
+
 	return poc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/testdata/test_pushover_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/test_pushover_valid_url_passes.golden
@@ -1,0 +1,7 @@
+receivers:
+- name: ""
+  pushover_configs:
+  - user_key: key
+    token: token
+    url: http://example.com
+templates: []


### PR DESCRIPTION
## Description

Adds URL validation for Pushover receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

Validated fields:
- `url`

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to #8193



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->

- Added test case for valid, invalid URL (`Test invalid url returns error`, `Test valid url passes validation`) 
- All tests pass

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add URL validation for Pushover receiver secrets
```
