### PR TITLE
fix: enqueue all Prometheus instances when namespace lookup fails

### DIFF
--- a/pkg/prometheus/server/operator_test.go
+++ b/pkg/prometheus/server/operator_test.go
@@ -16,6 +16,8 @@ package prometheus
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -256,6 +260,96 @@ func TestCreateThanosConfigSecret(t *testing.T) {
 			require.Equal(t, "tls_config:\n  insecure_skip_verify: true\n", string(get.Data[thanosPrometheusHTTPClientConfigFileName]))
 		})
 	}
+}
+
+func TestEnqueueForNamespaceFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		namespaceExists  bool
+		expectedEnqueued int
+		prometheusCount  int
+	}{
+		{
+			name:             "namespace not found triggers fallback - enqueues all instances",
+			namespaceExists:  false,
+			prometheusCount:  3,
+			expectedEnqueued: 3,
+		},
+		{
+			name:             "namespace found with matching prometheus",
+			namespaceExists:  true,
+			prometheusCount:  3,
+			expectedEnqueued: 1, // only the one in the same namespace
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fake namespace store
+			nsStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			if tc.namespaceExists {
+				err := nsStore.Add(&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ns",
+					},
+				})
+				require.NoError(t, err)
+			}
+
+			// Create fake prometheus store with test data
+			promStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			for i := 0; i < tc.prometheusCount; i++ {
+				ns := "other-ns"
+				if i == 0 {
+					ns = "test-ns" // First one is in the target namespace
+				}
+				err := promStore.Add(&monitoringv1.Prometheus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("prometheus-%d", i),
+						Namespace: ns,
+					},
+				})
+				require.NoError(t, err)
+			}
+
+			// Track enqueued items
+			var enqueuedItems []string
+			fakeRR := &fakeReconciler{
+				enqueueFunc: func(obj metav1.Object) {
+					enqueuedItems = append(enqueuedItems, fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName()))
+				},
+			}
+
+			fakeLister := &fakeLister{store: promStore}
+
+			enqueueForNamespaceInternal(slog.Default(), nsStore, "test-ns", fakeLister, fakeRR)
+
+			require.Len(t, enqueuedItems, tc.expectedEnqueued,
+				"expected %d items to be enqueued, got %d: %v",
+				tc.expectedEnqueued, len(enqueuedItems), enqueuedItems)
+		})
+	}
+}
+
+// fakeReconciler implements the reconciler interface for testing
+type fakeReconciler struct {
+	enqueueFunc func(obj metav1.Object)
+}
+
+func (f *fakeReconciler) EnqueueForReconciliation(obj metav1.Object) {
+	if f.enqueueFunc != nil {
+		f.enqueueFunc(obj)
+	}
+}
+
+// fakeLister implements the resourceLister interface for testing
+type fakeLister struct {
+	store cache.Store
+}
+
+func (f *fakeLister) ListAll(selector labels.Selector, appendFn cache.AppendFunc) error {
+	for _, obj := range f.store.List() {
+		appendFn(obj)
+	}
+	return nil
 }
 
 func TestShouldRetain(t *testing.T) {


### PR DESCRIPTION
## Issue

`enqueueForNamespace` relies on a namespace lookup from the informer cache when processing events from ServiceMonitors, PodMonitors, Probes, ScrapeConfigs, and PrometheusRules.
If the lookup fails (error or namespace not found), the function logs and returns immediately, without enqueuing any Prometheus instance for reconciliation.

As a result, configuration changes can be **silently dropped**, leaving Prometheus running with stale scrape targets or alerting rules until the periodic resync occurs.

```go
nsObject, found, err := store.GetByKey(nsName)
if err != nil || !found {
    // Previously: log and return
    return
}
```

This can occur during namespace lifecycle races, informer cache inconsistencies, or operator restarts.

## Type of change

* [x] `BUGFIX` (non-breaking change which fixes an issue)

## Fix

Instead of returning early when namespace lookup fails, the operator now **enqueues all Prometheus instances as a fallback**. This guarantees reconciliation and prevents configuration changes from being lost.

The fallback is safe because Prometheus reconciliation is idempotent and namespace selectors are re-evaluated during reconcile.

```go
if err != nil || !found {
    c.logger.Warn(
        "namespace lookup failed, enqueueing all Prometheus instances as fallback",
        "namespace", nsName,
        "err", err,
    )
    _ = c.promInfs.ListAll(labels.Everything(), func(obj any) {
        c.rr.EnqueueForReconciliation(obj.(*monitoringv1.Prometheus))
    })
    return
}
```

The log level was changed from **Error** to **Warn**, as this is an expected transient condition rather than a fatal failure.

## Verification

* Added unit tests covering both behaviors:

  * Namespace lookup failure → all Prometheus instances are enqueued (fallback path)
  * Namespace found → only matching Prometheus instances are enqueued (unchanged behavior)
* Tests validate that configuration changes are no longer silently dropped.
* All tests pass locally.

<img width="1175" height="220" alt="Screenshot 2026-01-23 025037" src="https://github.com/user-attachments/assets/5703289f-867d-4ff4-9206-6f0f5d9e4a5c" />

