### PR TITLE
fix: add missing duration values to alertmanager config tests

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -13455,9 +13455,11 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: monitoringv1.PrometheusSpec{
-					Alerting: tc.alerting,
+					Alerting:           tc.alerting,
+					EvaluationInterval: "30s",
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						ServiceDiscoveryRole: tc.sdRole,
+						ScrapeInterval:       "30s",
 					},
 				},
 			}
@@ -13673,9 +13675,11 @@ func TestAlertmanagerTLSConfig(t *testing.T) {
 			},
 			Spec: monitoringv1.PrometheusSpec{
 				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-					Version: tc.version,
+					Version:        tc.version,
+					ScrapeInterval: "30s",
 				},
-				Alerting: tc.alerting,
+				Alerting:           tc.alerting,
+				EvaluationInterval: "30s",
 			},
 		}
 

--- a/pkg/prometheus/testdata/AlertmanagerConfigEmpty.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigEmpty.golden
@@ -1,7 +1,7 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []

--- a/pkg/prometheus/testdata/AlertmanagerConfigEndpointSlice.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigEndpointSlice.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerConfigOtherNamespace.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigOtherNamespace.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerConfigProxyconfig.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigProxyconfig.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerConfigTLSconfig.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigTLSconfig.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerConfigTLSconfigOtherNamespace.golden
+++ b/pkg/prometheus/testdata/AlertmanagerConfigTLSconfigOtherNamespace.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig.golden
+++ b/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MaxVersion.golden
+++ b/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MaxVersion.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MaxVersion_MinVersion.golden
+++ b/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MaxVersion_MinVersion.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:

--- a/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MinVersion.golden
+++ b/pkg/prometheus/testdata/AlertmanagerTLSConfig_Valid_Prom_TLSConfig_MinVersion.golden
@@ -1,9 +1,9 @@
 global:
-  scrape_interval: ""
+  scrape_interval: 30s
   external_labels:
     prometheus: default/test
     prometheus_replica: $(POD_NAME)
-  evaluation_interval: ""
+  evaluation_interval: 30s
 scrape_configs: []
 alerting:
   alert_relabel_configs:


### PR DESCRIPTION
## Description

add missing `scrape_interval` and `evaluation_interval` to `TestGenerateAlertmanagerConfig` and `TestAlertmanagerTLSConfig`.
these tests were creating prometheus configs without required fields, which led to empty duration values in the golden files.
this unblocks strict promtool validation, since empty durations aren’t valid prometheus config values.
<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

related to: https://github.com/prometheus-operator/prometheus-operator/pull/8216#issuecomment-3739625211

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix empty duration values in Alertmanager config test golden files for promtool validation.
```
