### PR TITLE
docs: add tier-1/tier-2 SD support levels to ScrapeConfig

### DIFF
--- a/Documentation/developer/scrapeconfig.md
+++ b/Documentation/developer/scrapeconfig.md
@@ -69,15 +69,19 @@ spec:
 
 ## Use ScrapeConfig to scrape an external target
 
-`ScrapeConfig` currently supports a limited set of service discoveries:
+`ScrapeConfig` supports multiple service discovery mechanisms, categorized into two tiers based on the level of support from the project maintainers:
 
-- `static_config`
-- `file_sd`
-- `http_sd`
-- `kubernetes_sd`
-- `consul_sd`
+**Tier-1** (fully supported):
 
-The following examples are basic and don't cover all the supported service discovery mechanisms. The CRD is constantly evolving, adding new features and support for new Service Discoveries. Check the [API documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.ScrapeConfig) to see all supported fields.
+* Kubernetes Service Discovery
+* File Service Discovery
+* Static Service Discovery
+* DNS Service Discovery
+* HTTP Service Discovery
+
+**Tier-2** (maintainers review issues/PRs but don't actively maintain): includes cloud provider SDs like Azure, EC2, GCE, DigitalOcean and others. See the [ScrapeConfig graduation proposal]({{<ref "202405-scrapeconfig-graduation.md">}}) for the complete list.
+
+For the full list of supported fields and service discoveries, check the [API documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.ScrapeConfig).
 
 If you have an interest in another service discovery mechanism or you see something missing in the implementation, please
 [open an issue](https://github.com/prometheus-operator/prometheus-operator/issues).


### PR DESCRIPTION
## Description
updates the ScrapeConfig documentation to replace the outdated service discovery list with the tier-1/tier-2 support levels from the [ScrapeConfig graduation proposal](https://prometheusoperator.dev/docs/proposals/accepted/scrapeconfig-graduation/).

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

disussed here: https://github.com/prometheus-operator/prometheus-operator/pull/8208#discussion_r2687995135

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update ScrapeConfig documentation with tier-1/tier-2 service discovery support levels.
```
