### PR TITLE
fix: propagate volumes to daemonset from prometheusagent spec

### DIFF
--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -17,6 +17,7 @@ package prometheusagent
 import (
 	"fmt"
 	"maps"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -108,7 +109,7 @@ func makeDaemonSetSpec(
 	}
 
 	promArgs = append(promArgs, confArg)
-	volumes = append(volumes, configVol...)
+	volumes = slices.Concat(volumes, configVol, cpf.Volumes)
 	promVolumeMounts = append(promVolumeMounts, configMount...)
 
 	configReloaderWebConfigFile = confArg.Value

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -492,3 +492,32 @@ func TestStatefulSetUpdateStrategy(t *testing.T) {
 		})
 	}
 }
+
+func TestAdditionalStatefulSetVolumes(t *testing.T) {
+	addedVolumeName := "added-volume"
+	sset, err := makeStatefulSetFromPrometheus(
+		monitoringv1alpha1.PrometheusAgent{
+			Spec: monitoringv1alpha1.PrometheusAgentSpec{
+				CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+					Volumes: []v1.Volume{
+						{
+							Name: addedVolumeName,
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	hasAddedVolume := false
+	for _, vol := range sset.Spec.Template.Spec.Volumes {
+		if vol.Name == addedVolumeName && vol.EmptyDir != nil {
+			hasAddedVolume = true
+			break
+		}
+	}
+	require.True(t, hasAddedVolume, "expected to find added volume in StatefulSet spec")
+}


### PR DESCRIPTION
## Description

Closes: #7813

This PR ensures that additional volumes specified in the `volumes` field of the `PrometheusAgent` CRD are propagated correctly when running in DaemonSet mode.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Added unit tests for both modes to verify that DaemonSet mode now behaves as StatefulSet mode already does.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Propagate `volumes` to the managed DaemonSet when running the Agent in DaemonSet mode.
```
