### PR TITLE
add URL validation for Email receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2452,6 +2452,13 @@ func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		ec.AuthPasswordFile = ""
 	}
 
+	for key, value := range ec.Headers {
+		if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+			if _, err := validation.ValidateURL(value); err != nil {
+				return fmt.Errorf("invalid URL in header %q: %w", key, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -5584,6 +5584,43 @@ func TestSanitizeEmailConfig(t *testing.T) {
 	}
 }
 
+func TestSanitizeEmailConfigErrors(t *testing.T) {
+	logger := newNopLogger(t)
+
+	for _, tc := range []struct {
+		name           string
+		againstVersion semver.Version
+		in             *alertmanagerConfig
+		errorMsg       string
+	}{
+		{
+			name:           "Test invalid URL in email header fails",
+			againstVersion: semver.Version{Major: 0, Minor: 26},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						EmailConfigs: []*emailConfig{
+							{
+								To: "test@example.com",
+								Headers: map[string]string{
+									"List-Unsubscribe": "http://not a valid url with spaces",
+								},
+							},
+						},
+					},
+				},
+			},
+			errorMsg: "invalid URL in header",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.sanitize(tc.againstVersion, logger)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errorMsg)
+		})
+	}
+}
+
 func TestSanitizeVictorOpsConfig(t *testing.T) {
 	logger := newNopLogger(t)
 

--- a/pkg/alertmanager/testdata/test_email_valid_url_in_header_passes.golden
+++ b/pkg/alertmanager/testdata/test_email_valid_url_in_header_passes.golden
@@ -1,0 +1,8 @@
+receivers:
+- name: ""
+  email_configs:
+  - to: test@example.com
+    headers:
+      List-Archive: http://archive.example.com
+      List-Unsubscribe: https://example.com/unsubscribe
+templates: []


### PR DESCRIPTION
## Description
Adds URL validation for email receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.


<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to: #8193

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.
- Add test case for `SanitizeEmailConfigError`
- The test successfully passes
## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
