### PR TITLE
api: add listType markers to AlertmanagerConfig v1beta1

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -12424,6 +12424,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     sourceMatch:
                       description: |-
                         sourceMatch defines matchers for which one or more alerts have to exist for the inhibition
@@ -12458,6 +12459,7 @@ spec:
                         - name
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     targetMatch:
                       description: |-
                         targetMatch defines matchers that have to be fulfilled in the alerts to be muted.
@@ -12492,8 +12494,10 @@ spec:
                         - name
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               receivers:
                 description: receivers defines the list of receivers.
                 items:
@@ -13262,6 +13266,7 @@ spec:
                         - apiURL
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     emailConfigs:
                       description: emailConfigs defines the list of Email configurations.
                       items:
@@ -13357,6 +13362,7 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           hello:
                             description: |-
                               hello defines the hostname to identify to the SMTP server.
@@ -13582,6 +13588,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     msteamsConfigs:
                       description: |-
                         msteamsConfigs defines the list of MSTeams configurations.
@@ -14340,6 +14347,7 @@ spec:
                         - webhookUrl
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     msteamsv2Configs:
                       description: |-
                         msteamsv2Configs defines the list of MSTeamsV2 configurations.
@@ -15093,6 +15101,7 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: name defines the name of the receiver. Must be
                         unique across all items from the list.
@@ -15166,6 +15175,7 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           entity:
                             description: |-
                               entity defines an optional field that can be used to specify which domain alert is related to.
@@ -15933,6 +15943,7 @@ spec:
                               - type
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           sendResolved:
                             description: sendResolved defines whether or not to notify
                               about resolved alerts.
@@ -15951,6 +15962,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     pagerdutyConfigs:
                       description: pagerdutyConfigs defines the List of PagerDuty
                         configurations.
@@ -16819,6 +16831,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     pushoverConfigs:
                       description: pushoverConfigs defines the list of Pushover configurations.
                       items:
@@ -17657,6 +17670,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     rocketchatConfigs:
                       description: |-
                         rocketchatConfigs defines the list of RocketChat configurations.
@@ -17694,6 +17708,7 @@ spec:
                               type: object
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: atomic
                           apiURL:
                             description: |-
                               apiURL defines the API URL for RocketChat.
@@ -17746,6 +17761,7 @@ spec:
                               type: object
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: atomic
                           httpConfig:
                             description: httpConfig defines the HTTP client configuration
                               for RocketChat API requests.
@@ -18553,6 +18569,7 @@ spec:
                         - tokenID
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     slackConfigs:
                       description: slackConfigs defines the list of Slack configurations.
                       items:
@@ -19510,6 +19527,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     snsConfigs:
                       description: snsConfigs defines the list of SNS configurations
                       items:
@@ -20357,6 +20375,7 @@ spec:
                             type: boolean
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     telegramConfigs:
                       description: telegramConfigs defines the list of Telegram configurations.
                       items:
@@ -21138,6 +21157,7 @@ spec:
                         - chatID
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     victoropsConfigs:
                       description: victoropsConfigs defines the list of VictorOps
                         configurations.
@@ -21933,6 +21953,7 @@ spec:
                         - routingKey
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     webexConfigs:
                       description: webexConfigs defines the list of Webex configurations.
                       items:
@@ -22661,6 +22682,7 @@ spec:
                         - roomID
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     webhookConfigs:
                       description: webhookConfigs defines the List of webhook configurations.
                       items:
@@ -23421,6 +23443,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     wechatConfigs:
                       description: wechatConfigs defines the list of WeChat configurations.
                       items:
@@ -24201,10 +24224,14 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               route:
                 description: |-
                   route defines the Alertmanager route definition for incoming alerts. It will be added to the
@@ -24217,6 +24244,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                   continue:
                     description: |-
                       continue defines the boolean indicating whether an alert should continue matching subsequent
@@ -24231,6 +24259,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                   groupInterval:
                     description: |-
                       groupInterval defines how long to wait before sending an updated notification.
@@ -24281,12 +24310,14 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   muteTimeIntervals:
                     description: muteTimeIntervals is a list of MuteTimeInterval names
                       that will mute this route when matched,
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                   receiver:
                     description: |-
                       receiver defines the name of the receiver for this route. If not empty, it should be listed in
@@ -24305,6 +24336,7 @@ spec:
                     items:
                       x-kubernetes-preserve-unknown-fields: true
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               timeIntervals:
                 description: timeIntervals defines the list of timeIntervals specifying
@@ -24339,6 +24371,7 @@ spec:
                                   type: integer
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           months:
                             description: months defines a list of MonthRange
                             items:
@@ -24348,6 +24381,7 @@ spec:
                               pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|1[0-2]|[1-9]))$)|$)
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           times:
                             description: times defines a list of TimeRange
                             items:
@@ -24366,6 +24400,7 @@ spec:
                                   type: string
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           weekdays:
                             description: weekdays defines a list of WeekdayRange
                             items:
@@ -24375,6 +24410,7 @@ spec:
                               pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           years:
                             description: years defines a list of YearRange
                             items:
@@ -24382,12 +24418,15 @@ spec:
                               pattern: ^2\d{3}(?::2\d{3}|$)
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
             type: object
           status:
             description: |-

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -31,6 +31,7 @@
                         type: 'string',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'set',
                     },
                     sourceMatch: {
                       description: "sourceMatch defines matchers for which one or more alerts have to exist for the inhibition\nto take effect. The operator enforces that the alert matches the resource's namespace.\nThese are the \"trigger\" alerts that cause other alerts to be inhibited.",
@@ -63,6 +64,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     targetMatch: {
                       description: "targetMatch defines matchers that have to be fulfilled in the alerts to be muted.\nThe operator enforces that the alert matches the resource's namespace.\nWhen these conditions are met, matching alerts will be inhibited (silenced).",
@@ -95,11 +97,13 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                   },
                   type: 'object',
                 },
                 type: 'array',
+                'x-kubernetes-list-type': 'atomic',
               },
               receivers: {
                 description: 'receivers defines the list of receivers.',
@@ -806,6 +810,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     emailConfigs: {
                       description: 'emailConfigs defines the list of Email configurations.',
@@ -893,6 +898,7 @@
                               type: 'object',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           hello: {
                             description: 'hello defines the hostname to identify to the SMTP server.\nThis is used in the SMTP HELO/EHLO command during the connection handshake.',
@@ -1108,6 +1114,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     msteamsConfigs: {
                       description: 'msteamsConfigs defines the list of MSTeams configurations.\nIt requires Alertmanager >= 0.26.0.',
@@ -1798,6 +1805,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     msteamsv2Configs: {
                       description: 'msteamsv2Configs defines the list of MSTeamsV2 configurations.\nIt requires Alertmanager >= 0.28.0.',
@@ -2483,6 +2491,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     name: {
                       description: 'name defines the name of the receiver. Must be unique across all items from the list.',
@@ -2551,6 +2560,7 @@
                               type: 'object',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           entity: {
                             description: 'entity defines an optional field that can be used to specify which domain alert is related to.\nThis helps group related alerts together in OpsGenie.',
@@ -3249,6 +3259,7 @@
                               type: 'object',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           sendResolved: {
                             description: 'sendResolved defines whether or not to notify about resolved alerts.',
@@ -3268,6 +3279,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     pagerdutyConfigs: {
                       description: 'pagerdutyConfigs defines the List of PagerDuty configurations.',
@@ -4078,6 +4090,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     pushoverConfigs: {
                       description: 'pushoverConfigs defines the list of Pushover configurations.',
@@ -4835,6 +4848,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     rocketchatConfigs: {
                       description: 'rocketchatConfigs defines the list of RocketChat configurations.\nIt requires Alertmanager >= 0.28.0.',
@@ -4865,6 +4879,7 @@
                             },
                             minItems: 1,
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           apiURL: {
                             description: 'apiURL defines the API URL for RocketChat.\nDefaults to https://open.rocket.chat/ if not specified.',
@@ -4910,6 +4925,7 @@
                             },
                             minItems: 1,
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           httpConfig: {
                             description: 'httpConfig defines the HTTP client configuration for RocketChat API requests.',
@@ -5642,6 +5658,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     slackConfigs: {
                       description: 'slackConfigs defines the list of Slack configurations.',
@@ -6516,6 +6533,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     snsConfigs: {
                       description: 'snsConfigs defines the list of SNS configurations',
@@ -7287,6 +7305,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     telegramConfigs: {
                       description: 'telegramConfigs defines the list of Telegram configurations.',
@@ -7998,6 +8017,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     victoropsConfigs: {
                       description: 'victoropsConfigs defines the list of VictorOps configurations.',
@@ -8727,6 +8747,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     webexConfigs: {
                       description: 'webexConfigs defines the list of Webex configurations.',
@@ -9396,6 +9417,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     webhookConfigs: {
                       description: 'webhookConfigs defines the List of webhook configurations.',
@@ -10088,6 +10110,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                     wechatConfigs: {
                       description: 'wechatConfigs defines the list of WeChat configurations.',
@@ -10800,6 +10823,7 @@
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                   },
                   required: [
@@ -10808,6 +10832,10 @@
                   type: 'object',
                 },
                 type: 'array',
+                'x-kubernetes-list-map-keys': [
+                  'name',
+                ],
+                'x-kubernetes-list-type': 'map',
               },
               route: {
                 description: "route defines the Alertmanager route definition for incoming alerts. It will be added to the\ngenerated Alertmanager configuration as a first-level route. The matching behavior of the\nroute depends on the Alertmanager's AlertmanagerConfigMatcherStrategyType.",
@@ -10818,6 +10846,7 @@
                       type: 'string',
                     },
                     type: 'array',
+                    'x-kubernetes-list-type': 'set',
                   },
                   continue: {
                     description: 'continue defines the boolean indicating whether an alert should continue matching subsequent\nsibling nodes. It will always be overridden to true for the first-level\nroute by the Prometheus operator.',
@@ -10829,6 +10858,7 @@
                       type: 'string',
                     },
                     type: 'array',
+                    'x-kubernetes-list-type': 'set',
                   },
                   groupInterval: {
                     description: 'groupInterval defines how long to wait before sending an updated notification.\nMust be greater than 0.\nExample: "5m"',
@@ -10873,6 +10903,7 @@
                       type: 'object',
                     },
                     type: 'array',
+                    'x-kubernetes-list-type': 'atomic',
                   },
                   muteTimeIntervals: {
                     description: 'muteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,',
@@ -10880,6 +10911,7 @@
                       type: 'string',
                     },
                     type: 'array',
+                    'x-kubernetes-list-type': 'set',
                   },
                   receiver: {
                     description: 'receiver defines the name of the receiver for this route. If not empty, it should be listed in\nthe `receivers` field.',
@@ -10897,6 +10929,7 @@
                       'x-kubernetes-preserve-unknown-fields': true,
                     },
                     type: 'array',
+                    'x-kubernetes-list-type': 'atomic',
                   },
                 },
                 type: 'object',
@@ -10936,6 +10969,7 @@
                               type: 'object',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           months: {
                             description: 'months defines a list of MonthRange',
@@ -10945,6 +10979,7 @@
                               type: 'string',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           times: {
                             description: 'times defines a list of TimeRange',
@@ -10965,6 +11000,7 @@
                               type: 'object',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           weekdays: {
                             description: 'weekdays defines a list of WeekdayRange',
@@ -10974,6 +11010,7 @@
                               type: 'string',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                           years: {
                             description: 'years defines a list of YearRange',
@@ -10983,11 +11020,13 @@
                               type: 'string',
                             },
                             type: 'array',
+                            'x-kubernetes-list-type': 'atomic',
                           },
                         },
                         type: 'object',
                       },
                       type: 'array',
+                      'x-kubernetes-list-type': 'atomic',
                     },
                   },
                   required: [
@@ -10996,6 +11035,7 @@
                   type: 'object',
                 },
                 type: 'array',
+                'x-kubernetes-list-type': 'atomic',
               },
             },
             type: 'object',

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -85,13 +85,17 @@ type AlertmanagerConfigSpec struct {
 	// +optional
 	Route *Route `json:"route"`
 	// receivers defines the list of receivers.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Receivers []Receiver `json:"receivers"`
 	// inhibitRules defines the list of inhibition rules. The rules will only apply to alerts matching
 	// the resource's namespace.
+	// +listType=atomic
 	// +optional
 	InhibitRules []InhibitRule `json:"inhibitRules,omitempty"`
 	// timeIntervals defines the list of timeIntervals specifying when the routes should be muted.
+	// +listType=atomic
 	// +optional
 	TimeIntervals []TimeInterval `json:"timeIntervals,omitempty"`
 }
@@ -105,6 +109,7 @@ type Route struct {
 	// groupBy defines the list of labels to group by.
 	// Labels must not be repeated (unique list).
 	// Special label "..." (aggregate by all possible labels), if provided, must be the only element in the list.
+	// +listType=set
 	// +optional
 	GroupBy []string `json:"groupBy,omitempty"`
 	// groupWait defines how long to wait before sending the initial notification.
@@ -125,6 +130,7 @@ type Route struct {
 	// level route, the operator removes any existing equality and regexp
 	// matcher on the `namespace` label and adds a `namespace: <object namespace>` matcher,
 	// unless configured otherwise in Alertmanager's AlertmanagerConfigMatcherStrategyType.
+	// +listType=atomic
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// continue defines the boolean indicating whether an alert should continue matching subsequent
@@ -133,6 +139,7 @@ type Route struct {
 	// +optional
 	Continue bool `json:"continue,omitempty"` // nolint:kubeapilinter
 	// routes defines the child routes.
+	// +listType=atomic
 	// +optional
 	Routes []apiextensionsv1.JSON `json:"routes,omitempty"`
 	// Note: this comment applies to the field definition above but appears
@@ -144,9 +151,11 @@ type Route struct {
 	// JSON representation.
 
 	// muteTimeIntervals is a list of MuteTimeInterval names that will mute this route when matched,
+	// +listType=set
 	// +optional
 	MuteTimeIntervals []string `json:"muteTimeIntervals,omitempty"`
 	// activeTimeIntervals is a list of TimeInterval names when this route should be active.
+	// +listType=set
 	// +optional
 	ActiveTimeIntervals []string `json:"activeTimeIntervals,omitempty"`
 }
@@ -173,51 +182,66 @@ type Receiver struct {
 	// +required
 	Name string `json:"name"`
 	// opsgenieConfigs defines the list of OpsGenie configurations.
+	// +listType=atomic
 	// +optional
 	OpsGenieConfigs []OpsGenieConfig `json:"opsgenieConfigs,omitempty"`
 	// pagerdutyConfigs defines the List of PagerDuty configurations.
+	// +listType=atomic
 	// +optional
 	PagerDutyConfigs []PagerDutyConfig `json:"pagerdutyConfigs,omitempty"`
 	// discordConfigs defines the list of Discord configurations.
+	// +listType=atomic
 	// +optional
 	DiscordConfigs []DiscordConfig `json:"discordConfigs,omitempty"`
 	// slackConfigs defines the list of Slack configurations.
+	// +listType=atomic
 	// +optional
 	SlackConfigs []SlackConfig `json:"slackConfigs,omitempty"`
 	// webhookConfigs defines the List of webhook configurations.
+	// +listType=atomic
 	// +optional
 	WebhookConfigs []WebhookConfig `json:"webhookConfigs,omitempty"`
 	// wechatConfigs defines the list of WeChat configurations.
+	// +listType=atomic
 	// +optional
 	WeChatConfigs []WeChatConfig `json:"wechatConfigs,omitempty"`
 	// emailConfigs defines the list of Email configurations.
+	// +listType=atomic
 	// +optional
 	EmailConfigs []EmailConfig `json:"emailConfigs,omitempty"`
 	// victoropsConfigs defines the list of VictorOps configurations.
+	// +listType=atomic
 	// +optional
 	VictorOpsConfigs []VictorOpsConfig `json:"victoropsConfigs,omitempty"`
 	// pushoverConfigs defines the list of Pushover configurations.
+	// +listType=atomic
 	// +optional
 	PushoverConfigs []PushoverConfig `json:"pushoverConfigs,omitempty"`
 	// snsConfigs defines the list of SNS configurations
+	// +listType=atomic
 	// +optional
 	SNSConfigs []SNSConfig `json:"snsConfigs,omitempty"`
 	// telegramConfigs defines the list of Telegram configurations.
+	// +listType=atomic
 	// +optional
 	TelegramConfigs []TelegramConfig `json:"telegramConfigs,omitempty"`
 	// webexConfigs defines the list of Webex configurations.
+	// +listType=atomic
 	// +optional
 	WebexConfigs []WebexConfig `json:"webexConfigs,omitempty"`
 	// msteamsConfigs defines the list of MSTeams configurations.
 	// It requires Alertmanager >= 0.26.0.
+	// +listType=atomic
 	// +optional
 	MSTeamsConfigs []MSTeamsConfig `json:"msteamsConfigs,omitempty"`
 	// msteamsv2Configs defines the list of MSTeamsV2 configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +listType=atomic
 	// +optional
 	MSTeamsV2Configs []MSTeamsV2Config `json:"msteamsv2Configs,omitempty"`
 	// rocketchatConfigs defines the list of RocketChat configurations.
 	// It requires Alertmanager >= 0.28.0.
+	// +listType=atomic
 	// +optional
 	RocketChatConfigs []RocketChatConfig `json:"rocketchatConfigs,omitempty"`
 }
@@ -641,10 +665,12 @@ type OpsGenieConfig struct {
 	Priority *string `json:"priority,omitempty"`
 	// details defines a set of arbitrary key/value pairs that provide further detail about the incident.
 	// These appear as additional fields in the OpsGenie alert.
+	// +listType=atomic
 	// +optional
 	Details []KeyValue `json:"details,omitempty"`
 	// responders defines the list of responders responsible for notifications.
 	// These determine who gets notified when the alert is created.
+	// +listType=atomic
 	// +optional
 	Responders []OpsGenieConfigResponder `json:"responders,omitempty"`
 	// httpConfig defines the HTTP client configuration for OpsGenie API requests.
@@ -864,6 +890,7 @@ type EmailConfig struct {
 	AuthIdentity *string `json:"authIdentity,omitempty"`
 	// headers defines additional email header key/value pairs.
 	// These override any headers previously set by the notification implementation.
+	// +listType=atomic
 	// +optional
 	Headers []KeyValue `json:"headers,omitempty"`
 	// html defines the HTML body of the email notification.
@@ -1272,6 +1299,7 @@ type RocketChatConfig struct {
 	// fields defines additional fields for the message attachment.
 	// These appear as structured key-value pairs within the message.
 	// +kubebuilder:validation:MinItems=1
+	// +listType=atomic
 	// +optional
 	Fields []RocketChatFieldConfig `json:"fields,omitempty"`
 	// shortFields defines whether to use short fields in the message layout.
@@ -1293,6 +1321,7 @@ type RocketChatConfig struct {
 	// actions defines interactive actions to include in the message.
 	// These appear as buttons that users can click to trigger responses.
 	// +kubebuilder:validation:MinItems=1
+	// +listType=atomic
 	// +optional
 	Actions []RocketChatActionConfig `json:"actions,omitempty"`
 	// httpConfig defines the HTTP client configuration for RocketChat API requests.
@@ -1343,15 +1372,18 @@ type InhibitRule struct {
 	// targetMatch defines matchers that have to be fulfilled in the alerts to be muted.
 	// The operator enforces that the alert matches the resource's namespace.
 	// When these conditions are met, matching alerts will be inhibited (silenced).
+	// +listType=atomic
 	// +optional
 	TargetMatch []Matcher `json:"targetMatch,omitempty"`
 	// sourceMatch defines matchers for which one or more alerts have to exist for the inhibition
 	// to take effect. The operator enforces that the alert matches the resource's namespace.
 	// These are the "trigger" alerts that cause other alerts to be inhibited.
+	// +listType=atomic
 	// +optional
 	SourceMatch []Matcher `json:"sourceMatch,omitempty"`
 	// equal defines labels that must have an equal value in the source and target alert
 	// for the inhibition to take effect. This ensures related alerts are properly grouped.
+	// +listType=set
 	// +optional
 	Equal []string `json:"equal,omitempty"`
 }
@@ -1478,6 +1510,7 @@ type TimeInterval struct {
 	// +required
 	Name string `json:"name,omitempty"`
 	// timeIntervals defines a list of TimePeriod.
+	// +listType=atomic
 	// +optional
 	TimeIntervals []TimePeriod `json:"timeIntervals,omitempty"`
 }
@@ -1485,18 +1518,23 @@ type TimeInterval struct {
 // TimePeriod describes periods of time.
 type TimePeriod struct {
 	// times defines a list of TimeRange
+	// +listType=atomic
 	// +optional
 	Times []TimeRange `json:"times,omitempty"`
 	// weekdays defines a list of WeekdayRange
+	// +listType=atomic
 	// +optional
 	Weekdays []WeekdayRange `json:"weekdays,omitempty"`
 	// daysOfMonth defines a list of DayOfMonthRange
+	// +listType=atomic
 	// +optional
 	DaysOfMonth []DayOfMonthRange `json:"daysOfMonth,omitempty"`
 	// months defines a list of MonthRange
+	// +listType=atomic
 	// +optional
 	Months []MonthRange `json:"months,omitempty"`
 	// years defines a list of YearRange
+	// +listType=atomic
 	// +optional
 	Years []YearRange `json:"years,omitempty"`
 }


### PR DESCRIPTION
## Description

Add SSA (Server-Side Apply) listType markers to all slice fields in `v1beta1/alertmanager_config_types.go` to satisfy the KAL ssatags linter.

- Use `listType=map` with `listMapKey=name` for Receivers (Alertmanager expects unique names)
- Use `listType=set` for unique string lists (GroupBy, MuteTimeIntervals, ActiveTimeIntervals, Equal)
- Use `listType=atomic` for all other complex object lists

Related to: #8131

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Ran the linter locally with ssatags enabled, no violations left in v1beta1/alertmanager_config_types.go

## Changelog entry

```release-note
NONE
```