### PR TITLE
fix: labelmap replacement validation for template variables

### DIFF
--- a/pkg/prometheus/validation/validator_test.go
+++ b/pkg/prometheus/validation/validator_test.go
@@ -385,6 +385,24 @@ func TestValidateRelabelConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			scenario: "valid labelmap config with replacement containing template variable",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "labelmap",
+				Regex:       "^(cluster)$",
+				Replacement: ptr.To("exported_${1}"),
+			},
+			prometheus: defaultPrometheusSpec,
+		},
+		{
+			scenario: "valid labelmap config with replacement",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "labelmap",
+				Regex:       "__meta_kubernetes_(.*)",
+				Replacement: ptr.To("k8s_${1}"),
+			},
+			prometheus: defaultPrometheusSpec,
+		},
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			lcv, err := NewLabelConfigValidator(&tc.prometheus)


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: https://github.com/prometheus-operator/prometheus-operator/issues/8336

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
