### PR TITLE
fix: add missing ForgetObject call in Alertmanager controller

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -590,6 +590,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 
 	// Check if the Alertmanager instance is marked for deletion.
 	if c.rr.DeletionInProgress(am) {
+		c.reconciliations.ForgetObject(key)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a lifecycle inconsistency in the Alertmanager controller where reconciliation state was not properly cleaned up when an `Alertmanager` resource was deleted.

Specifically, the Alertmanager controller returned early when a resource was marked for deletion without removing the corresponding entry from the reconciliation tracker. This caused stale reconciliation state to persist indefinitely, unlike the behavior of the Prometheus, PrometheusAgent, and ThanosRuler controllers, which already handle this case correctly.

This change updates the Alertmanager controller to follow the same, correct deletion lifecycle pattern as the other controllers.

---

## Fix

The fix adds a missing call to `ForgetObject(key)` when an Alertmanager instance is detected as being in the deletion phase. This ensures reconciliation tracking state is properly cleaned up once the resource will no longer be reconciled.

**Before:**

```go
// Check if the Alertmanager instance is marked for deletion.
if c.rr.DeletionInProgress(am) {
    return nil
}
```

**After:**

```go
// Check if the Alertmanager instance is marked for deletion.
if c.rr.DeletionInProgress(am) {
    c.reconciliations.ForgetObject(key)
    return nil
}
```

With this change, the Alertmanager controller now behaves consistently with the other controllers that already remove reconciliation tracking state during deletion.

---

## Verification

* ✅ Code compiles successfully
* ✅ All Alertmanager package tests pass
* ✅ Manual consistency check confirms Alertmanager now matches the deletion handling pattern used by:

  * Prometheus
  * PrometheusAgent
  * ThanosRuler

---

## Type of change

* [x] `BUGFIX` (non-breaking change which fixes an issue)