### PR TITLE
fix: nil pointer dereference in shouldRetain when ShardRetentionPolic…

### DIFF
--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1182,6 +1182,10 @@ func (c *Operator) shouldRetain(p *monitoringv1.Prometheus) (bool, error) {
 		// Feature-gate is disabled, default behavior is always to delete.
 		return false, nil
 	}
+	if p.Spec.ShardRetentionPolicy == nil {
+		// ShardRetentionPolicy not configured, default behavior is to delete.
+		return false, nil
+	}
 	if ptr.Deref(p.Spec.ShardRetentionPolicy.WhenScaled,
 		monitoringv1.DeleteWhenScaledRetentionType) == monitoringv1.RetainWhenScaledRetentionType {
 		return true, nil


### PR DESCRIPTION
## Description

This PR fixes a nil pointer dereference in `shouldRetain()` that could crash the Prometheus Operator when scaling down Prometheus shards with the `PrometheusShardRetentionPolicy` feature gate enabled.

If the feature gate is enabled but `spec.shardRetentionPolicy` is not set (which is the default for existing Prometheus CRs), the operator would attempt to access a nested field without checking for nil and panic during reconciliation. Since this happens in the main reconciliation loop, the operator could crash and repeatedly restart.

The fix adds a simple nil check and preserves the default behavior (delete excess shards). A regression test is included to ensure the operator no longer panics when the field is unset.

---

## Type of change

* [x] `BUGFIX` (non-breaking change which fixes an issue)

---

## Verification

* Added a unit regression test for `shouldRetain()` covering the nil `ShardRetentionPolicy` case and other expected behaviors.
* Verified locally with:

  ```bash
  go test -v -run TestShouldRetain ./pkg/prometheus/server/
  ```
* All tests pass.

<img width="973" height="354" alt="reg test" src="https://github.com/user-attachments/assets/8ca5174e-0b02-4fc1-b545-1142f4ddefc5" />

---

## Changelog entry

```release-note
Fix a crash when scaling down Prometheus shards with the PrometheusShardRetentionPolicy feature gate enabled and shardRetentionPolicy unset.
```
