### PR TITLE
Fix stuck deletion when paused ThanosRuler skips finalizer cleanup

### DIFF
--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -484,10 +484,6 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	if tr.Spec.Paused {
-		return nil
-	}
-
 	logger := o.logger.With("key", key)
 
 	statusCleanup := func() error {
@@ -508,6 +504,10 @@ func (o *Operator) sync(ctx context.Context, key string) error {
 	// Check if the Thanos instance is marked for deletion.
 	if o.rr.DeletionInProgress(tr) {
 		o.reconciliations.ForgetObject(key)
+		return nil
+	}
+
+	if tr.Spec.Paused {
 		return nil
 	}
 


### PR DESCRIPTION
This PR fixes a deletion edge case where a paused ThanosRuler resource can remain stuck in Terminating.

In the current sync flow, the controller returns early when spec.paused is set, before running finalizer handling. If a paused ThanosRuler is deleted, this prevents the finalizer cleanup logic from running and the finalizer is never removed, leaving the resource permanently in the deleting state.

This change moves the paused check to occur after finalizer processing and deletion handling. This ensures that:
	•	finalizer cleanup always runs when a resource is being deleted
	•	finalizers are correctly removed even if the resource is paused
	•	normal reconciliation behavior for paused resources remains unchanged

The overall reconciliation logic is preserved, and this only affects the deletion path for paused resources.

Thanks for reviewing!