### PR TITLE
fix: make mattermost text field optional in alertmanager config

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -4872,6 +4872,22 @@ func TestSanitizeConfig(t *testing.T) {
 			golden: "test_webhook_url_takes_precedence_in_mattermost_config.golden",
 		},
 		{
+			name:           "Test text is optional in mattermost config",
+			againstVersion: versionMattermostConfigAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						MattermostConfigs: []*mattermostConfig{
+							{
+								WebhookURL: "www.test.com",
+							},
+						},
+					},
+				},
+			},
+			golden: "test_mattermos_text_is_optional.golden",
+		},
+		{
 			name:           "Test timeout is dropped in pagerduty config for unsupported versions",
 			againstVersion: versionTimeoutConfigNotAllowed,
 

--- a/pkg/alertmanager/testdata/test_mattermos_text_is_optional.golden
+++ b/pkg/alertmanager/testdata/test_mattermos_text_is_optional.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  mattermost_configs:
+  - webhook_url: www.test.com
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -513,7 +513,7 @@ type mattermostConfig struct {
 	WebhookURLFile string                        `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 	Channel        string                        `yaml:"channel,omitempty" json:"channel,omitempty"`
 	Username       string                        `yaml:"username,omitempty" json:"username,omitempty"`
-	Text           string                        `yaml:"text" json:"text"`
+	Text           string                        `yaml:"text,omitempty" json:"text,omitempty"`
 	IconURL        string                        `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
 	IconEmoji      string                        `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
 	Attachments    []*mattermostAttachmentConfig `yaml:"attachments,omitempty" json:"attachments,omitempty"`


### PR DESCRIPTION
## Description

Alertmanager allows mattermost receivers without a text field, but prometheus-operator was always rendering an empty string when it was not set. This change avoids emitting text when it is not configured.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Make Mattermost text field optional in Alertmanager config.
```
