### PR TITLE
fix: add missing ScrapeConfigNamespaceSelector in handleMonitorNamesp…

### DIFF
--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -1199,13 +1199,14 @@ func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
 	c.metrics.TriggerByCounter("Namespace", operator.UpdateEvent).Inc()
 
 	// Check for Prometheus Agent instances selecting ServiceMonitors, PodMonitors,
-	// and Probes in the namespace.
+	// Probes and ScrapeConfigs in the namespace.
 	err := c.promInfs.ListAll(labels.Everything(), func(obj any) {
 		p := obj.(*monitoringv1alpha1.PrometheusAgent)
 
 		for name, selector := range map[string]*metav1.LabelSelector{
 			"PodMonitors":     p.Spec.PodMonitorNamespaceSelector,
 			"Probes":          p.Spec.ProbeNamespaceSelector,
+			"ScrapeConfigs":   p.Spec.ScrapeConfigNamespaceSelector,
 			"ServiceMonitors": p.Spec.ServiceMonitorNamespaceSelector,
 		} {
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -774,7 +774,7 @@ func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
 	c.metrics.TriggerByCounter("Namespace", operator.UpdateEvent).Inc()
 
 	// Check for Prometheus instances selecting ServiceMonitors, PodMonitors,
-	// Probes and PrometheusRules in the namespace.
+	// Probes, PrometheusRules and ScrapeConfigs in the namespace.
 	err := c.promInfs.ListAll(labels.Everything(), func(obj any) {
 		p := obj.(*monitoringv1.Prometheus)
 
@@ -782,6 +782,7 @@ func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
 			"PodMonitors":     p.Spec.PodMonitorNamespaceSelector,
 			"Probes":          p.Spec.ProbeNamespaceSelector,
 			"PrometheusRules": p.Spec.RuleNamespaceSelector,
+			"ScrapeConfigs":   p.Spec.ScrapeConfigNamespaceSelector,
 			"ServiceMonitors": p.Spec.ServiceMonitorNamespaceSelector,
 		} {
 


### PR DESCRIPTION
## Summary

`handleMonitorNamespaceUpdate` is responsible for re-reconciling Prometheus and PrometheusAgent instances when **namespace labels change**. This logic currently evaluates namespace selectors for `ServiceMonitor`, `PodMonitor`, `Probe`, and `PrometheusRule`, but **omits `ScrapeConfigNamespaceSelector`**.

As a result, when a namespace label changes in a way that should bring a namespace **into or out of scope** of a `ScrapeConfigNamespaceSelector`, the affected Prometheus instance is **not re-enqueued**. ScrapeConfigs from that namespace are therefore silently missed or incorrectly retained until the next periodic resync.

This creates a correctness gap between:

* `enqueueForNamespace`, which already handles `ScrapeConfigNamespaceSelector`, and
* `handleMonitorNamespaceUpdate`, which should react equivalently to namespace label changes.

---

## Fix

This PR adds the missing `ScrapeConfigNamespaceSelector` to the selector maps used in `handleMonitorNamespaceUpdate` for both:

* Prometheus server controller
* PrometheusAgent controller

With this change, namespace label updates that affect `ScrapeConfigNamespaceSelector` now correctly trigger reconciliation, bringing ScrapeConfig behavior in line with other configuration resources.

No other logic is modified. Once reconciliation is triggered, the existing selection and config generation pipeline already handles ScrapeConfigs correctly.

---

## Type of change

*What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply.*

* [x] `BUGFIX` (non-breaking change which fixes an issue)
