### PR TITLE
fix: SD config test data for promtool validation

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -6275,7 +6275,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{
 					{
-						Targets: []monitoringv1alpha1.Target{"http://localhost:9100"},
+						Targets: []monitoringv1alpha1.Target{"localhost:9100"},
 						Labels: map[string]string{
 							"label1": "value1",
 						},
@@ -6292,7 +6292,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{
 					{
-						Targets: []monitoringv1alpha1.Target{"http://localhost:9100"},
+						Targets: []monitoringv1alpha1.Target{"localhost:9100"},
 						Labels: map[string]string{
 							"label1": "value1_sharded",
 						},
@@ -6319,7 +6319,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				StaticConfigs: []monitoringv1alpha1.StaticConfig{
 					{
-						Targets: []monitoringv1alpha1.Target{"http://localhost:9100"},
+						Targets: []monitoringv1alpha1.Target{"localhost:9100"},
 						Labels: map[string]string{
 							"label1": "value1",
 						},
@@ -7331,7 +7331,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -7650,7 +7650,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -8074,7 +8074,7 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -8272,7 +8272,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				AzureSDConfigs: []monitoringv1alpha1.AzureSDConfig{
 					{
-						SubscriptionID: "11AAAA11-A11A-111A-A111-1111A1111A11",
+						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
+						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 					},
 				},
 			},
@@ -8299,7 +8300,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				AzureSDConfigs: []monitoringv1alpha1.AzureSDConfig{
 					{
-						SubscriptionID: "11AAAA11-A11A-111A-A111-1111A1111A11",
+						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
+						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						Authorization: &monitoringv1.SafeAuthorization{
 							Credentials: &v1.SecretKeySelector{
 								LocalObjectReference: v1.LocalObjectReference{
@@ -8311,7 +8313,7 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -8335,7 +8337,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				AzureSDConfigs: []monitoringv1alpha1.AzureSDConfig{
 					{
-						SubscriptionID: "11AAAA11-A11A-111A-A111-1111A1111A11",
+						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
+						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
 								Secret: &v1.SecretKeySelector{
@@ -8384,7 +8387,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				AzureSDConfigs: []monitoringv1alpha1.AzureSDConfig{
 					{
-						SubscriptionID: "11AAAA11-A11A-111A-A111-1111A1111A11",
+						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
+						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
 								ConfigMap: &v1.ConfigMapKeySelector{
@@ -8714,7 +8718,7 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -8898,7 +8902,7 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -9273,7 +9277,7 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -9457,7 +9461,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -9488,7 +9492,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -9520,7 +9524,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -10209,7 +10213,7 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11039,7 +11043,7 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11218,7 +11222,7 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11403,7 +11407,7 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11454,7 +11458,7 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11638,7 +11642,7 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11683,7 +11687,7 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11908,7 +11912,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -11952,7 +11956,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -12231,7 +12235,7 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{
@@ -12379,7 +12383,7 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
-							ProxyFromEnvironment: ptr.To(true),
+							ProxyFromEnvironment: ptr.To(false),
 							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
 								"header": {
 									{

--- a/pkg/prometheus/testdata/ConsulScrapeConfig.golden
+++ b/pkg/prometheus/testdata/ConsulScrapeConfig.golden
@@ -9,7 +9,7 @@ scrape_configs:
   consul_sd_configs:
   - proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Already_Sharded.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Already_Sharded.golden
@@ -8,7 +8,7 @@ scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   static_configs:
   - targets:
-    - http://localhost:9100
+    - localhost:9100
     labels:
       label1: value1_sharded
   relabel_configs:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValidWithSubscriptionID.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValidWithSubscriptionID.golden
@@ -7,7 +7,8 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+  - authentication_method: SDK
+    subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:
     - job

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_basic_auth_and_TLS.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_basic_auth_and_TLS.golden
@@ -7,7 +7,8 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+  - authentication_method: SDK
+    subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:
     - job

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_http_config.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_http_config.golden
@@ -7,7 +7,8 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+  - authentication_method: SDK
+    subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:
     - job

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_with_oauth2.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_with_oauth2.golden
@@ -7,7 +7,8 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
+  - authentication_method: SDK
+    subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:
     - job

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSDConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerSDConfig.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerswarmSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerswarmSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerswarmSD_withBasicAuth.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_DockerswarmSD_withBasicAuth.golden
@@ -12,7 +12,7 @@ scrape_configs:
       password: ""
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withProxyConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EC2SD_withProxyConfig.golden
@@ -9,7 +9,7 @@ scrape_configs:
   ec2_sd_configs:
   - proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - ""

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EurekaSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_EurekaSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSD.golden
@@ -9,7 +9,7 @@ scrape_configs:
   hetzner_sd_configs:
   - proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSDLabelSelector.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSDLabelSelector.golden
@@ -9,7 +9,7 @@ scrape_configs:
   hetzner_sd_configs:
   - proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSDNoLabelSelector.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_HetznerSDNoLabelSelector.golden
@@ -9,7 +9,7 @@ scrape_configs:
   hetzner_sd_configs:
   - proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_IonosSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_IonosSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_K8SSD.golden
@@ -10,7 +10,7 @@ scrape_configs:
   - role: node
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_KumaSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_KumaSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LightSailSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LightSailSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LightSailSD_withBasicAuth.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LightSailSD_withBasicAuth.golden
@@ -12,7 +12,7 @@ scrape_configs:
       password: ""
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LinodeSDConfig.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_LinodeSDConfig.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_NomadSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_NomadSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_PuppetDBSD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_PuppetDBSD.golden
@@ -12,7 +12,7 @@ scrape_configs:
       credentials: value
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_PuppetDBSD_withBasicAuth.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_PuppetDBSD_withBasicAuth.golden
@@ -12,7 +12,7 @@ scrape_configs:
       password: ""
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ScaleWaySD.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_ScaleWaySD.golden
@@ -21,7 +21,7 @@ scrape_configs:
     refresh_interval: 30s
     proxy_url: http://no-proxy.com
     no_proxy: 0.0.0.0
-    proxy_from_environment: true
+    proxy_from_environment: false
     proxy_connect_header:
       header:
       - value

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Sharded.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Sharded.golden
@@ -8,7 +8,7 @@ scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   static_configs:
   - targets:
-    - http://localhost:9100
+    - localhost:9100
     labels:
       label1: value1
   relabel_configs:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Static.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_Static.golden
@@ -8,7 +8,7 @@ scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   static_configs:
   - targets:
-    - http://localhost:9100
+    - localhost:9100
     labels:
       label1: value1
   relabel_configs:


### PR DESCRIPTION
## Description
fixed the service discovery test configs so they pass `promtool check config`. this is part of the ongoing cleanup to get strict promtool validation running in ci. the changes are small but required: static targets now use `host:port` instead of an `http://` scheme, the azure sd config explicitly sets `authenticationmethod: sdk` and proxy settings no longer conflict by disabling `proxyfromenvironment` when a `proxyurl` is already defined.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

related: https://github.com/prometheus-operator/prometheus-operator/pull/8216#issuecomment-3739625211

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix service discovery test configurations for promtool validation.
```
