### PR TITLE
add URL validation for WeChat receiver

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2788,6 +2788,12 @@ func (tc *msTeamsV2Config) sanitize(amVersion semver.Version, logger *slog.Logge
 }
 
 func (wcc *weChatConfig) sanitize(amVersion semver.Version, logger *slog.Logger) error {
+	if wcc.APIURL != "" {
+		if _, err := validation.ValidateURL(wcc.APIURL); err != nil {
+			return fmt.Errorf("invalid 'api_url': %w", err)
+		}
+	}
+
 	return wcc.HTTPConfig.sanitize(amVersion, logger)
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -7211,6 +7211,68 @@ func TestSanitizeWebexConfig(t *testing.T) {
 	}
 }
 
+func TestSanitizeWeChatConfig(t *testing.T) {
+	logger := newNopLogger(t)
+	versionWeChatAllowed := semver.Version{Major: 0, Minor: 26}
+
+	for _, tc := range []struct {
+		name           string
+		againstVersion semver.Version
+		in             *alertmanagerConfig
+		golden         string
+		expectErr      bool
+	}{
+		{
+			name:           "wechat invalid api_url returns error",
+			againstVersion: versionWeChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						WeChatConfigs: []*weChatConfig{
+							{
+								APIURL: "not-a-valid-url",
+								CorpID: "foo",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "wechat valid api_url passes validation",
+			againstVersion: versionWeChatAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						WeChatConfigs: []*weChatConfig{
+							{
+								APIURL: "https://api.weixin.qq.com/cgi-bin/message/send",
+								CorpID: "foo",
+							},
+						},
+					},
+				},
+			},
+			golden: "wechat_valid_url_passes.golden",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.in.sanitize(tc.againstVersion, logger)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			amConfigs, err := yaml.Marshal(tc.in)
+			require.NoError(t, err)
+
+			golden.Assert(t, string(amConfigs), tc.golden)
+		})
+	}
+}
+
 func TestSanitizeOpsGenieConfig(t *testing.T) {
 	logger := newNopLogger(t)
 	versionOpsGenieAllowed := semver.Version{Major: 0, Minor: 25}

--- a/pkg/alertmanager/testdata/wechat_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/wechat_valid_url_passes.golden
@@ -1,0 +1,6 @@
+receivers:
+- name: ""
+  wechat_configs:
+  - api_url: https://api.weixin.qq.com/cgi-bin/message/send
+    corp_id: foo
+templates: []


### PR DESCRIPTION
## Description
Adds URL validation for WeChat receiver configuration fields when loaded from secrets. This ensures URLs are validated regardless of whether configurations come from CustomResources or secrets.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to: #8193

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.
- Add test case for Invalid URL test: Verifies that invalid URLs are caught and return an error
- Add test case for Valid URL test: Verifies that valid URLs pass validation successfully
- All test cases pass succesfully
## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
