### PR TITLE
fix: use correct gce_sd_configs key name

### DIFF
--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_one_prometheus_shard.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_one_prometheus_shard.golden
@@ -12,7 +12,7 @@ scrape_configs:
     - localhost:9090
 - job_name: gce_app_bar
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo
     zone: us-central1
   relabel_configs:
@@ -22,7 +22,7 @@ scrape_configs:
     regex: my_app
 - job_name: gce_app_bar_custom_shard_relabeling
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo_custom_shard_relabeling
     zone: us-central1
   relabel_configs:

--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_sharded prometheus.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_sharded prometheus.golden
@@ -30,7 +30,7 @@ scrape_configs:
     action: keep
 - job_name: gce_app_bar
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo
     zone: us-central1
   relabel_configs:
@@ -57,7 +57,7 @@ scrape_configs:
     action: keep
 - job_name: gce_app_bar_custom_shard_relabeling
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo_custom_shard_relabeling
     zone: us-central1
   relabel_configs:

--- a/pkg/prometheus/testdata/AdditionalScrapeConfigs_unsharded_prometheus.golden
+++ b/pkg/prometheus/testdata/AdditionalScrapeConfigs_unsharded_prometheus.golden
@@ -12,7 +12,7 @@ scrape_configs:
     - localhost:9090
 - job_name: gce_app_bar
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo
     zone: us-central1
   relabel_configs:
@@ -22,7 +22,7 @@ scrape_configs:
     regex: my_app
 - job_name: gce_app_bar_custom_shard_relabeling
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
   - project: foo_custom_shard_relabeling
     zone: us-central1
   relabel_configs:

--- a/pkg/prometheus/testdata/TestAdditionalScrapeConfigsAdditionalScrapeConfig.golden
+++ b/pkg/prometheus/testdata/TestAdditionalScrapeConfigsAdditionalScrapeConfig.golden
@@ -4,7 +4,7 @@
     - targets: ["localhost:9090"]
 - job_name: gce_app_bar
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
     - project: foo
       zone: us-central1
   relabel_configs:
@@ -14,7 +14,7 @@
       regex: my_app
 - job_name: gce_app_bar_custom_shard_relabeling
   scrape_interval: 5s
-  gce_sd_config:
+  gce_sd_configs:
     - project: foo_custom_shard_relabeling
       zone: us-central1
   relabel_configs:


### PR DESCRIPTION
## Description

incorrect prometheus configuration key `gce_sd_config` (singular) to the correct `gce_sd_configs` (plural) in the additional scrape configs test data.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

related: https://github.com/prometheus-operator/prometheus-operator/pull/8216#issuecomment-3738567050

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix incorrect `gce_sd_config` key to `gce_sd_configs` in additional scrape configs test data.
```
