### PR TITLE
fix: missing target label and removed invalid test file for promtool

### DIFF
--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -182,7 +182,7 @@ func TestGlobalSettings(t *testing.T) {
 			ExternalLabels: map[string]string{
 				"prometheus_replica": "1",
 				"prometheus":         "prometheus-k8s-1",
-				"some_other_key":     "some-value",
+				"some-other-key":     "some-value",
 			},
 			PrometheusExternalLabelName: ptr.To("prometheus"),
 			ReplicaExternalLabelName:    ptr.To("prometheus_replica"),
@@ -1730,7 +1730,7 @@ func TestServiceMonitorWithServiceDiscoveryRole(t *testing.T) {
 
 func TestEnforcedNamespaceLabelPodMonitor(t *testing.T) {
 	p := defaultPrometheus()
-	p.Spec.CommonPrometheusFields.EnforcedNamespaceLabel = "ns_key"
+	p.Spec.CommonPrometheusFields.EnforcedNamespaceLabel = "ns-key"
 
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.GenerateServerConfiguration(
@@ -1855,7 +1855,7 @@ func TestEnforcedNamespaceLabelOnExcludedPodMonitor(t *testing.T) {
 
 func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 	p := defaultPrometheus()
-	p.Spec.CommonPrometheusFields.EnforcedNamespaceLabel = "ns_key"
+	p.Spec.CommonPrometheusFields.EnforcedNamespaceLabel = "ns-key"
 
 	cg := mustNewConfigGenerator(t, p)
 	cfg, err := cg.GenerateServerConfiguration(
@@ -1888,7 +1888,7 @@ func TestEnforcedNamespaceLabelServiceMonitor(t *testing.T) {
 									Action:       "drop",
 									Regex:        "my-job-pod-.+",
 									SourceLabels: []monitoringv1.LabelName{"pod_name"},
-									TargetLabel:  "ns_key",
+									TargetLabel:  "ns-key",
 								},
 							},
 							RelabelConfigs: []monitoringv1.RelabelConfig{
@@ -1960,7 +1960,7 @@ func TestEnforcedNamespaceLabelOnExcludedServiceMonitor(t *testing.T) {
 									Action:       "drop",
 									Regex:        "my-job-pod-.+",
 									SourceLabels: []monitoringv1.LabelName{"pod_name"},
-									TargetLabel:  "ns_key",
+									TargetLabel:  "ns-key",
 								},
 							},
 							RelabelConfigs: []monitoringv1.RelabelConfig{

--- a/pkg/prometheus/testdata/AdditionalAlertRelabelConfigs.golden
+++ b/pkg/prometheus/testdata/AdditionalAlertRelabelConfigs.golden
@@ -1,7 +1,7 @@
 - action: drop
   source_labels: [__meta_kubernetes_node_name]
   regex: spot-(.+)
-- source_labels: [label_a, label_b]
+- source_labels: [label-a, label-b]
   separator: ""
   action: replace
-  target_label: custom_label
+  target_label: custom-label

--- a/pkg/prometheus/testdata/AdditionalAlertRelabelConfigs_Expected.golden
+++ b/pkg/prometheus/testdata/AdditionalAlertRelabelConfigs_Expected.golden
@@ -14,11 +14,11 @@ alerting:
     - __meta_kubernetes_node_name
     regex: spot-(.+)
   - source_labels:
-    - label_a
-    - label_b
+    - label-a
+    - label-b
     separator: ""
     action: replace
-    target_label: custom_label
+    target_label: custom-label
   alertmanagers:
   - kubernetes_sd_configs:
     - role: endpoints

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedServiceMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelOnExcludedServiceMonitor_Expected.golden
@@ -88,6 +88,6 @@ scrape_configs:
   metric_relabel_configs:
   - source_labels:
     - pod_name
-    target_label: ns_key
+    target_label: ns-key
     regex: my-job-pod-.+
     action: drop

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelPodMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelPodMonitor_Expected.golden
@@ -54,7 +54,7 @@ scrape_configs:
     regex: (.*)
     replacement: $1
     action: replace
-  - target_label: ns_key
+  - target_label: ns-key
     replacement: pod-monitor-ns
   - source_labels:
     - __address__
@@ -79,5 +79,5 @@ scrape_configs:
     target_label: my-ns
     regex: my-job-pod-.+
     action: drop
-  - target_label: ns_key
+  - target_label: ns-key
     replacement: pod-monitor-ns

--- a/pkg/prometheus/testdata/EnforcedNamespaceLabelServiceMonitor_Expected.golden
+++ b/pkg/prometheus/testdata/EnforcedNamespaceLabelServiceMonitor_Expected.golden
@@ -73,7 +73,7 @@ scrape_configs:
     regex: (.*)
     replacement: $1
     action: replace
-  - target_label: ns_key
+  - target_label: ns-key
     replacement: default
   - source_labels:
     - __address__
@@ -95,8 +95,8 @@ scrape_configs:
   metric_relabel_configs:
   - source_labels:
     - pod_name
-    target_label: ns_key
+    target_label: ns-key
     regex: my-job-pod-.+
     action: drop
-  - target_label: ns_key
+  - target_label: ns-key
     replacement: default

--- a/pkg/prometheus/testdata/external_label_specified_along_with_reserved_labels.golden
+++ b/pkg/prometheus/testdata/external_label_specified_along_with_reserved_labels.golden
@@ -3,6 +3,6 @@ global:
   external_labels:
     prometheus: test/example
     prometheus_replica: $(POD_NAME)
-    some_other_key: some-value
+    some-other-key: some-value
   evaluation_interval: 30s
 scrape_configs: []


### PR DESCRIPTION
## Description

addresses specific `promtool` validation failures related to missing target labels in relabel configs and an orphaned test file with conflicting settings.

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

related # https://github.com/prometheus-operator/prometheus-operator/pull/8216#issuecomment-3739625211

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix missing target_labels in Prometheus config generation tests and remove invalid orphaned test file.
```
