### PR TITLE
Fix nil pointer panic in OnUpdate event handler

### DIFF
--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -454,11 +454,13 @@ func (rr *ResourceReconciler) OnUpdate(old, cur any) {
 	mOld, err := meta.Accessor(old)
 	if err != nil {
 		rr.logger.Error("failed to get old object meta", "err", err, "key", key)
+		return
 	}
 
 	mCur, err := meta.Accessor(cur)
 	if err != nil {
 		rr.logger.Error("failed to get current object meta", "err", err, "key", key)
+		return
 	}
 
 	if !rr.isManagedByController(mCur) {


### PR DESCRIPTION
This PR fixes a nil pointer dereference in the OnUpdate event handler of ResourceReconciler.

If meta.Accessor() fails for either the old or current object, the handler logged the error but continued execution, which can lead to dereferencing nil metadata and panicking the controller.

OnAdd and OnDelete already return early on this error; this change makes OnUpdate consistent and prevents controller crashes on malformed or partially synced objects.

Thanks for reviewing!