### PR TITLE
Trigger statefulset recreation on clusterTLS configuration changes

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -631,9 +631,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to synchronize the web config secret: %w", err)
 	}
 
-	// TODO(simonpasquier): the operator should take into account changes to
-	// the cluster TLS configuration to trigger a rollout of the pods (this
-	// configuration doesn't support live reload).
 	if err := c.createOrUpdateClusterTLSConfigSecret(ctx, am); err != nil {
 		return fmt.Errorf("failed to synchronize the cluster TLS config secret: %w", err)
 	}
@@ -819,6 +816,7 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *opera
 		Config                  Config
 		StatefulSetSpec         appsv1.StatefulSetSpec
 		ShardedSecret           *operator.ShardedSecret
+		ClusterTLS              *monitoringv1.ClusterTLSConfig
 	}{
 		AlertmanagerLabels:      a.Labels,
 		AlertmanagerAnnotations: a.Annotations,
@@ -827,6 +825,7 @@ func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *opera
 		Config:                  c,
 		StatefulSetSpec:         s,
 		ShardedSecret:           tlsAssets,
+		ClusterTLS:              a.Spec.ClusterTLS,
 	},
 		nil,
 	)

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -166,6 +166,48 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 
 			equal: false,
 		},
+		{
+			name: "different ClusterTLS",
+			a: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+					ClusterTLS: &monitoringv1.ClusterTLSConfig{
+						ServerTLS: monitoringv1.WebTLSConfig{
+							KeySecret: v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "server-tls-secret"},
+								Key:                  "tls.key",
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{Name: "server-tls-secret"},
+									Key:                  "tls.crt",
+								},
+							},
+						},
+						ClientTLS: monitoringv1.SafeTLSConfig{
+							KeySecret: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{Name: "client-tls-secret"},
+								Key:                  "tls.key",
+							},
+							Cert: monitoringv1.SecretOrConfigMap{
+								Secret: &v1.SecretKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{Name: "client-tls-secret"},
+									Key:                  "tls.crt",
+								},
+							},
+						},
+					},
+				},
+			},
+			b: monitoringv1.Alertmanager{
+				Spec: monitoringv1.AlertmanagerSpec{
+					Version: "v0.0.1",
+					// No ClusterTLS - should produce different hash!
+				},
+			},
+
+			equal: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			a1Hash, err := createSSetInputHash(tc.a, Config{}, &operator.ShardedSecret{}, appsv1.StatefulSetSpec{})


### PR DESCRIPTION
## Description

Include clustertls configuration in the statefulset hash so pods are recreated when cluster tls settings change. since alertmanager does not support live reload for cluster tls, restarting pods is required. this ensures pod restarts on add, update, or removal of clustertls config.

Closes: #7372 

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
- Added unit test `TestCreateStatefulSetInputHash/different_ClusterTLS` to verify that Alertmanagers with different ClusterTLS configurations produce different hashes.
- All existing unit tests pass.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Trigger Alertmanager StatefulSet recreation when ClusterTLS configuration changes.
```
