### PR TITLE
Feat: Add validations to Email Receiver in Alertmanager Config

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1020,6 +1020,7 @@ spec:
                             description: |-
                               authIdentity defines the identity to use for SMTP authentication.
                               This is typically used with PLAIN authentication mechanism.
+                            minLength: 1
                             type: string
                           authPassword:
                             description: |-
@@ -1080,11 +1081,13 @@ spec:
                             description: |-
                               authUsername defines the username to use for SMTP authentication.
                               This is used for SMTP AUTH when the server requires authentication.
+                            minLength: 1
                             type: string
                           from:
                             description: |-
                               from defines the sender address for email notifications.
                               This appears as the "From" field in the email header.
+                            minLength: 1
                             type: string
                           headers:
                             description: |-
@@ -1114,11 +1117,13 @@ spec:
                             description: |-
                               hello defines the hostname to identify to the SMTP server.
                               This is used in the SMTP HELO/EHLO command during the connection handshake.
+                            minLength: 1
                             type: string
                           html:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
+                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-
@@ -1133,11 +1138,13 @@ spec:
                             description: |-
                               smarthost defines the SMTP host and port through which emails are sent.
                               Format should be "hostname:port", e.g. "smtp.example.com:587".
+                            minLength: 1
                             type: string
                           text:
                             description: |-
                               text defines the plain text body of the email notification.
                               This provides a fallback for email clients that don't support HTML.
+                            minLength: 1
                             type: string
                           tlsConfig:
                             description: |-
@@ -1312,6 +1319,7 @@ spec:
                             description: |-
                               to defines the email address to send notifications to.
                               This is the recipient address for alert notifications.
+                            minLength: 1
                             type: string
                         type: object
                       type: array
@@ -13182,6 +13190,7 @@ spec:
                             description: |-
                               authIdentity defines the identity to use for SMTP authentication.
                               This is typically used with PLAIN authentication mechanism.
+                            minLength: 1
                             type: string
                           authPassword:
                             description: |-
@@ -13228,11 +13237,13 @@ spec:
                             description: |-
                               authUsername defines the username to use for SMTP authentication.
                               This is used for SMTP AUTH when the server requires authentication.
+                            minLength: 1
                             type: string
                           from:
                             description: |-
                               from defines the sender address for email notifications.
                               This appears as the "From" field in the email header.
+                            minLength: 1
                             type: string
                           headers:
                             description: |-
@@ -13261,11 +13272,13 @@ spec:
                             description: |-
                               hello defines the hostname to identify to the SMTP server.
                               This is used in the SMTP HELO/EHLO command during the connection handshake.
+                            minLength: 1
                             type: string
                           html:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
+                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-
@@ -13280,11 +13293,13 @@ spec:
                             description: |-
                               smarthost defines the SMTP host and port through which emails are sent.
                               Format should be "hostname:port", e.g. "smtp.example.com:587".
+                            minLength: 1
                             type: string
                           text:
                             description: |-
                               text defines the plain text body of the email notification.
                               This provides a fallback for email clients that don't support HTML.
+                            minLength: 1
                             type: string
                           tlsConfig:
                             description: |-
@@ -13459,6 +13474,7 @@ spec:
                             description: |-
                               to defines the email address to send notifications to.
                               This is the recipient address for alert notifications.
+                            minLength: 1
                             type: string
                         type: object
                       type: array

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1123,7 +1123,6 @@ spec:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
-                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-
@@ -13278,7 +13277,6 @@ spec:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
-                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1021,6 +1021,7 @@ spec:
                             description: |-
                               authIdentity defines the identity to use for SMTP authentication.
                               This is typically used with PLAIN authentication mechanism.
+                            minLength: 1
                             type: string
                           authPassword:
                             description: |-
@@ -1081,11 +1082,13 @@ spec:
                             description: |-
                               authUsername defines the username to use for SMTP authentication.
                               This is used for SMTP AUTH when the server requires authentication.
+                            minLength: 1
                             type: string
                           from:
                             description: |-
                               from defines the sender address for email notifications.
                               This appears as the "From" field in the email header.
+                            minLength: 1
                             type: string
                           headers:
                             description: |-
@@ -1115,11 +1118,13 @@ spec:
                             description: |-
                               hello defines the hostname to identify to the SMTP server.
                               This is used in the SMTP HELO/EHLO command during the connection handshake.
+                            minLength: 1
                             type: string
                           html:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
+                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-
@@ -1134,11 +1139,13 @@ spec:
                             description: |-
                               smarthost defines the SMTP host and port through which emails are sent.
                               Format should be "hostname:port", e.g. "smtp.example.com:587".
+                            minLength: 1
                             type: string
                           text:
                             description: |-
                               text defines the plain text body of the email notification.
                               This provides a fallback for email clients that don't support HTML.
+                            minLength: 1
                             type: string
                           tlsConfig:
                             description: |-
@@ -1313,6 +1320,7 @@ spec:
                             description: |-
                               to defines the email address to send notifications to.
                               This is the recipient address for alert notifications.
+                            minLength: 1
                             type: string
                         type: object
                       type: array

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -1124,7 +1124,6 @@ spec:
                             description: |-
                               html defines the HTML body of the email notification.
                               This allows for rich formatting in the email content.
-                            minLength: 1
                             type: string
                           requireTLS:
                             description: |-

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -1047,7 +1047,6 @@
                               },
                               "html": {
                                 "description": "html defines the HTML body of the email notification.\nThis allows for rich formatting in the email content.",
-                                "minLength": 1,
                                 "type": "string"
                               },
                               "requireTLS": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -957,6 +957,7 @@
                             "properties": {
                               "authIdentity": {
                                 "description": "authIdentity defines the identity to use for SMTP authentication.\nThis is typically used with PLAIN authentication mechanism.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "authPassword": {
@@ -1007,10 +1008,12 @@
                               },
                               "authUsername": {
                                 "description": "authUsername defines the username to use for SMTP authentication.\nThis is used for SMTP AUTH when the server requires authentication.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "from": {
                                 "description": "from defines the sender address for email notifications.\nThis appears as the \"From\" field in the email header.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "headers": {
@@ -1039,10 +1042,12 @@
                               },
                               "hello": {
                                 "description": "hello defines the hostname to identify to the SMTP server.\nThis is used in the SMTP HELO/EHLO command during the connection handshake.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "html": {
                                 "description": "html defines the HTML body of the email notification.\nThis allows for rich formatting in the email content.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "requireTLS": {
@@ -1055,10 +1060,12 @@
                               },
                               "smarthost": {
                                 "description": "smarthost defines the SMTP host and port through which emails are sent.\nFormat should be \"hostname:port\", e.g. \"smtp.example.com:587\".",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "text": {
                                 "description": "text defines the plain text body of the email notification.\nThis provides a fallback for email clients that don't support HTML.",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "tlsConfig": {
@@ -1224,6 +1231,7 @@
                               },
                               "to": {
                                 "description": "to defines the email address to send notifications to.\nThis is the recipient address for alert notifications.",
+                                "minLength": 1,
                                 "type": "string"
                               }
                             },

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -897,7 +897,6 @@
                           },
                           html: {
                             description: 'html defines the HTML body of the email notification.\nThis allows for rich formatting in the email content.',
-                            minLength: 1,
                             type: 'string',
                           },
                           requireTLS: {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -814,6 +814,7 @@
                         properties: {
                           authIdentity: {
                             description: 'authIdentity defines the identity to use for SMTP authentication.\nThis is typically used with PLAIN authentication mechanism.',
+                            minLength: 1,
                             type: 'string',
                           },
                           authPassword: {
@@ -858,10 +859,12 @@
                           },
                           authUsername: {
                             description: 'authUsername defines the username to use for SMTP authentication.\nThis is used for SMTP AUTH when the server requires authentication.',
+                            minLength: 1,
                             type: 'string',
                           },
                           from: {
                             description: 'from defines the sender address for email notifications.\nThis appears as the "From" field in the email header.',
+                            minLength: 1,
                             type: 'string',
                           },
                           headers: {
@@ -889,10 +892,12 @@
                           },
                           hello: {
                             description: 'hello defines the hostname to identify to the SMTP server.\nThis is used in the SMTP HELO/EHLO command during the connection handshake.',
+                            minLength: 1,
                             type: 'string',
                           },
                           html: {
                             description: 'html defines the HTML body of the email notification.\nThis allows for rich formatting in the email content.',
+                            minLength: 1,
                             type: 'string',
                           },
                           requireTLS: {
@@ -905,10 +910,12 @@
                           },
                           smarthost: {
                             description: 'smarthost defines the SMTP host and port through which emails are sent.\nFormat should be "hostname:port", e.g. "smtp.example.com:587".',
+                            minLength: 1,
                             type: 'string',
                           },
                           text: {
                             description: "text defines the plain text body of the email notification.\nThis provides a fallback for email clients that don't support HTML.",
+                            minLength: 1,
                             type: 'string',
                           },
                           tlsConfig: {
@@ -1074,6 +1081,7 @@
                           },
                           to: {
                             description: 'to defines the email address to send notifications to.\nThis is the recipient address for alert notifications.',
+                            minLength: 1,
                             type: 'string',
                           },
                         },

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1216,30 +1216,30 @@ func (cb *ConfigBuilder) convertWebexConfig(ctx context.Context, in monitoringv1
 func (cb *ConfigBuilder) convertEmailConfig(ctx context.Context, in monitoringv1alpha1.EmailConfig, crKey types.NamespacedName) (*emailConfig, error) {
 	out := &emailConfig{
 		VSendResolved: in.SendResolved,
-		To:            in.To,
-		From:          in.From,
-		Hello:         in.Hello,
-		AuthUsername:  in.AuthUsername,
-		AuthIdentity:  in.AuthIdentity,
+		To:            ptr.Deref(in.To, ""),
+		From:          ptr.Deref(in.From, ""),
+		Hello:         ptr.Deref(in.Hello, ""),
+		AuthUsername:  ptr.Deref(in.AuthUsername, ""),
+		AuthIdentity:  ptr.Deref(in.AuthIdentity, ""),
 		HTML:          in.HTML,
 		Text:          in.Text,
 		RequireTLS:    in.RequireTLS,
 	}
 
-	if in.Smarthost == "" {
+	if ptr.Deref(in.Smarthost, "") == "" {
 		if cb.cfg.Global == nil || cb.cfg.Global.SMTPSmarthost.Host == "" {
 			return nil, fmt.Errorf("SMTP smarthost is a mandatory field, it is neither specified at global config nor at receiver level")
 		}
 	}
 
-	if in.From == "" {
+	if ptr.Deref(in.From, "") == "" {
 		if cb.cfg.Global == nil || cb.cfg.Global.SMTPFrom == "" {
 			return nil, fmt.Errorf("SMTP from is a mandatory field, it is neither specified at global config nor at receiver level")
 		}
 	}
 
-	if in.Smarthost != "" {
-		out.Smarthost.Host, out.Smarthost.Port, _ = net.SplitHostPort(in.Smarthost)
+	if ptr.Deref(in.Smarthost, "") != "" {
+		out.Smarthost.Host, out.Smarthost.Port, _ = net.SplitHostPort(*in.Smarthost)
 	}
 
 	if in.AuthPassword != nil {

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -875,10 +875,10 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 							EmailConfigs: []monitoringv1alpha1.EmailConfig{
 								{
 									SendResolved: ptr.To(true),
-									Smarthost:    "abc:1234",
-									From:         "a",
-									To:           "b",
-									AuthUsername: "foo",
+									Smarthost:    ptr.To("abc:1234"),
+									From:         ptr.To("a"),
+									To:           ptr.To("b"),
+									AuthUsername: ptr.To("foo"),
 								},
 							},
 						},
@@ -3698,9 +3698,9 @@ func TestGenerateConfig(t *testing.T) {
 								Name: "test",
 								EmailConfigs: []monitoringv1alpha1.EmailConfig{
 									{
-										Smarthost: "example.com:25",
-										From:      "admin@example.com",
-										To:        "customers@example.com",
+										Smarthost: ptr.To("example.com:25"),
+										From:      ptr.To("admin@example.com"),
+										To:        ptr.To("customers@example.com"),
 									},
 								},
 							},
@@ -3735,8 +3735,8 @@ func TestGenerateConfig(t *testing.T) {
 								Name: "test",
 								EmailConfigs: []monitoringv1alpha1.EmailConfig{
 									{
-										From: "admin@example.com",
-										To:   "customers@example.com",
+										From: ptr.To("admin@example.com"),
+										To:   ptr.To("customers@example.com"),
 									},
 								},
 							},
@@ -3771,8 +3771,8 @@ func TestGenerateConfig(t *testing.T) {
 								Name: "test",
 								EmailConfigs: []monitoringv1alpha1.EmailConfig{
 									{
-										From: "admin@example.com",
-										To:   "customers@example.com",
+										From: ptr.To("admin@example.com"),
+										To:   ptr.To("customers@example.com"),
 									},
 								},
 							},
@@ -3814,7 +3814,7 @@ func TestGenerateConfig(t *testing.T) {
 								Name: "test",
 								EmailConfigs: []monitoringv1alpha1.EmailConfig{
 									{
-										To: "customers@example.com",
+										To: ptr.To("customers@example.com"),
 									},
 								},
 							},

--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 )
@@ -258,12 +260,12 @@ func validateWechatConfigs(configs []monitoringv1alpha1.WeChatConfig) error {
 
 func validateEmailConfig(configs []monitoringv1alpha1.EmailConfig) error {
 	for _, config := range configs {
-		if config.To == "" {
+		if ptr.Deref(config.To, "") == "" {
 			return errors.New("missing 'to' address")
 		}
 
-		if config.Smarthost != "" {
-			_, _, err := net.SplitHostPort(config.Smarthost)
+		if ptr.Deref(config.Smarthost, "") != "" {
+			_, _, err := net.SplitHostPort(*config.Smarthost)
 			if err != nil {
 				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
 			}

--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -267,7 +267,7 @@ func validateEmailConfig(configs []monitoringv1alpha1.EmailConfig) error {
 		if ptr.Deref(config.Smarthost, "") != "" {
 			_, _, err := net.SplitHostPort(*config.Smarthost)
 			if err != nil {
-				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
+				return fmt.Errorf("invalid 'smarthost' %s: %w", *config.Smarthost, err)
 			}
 		}
 

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -244,7 +244,7 @@ func validateEmailConfig(configs []monitoringv1beta1.EmailConfig) error {
 		if ptr.Deref(config.Smarthost, "") != "" {
 			_, _, err := net.SplitHostPort(*config.Smarthost)
 			if err != nil {
-				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
+				return fmt.Errorf("invalid 'smarthost' %s: %w", *config.Smarthost, err)
 			}
 		}
 

--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/prometheus-operator/prometheus-operator/pkg/alertmanager/validation"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 )
@@ -235,12 +237,12 @@ func validateWechatConfigs(configs []monitoringv1beta1.WeChatConfig) error {
 
 func validateEmailConfig(configs []monitoringv1beta1.EmailConfig) error {
 	for _, config := range configs {
-		if config.To == "" {
+		if ptr.Deref(config.To, "") == "" {
 			return errors.New("missing 'to' address")
 		}
 
-		if config.Smarthost != "" {
-			_, _, err := net.SplitHostPort(config.Smarthost)
+		if ptr.Deref(config.Smarthost, "") != "" {
+			_, _, err := net.SplitHostPort(*config.Smarthost)
 			if err != nil {
 				return fmt.Errorf("invalid 'smarthost' %s: %w", config.Smarthost, err)
 			}

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -172,8 +172,8 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							EmailConfigs: []monitoringv1beta1.EmailConfig{
 								{
-									To:        "a",
-									Smarthost: "invalid",
+									To:        ptr.To("a"),
+									Smarthost: ptr.To("invalid"),
 								},
 							},
 						},
@@ -531,8 +531,8 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 							},
 							EmailConfigs: []monitoringv1beta1.EmailConfig{
 								{
-									To:        "a",
-									Smarthost: "b:8080",
+									To:        ptr.To("a"),
+									Smarthost: ptr.To("b:8080"),
 									Headers: []monitoringv1beta1.KeyValue{
 										{
 											Key:   "c",

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -963,7 +963,6 @@ type EmailConfig struct {
 	Headers []KeyValue `json:"headers,omitempty"`
 	// html defines the HTML body of the email notification.
 	// This allows for rich formatting in the email content.
-	// +kubebuilder:validation:MinLength=1
 	// +optional
 	HTML *string `json:"html,omitempty"`
 	// text defines the plain text body of the email notification.

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -917,24 +917,29 @@ type EmailConfig struct {
 	SendResolved *bool `json:"sendResolved,omitempty"` // nolint:kubeapilinter
 	// to defines the email address to send notifications to.
 	// This is the recipient address for alert notifications.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	To string `json:"to,omitempty"`
+	To *string `json:"to,omitempty"`
 	// from defines the sender address for email notifications.
 	// This appears as the "From" field in the email header.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	From string `json:"from,omitempty"`
+	From *string `json:"from,omitempty"`
 	// hello defines the hostname to identify to the SMTP server.
 	// This is used in the SMTP HELO/EHLO command during the connection handshake.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	Hello string `json:"hello,omitempty"`
+	Hello *string `json:"hello,omitempty"`
 	// smarthost defines the SMTP host and port through which emails are sent.
 	// Format should be "hostname:port", e.g. "smtp.example.com:587".
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	Smarthost string `json:"smarthost,omitempty"`
+	Smarthost *string `json:"smarthost,omitempty"`
 	// authUsername defines the username to use for SMTP authentication.
 	// This is used for SMTP AUTH when the server requires authentication.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	AuthUsername string `json:"authUsername,omitempty"`
+	AuthUsername *string `json:"authUsername,omitempty"`
 	// authPassword defines the secret's key that contains the password to use for authentication.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
@@ -948,8 +953,9 @@ type EmailConfig struct {
 	AuthSecret *v1.SecretKeySelector `json:"authSecret,omitempty"`
 	// authIdentity defines the identity to use for SMTP authentication.
 	// This is typically used with PLAIN authentication mechanism.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	AuthIdentity string `json:"authIdentity,omitempty"`
+	AuthIdentity *string `json:"authIdentity,omitempty"`
 	// headers defines additional email header key/value pairs.
 	// These override any headers previously set by the notification implementation.
 	// +listType=atomic
@@ -957,10 +963,12 @@ type EmailConfig struct {
 	Headers []KeyValue `json:"headers,omitempty"`
 	// html defines the HTML body of the email notification.
 	// This allows for rich formatting in the email content.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	HTML *string `json:"html,omitempty"`
 	// text defines the plain text body of the email notification.
 	// This provides a fallback for email clients that don't support HTML.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	Text *string `json:"text,omitempty"`
 	// requireTLS defines the SMTP TLS requirement.

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -691,6 +691,31 @@ func (in *EmailConfig) DeepCopyInto(out *EmailConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.To != nil {
+		in, out := &in.To, &out.To
+		*out = new(string)
+		**out = **in
+	}
+	if in.From != nil {
+		in, out := &in.From, &out.From
+		*out = new(string)
+		**out = **in
+	}
+	if in.Hello != nil {
+		in, out := &in.Hello, &out.Hello
+		*out = new(string)
+		**out = **in
+	}
+	if in.Smarthost != nil {
+		in, out := &in.Smarthost, &out.Smarthost
+		*out = new(string)
+		**out = **in
+	}
+	if in.AuthUsername != nil {
+		in, out := &in.AuthUsername, &out.AuthUsername
+		*out = new(string)
+		**out = **in
+	}
 	if in.AuthPassword != nil {
 		in, out := &in.AuthPassword, &out.AuthPassword
 		*out = new(corev1.SecretKeySelector)
@@ -700,6 +725,11 @@ func (in *EmailConfig) DeepCopyInto(out *EmailConfig) {
 		in, out := &in.AuthSecret, &out.AuthSecret
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.AuthIdentity != nil {
+		in, out := &in.AuthIdentity, &out.AuthIdentity
+		*out = new(string)
+		**out = **in
 	}
 	if in.Headers != nil {
 		in, out := &in.Headers, &out.Headers

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -886,24 +886,29 @@ type EmailConfig struct {
 	SendResolved *bool `json:"sendResolved,omitempty"` // nolint:kubeapilinter
 	// to defines the email address to send notifications to.
 	// This is the recipient address for alert notifications.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	To string `json:"to,omitempty"`
+	To *string `json:"to,omitempty"`
 	// from defines the sender address for email notifications.
 	// This appears as the "From" field in the email header.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	From string `json:"from,omitempty"`
+	From *string `json:"from,omitempty"`
 	// hello defines the hostname to identify to the SMTP server.
 	// This is used in the SMTP HELO/EHLO command during the connection handshake.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	Hello string `json:"hello,omitempty"`
+	Hello *string `json:"hello,omitempty"`
 	// smarthost defines the SMTP host and port through which emails are sent.
 	// Format should be "hostname:port", e.g. "smtp.example.com:587".
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	Smarthost string `json:"smarthost,omitempty"`
+	Smarthost *string `json:"smarthost,omitempty"`
 	// authUsername defines the username to use for SMTP authentication.
 	// This is used for SMTP AUTH when the server requires authentication.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	AuthUsername string `json:"authUsername,omitempty"`
+	AuthUsername *string `json:"authUsername,omitempty"`
 	// authPassword defines the secret's key that contains the password to use for authentication.
 	// The secret needs to be in the same namespace as the AlertmanagerConfig
 	// object and accessible by the Prometheus Operator.
@@ -917,18 +922,21 @@ type EmailConfig struct {
 	AuthSecret *SecretKeySelector `json:"authSecret,omitempty"`
 	// authIdentity defines the identity to use for SMTP authentication.
 	// This is typically used with PLAIN authentication mechanism.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
-	AuthIdentity string `json:"authIdentity,omitempty"`
+	AuthIdentity *string `json:"authIdentity,omitempty"`
 	// headers defines additional email header key/value pairs.
 	// These override any headers previously set by the notification implementation.
 	// +optional
 	Headers []KeyValue `json:"headers,omitempty"`
 	// html defines the HTML body of the email notification.
 	// This allows for rich formatting in the email content.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	HTML *string `json:"html,omitempty"`
 	// text defines the plain text body of the email notification.
 	// This provides a fallback for email clients that don't support HTML.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	Text *string `json:"text,omitempty"`
 	// requireTLS defines the SMTP TLS requirement.

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -931,7 +931,6 @@ type EmailConfig struct {
 	Headers []KeyValue `json:"headers,omitempty"`
 	// html defines the HTML body of the email notification.
 	// This allows for rich formatting in the email content.
-	// +kubebuilder:validation:MinLength=1
 	// +optional
 	HTML *string `json:"html,omitempty"`
 	// text defines the plain text body of the email notification.

--- a/pkg/apis/monitoring/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1beta1/zz_generated.deepcopy.go
@@ -182,6 +182,31 @@ func (in *EmailConfig) DeepCopyInto(out *EmailConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.To != nil {
+		in, out := &in.To, &out.To
+		*out = new(string)
+		**out = **in
+	}
+	if in.From != nil {
+		in, out := &in.From, &out.From
+		*out = new(string)
+		**out = **in
+	}
+	if in.Hello != nil {
+		in, out := &in.Hello, &out.Hello
+		*out = new(string)
+		**out = **in
+	}
+	if in.Smarthost != nil {
+		in, out := &in.Smarthost, &out.Smarthost
+		*out = new(string)
+		**out = **in
+	}
+	if in.AuthUsername != nil {
+		in, out := &in.AuthUsername, &out.AuthUsername
+		*out = new(string)
+		**out = **in
+	}
 	if in.AuthPassword != nil {
 		in, out := &in.AuthPassword, &out.AuthPassword
 		*out = new(SecretKeySelector)
@@ -190,6 +215,11 @@ func (in *EmailConfig) DeepCopyInto(out *EmailConfig) {
 	if in.AuthSecret != nil {
 		in, out := &in.AuthSecret, &out.AuthSecret
 		*out = new(SecretKeySelector)
+		**out = **in
+	}
+	if in.AuthIdentity != nil {
+		in, out := &in.AuthIdentity, &out.AuthIdentity
+		*out = new(string)
 		**out = **in
 	}
 	if in.Headers != nil {

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1146,9 +1146,9 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					SendResolved: func(b bool) *bool {
 						return &b
 					}(true),
-					Smarthost: "example.com:25",
-					From:      "admin@example.com",
-					To:        "test@example.com",
+					Smarthost: ptr.To("example.com:25"),
+					From:      ptr.To("admin@example.com"),
+					To:        ptr.To("test@example.com"),
 					AuthPassword: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: testingSecret,


### PR DESCRIPTION
## Description

This PR updates the following to the Alertmanager Config Email Receiver
- Change from string to *string for the optional string variables
- Add MinLength=1 validation for optional string variables

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
- Update string variable validations for Email Receiver in Alertmanager Config
```
