### PR TITLE
fix: incident.io config typo

### DIFF
--- a/pkg/alertmanager/testdata/incidentio_configs_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/incidentio_configs_for_supported_versions.golden
@@ -1,6 +1,6 @@
 receivers:
 - name: ""
-  incidentio_config:
+  incidentio_configs:
   - url: http://example.com
     alert_source_token: token123
 templates: []

--- a/pkg/alertmanager/testdata/incidentio_configs_with_http_authorization.golden
+++ b/pkg/alertmanager/testdata/incidentio_configs_with_http_authorization.golden
@@ -1,6 +1,6 @@
 receivers:
 - name: ""
-  incidentio_config:
+  incidentio_configs:
   - http_config:
       authorization:
         type: Bearer

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -120,7 +120,7 @@ type receiver struct {
 	JiraConfigs       []*jiraConfig       `yaml:"jira_configs,omitempty"`
 	RocketChatConfigs []*rocketChatConfig `yaml:"rocketchat_configs,omitempty"`
 	MattermostConfigs []*mattermostConfig `yaml:"mattermost_configs,omitempty"`
-	IncidentioConfigs []*incidentioConfig `yaml:"incidentio_config,omitempty"`
+	IncidentioConfigs []*incidentioConfig `yaml:"incidentio_configs,omitempty"`
 }
 
 type webhookConfig struct {


### PR DESCRIPTION
## Description
Following https://github.com/prometheus-operator/prometheus-operator/pull/8190 there as a typo in the am types for incident io, pr to fix

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
