### PR TITLE
pkg/alertmanager: add URL validation for Telegram receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2711,6 +2711,12 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 		tc.MessageThreadID = 0
 	}
 
+	if tc.APIUrl != "" {
+		if _, err := validation.ValidateURL(tc.APIUrl); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
+
 	return tc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -6694,6 +6694,70 @@ func TestConvertHTTPConfig(t *testing.T) {
 	}
 }
 
+func TestSanitizeTelegramConfig(t *testing.T) {
+	logger := newNopLogger(t)
+	versionTelegramExampleAllowed := semver.Version{Major: 0, Minor: 26}
+
+	for _, tc := range []struct {
+		name           string
+		againstVersion semver.Version
+		in             *alertmanagerConfig
+		golden         string
+		expectErr      bool
+	}{
+		{
+			name:           "telegram invalid api_url returns error",
+			againstVersion: versionTelegramExampleAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						TelegramConfigs: []*telegramConfig{
+							{
+								APIUrl:   "not-a-valid-url",
+								BotToken: "token",
+								ChatID:   12345,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "telegram valid api_url passes validation",
+			againstVersion: versionTelegramExampleAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						TelegramConfigs: []*telegramConfig{
+							{
+								APIUrl:   "http://example.com",
+								BotToken: "token",
+								ChatID:   12345,
+							},
+						},
+					},
+				},
+			},
+			golden: "telegram_valid_url_passes.golden",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.sanitize(tc.againstVersion, logger)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			amConfigs, err := yaml.Marshal(tc.in)
+			require.NoError(t, err)
+
+			golden.Assert(t, string(amConfigs), tc.golden)
+		})
+	}
+}
+
 func newNopLogger(t *testing.T) *slog.Logger {
 	t.Helper()
 	return slog.New(slog.DiscardHandler)

--- a/pkg/alertmanager/testdata/telegram_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/telegram_valid_url_passes.golden
@@ -1,0 +1,7 @@
+receivers:
+- name: ""
+  telegram_configs:
+  - api_url: http://example.com
+    bot_token: token
+    chat_id: 12345
+templates: []


### PR DESCRIPTION
## Description

Adds URL validation for Telegram receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

Validated fields:
- `api_url`

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to #8193

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.
- Added test case for invalid API URL (`telegram invalid api_url returns error`)
- Added test case for valid API URL (`telegram valid api_url passes validation`) 
- All tests pass

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add URL validation for Telegram receiver secrets
```
