### PR TITLE
change: use narrower selector for informers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* [CHANGE] Use narrower selectors for statefulset informers in Alertmanager and ThanosRuler controllers. It is recommended to upgrade from v0.85.0 (at least). #8246
 * [FEATURE] Add `podManagementPolicy` field for `Prometheus`, `PrometheusAgent`, `Alertmanager` and `ThanosRuler` CRDs. #8119
 * [FEATURE] Add `updateStrategy` field for `Prometheus`, `PrometheusAgent`, `Alertmanager` and `ThanosRuler` CRDs. #8202
 * [ENHANCEMENT] Use `.spec.minReadySeconds` to delay the first flush of aggregation groups in Alertmanager. #8201

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -284,17 +284,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 			c.kclient,
 			resyncPeriod,
 			func(options *metav1.ListOptions) {
-				// TODO(simonpasquier): use a more restrictive label selector
-				// selecting only Alertmanager statefulsets (e.g.
-				// "app.kubernetes.io/name in (alertmanager)").
-				//
-				// We need to wait for a couple of releases after [1] merges to
-				// ensure that the expected labels have been propagated to the
-				// Alertmanager statefulsets otherwise the informer won't
-				// select any object.
-				//
-				// [1] https://github.com/prometheus-operator/prometheus-operator/pull/7786
-				options.LabelSelector = operator.ManagedByOperatorLabelSelector()
+				options.LabelSelector = labelSelectorForStatefulSets()
 			},
 		),
 		appsv1.SchemeGroupVersion.WithResource("statefulsets"),
@@ -774,6 +764,7 @@ func (c *Operator) UpdateStatus(ctx context.Context, key string) error {
 	return nil
 }
 
+// makeSelectorLabels returns the default selector for the pods of the Alertmanager statefulset.
 func makeSelectorLabels(name string) map[string]string {
 	return map[string]string{
 		operator.ApplicationNameLabelKey:     applicationNameLabelValue,
@@ -781,6 +772,16 @@ func makeSelectorLabels(name string) map[string]string {
 		operator.ApplicationInstanceLabelKey: name,
 		"alertmanager":                       name,
 	}
+}
+
+// labelSelectorForStatefulSets returns a label selector which selects
+// all Alertmanager statefulsets.
+func labelSelectorForStatefulSets() string {
+	return fmt.Sprintf(
+		"%s in (%s),%s in (%s)",
+		operator.ManagedByLabelKey, operator.ManagedByLabelValue,
+		operator.ApplicationNameLabelKey, applicationNameLabelValue,
+	)
 }
 
 func createSSetInputHash(a monitoringv1.Alertmanager, c Config, tlsAssets *operator.ShardedSecret, s appsv1.StatefulSetSpec) (string, error) {

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -73,7 +73,8 @@ var (
 	LabelPrometheusName       = "prometheus-name"
 )
 
-// LabelSelectorForStatefulSets returns a label selector which selects statefulsets deployed with the server or agent mode.
+// LabelSelectorForStatefulSets returns a label selector which selects
+// statefulsets deployed with the server or agent mode.
 func LabelSelectorForStatefulSets(mode string) string {
 	return fmt.Sprintf(
 		"%s,%s,%s,%s in (%s)",


### PR DESCRIPTION
## Description

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
