### PR TITLE
# Fix silent StatefulSet cleanup failures during Prometheus shard scale-down

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -16,6 +16,7 @@ package prometheusagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -867,6 +868,7 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 		ssets[ssetName] = struct{}{}
 	}
 
+	var deleteErrs []error
 	err := c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabelName: prometheusMode}), func(obj any) {
 		s := obj.(*appsv1.StatefulSet)
 
@@ -880,12 +882,17 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 			return
 		}
 
-		if err := ssetClient.Delete(ctx, s.GetName(), metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
-			c.logger.Error("failed to delete StatefulSet object", "err", err, "name", s.GetName(), "namespace", s.GetNamespace())
+		if delErr := ssetClient.Delete(ctx, s.GetName(), metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); delErr != nil {
+			if !apierrors.IsNotFound(delErr) {
+				deleteErrs = append(deleteErrs, fmt.Errorf("failed to delete StatefulSet %s: %w", s.GetName(), delErr))
+			}
 		}
 	})
 	if err != nil {
 		return fmt.Errorf("listing StatefulSet resources failed: %w", err)
+	}
+	if len(deleteErrs) > 0 {
+		return fmt.Errorf("failed to clean up excess StatefulSets: %w", errors.Join(deleteErrs...))
 	}
 
 	return nil

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -16,6 +16,7 @@ package prometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -1023,6 +1024,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		ssets[ssetName] = struct{}{}
 	}
 
+	var deleteErrs []error
 	err = c.ssetInfs.ListAllByNamespace(p.Namespace, labels.SelectorFromSet(labels.Set{prompkg.PrometheusNameLabelName: p.Name, prompkg.PrometheusModeLabelName: prometheusMode}), func(obj any) {
 		s := obj.(*appsv1.StatefulSet)
 
@@ -1036,21 +1038,26 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 			return
 		}
 
-		shouldRetain, err := c.shouldRetain(p)
-		if err != nil {
-			c.logger.Error("failed to determine if StatefulSet should be retained", "err", err, "name", s.GetName(), "namespace", s.GetNamespace())
+		shouldRetain, retainErr := c.shouldRetain(p)
+		if retainErr != nil {
+			deleteErrs = append(deleteErrs, fmt.Errorf("failed to determine if StatefulSet %s should be retained: %w", s.GetName(), retainErr))
 			return
 		}
 		if shouldRetain {
 			return
 		}
 
-		if err := ssetClient.Delete(ctx, s.GetName(), metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); err != nil {
-			c.logger.Error("failed to delete StatefulSet object", "err", err, "name", s.GetName(), "namespace", s.GetNamespace())
+		if delErr := ssetClient.Delete(ctx, s.GetName(), metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)}); delErr != nil {
+			if !apierrors.IsNotFound(delErr) {
+				deleteErrs = append(deleteErrs, fmt.Errorf("failed to delete StatefulSet %s: %w", s.GetName(), delErr))
+			}
 		}
 	})
 	if err != nil {
 		return fmt.Errorf("listing StatefulSet resources failed: %w", err)
+	}
+	if len(deleteErrs) > 0 {
+		return fmt.Errorf("failed to clean up excess StatefulSets: %w", errors.Join(deleteErrs...))
 	}
 
 	err = c.updateConfigResourcesStatus(ctx, p, *resources)


### PR DESCRIPTION
## Summary

When scaling Prometheus shards down, the operator may fail to delete excess StatefulSets but still report a successful reconciliation.  
Deletion errors are currently logged but not returned, allowing orphaned Prometheus shards to continue running with stale configuration.

This PR ensures deletion failures are propagated so reconciliation retries until cleanup succeeds, keeping configuration and running shards consistent.

---

## Problem

During shard scale-down, the operator:
1. Updates the Prometheus configuration for the reduced shard count
2. Attempts to delete excess StatefulSets
3. Logs deletion errors but does not return them
4. Continues reconciliation as if cleanup succeeded

This leads to:
- Orphaned Prometheus shards running stale configs
- Duplicate scraping and alert duplication
- Increased load on scrape targets
- Silent failure (logs only, no retry or status signal)

This occurs under normal Kubernetes conditions such as:
- PodDisruptionBudgets blocking deletions
- Finalizers on StatefulSets
- Temporary RBAC or API server failures

---

## Root Cause

Deletion errors inside `ListAllByNamespace()` callbacks are swallowed:
- Errors from `StatefulSet` deletions are logged but ignored
- Reconciliation completes successfully
- Failed deletions are never retried

The same issue exists in both the Prometheus and PrometheusAgent controllers.

---

## Fix

- Collect StatefulSet deletion errors during cleanup
- Ignore `NotFound` errors (already deleted is desired state)
- Return aggregated deletion errors from reconciliation
- Allow the workqueue to retry until cleanup succeeds
- Preserve existing behavior for the success path

Affected controllers:
- `pkg/prometheus/server/operator.go`
- `pkg/prometheus/agent/operator.go`

---

## Steps to Reproduce

1. Create a Prometheus with multiple shards:
   ```yaml
   spec:
     shards: 3
