### PR TITLE
fix: undo url checks in webhook

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2725,12 +2725,6 @@ func (whc *webhookConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 		whc.Timeout = nil
 	}
 
-	if whc.URL != "" {
-		if _, err := validation.ValidateURL(whc.URL); err != nil {
-			return fmt.Errorf("invalid 'url': %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -5668,7 +5668,6 @@ func TestSanitizeWebhookConfig(t *testing.T) {
 		againstVersion semver.Version
 		in             *alertmanagerConfig
 		golden         string
-		expectErr      bool
 	}{
 		{
 			name:           "Test webhook_url_file is dropped in webhook config for unsupported versions",
@@ -5694,7 +5693,7 @@ func TestSanitizeWebhookConfig(t *testing.T) {
 					{
 						WebhookConfigs: []*webhookConfig{
 							{
-								URL:     "http://example.com/foo",
+								URL:     "foo",
 								URLFile: "bar",
 							},
 						},
@@ -5735,45 +5734,9 @@ func TestSanitizeWebhookConfig(t *testing.T) {
 			},
 			golden: "test_webhook_timeout_is_added_in_webhook_config_for_supported_versions.golden",
 		},
-		{
-			name:           "Test invalid url returns error",
-			againstVersion: semver.Version{Major: 0, Minor: 26},
-			in: &alertmanagerConfig{
-				Receivers: []*receiver{
-					{
-						WebhookConfigs: []*webhookConfig{
-							{
-								URL: "not-a-valid-url",
-							},
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-		{
-			name:           "Test valid url passes validation",
-			againstVersion: semver.Version{Major: 0, Minor: 26},
-			in: &alertmanagerConfig{
-				Receivers: []*receiver{
-					{
-						WebhookConfigs: []*webhookConfig{
-							{
-								URL: "http://example.com/webhook",
-							},
-						},
-					},
-				},
-			},
-			golden: "test_webhook_valid_url_passes.golden",
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)
-			if tc.expectErr {
-				require.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 
 			amConfigs, err := yaml.Marshal(tc.in)

--- a/pkg/alertmanager/testdata/test_url_takes_precedence_in_webhook_config.golden
+++ b/pkg/alertmanager/testdata/test_url_takes_precedence_in_webhook_config.golden
@@ -1,5 +1,0 @@
-receivers:
-- name: ""
-  webhook_configs:
-  - url: http://example.com/foo
-templates: []

--- a/pkg/alertmanager/testdata/test_webhook_valid_url_passes.golden
+++ b/pkg/alertmanager/testdata/test_webhook_valid_url_passes.golden
@@ -1,5 +1,0 @@
-receivers:
-- name: ""
-  webhook_configs:
-  - url: http://example.com/webhook
-templates: []


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Relates to: https://github.com/prometheus-operator/prometheus-operator/issues/8291

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
