### PR TITLE
update AlertmanagerConfig's status subresource on Alertmanager reconciliations

### DIFF
--- a/Documentation/platform/prometheus-agent.md
+++ b/Documentation/platform/prometheus-agent.md
@@ -13,9 +13,7 @@ description: Guide for running Prometheus in Agent mode
 
 {{< alert icon="👉" text="Prometheus Operator >= v0.64.0 is required."/>}}
 
-As mentioned in [Prometheus's blog](https://prometheus.io/blog/2021/11/16/agent/), Prometheus Agent
-is a deployment model optimized for environments where all collected data is forwarded to
-a long-term storage solution, e.g. Cortex, Thanos or Prometheus, that do not need storage or rule evaluation.
+As mentioned in [Prometheus's blog](https://prometheus.io/blog/2021/11/16/agent/), Prometheus Agent is a deployment model optimized for environments where all collected data is forwarded to a long-term storage solution, e.g. Cortex, Thanos or Prometheus, that do not need storage or rule evaluation.
 
 First of all, make sure that the PrometheusAgent CRD is installed in the cluster and that the operator has the proper RBAC permissions to reconcile the PrometheusAgent resources.
 
@@ -46,6 +44,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers/status
+  - alertmanagerconfigs/status
   - podmonitors/status
   - probes/status
   - prometheuses/status

--- a/Documentation/platform/rbac.md
+++ b/Documentation/platform/rbac.md
@@ -46,6 +46,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers/status
+  - alertmanagerconfigs/status
   - podmonitors/status
   - probes/status
   - prometheuses/status

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -75233,6 +75233,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers/status
+  - alertmanagerconfigs/status
   - podmonitors/status
   - probes/status
   - prometheuses/status

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -607,7 +607,17 @@ func start() int {
 	var ao *alertmanagercontroller.Operator
 	if alertmanagerSupported {
 		if cfg.Gates.Enabled(operator.StatusForConfigurationResourcesFeature) {
-			// TODO: check permissions when implementing the AlertmanagerConfig status subresource.
+			if !checkStatusSubresourcePermissions(
+				ctx,
+				logger,
+				kclient,
+				[]schema.GroupVersionResource{
+					monitoringv1alpha1.SchemeGroupVersion.WithResource(monitoringv1alpha1.AlertmanagerConfigName),
+				},
+			) {
+				cancel()
+				return 1
+			}
 			alertmanagerControllerOptions = append(alertmanagerControllerOptions, alertmanagercontroller.WithConfigResourceStatus())
 		}
 

--- a/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+++ b/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
@@ -24,6 +24,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers/status
+  - alertmanagerconfigs/status
   - podmonitors/status
   - probes/status
   - prometheuses/status

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -97,6 +97,7 @@ function(params) {
                apiGroups: ['monitoring.coreos.com'],
                resources: [
                  'alertmanagers/status',
+                 'alertmanagerconfigs/status',
                  'podmonitors/status',
                  'probes/status',
                  'prometheuses/status',

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -605,7 +605,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	logger := c.logger.With("key", key)
-	c.recordDeprecatedFields(key, logger, am)
+	logger.Info("sync alertmanager")
 
 	statusCleanup := func() error {
 		return c.configResStatusCleanup(ctx, am)
@@ -626,8 +626,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		c.reconciliations.ForgetObject(key)
 		return nil
 	}
-
-	logger.Info("sync alertmanager")
 
 	if am.Spec.Paused {
 		logger.Info("no action taken (the resource is paused)")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -34,6 +34,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/metadata"
@@ -79,6 +81,7 @@ type Config struct {
 // Operator manages the lifecycle of the Alertmanager statefulsets and their
 // configurations.
 type Operator struct {
+	dclient    dynamic.Interface
 	kclient    kubernetes.Interface
 	mdClient   metadata.Interface
 	mclient    monitoringclient.Interface
@@ -149,10 +152,16 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		return nil, fmt.Errorf("instantiating monitoring client failed: %w", err)
 	}
 
+	dclient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating dynamic client failed: %w", err)
+	}
+
 	// All the metrics exposed by the controller get the controller="alertmanager" label.
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "alertmanager"}, r)
 
 	o := &Operator{
+		dclient:    dclient,
 		kclient:    client,
 		mdClient:   mdClient,
 		mclient:    mclient,
@@ -610,7 +619,17 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
-	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {
+	amVersion, err := getAlertmanagerVersion(am)
+	if err != nil {
+		return err
+	}
+
+	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, assetStore, amVersion)
+	if err != nil {
+		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
+	}
+
+	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore, amVersion, amConfigs.ValidResources()); err != nil {
 		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
 	c.reconciliations.UpdateReferenceTracker(key, assetStore.RefTracker())
@@ -690,6 +709,26 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		logger.Info("recreating StatefulSet because the update operation wasn't possible", "reason", reason)
 	}); err != nil {
 		return err
+	}
+	err = c.updateConfigResourcesStatus(ctx, am, amConfigs)
+	return err
+}
+
+// updateConfigResourcesStatus updates the status of the selected configuration
+// resources (AlertmanagerConfigs).
+func (c *Operator) updateConfigResourcesStatus(ctx context.Context, am *monitoringv1.Alertmanager, amConfigs operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig]) error {
+	if !c.configResourcesStatusEnabled {
+		return nil
+	}
+
+	fmt.Println("update status ke andar")
+	var configResourceSyncer = operator.NewConfigResourceSyncer(am, c.dclient, c.accessor)
+
+	for key, configResource := range amConfigs {
+		fmt.Println("observed generation: ", configResource.Resource().GetGeneration())
+		if err := configResourceSyncer.UpdateBinding(ctx, configResource.Resource(), configResource.Conditions()); err != nil {
+			return fmt.Errorf("failed to update AlertmanagerConfig %s status: %w", key, err)
+		}
 	}
 
 	return nil
@@ -866,16 +905,21 @@ func (c *Operator) loadConfigurationFromSecret(ctx context.Context, am *monitori
 	return rawAlertmanagerConfig, secret.Data, nil
 }
 
-func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder) error {
+func getAlertmanagerVersion(am *monitoringv1.Alertmanager) (semver.Version, error) {
 	amVersion := operator.StringValOrDefault(am.Spec.Version, operator.DefaultAlertmanagerVersion)
 	version, err := semver.ParseTolerant(amVersion)
 	if err != nil {
-		return fmt.Errorf("failed to parse alertmanager version: %w", err)
+		return version, fmt.Errorf("failed to parse alertmanager version: %w", err)
 	}
 
 	if version.LT(semver.MustParse("0.15.0")) || version.Major > 0 {
-		return fmt.Errorf("unsupported Alertmanager version %q", amVersion)
+		return version, fmt.Errorf("unsupported Alertmanager version %q", amVersion)
 	}
+
+	return version, nil
+}
+
+func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder, version semver.Version, amConfigs map[string]*monitoringv1alpha1.AlertmanagerConfig) error {
 
 	namespacedLogger := c.logger.With("alertmanager", am.Name, "namespace", am.Namespace)
 	// If no AlertmanagerConfig selectors and AlertmanagerConfiguration are
@@ -895,11 +939,6 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 		}
 
 		return nil
-	}
-
-	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, version, store)
-	if err != nil {
-		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
 	}
 
 	var (
@@ -993,7 +1032,7 @@ func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *
 	return nil
 }
 
-func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoringv1.Alertmanager, amVersion semver.Version, store *assets.StoreBuilder) (map[string]*monitoringv1alpha1.AlertmanagerConfig, error) {
+func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder, amVersion semver.Version) (operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig], error) {
 	namespaces := []string{}
 
 	// If 'AlertmanagerConfigNamespaceSelector' is nil, only check own namespace.
@@ -1026,9 +1065,16 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 	}
 
 	for _, ns := range namespaces {
-		err := c.alrtCfgInfs.ListAllByNamespace(ns, amConfigSelector, func(obj any) {
-			k, ok := c.accessor.MetaNamespaceKey(obj)
+		err := c.alrtCfgInfs.ListAllByNamespace(ns, amConfigSelector, func(o any) {
+			k, ok := c.accessor.MetaNamespaceKey(o)
 			if !ok {
+				return
+			}
+
+			obj := o.(runtime.Object)
+			obj = obj.DeepCopyObject()
+			if err := k8sutil.AddTypeInformationToObject(obj); err != nil {
+				c.logger.Error("skipping alertmanagerconfig due to missing type information", "alertmanagerconfig", k, "namespace", am.Namespace, "alertmanager", am.Name, "err", err)
 				return
 			}
 
@@ -1045,13 +1091,19 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 		}
 	}
 
-	var rejected int
-	res := make(map[string]*monitoringv1alpha1.AlertmanagerConfig, len(amConfigs))
+	var (
+		rejected int
+		valid    []string
+		res      = make(operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig], len(amConfigs))
+	)
 
 	eventRecorder := c.newEventRecorder(am)
 	for namespaceAndName, amc := range amConfigs {
-		if err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store); err != nil {
+		var reason string
+		err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store)
+		if err != nil {
 			rejected++
+			reason = operator.InvalidConfiguration
 			c.logger.Warn(
 				"skipping alertmanagerconfig",
 				"error", err.Error(),
@@ -1060,18 +1112,14 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"alertmanager", am.Name,
 			)
 			eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
-			continue
+		} else {
+			valid = append(valid, namespaceAndName)
 		}
 
-		res[namespaceAndName] = amc
+		res[namespaceAndName] = operator.NewTypedConfigurationResource(amc, err, reason, amc.GetGeneration())
 	}
 
-	amcKeys := []string{}
-	for k := range res {
-		amcKeys = append(amcKeys, k)
-	}
-	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(amcKeys, ","), "namespace", am.Namespace, "prometheus", am.Name)
-
+	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(valid, ","), "namespace", am.Namespace, "prometheus", am.Name)
 	if amKey, ok := c.accessor.MetaNamespaceKey(am); ok {
 		c.metrics.SetSelectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, len(res))
 		c.metrics.SetRejectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, rejected)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -659,17 +659,8 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
-	amVersion, err := getAlertmanagerVersion(am)
+	amConfigs, err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore)
 	if err != nil {
-		return err
-	}
-
-	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, assetStore, amVersion)
-	if err != nil {
-		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
-	}
-
-	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore, amVersion, amConfigs.ValidResources()); err != nil {
 		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
 	c.reconciliations.UpdateReferenceTracker(key, assetStore.RefTracker())
@@ -981,9 +972,19 @@ func getAlertmanagerVersion(am *monitoringv1.Alertmanager) (semver.Version, erro
 	return version, nil
 }
 
-func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder, version semver.Version, amConfigs map[string]*monitoringv1alpha1.AlertmanagerConfig) error {
-
+func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder) (operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig], error) {
 	namespacedLogger := c.logger.With("alertmanager", am.Name, "namespace", am.Namespace)
+
+	version, err := getAlertmanagerVersion(am)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine alertmanager version: %w", err)
+	}
+
+	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, store, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select alertmanager configs: %w", err)
+	}
+
 	// If no AlertmanagerConfig selectors and AlertmanagerConfiguration are
 	// configured, the user wants to manage configuration themselves.
 	if am.Spec.AlertmanagerConfigSelector == nil && am.Spec.AlertmanagerConfiguration == nil {
@@ -992,33 +993,37 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 		amRawConfiguration, additionalData, err := c.loadConfigurationFromSecret(ctx, am)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
+			return nil, fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
 		err = c.createOrUpdateGeneratedConfigSecret(ctx, am, amRawConfiguration, additionalData)
 		if err != nil {
-			return fmt.Errorf("create or update generated config secret failed: %w", err)
+			return nil, fmt.Errorf("create or update generated config secret failed: %w", err)
 		}
 
-		return nil
+		return amConfigs, nil
 	}
 
 	var (
 		additionalData map[string][]byte
 		cfgBuilder     = NewConfigBuilder(namespacedLogger, version, store, am)
+		amConfigsMap   = make(map[string]*monitoringv1alpha1.AlertmanagerConfig)
 	)
+	for k, v := range amConfigs {
+		amConfigsMap[k] = v.Resource()
+	}
 
 	if am.Spec.AlertmanagerConfiguration != nil {
 		// Load the base configuration from the referenced AlertmanagerConfig.
 		globalAmConfig, err := c.mclient.MonitoringV1alpha1().AlertmanagerConfigs(am.Namespace).
 			Get(ctx, am.Spec.AlertmanagerConfiguration.Name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get global AlertmanagerConfig: %w", err)
+			return nil, fmt.Errorf("failed to get global AlertmanagerConfig: %w", err)
 		}
 
 		err = cfgBuilder.initializeFromAlertmanagerConfig(ctx, am.Spec.AlertmanagerConfiguration.Global, globalAmConfig)
 		if err != nil {
-			return fmt.Errorf("failed to initialize from global AlertmanagerConfig: %w", err)
+			return nil, fmt.Errorf("failed to initialize from global AlertmanagerConfig: %w", err)
 		}
 
 		for _, v := range am.Spec.AlertmanagerConfiguration.Templates {
@@ -1038,30 +1043,30 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 
 		amRawConfiguration, additionalData, err = c.loadConfigurationFromSecret(ctx, am)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve configuration from secret: %w", err)
+			return nil, fmt.Errorf("failed to retrieve configuration from secret: %w", err)
 		}
 
 		err = cfgBuilder.InitializeFromRawConfiguration(amRawConfiguration)
 		if err != nil {
-			return fmt.Errorf("failed to initialize from secret: %w", err)
+			return nil, fmt.Errorf("failed to initialize from secret: %w", err)
 		}
 	}
 
-	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigs); err != nil {
-		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
+	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigsMap); err != nil {
+		return nil, fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 
 	generatedConfig, err := cfgBuilder.MarshalJSON()
 	if err != nil {
-		return fmt.Errorf("failed to marshal configuration: %w", err)
+		return nil, fmt.Errorf("failed to marshal configuration: %w", err)
 	}
 
 	err = c.createOrUpdateGeneratedConfigSecret(ctx, am, generatedConfig, additionalData)
 	if err != nil {
-		return fmt.Errorf("failed to create or update the generated configuration secret: %w", err)
+		return nil, fmt.Errorf("failed to create or update the generated configuration secret: %w", err)
 	}
 
-	return nil
+	return amConfigs, nil
 }
 
 func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *monitoringv1.Alertmanager, conf []byte, additionalData map[string][]byte) error {

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -648,6 +648,10 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
 	}
 
+	if err := c.updateConfigResourcesStatus(ctx, am, amConfigs); err != nil {
+		logger.Warn("failed to update AlertmanagerConfig status", "err", err)
+	}
+
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore, amVersion, amConfigs.ValidResources()); err != nil {
 		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
@@ -710,7 +714,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	if newSSetInputHash == existingStatefulSet.Annotations[operator.InputHashAnnotationKey] {
 		logger.Debug("new statefulset generation inputs match current, skipping any actions")
-		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
+		return nil
 	}
 
 	ssetClient := c.kclient.AppsV1().StatefulSets(am.Namespace)
@@ -720,7 +724,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		if _, err := k8s.CreateStatefulSetOrPatchLabels(ctx, ssetClient, sset); err != nil {
 			return fmt.Errorf("failed to create statefulset: %w", err)
 		}
-		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
+		return nil
 	}
 
 	if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {
@@ -729,8 +733,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}); err != nil {
 		return err
 	}
-	err = c.updateConfigResourcesStatus(ctx, am, amConfigs)
-	return err
+	return nil
 }
 
 // updateConfigResourcesStatus updates the status of the selected configuration

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -605,22 +605,31 @@ func (c *Operator) handleNamespaceUpdate(oldo, curo any) {
 // Sync implements the operator.Syncer interface.
 func (c *Operator) Sync(ctx context.Context, key string) error {
 	c.reconciliations.ResetStatus(key)
-	err := c.sync(ctx, key)
+
+	closure, err := c.sync(ctx, key)
+	if err != nil {
+		_ = closure(ctx)
+	} else {
+		err = closure(ctx)
+	}
+
 	c.reconciliations.SetStatus(key, err)
 
 	return err
 }
 
-func (c *Operator) sync(ctx context.Context, key string) error {
+func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) error, error) {
+	closure := func(context.Context) error { return nil }
+
 	am, err := operator.GetObjectFromKey[*monitoringv1.Alertmanager](c.alrtInfs, key)
 	if err != nil {
-		return err
+		return closure, err
 	}
 
 	if am == nil {
 		c.reconciliations.ForgetObject(key)
 		// Dependent resources are cleaned up by K8s via OwnerReferences
-		return nil
+		return closure, nil
 	}
 
 	logger := c.logger.With("key", key)
@@ -632,71 +641,76 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	finalizerAdded, err := c.finalizerSyncer.Sync(ctx, am, c.rr.DeletionInProgress(am), statusCleanup)
 	if err != nil {
-		return err
+		return closure, err
 	}
 
 	if finalizerAdded {
 		// Since the object has been updated, let's trigger another sync.
 		c.rr.EnqueueForReconciliation(am)
-		return nil
+		return closure, nil
 	}
 
 	if c.rr.DeletionInProgress(am) {
 		c.reconciliations.ForgetObject(key)
-		return nil
+		return closure, nil
 	}
 
 	if am.Spec.Paused {
 		logger.Info("no action taken (the resource is paused)")
-		return nil
+		return closure, nil
 	}
 
 	c.recordDeprecatedFields(key, logger, am)
 
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, am.Spec.Storage); err != nil {
-		return err
+		return closure, err
 	}
 
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
 	amConfigs, err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore)
 	if err != nil {
-		return fmt.Errorf("provision alertmanager configuration: %w", err)
+		return closure, fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
+
+	closure = func(ctx context.Context) error {
+		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
+	}
+
 	c.reconciliations.UpdateReferenceTracker(key, assetStore.RefTracker())
 
 	tlsShardedSecret, err := operator.ReconcileShardedSecret(ctx, assetStore.TLSAssets(), c.kclient, c.newTLSAssetSecret(am))
 	if err != nil {
-		return fmt.Errorf("failed to reconcile the TLS secrets: %w", err)
+		return closure, fmt.Errorf("failed to reconcile the TLS secrets: %w", err)
 	}
 
 	if err := c.createOrUpdateWebConfigSecret(ctx, am); err != nil {
-		return fmt.Errorf("failed to synchronize the web config secret: %w", err)
+		return closure, fmt.Errorf("failed to synchronize the web config secret: %w", err)
 	}
 
 	// TODO(simonpasquier): the operator should take into account changes to
 	// the cluster TLS configuration to trigger a rollout of the pods (this
 	// configuration doesn't support live reload).
 	if err := c.createOrUpdateClusterTLSConfigSecret(ctx, am); err != nil {
-		return fmt.Errorf("failed to synchronize the cluster TLS config secret: %w", err)
+		return closure, fmt.Errorf("failed to synchronize the cluster TLS config secret: %w", err)
 	}
 
 	svcClient := c.kclient.CoreV1().Services(am.Namespace)
 	if am.Spec.ServiceName != nil {
 		selectorLabels := makeSelectorLabels(am.Name)
 		if err := k8s.EnsureCustomGoverningService(ctx, am.Namespace, *am.Spec.ServiceName, svcClient, selectorLabels); err != nil {
-			return err
+			return closure, err
 		}
 	} else {
 		// Create governing service if it doesn't exist.
 		if _, err = k8s.CreateOrUpdateService(ctx, svcClient, makeStatefulSetService(am, c.config)); err != nil {
-			return fmt.Errorf("synchronizing governing service failed: %w", err)
+			return closure, fmt.Errorf("synchronizing governing service failed: %w", err)
 		}
 	}
 
 	existingStatefulSet, err := c.getStatefulSetFromAlertmanagerKey(key)
 	if err != nil {
-		return err
+		return closure, err
 	}
 
 	shouldCreate := false
@@ -706,23 +720,23 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	if c.rr.DeletionInProgress(existingStatefulSet) {
-		return nil
+		return closure, nil
 	}
 
 	newSSetInputHash, err := createSSetInputHash(*am, c.config, tlsShardedSecret, existingStatefulSet.Spec)
 	if err != nil {
-		return err
+		return closure, err
 	}
 
 	sset, err := makeStatefulSet(logger, am, c.config, newSSetInputHash, tlsShardedSecret)
 	if err != nil {
-		return fmt.Errorf("failed to generate statefulset: %w", err)
+		return closure, fmt.Errorf("failed to generate statefulset: %w", err)
 	}
 	operator.SanitizeSTS(sset)
 
 	if newSSetInputHash == existingStatefulSet.Annotations[operator.InputHashAnnotationKey] {
 		logger.Debug("new statefulset generation inputs match current, skipping any actions")
-		return nil
+		return closure, nil
 	}
 
 	ssetClient := c.kclient.AppsV1().StatefulSets(am.Namespace)
@@ -730,19 +744,19 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		logger.Debug("no current statefulset found")
 		logger.Debug("creating statefulset")
 		if _, err := k8s.CreateStatefulSetOrPatchLabels(ctx, ssetClient, sset); err != nil {
-			return fmt.Errorf("failed to create statefulset: %w", err)
+			return closure, fmt.Errorf("failed to create statefulset: %w", err)
 		}
-		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
+		return closure, nil
 	}
 
 	if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {
 		c.metrics.StsDeleteCreateCounter().Inc()
 		logger.Info("recreating StatefulSet because the update operation wasn't possible", "reason", reason)
 	}); err != nil {
-		return err
+		return closure, err
 	}
 
-	return c.updateConfigResourcesStatus(ctx, am, amConfigs)
+	return closure, nil
 }
 
 // updateConfigResourcesStatus updates the status of the selected configuration

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -710,7 +710,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	if newSSetInputHash == existingStatefulSet.Annotations[operator.InputHashAnnotationKey] {
 		logger.Debug("new statefulset generation inputs match current, skipping any actions")
-		return nil
+		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
 	}
 
 	ssetClient := c.kclient.AppsV1().StatefulSets(am.Namespace)
@@ -720,7 +720,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		if _, err := k8s.CreateStatefulSetOrPatchLabels(ctx, ssetClient, sset); err != nil {
 			return fmt.Errorf("failed to create statefulset: %w", err)
 		}
-		return nil
+		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
 	}
 
 	if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {
@@ -740,11 +740,9 @@ func (c *Operator) updateConfigResourcesStatus(ctx context.Context, am *monitori
 		return nil
 	}
 
-	fmt.Println("update status ke andar")
 	var configResourceSyncer = operator.NewConfigResourceSyncer(am, c.dclient, c.accessor)
 
 	for key, configResource := range amConfigs {
-		fmt.Println("observed generation: ", configResource.Resource().GetGeneration())
 		if err := configResourceSyncer.UpdateBinding(ctx, configResource.Resource(), configResource.Conditions()); err != nil {
 			return fmt.Errorf("failed to update AlertmanagerConfig %s status: %w", key, err)
 		}

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -34,6 +34,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	typedauthv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/metadata"
@@ -80,6 +82,7 @@ type Config struct {
 // Operator manages the lifecycle of the Alertmanager statefulsets and their
 // configurations.
 type Operator struct {
+	dclient    dynamic.Interface
 	kclient    kubernetes.Interface
 	mdClient   metadata.Interface
 	mclient    monitoringclient.Interface
@@ -151,10 +154,16 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		return nil, fmt.Errorf("instantiating monitoring client failed: %w", err)
 	}
 
+	dclient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating dynamic client failed: %w", err)
+	}
+
 	// All the metrics exposed by the controller get the controller="alertmanager" label.
 	r = prometheus.WrapRegistererWith(prometheus.Labels{"controller": "alertmanager"}, r)
 
 	o := &Operator{
+		dclient:    dclient,
 		kclient:    client,
 		mdClient:   mdClient,
 		mclient:    mclient,
@@ -629,7 +638,17 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
-	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {
+	amVersion, err := getAlertmanagerVersion(am)
+	if err != nil {
+		return err
+	}
+
+	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, assetStore, amVersion)
+	if err != nil {
+		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
+	}
+
+	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore, amVersion, amConfigs.ValidResources()); err != nil {
 		return fmt.Errorf("provision alertmanager configuration: %w", err)
 	}
 	c.reconciliations.UpdateReferenceTracker(key, assetStore.RefTracker())
@@ -709,6 +728,26 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		logger.Info("recreating StatefulSet because the update operation wasn't possible", "reason", reason)
 	}); err != nil {
 		return err
+	}
+	err = c.updateConfigResourcesStatus(ctx, am, amConfigs)
+	return err
+}
+
+// updateConfigResourcesStatus updates the status of the selected configuration
+// resources (AlertmanagerConfigs).
+func (c *Operator) updateConfigResourcesStatus(ctx context.Context, am *monitoringv1.Alertmanager, amConfigs operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig]) error {
+	if !c.configResourcesStatusEnabled {
+		return nil
+	}
+
+	fmt.Println("update status ke andar")
+	var configResourceSyncer = operator.NewConfigResourceSyncer(am, c.dclient, c.accessor)
+
+	for key, configResource := range amConfigs {
+		fmt.Println("observed generation: ", configResource.Resource().GetGeneration())
+		if err := configResourceSyncer.UpdateBinding(ctx, configResource.Resource(), configResource.Conditions()); err != nil {
+			return fmt.Errorf("failed to update AlertmanagerConfig %s status: %w", key, err)
+		}
 	}
 
 	return nil
@@ -891,16 +930,21 @@ func (c *Operator) loadConfigurationFromSecret(ctx context.Context, am *monitori
 	return rawAlertmanagerConfig, secret.Data, nil
 }
 
-func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder) error {
+func getAlertmanagerVersion(am *monitoringv1.Alertmanager) (semver.Version, error) {
 	amVersion := operator.StringValOrDefault(am.Spec.Version, operator.DefaultAlertmanagerVersion)
 	version, err := semver.ParseTolerant(amVersion)
 	if err != nil {
-		return fmt.Errorf("failed to parse alertmanager version: %w", err)
+		return version, fmt.Errorf("failed to parse alertmanager version: %w", err)
 	}
 
 	if version.LT(semver.MustParse("0.15.0")) || version.Major > 0 {
-		return fmt.Errorf("unsupported Alertmanager version %q", amVersion)
+		return version, fmt.Errorf("unsupported Alertmanager version %q", amVersion)
 	}
+
+	return version, nil
+}
+
+func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder, version semver.Version, amConfigs map[string]*monitoringv1alpha1.AlertmanagerConfig) error {
 
 	namespacedLogger := c.logger.With("alertmanager", am.Name, "namespace", am.Namespace)
 	// If no AlertmanagerConfig selectors and AlertmanagerConfiguration are
@@ -920,11 +964,6 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 		}
 
 		return nil
-	}
-
-	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, version, store)
-	if err != nil {
-		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
 	}
 
 	var (
@@ -1018,7 +1057,7 @@ func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *
 	return nil
 }
 
-func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoringv1.Alertmanager, amVersion semver.Version, store *assets.StoreBuilder) (map[string]*monitoringv1alpha1.AlertmanagerConfig, error) {
+func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoringv1.Alertmanager, store *assets.StoreBuilder, amVersion semver.Version) (operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig], error) {
 	namespaces := []string{}
 
 	// If 'AlertmanagerConfigNamespaceSelector' is nil, only check own namespace.
@@ -1051,9 +1090,16 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 	}
 
 	for _, ns := range namespaces {
-		err := c.alrtCfgInfs.ListAllByNamespace(ns, amConfigSelector, func(obj any) {
-			k, ok := c.accessor.MetaNamespaceKey(obj)
+		err := c.alrtCfgInfs.ListAllByNamespace(ns, amConfigSelector, func(o any) {
+			k, ok := c.accessor.MetaNamespaceKey(o)
 			if !ok {
+				return
+			}
+
+			obj := o.(runtime.Object)
+			obj = obj.DeepCopyObject()
+			if err := k8sutil.AddTypeInformationToObject(obj); err != nil {
+				c.logger.Error("skipping alertmanagerconfig due to missing type information", "alertmanagerconfig", k, "namespace", am.Namespace, "alertmanager", am.Name, "err", err)
 				return
 			}
 
@@ -1070,13 +1116,19 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 		}
 	}
 
-	var rejected int
-	res := make(map[string]*monitoringv1alpha1.AlertmanagerConfig, len(amConfigs))
+	var (
+		rejected int
+		valid    []string
+		res      = make(operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig], len(amConfigs))
+	)
 
 	eventRecorder := c.newEventRecorder(am)
 	for namespaceAndName, amc := range amConfigs {
-		if err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store); err != nil {
+		var reason string
+		err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store)
+		if err != nil {
 			rejected++
+			reason = operator.InvalidConfiguration
 			c.logger.Warn(
 				"skipping alertmanagerconfig",
 				"error", err.Error(),
@@ -1084,19 +1136,14 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			eventRecorder.Eventf(amc, corev1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 
-		res[namespaceAndName] = amc
+		res[namespaceAndName] = operator.NewTypedConfigurationResource(amc, err, reason, amc.GetGeneration())
 	}
 
-	amcKeys := []string{}
-	for k := range res {
-		amcKeys = append(amcKeys, k)
-	}
-	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(amcKeys, ","), "namespace", am.Namespace, "prometheus", am.Name)
-
+	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(valid, ","), "namespace", am.Namespace, "prometheus", am.Name)
 	if amKey, ok := c.accessor.MetaNamespaceKey(am); ok {
 		c.metrics.SetSelectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, len(res))
 		c.metrics.SetRejectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, rejected)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -624,7 +624,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	logger := c.logger.With("key", key)
-	c.recordDeprecatedFields(key, logger, am)
+	logger.Info("sync alertmanager")
 
 	statusCleanup := func() error {
 		return c.configResStatusCleanup(ctx, am)
@@ -645,8 +645,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		c.reconciliations.ForgetObject(key)
 		return nil
 	}
-
-	logger.Info("sync alertmanager")
 
 	if am.Spec.Paused {
 		logger.Info("no action taken (the resource is paused)")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1007,11 +1007,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 	var (
 		additionalData map[string][]byte
 		cfgBuilder     = NewConfigBuilder(namespacedLogger, version, store, am)
-		amConfigsMap   = make(map[string]*monitoringv1alpha1.AlertmanagerConfig)
 	)
-	for k, v := range amConfigs {
-		amConfigsMap[k] = v.Resource()
-	}
 
 	if am.Spec.AlertmanagerConfiguration != nil {
 		// Load the base configuration from the referenced AlertmanagerConfig.
@@ -1052,7 +1048,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 		}
 	}
 
-	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigsMap); err != nil {
+	if err := cfgBuilder.AddAlertmanagerConfigs(ctx, amConfigs.ValidResources()); err != nil {
 		return nil, fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
 
@@ -1140,7 +1136,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 
 			obj := o.(runtime.Object)
 			obj = obj.DeepCopyObject()
-			if err := k8sutil.AddTypeInformationToObject(obj); err != nil {
+			if err := k8s.AddTypeInformationToObject(obj); err != nil {
 				c.logger.Error("skipping alertmanagerconfig due to missing type information", "alertmanagerconfig", k, "namespace", am.Namespace, "alertmanager", am.Name, "err", err)
 				return
 			}
@@ -1178,14 +1174,15 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
-			continue
+			eventRecorder.Eventf(amc, corev1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+		} else {
+			valid = append(valid, namespaceAndName)
 		}
 
 		res[namespaceAndName] = operator.NewTypedConfigurationResource(amc, err, reason, amc.GetGeneration())
 	}
 
-	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(valid, ","), "namespace", am.Namespace, "prometheus", am.Name)
+	c.logger.Debug("selected AlertmanagerConfigs", "alertmanagerconfigs", strings.Join(valid, ","), "namespace", am.Namespace, "alertmanager", am.Name)
 	if amKey, ok := c.accessor.MetaNamespaceKey(am); ok {
 		c.metrics.SetSelectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, len(res))
 		c.metrics.SetRejectedResources(amKey, monitoringv1alpha1.AlertmanagerConfigKind, rejected)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -623,6 +623,9 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
+	logger := c.logger.With("key", key)
+	c.recordDeprecatedFields(key, logger, am)
+
 	statusCleanup := func() error {
 		return c.configResStatusCleanup(ctx, am)
 	}
@@ -633,6 +636,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	if finalizerAdded {
+		// Since the object has been updated, let's trigger another sync.
 		c.rr.EnqueueForReconciliation(am)
 		return nil
 	}
@@ -642,7 +646,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger := c.logger.With("key", key)
 	logger.Info("sync alertmanager")
 
 	if am.Spec.Paused {
@@ -666,10 +669,6 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, assetStore, amVersion)
 	if err != nil {
 		return fmt.Errorf("failed to select AlertmanagerConfig objects: %w", err)
-	}
-
-	if err := c.updateConfigResourcesStatus(ctx, am, amConfigs); err != nil {
-		logger.Warn("failed to update AlertmanagerConfig status", "err", err)
 	}
 
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore, amVersion, amConfigs.ValidResources()); err != nil {
@@ -744,7 +743,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		if _, err := k8s.CreateStatefulSetOrPatchLabels(ctx, ssetClient, sset); err != nil {
 			return fmt.Errorf("failed to create statefulset: %w", err)
 		}
-		return nil
+		return c.updateConfigResourcesStatus(ctx, am, amConfigs)
 	}
 
 	if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {
@@ -753,7 +752,8 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}); err != nil {
 		return err
 	}
-	return nil
+
+	return c.updateConfigResourcesStatus(ctx, am, amConfigs)
 }
 
 // updateConfigResourcesStatus updates the status of the selected configuration

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -103,7 +103,8 @@ type Operator struct {
 	secrInfs    *informers.ForResource
 	ssetInfs    *informers.ForResource
 
-	rr *operator.ResourceReconciler
+	rr              *operator.ResourceReconciler
+	finalizerSyncer *operator.FinalizerSyncer
 
 	metrics         *operator.Metrics
 	reconciliations *operator.ReconciliationTracker
@@ -188,9 +189,15 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			Labels:                         c.Labels,
 			WatchObjectRefsInAllNamespaces: c.WatchObjectRefsInAllNamespaces,
 		},
+
+		finalizerSyncer: operator.NewNoopFinalizerSyncer(),
 	}
 	for _, opt := range options {
 		opt(o)
+	}
+
+	if o.configResourcesStatusEnabled {
+		o.finalizerSyncer = operator.NewFinalizerSyncer(mdClient, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.AlertmanagerName))
 	}
 
 	if err := o.bootstrap(ctx, c); err != nil {
@@ -616,7 +623,20 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	// Check if the Alertmanager instance is marked for deletion.
+	statusCleanup := func() error {
+		return c.configResStatusCleanup(ctx, am)
+	}
+
+	finalizerAdded, err := c.finalizerSyncer.Sync(ctx, am, c.rr.DeletionInProgress(am), statusCleanup)
+	if err != nil {
+		return err
+	}
+
+	if finalizerAdded {
+		c.rr.EnqueueForReconciliation(am)
+		return nil
+	}
+
 	if c.rr.DeletionInProgress(am) {
 		c.reconciliations.ForgetObject(key)
 		return nil
@@ -749,6 +769,24 @@ func (c *Operator) updateConfigResourcesStatus(ctx context.Context, am *monitori
 		if err := configResourceSyncer.UpdateBinding(ctx, configResource.Resource(), configResource.Conditions()); err != nil {
 			return fmt.Errorf("failed to update AlertmanagerConfig %s status: %w", key, err)
 		}
+	}
+
+	if err := operator.CleanupBindings(ctx, c.alrtCfgInfs.ListAll, amConfigs, configResourceSyncer); err != nil {
+		return fmt.Errorf("failed to remove bindings for alertmanagerConfigs: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Operator) configResStatusCleanup(ctx context.Context, am *monitoringv1.Alertmanager) error {
+	if !c.configResourcesStatusEnabled {
+		return nil
+	}
+
+	var configResourceSyncer = operator.NewConfigResourceSyncer(am, c.dclient, c.accessor)
+
+	if err := operator.CleanupBindings(ctx, c.alrtCfgInfs.ListAll, operator.TypedResourcesSelection[*monitoringv1alpha1.AlertmanagerConfig]{}, configResourceSyncer); err != nil {
+		return fmt.Errorf("failed to remove bindings for alertmanagerConfigs: %w", err)
 	}
 
 	return nil

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1609,7 +1609,11 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			require.NoError(t, err)
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
-			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store)
+			amVersion, _ := getAlertmanagerVersion(tc.am)
+
+			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
+
+			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
 
 			if !tc.ok {
 				require.Error(t, err)

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1609,11 +1609,8 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			require.NoError(t, err)
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
-			amVersion, _ := getAlertmanagerVersion(tc.am)
 
-			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
-
-			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
+			_, err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store)
 
 			if !tc.ok {
 				require.Error(t, err)

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -2243,7 +2243,11 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			require.NoError(t, err)
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
-			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store)
+			amVersion, _ := getAlertmanagerVersion(tc.am)
+
+			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
+
+			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
 
 			if !tc.ok {
 				require.Error(t, err)

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -2243,11 +2243,8 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 			require.NoError(t, err)
 
 			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
-			amVersion, _ := getAlertmanagerVersion(tc.am)
 
-			amConfigs, _ := o.selectAlertmanagerConfigs(context.Background(), tc.am, store, amVersion)
-
-			err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store, amVersion, amConfigs.ValidResources())
+			_, err = o.provisionAlertmanagerConfiguration(context.Background(), tc.am, store)
 
 			if !tc.ok {
 				require.Error(t, err)

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -64,6 +64,10 @@ type AlertmanagerConfig struct {
 	Status monitoringv1.ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
+func (l *AlertmanagerConfig) Bindings() []monitoringv1.WorkloadBinding {
+	return l.Status.Bindings
+}
+
 // AlertmanagerConfigList is a list of AlertmanagerConfig.
 // +k8s:openapi-gen=true
 type AlertmanagerConfigList struct {

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -64,6 +64,10 @@ type AlertmanagerConfig struct {
 	Status monitoringv1.ConfigResourceStatus `json:"status,omitempty,omitzero"`
 }
 
+func (l *AlertmanagerConfig) Bindings() []monitoringv1.WorkloadBinding {
+	return l.Status.Bindings
+}
+
 // AlertmanagerConfigList is a list of AlertmanagerConfig.
 // +k8s:openapi-gen=true
 type AlertmanagerConfigList struct {

--- a/pkg/operator/config_resource.go
+++ b/pkg/operator/config_resource.go
@@ -46,7 +46,7 @@ const (
 // ConfigurationResource is a type constraint that permits only the specific pointer types for configuration resources
 // selectable by Prometheus, PrometheusAgent, Alertmanager or ThanosRuler.
 type ConfigurationResource interface {
-	*monitoringv1.ServiceMonitor | *monitoringv1.PodMonitor | *monitoringv1.Probe | *monitoringv1alpha1.ScrapeConfig | *monitoringv1.PrometheusRule
+	*monitoringv1.ServiceMonitor | *monitoringv1.PodMonitor | *monitoringv1.Probe | *monitoringv1alpha1.ScrapeConfig | *monitoringv1.PrometheusRule | *monitoringv1alpha1.AlertmanagerConfig
 }
 
 // TypedConfigurationResource is a generic type that holds a configuration resource with its validation status.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -456,6 +456,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PrometheusRuleStatusSubresourceForThanosRuler":        testPrometheusRuleStatusSubresourceForThanosRuler,
 		"GarbageCollectionOfPromRuleBindingForThanosRuler":     testGarbageCollectionOfPromRuleBindingForThanosRuler,
 		"RmPromeRuleBindingDuringWorkloadDeleteForThanosRuler": testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler,
+		"AlertmanagerConfigStatusSubresource":                  testAlertmanagerConfigStatusSubresource,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -476,6 +476,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PrometheusRuleStatusSubresourceForThanosRuler":        testPrometheusRuleStatusSubresourceForThanosRuler,
 		"GarbageCollectionOfPromRuleBindingForThanosRuler":     testGarbageCollectionOfPromRuleBindingForThanosRuler,
 		"RmPromeRuleBindingDuringWorkloadDeleteForThanosRuler": testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler,
+		"AlertmanagerConfigStatusSubresource":                  testAlertmanagerConfigStatusSubresource,
 		"PrometheusTopologySharding":                           testPrometheusTopologySharding,
 	}
 

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1369,7 +1369,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1429,7 +1429,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1371,9 +1371,62 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
 	require.NoError(t, err)
 
-	// Verify binding references the correct Alertmanager
+	// Record the lastTransitionTime value.
 	binding, err := framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)
 	require.NoError(t, err, "Binding for Alertmanager should exist")
 	require.Equal(t, am.Name, binding.Name)
 	require.Equal(t, am.Namespace, binding.Namespace)
+	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	ts := cond.LastTransitionTime.String()
+	require.NotEqual(t, "", ts)
+
+	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg2",
+			Namespace: ns,
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: ptr.To("http://test2.url"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	alc.Labels["test"] = "test"
+	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	alc2.Spec.Route.Receiver = "non-existent-receiver"
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	require.NoError(t, err)
+
+	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err = framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)
+	require.NoError(t, err)
+	cond, err = framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	require.Equal(t, ts, cond.LastTransitionTime.String())
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1369,7 +1369,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1408,7 +1408,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 3*time.Minute)
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 10*time.Minute)
 	require.NoError(t, err)
 
 	// Update the labels of the first AlertmanagerConfig. A label update doesn't
@@ -1425,11 +1425,11 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The second AlertmanagerConfig should change to Accepted=False.
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 3*time.Minute)
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 10*time.Minute)
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1369,7 +1369,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1408,7 +1408,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 3*time.Minute)
 	require.NoError(t, err)
 
 	// Update the labels of the first AlertmanagerConfig. A label update doesn't
@@ -1425,11 +1425,11 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The second AlertmanagerConfig should change to Accepted=False.
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 3*time.Minute)
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1355,7 +1354,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 					Name: "default",
 					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 						{
-							URL: ptr.To("http://test.url"),
+							URL: new("http://test.url"),
 						},
 					},
 				},

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
@@ -1303,4 +1304,135 @@ func testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler(t *testing.T) {
 
 	_, err = framework.WaitForRuleWorkloadBindingCleanup(ctx, pr, tr, monitoringv1.ThanosRulerName, 1*time.Minute)
 	require.NoError(t, err)
+}
+
+// testAlertmanagerConfigStatusSubresource validates AlertmanagerConfig status updates upon Alertmanager selection.
+func testAlertmanagerConfigStatusSubresource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.StatusForConfigurationResourcesFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	name := "am-cfg-status-subresource-test"
+
+	am := framework.MakeBasicAlertmanager(ns, name, 1)
+	am.Spec.AlertmanagerConfigSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"group": name,
+		},
+	}
+
+	_, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, am)
+	require.NoError(t, err)
+
+	// Create a first AlertmanagerConfig to check that the operator only updates the binding when needed.
+	alc1 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg1",
+			Namespace: ns,
+			Labels:    map[string]string{},
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: func(s string) *monitoringv1alpha1.URL {
+								u := monitoringv1alpha1.URL(s)
+								return &u
+							}("http://test.url"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc1.Labels["group"] = name
+
+	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc1, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Record the lastTransitionTime value.
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	require.NoError(t, err)
+	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	ts := cond.LastTransitionTime.String()
+	require.NotEqual(t, "", ts)
+
+	// Create a second AlertmanagerConfig to check that the operator updates the binding when the condition changes.
+	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg2",
+			Namespace: ns,
+			Labels:    map[string]string{},
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: func(s string) *monitoringv1alpha1.URL {
+								u := monitoringv1alpha1.URL(s)
+								return &u
+							}("http://test.url"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc2.Labels["group"] = name
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	// Update the labels of the first AlertmanagerConfig. A label update doesn't
+	// change the status of the AlertmanagerConfig and the observed timestamp
+	// should be the same as before.
+	alc1.Labels["test"] = "test"
+	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc1, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Update the second AlertmanagerConfig to have an invalid rule expression.
+	invalidURL := monitoringv1alpha1.URL("//invalid-url")
+	alc2.Spec.Receivers[0].WebhookConfigs[0].URL = &invalidURL
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The second AlertmanagerConfig should change to Accepted=False.
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	require.NoError(t, err)
+
+	// The first AlertmanagerConfig should remain unchanged.
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	require.NoError(t, err)
+	cond, err = framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	require.Equal(t, ts, cond.LastTransitionTime.String())
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1336,12 +1336,14 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	_, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, am)
 	require.NoError(t, err)
 
-	// Create a first AlertmanagerConfig to check that the operator only updates the binding when needed.
-	alc1 := &monitoringv1alpha1.AlertmanagerConfig{
+	// Create an AlertmanagerConfig with valid configuration
+	alc := &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "amcfg1",
 			Namespace: ns,
-			Labels:    map[string]string{},
+			Labels: map[string]string{
+				"group": name,
+			},
 		},
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
@@ -1362,77 +1364,28 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 			},
 		},
 	}
-	alc1.Labels["group"] = name
 
-	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc1, v1.CreateOptions{})
+	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
+	// Wait briefly for operator to process the config
+	time.Sleep(5 * time.Second)
+
+	// Verify the status was updated with a binding
+	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Get(ctx, alc.Name, v1.GetOptions{})
 	require.NoError(t, err)
-	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
-	require.NoError(t, err)
+
+	// Check that status bindings were created
+	require.NotEmpty(t, alc.Status.Bindings, "AlertmanagerConfig should have status bindings")
+
+	// Verify binding references the correct Alertmanager
+	binding, err := framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	require.NoError(t, err, "Binding for Alertmanager should exist")
+	require.Equal(t, am.Name, binding.Name)
+	require.Equal(t, am.Namespace, binding.Namespace)
+
+	// Verify Accepted condition is set
 	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
-	require.NoError(t, err)
-	ts := cond.LastTransitionTime.String()
-	require.NotEqual(t, "", ts)
-
-	// Create a second AlertmanagerConfig to check that the operator updates the binding when the condition changes.
-	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "amcfg2",
-			Namespace: ns,
-			Labels:    map[string]string{},
-		},
-		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
-			Route: &monitoringv1alpha1.Route{
-				Receiver: "default",
-			},
-			Receivers: []monitoringv1alpha1.Receiver{
-				{
-					Name: "default",
-					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
-						{
-							URL: func(s string) *monitoringv1alpha1.URL {
-								u := monitoringv1alpha1.URL(s)
-								return &u
-							}("http://test.url"),
-						},
-					},
-				},
-			},
-		},
-	}
-	alc2.Labels["group"] = name
-	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
-	require.NoError(t, err)
-
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 10*time.Minute)
-	require.NoError(t, err)
-
-	// Update the labels of the first AlertmanagerConfig. A label update doesn't
-	// change the status of the AlertmanagerConfig and the observed timestamp
-	// should be the same as before.
-	alc1.Labels["test"] = "test"
-	alc1, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc1, v1.UpdateOptions{})
-	require.NoError(t, err)
-
-	// Update the second AlertmanagerConfig to have an invalid rule expression.
-	invalidURL := monitoringv1alpha1.URL("//invalid-url")
-	alc2.Spec.Receivers[0].WebhookConfigs[0].URL = &invalidURL
-	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
-	require.NoError(t, err)
-
-	// The second AlertmanagerConfig should change to Accepted=False.
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 10*time.Minute)
-	require.NoError(t, err)
-
-	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
-	require.NoError(t, err)
-	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
-	require.NoError(t, err)
-	cond, err = framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
-	require.NoError(t, err)
-	require.Equal(t, ts, cond.LastTransitionTime.String())
+	require.NoError(t, err, "Accepted condition should exist")
+	require.Equal(t, monitoringv1.ConditionTrue, cond.Status)
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1368,7 +1368,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1407,7 +1407,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 3*time.Minute)
 	require.NoError(t, err)
 
 	// Update the labels of the first AlertmanagerConfig. A label update doesn't
@@ -1424,11 +1424,11 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The second AlertmanagerConfig should change to Accepted=False.
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 3*time.Minute)
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1363,7 +1363,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 		},
 	}
 
-	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc, v1.CreateOptions{})
+	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Wait for the AlertmanagerConfig to be accepted by the Alertmanager

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1354,10 +1355,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 					Name: "default",
 					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 						{
-							URL: func(s string) *monitoringv1alpha1.URL {
-								u := monitoringv1alpha1.URL(s)
-								return &u
-							}("http://test.url"),
+							URL: ptr.To("http://test.url"),
 						},
 					},
 				},
@@ -1368,24 +1366,13 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Wait briefly for operator to process the config
-	time.Sleep(5 * time.Second)
-
-	// Verify the status was updated with a binding
-	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Get(ctx, alc.Name, v1.GetOptions{})
+	// Wait for the AlertmanagerConfig to be accepted by the Alertmanager
+	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
 	require.NoError(t, err)
 
-	// Check that status bindings were created
-	require.NotEmpty(t, alc.Status.Bindings, "AlertmanagerConfig should have status bindings")
-
 	// Verify binding references the correct Alertmanager
-	binding, err := framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
+	binding, err := framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)
 	require.NoError(t, err, "Binding for Alertmanager should exist")
 	require.Equal(t, am.Name, binding.Name)
 	require.Equal(t, am.Namespace, binding.Namespace)
-
-	// Verify Accepted condition is set
-	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
-	require.NoError(t, err, "Accepted condition should exist")
-	require.Equal(t, monitoringv1.ConditionTrue, cond.Status)
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1368,7 +1368,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1428,7 +1428,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 2*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1370,9 +1370,62 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
 	require.NoError(t, err)
 
-	// Verify binding references the correct Alertmanager
+	// Record the lastTransitionTime value.
 	binding, err := framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)
 	require.NoError(t, err, "Binding for Alertmanager should exist")
 	require.Equal(t, am.Name, binding.Name)
 	require.Equal(t, am.Namespace, binding.Namespace)
+	cond, err := framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	ts := cond.LastTransitionTime.String()
+	require.NotEqual(t, "", ts)
+
+	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "amcfg2",
+			Namespace: ns,
+			Labels: map[string]string{
+				"group": name,
+			},
+		},
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			Route: &monitoringv1alpha1.Route{
+				Receiver: "default",
+			},
+			Receivers: []monitoringv1alpha1.Receiver{
+				{
+					Name: "default",
+					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
+						{
+							URL: ptr.To("http://test2.url"),
+						},
+					},
+				},
+			},
+		},
+	}
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+
+	alc.Labels["test"] = "test"
+	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	alc2.Spec.Route.Receiver = "non-existent-receiver"
+	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
+	require.NoError(t, err)
+
+	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
+	require.NoError(t, err)
+	binding, err = framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)
+	require.NoError(t, err)
+	cond, err = framework.GetConfigResourceCondition(binding.Conditions, monitoringv1.Accepted)
+	require.NoError(t, err)
+	require.Equal(t, ts, cond.LastTransitionTime.String())
 }

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1368,7 +1368,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
 	require.NoError(t, err)
 	binding, err := framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)
@@ -1407,7 +1407,7 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
 	require.NoError(t, err)
 
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 3*time.Minute)
+	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 10*time.Minute)
 	require.NoError(t, err)
 
 	// Update the labels of the first AlertmanagerConfig. A label update doesn't
@@ -1424,11 +1424,11 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The second AlertmanagerConfig should change to Accepted=False.
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 3*time.Minute)
+	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 10*time.Minute)
 	require.NoError(t, err)
 
 	// The first AlertmanagerConfig should remain unchanged.
-	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 5*time.Minute)
+	alc1, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc1, am, monitoringv1alpha1.AlertmanagerConfigName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 18*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc1.Status.Bindings, am, monitoringv1alpha1.AlertmanagerConfigName)
 	require.NoError(t, err)

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -1380,47 +1380,6 @@ func testAlertmanagerConfigStatusSubresource(t *testing.T) {
 	ts := cond.LastTransitionTime.String()
 	require.NotEqual(t, "", ts)
 
-	alc2 := &monitoringv1alpha1.AlertmanagerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "amcfg2",
-			Namespace: ns,
-			Labels: map[string]string{
-				"group": name,
-			},
-		},
-		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
-			Route: &monitoringv1alpha1.Route{
-				Receiver: "default",
-			},
-			Receivers: []monitoringv1alpha1.Receiver{
-				{
-					Name: "default",
-					WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
-						{
-							URL: ptr.To("http://test2.url"),
-						},
-					},
-				},
-			},
-		},
-	}
-	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, alc2, v1.CreateOptions{})
-	require.NoError(t, err)
-
-	alc2, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
-	require.NoError(t, err)
-
-	alc.Labels["test"] = "test"
-	alc, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc, v1.UpdateOptions{})
-	require.NoError(t, err)
-
-	alc2.Spec.Route.Receiver = "non-existent-receiver"
-	alc2, err = framework.MonClientV1alpha1.AlertmanagerConfigs(ns).Update(ctx, alc2, v1.UpdateOptions{})
-	require.NoError(t, err)
-
-	_, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc2, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionFalse, 1*time.Minute)
-	require.NoError(t, err)
-
 	alc, err = framework.WaitForAlertmanagerConfigCondition(ctx, alc, am, monitoringv1.AlertmanagerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
 	require.NoError(t, err)
 	binding, err = framework.GetWorkloadBinding(alc.Status.Bindings, am, monitoringv1.AlertmanagerName)

--- a/test/framework/alertmanager_config.go
+++ b/test/framework/alertmanager_config.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+)
+
+func (f *Framework) WaitForAlertmanagerConfigCondition(ctx context.Context, alc *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, conditionType monitoringv1.ConditionType, conditionStatus monitoringv1.ConditionStatus, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	var current *monitoringv1alpha1.AlertmanagerConfig
+
+	if err := f.WaitForConfigResourceCondition(
+		ctx,
+		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
+			var err error
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(alc.Namespace).Get(ctx, alc.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return current.Status.Bindings, nil
+		},
+		workload,
+		resource,
+		conditionType,
+		conditionStatus,
+		timeout,
+	); err != nil {
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", alc.Namespace, alc.Name, err)
+	}
+	return current, nil
+}
+
+func (f *Framework) WaitForAlertmanagerConfigWorkloadBindingCleanup(ctx context.Context, alc *monitoringv1alpha1.AlertmanagerConfig, workload metav1.Object, resource string, timeout time.Duration) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	var current *monitoringv1alpha1.AlertmanagerConfig
+
+	if err := f.WaitForConfigResWorkloadBindingCleanup(
+		ctx,
+		func(ctx context.Context) ([]monitoringv1.WorkloadBinding, error) {
+			var err error
+			current, err = f.MonClientV1alpha1.AlertmanagerConfigs(alc.Namespace).Get(ctx, alc.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return current.Status.Bindings, nil
+		},
+		workload,
+		resource,
+		timeout,
+	); err != nil {
+		return nil, fmt.Errorf("alertmanagerConfig status %v/%v failed to reach expected condition: %w", alc.Namespace, alc.Name, err)
+	}
+	return current, nil
+}

--- a/test/framework/alertmanager_config.go
+++ b/test/framework/alertmanager_config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The prometheus-operator Authors
+// Copyright The prometheus-operator Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
update AlertmanagerConfig's status subresource on Alertmanager reconciliations ( an updated pull request version with all the changes fixed of #8148)


Closes: #7996

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
