### PR TITLE
fix: use update-in-place for PrometheusRule ConfigMaps

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -388,26 +388,32 @@ func (prs *PrometheusRuleSyncer) Sync(ctx context.Context, rules map[string]stri
 		return nil, fmt.Errorf("failed to generate ConfigMaps for PrometheusRule: %w", err)
 	}
 
-	// Delete and recreate the configmap(s). It's not very efficient but proved
-	// to be robust enough so far.
-	if len(current) > 0 {
-		prs.logger.Debug("deleting ConfigMaps for PrometheusRule")
-		// In theory we could use DeleteCollection but the method isn't
-		// supported by the fake client.
-		// See https://github.com/kubernetes/kubernetes/issues/105357
-		for _, cm := range current {
-			err := prs.cmClient.Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("failed to delete ConfigMap %q: %w", cm.Name, err)
-			}
+	// Build a set of desired ConfigMap names for quick lookup.
+	desiredNames := make(map[string]struct{}, len(configMaps))
+	for _, cm := range configMaps {
+		desiredNames[cm.Name] = struct{}{}
+	}
+
+	// Create or update the desired ConfigMaps first to ensure rules are never
+	// missing. This avoids the race condition where deleting ConfigMaps before
+	// creating new ones could cause the config-reloader to reload Prometheus
+	// with missing rules.
+	prs.logger.Debug("creating/updating ConfigMaps for PrometheusRule")
+	for i := range configMaps {
+		if err := k8sutil.CreateOrUpdateConfigMap(ctx, prs.cmClient, &configMaps[i]); err != nil {
+			return nil, fmt.Errorf("failed to create or update ConfigMap %q: %w", configMaps[i].Name, err)
 		}
 	}
 
-	prs.logger.Debug("creating ConfigMaps for PrometheusRule")
-	for _, cm := range configMaps {
-		_, err = prs.cmClient.Create(ctx, &cm, metav1.CreateOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create ConfigMap %q: %w", cm.Name, err)
+	// Delete ConfigMaps that are no longer needed (excess shards from previous
+	// reconciliations). This happens after creates/updates to ensure rules
+	// remain available throughout the sync process.
+	for _, cm := range current {
+		if _, exists := desiredNames[cm.Name]; !exists {
+			prs.logger.Debug("deleting excess ConfigMap for PrometheusRule", "configmap", cm.Name)
+			if err := prs.cmClient.Delete(ctx, cm.Name, metav1.DeleteOptions{}); err != nil {
+				return nil, fmt.Errorf("failed to delete excess ConfigMap %q: %w", cm.Name, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a non-atomic reconciliation pattern in `PrometheusRuleSyncer.Sync()` that could cause **temporary and silent loss of alerting and recording rules** during PrometheusRule updates.

Previously, the operator deleted all existing rule ConfigMaps before recreating them. This introduced a time window where no rule ConfigMaps existed, allowing the config-reloader sidecar to trigger a Prometheus reload with **missing or partial rules**. The issue is triggered during normal reconciliation and can impact production alerting without any visible errors.

This change makes PrometheusRule reconciliation **continuous and safe** by switching to update-in-place semantics.

---

## Type of change

* [x] `BUGFIX`
* [x] `ENHANCEMENT`

---

## What was wrong (root cause)

`PrometheusRuleSyncer.Sync()` used a delete-then-create pattern for rule ConfigMaps:

```go
// Delete and recreate the configmap(s).
for _, cm := range current {
    err := prs.cmClient.Delete(ctx, cm.Name, metav1.DeleteOptions{})
    if err != nil {
        return nil, err
    }
}

for _, cm := range configMaps {
    _, err := prs.cmClient.Create(ctx, &cm, metav1.CreateOptions{})
    if err != nil {
        return nil, err
    }
}
```

During this deletion window:

* ConfigMaps briefly do not exist
* The config-reloader detects the change and reloads Prometheus
* Prometheus reloads with missing alerting / recording rules
* No error is surfaced, resulting in a silent monitoring gap

This happens during **any PrometheusRule update**, including label or selector changes.

---

## Impact

**Before this fix:**

* Alerting rules can temporarily disappear → alerts cannot fire
* Recording rules can disappear → dashboards and derived metrics break
* Failures are silent (no logs, no reconciliation errors)
* HA setups do not help (replicas reconcile simultaneously)

**After this fix:**

* Rules remain continuously available during reconciliation
* Config reloads always see a valid rule set
* Partial failures no longer result in empty rules
* Alerting behavior is predictable and safe

---

## Fix summary

### 1. Added `CreateOrUpdateConfigMap` helper

A new utility function was added to atomically create or update ConfigMaps:

```go
func CreateOrUpdateConfigMap(
    ctx context.Context,
    cmClient clientv1.ConfigMapInterface,
    desired *v1.ConfigMap,
) error
```

Key properties:

* Uses `retry.RetryOnConflict`
* Creates the ConfigMap if it does not exist
* Updates in place if it already exists
* Preserves external labels and annotations

---

### 2. Rewrote `PrometheusRuleSyncer.Sync()`

The reconciliation order was changed to avoid rule disappearance:

**Before**

1. Delete all ConfigMaps
2. Create new ConfigMaps
3. ❌ Rules temporarily missing

**After**

1. Create or update desired ConfigMaps
2. Delete only excess ConfigMaps that are no longer needed
3. ✅ Rules always present

This mirrors the existing `CreateOrUpdateSecret` pattern used for Alertmanager configuration.

---

## Verification

* ✅ Code builds successfully
* ✅ Existing PrometheusRule sync tests pass
* ✅ No behavior change outside rule reconciliation logic
