### PR TITLE
docs: fix heading levels in scrapeconfig.md

### DIFF
--- a/Documentation/developer/scrapeconfig.md
+++ b/Documentation/developer/scrapeconfig.md
@@ -15,11 +15,12 @@ Starting with prometheus-operator v0.65.x, one can use the `ScrapeConfig` CRD to
 Kubernetes cluster or create scrape configurations that are not possible with the higher level
 `ServiceMonitor`/`Probe`/`PodMonitor` resources.
 
-# Prerequisites
+## Prerequisites
+
 * `prometheus-operator` `>v0.65.1`
 * `ScrapeConfig` CRD installed in the cluster. Make sure to (re)start the operator after the CRD has been created/updated.
 
-# Configure Prometheus or PrometheusAgent to select ScrapeConfigs
+## Configure Prometheus or PrometheusAgent to select ScrapeConfigs
 
 Both the Prometheus and PrometheusAgent CRD have a `scrapeConfigSelector` field. This field needs to be set to a list of
 labels to match `ScrapeConfigs`:
@@ -34,7 +35,7 @@ spec:
 With this example, all `ScrapeConfig` having the `prometheus` label set to `system-monitoring-prometheus` will be used
 to generate scrape configurations.
 
-# Use ScrapeConfig to scrape an external target
+## Use ScrapeConfig to scrape an external target
 
 `ScrapeConfig` currently supports a limited set of service discoveries:
 * `static_config`


### PR DESCRIPTION
## Description

Fixes incorrect heading levels.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

discussed here: https://github.com/prometheus-operator/prometheus-operator/pull/8208#pullrequestreview-3650733331

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix heading levels in ScrapeConfig documentation.
```
