### PR TITLE
### Fix: Clear Stale Reconciliation Status in Alertmanager, Thanos, and PrometheusAgent Controllers

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -569,11 +569,11 @@ func (c *Operator) handleNamespaceUpdate(oldo, curo any) {
 
 // Sync implements the operator.Syncer interface.
 func (c *Operator) Sync(ctx context.Context, key string) error {
+	c.reconciliations.ResetStatus(key)
 	err := c.sync(ctx, key)
 	c.reconciliations.SetStatus(key, err)
 
 	return err
-
 }
 
 func (c *Operator) sync(ctx context.Context, key string) error {

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -609,6 +609,7 @@ func (c *Operator) addHandlers() {
 
 // Sync implements the operator.Syncer interface.
 func (c *Operator) Sync(ctx context.Context, key string) error {
+	c.reconciliations.ResetStatus(key)
 	err := c.sync(ctx, key)
 	c.reconciliations.SetStatus(key, err)
 

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -464,6 +464,7 @@ func (o *Operator) handleNamespaceUpdate(oldo, curo any) {
 
 // Sync implements the operator.Syncer interface.
 func (o *Operator) Sync(ctx context.Context, key string) error {
+	o.reconciliations.ResetStatus(key)
 	err := o.sync(ctx, key)
 	o.reconciliations.SetStatus(key, err)
 


### PR DESCRIPTION
### Summary

This PR fixes an issue where the Reconciled condition’s Reason and Message fields could remain
stale in Alertmanager, Thanos, and PrometheusAgent controllers even after reconciliation
succeeds.

These controllers were missing a call to reset reconciliation status at the beginning of each
sync cycle, causing old reason/message values to persist across reconciliations. This led to
misleading status conditions that did not reflect the current state of the workload.

This change aligns all controllers with the correct behavior already used by the Prometheus
Server controller.

---

### Root Cause

Reconciliation status is tracked using `ReconciliationTracker`, which maintains:

- an error field for reconciliation result
- reason and message fields for contextual status

In Alertmanager, Thanos, and PrometheusAgent controllers, only the error field was updated after
each reconciliation. Since the previous reason and message were never cleared, they remained
even when the underlying issue was resolved.

The Prometheus Server controller correctly resets reconciliation status at the start of each
sync cycle, but the other three controllers were missing this reset step.

---

### Steps to Reproduce

1. Create a resource that initially has no selected configuration or uses deprecated fields
2. Wait for reconciliation and observe that a specific status reason is set
3. Update the configuration so reconciliation should now succeed
4. Wait for the next reconciliation cycle
5. Observe that the error is cleared but the previous reason/message remains unchanged

This behavior occurs in Alertmanager, ThanosRuler, and PrometheusAgent resources.

---

### Fix Applied

A call to reset reconciliation status is added at the start of `Sync()` in:

- Alertmanager controller
- Thanos controller
- PrometheusAgent controller

All controllers now follow the same lifecycle as the Prometheus Server controller:

1. Reset previous reconciliation status
2. Perform reconciliation
3. Set final reconciliation result

This ensures that reason and message fields always reflect the current reconciliation cycle.

---

### Impact

- Prevents stale and misleading status conditions
- Ensures accurate reporting of reconciliation state
- Makes controller behavior consistent across all components
- Improves reliability of monitoring and alerting
- No change to reconciliation logic or workload behavior

---

### Testing

- Pattern verified against Prometheus Server controller behavior
- No functional changes introduced to reconciliation flow
- CI will validate integration behavior