### PR TITLE
fix: add nil check for sconInfs before ScrapeConfig cleanup

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1116,8 +1116,11 @@ func (c *Operator) updateConfigResourcesStatus(ctx context.Context, p *monitorin
 
 	// Remove bindings from scrapeConfigs which reference the
 	// workload but aren't selected anymore.
-	if err := operator.CleanupBindings(ctx, c.sconInfs.ListAll, resources.scrapeConfigs, configResourceSyncer); err != nil {
-		return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
+	// Only cleanup if ScrapeConfig support is enabled (sconInfs is initialized).
+	if c.sconInfs != nil {
+		if err := operator.CleanupBindings(ctx, c.sconInfs.ListAll, resources.scrapeConfigs, configResourceSyncer); err != nil {
+			return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
+		}
 	}
 
 	// Remove bindings from probes which reference the
@@ -1153,8 +1156,11 @@ func (c *Operator) configResStatusCleanup(ctx context.Context, p *monitoringv1.P
 	}
 
 	// Remove bindings from all scrapeConfigs which reference the workload.
-	if err := operator.CleanupBindings(ctx, c.sconInfs.ListAll, operator.TypedResourcesSelection[*monitoringv1alpha1.ScrapeConfig]{}, configResourceSyncer); err != nil {
-		return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
+	// Only cleanup if ScrapeConfig support is enabled (sconInfs is initialized).
+	if c.sconInfs != nil {
+		if err := operator.CleanupBindings(ctx, c.sconInfs.ListAll, operator.TypedResourcesSelection[*monitoringv1alpha1.ScrapeConfig]{}, configResourceSyncer); err != nil {
+			return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
+		}
 	}
 
 	// Remove bindings from all probes which reference the workload.


### PR DESCRIPTION
## Description (Summary)

This PR fixes a **nil pointer dereference panic** in the Prometheus controller that occurs when the `StatusForConfigurationResources` feature gate is enabled while **ScrapeConfig CRD support is unavailable**.

The crash happens during normal reconciliation and causes the operator to enter a crash loop, preventing any Prometheus resources from being reconciled. The issue stems from an assumption that ScrapeConfig informers are always initialized when config resource status handling is enabled, which is not always true.

This change makes the controller resilient to that configuration by safely handling the absence of ScrapeConfig informers.

---

## Steps to Reproduce

1. Deploy `prometheus-operator` with the feature gate enabled:

   ```
   --feature-gates=StatusForConfigurationResources=true
   ```
2. Ensure **ScrapeConfig CRD is not installed** in the cluster (or detected as unsupported).
3. Create a Prometheus resource:

   ```yaml
   apiVersion: monitoring.coreos.com/v1
   kind: Prometheus
   metadata:
     name: test
   spec:
     serviceMonitorSelector: {}
   ```
4. Observe the operator panic with:

   ```
   panic: runtime error: invalid memory address or nil pointer dereference
   ```
5. The operator enters a crash loop and fails to reconcile any Prometheus instances.

---

## Root Cause

The `sconInfs` (ScrapeConfig informer) field is **only initialized when ScrapeConfig CRD support is detected**:

```go
if o.scrapeConfigSupported {
    o.sconInfs, err = informers.NewInformersForResource(...)
}
```

However, the following functions unconditionally accessed `c.sconInfs.ListAll`:

* `updateConfigResourcesStatus()`
* `configResStatusCleanup()`

These functions are guarded by `configResourcesStatusEnabled`, which is **independent** of `scrapeConfigSupported`.
When the feature gate is enabled but ScrapeConfig support is unavailable, `c.sconInfs` is `nil`, leading to a panic.

---

## Fix

This PR adds **explicit nil checks** before accessing `c.sconInfs.ListAll`, ensuring ScrapeConfig-related cleanup logic only runs when the informer is actually available.

### Example change

```go
if c.sconInfs != nil {
    if err := operator.CleanupBindings(
        ctx,
        c.sconInfs.ListAll,
        resources.scrapeConfigs,
        configResourceSyncer,
    ); err != nil {
        return fmt.Errorf("failed to remove bindings for scrapeConfigs: %w", err)
    }
}
```

The same guard is applied in `configResStatusCleanup()`.

---

## Impact

* **Before fix:**
  Operator crashes during reconciliation when `StatusForConfigurationResources` is enabled without ScrapeConfig CRD support.

* **After fix:**
  Operator safely skips ScrapeConfig binding cleanup when ScrapeConfig support is unavailable.

* **Backward compatible:**
  No behavior change for clusters where ScrapeConfig CRD is installed.

* **No functional regression:**
  ScrapeConfig bindings are still cleaned up correctly when the informer exists.

---

## Verification

* Verified that the operator no longer panics when:

  * `StatusForConfigurationResources` is enabled
  * ScrapeConfig CRD is not installed
* Confirmed normal reconciliation continues for Prometheus resources.
* Confirmed existing behavior remains unchanged when ScrapeConfig support is present.

---

## Type of Change

* [x] **BUGFIX** (non-breaking change which fixes an issue)
