### PR TITLE
add URL validation for Webex receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2863,6 +2863,12 @@ func (tc *webexConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		return fmt.Errorf("mandatory field %q is empty", "room_id")
 	}
 
+	if tc.APIURL != "" {
+		if _, err := validation.ValidateURL(tc.APIURL); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
+
 	return tc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/testdata/webex_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/webex_valid_url_passes.golden
@@ -1,0 +1,6 @@
+receivers:
+- name: ""
+  webex_configs:
+  - api_url: https://webexapis.com/v1/messages
+    room_id: foo
+templates: []


### PR DESCRIPTION
## Description
Adds URL validation for Webex receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to: #8193 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.
- Add test case for Invalid URL test: Verifies that invalid URLs are caught and return an error
- Add test case for Valid URL test: Verifies that valid URLs like "https://webexapis.com/v1/messages" pass validation 
- All tests pass successfully
## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
