### PR TITLE
refactor: extract shared validation helpers for alertmanager config

### DIFF
--- a/pkg/alertmanager/validation/v1beta1/validation.go
+++ b/pkg/alertmanager/validation/v1beta1/validation.go
@@ -17,8 +17,6 @@ package v1beta1
 import (
 	"errors"
 	"fmt"
-	"net"
-	"strings"
 
 	"k8s.io/utils/ptr"
 
@@ -130,8 +128,8 @@ func validatePagerDutyConfigs(configs []monitoringv1beta1.PagerDutyConfig) error
 			}
 		}
 
-		if conf.RoutingKey == nil && conf.ServiceKey == nil {
-			return errors.New("one of 'routingKey' or 'serviceKey' is required")
+		if err := validation.ValidatePagerDutyConfig(conf.RoutingKey != nil, conf.ServiceKey != nil); err != nil {
+			return err
 		}
 
 		for j, lc := range conf.PagerDutyLinkConfigs {
@@ -190,8 +188,8 @@ func validateSlackConfigs(configs []monitoringv1beta1.SlackConfig) error {
 
 func validateWebhookConfigs(configs []monitoringv1beta1.WebhookConfig) error {
 	for i, config := range configs {
-		if config.URL == nil && config.URLSecret == nil {
-			return fmt.Errorf("[%d]: one of 'url' or 'urlSecret' must be specified", i)
+		if err := validation.ValidateWebhookConfig(config.URL != nil, config.URLSecret != nil); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
 		}
 
 		if err := validation.ValidateTemplateURLPtr(config.URL); err != nil {
@@ -226,22 +224,19 @@ func validateEmailConfig(configs []monitoringv1beta1.EmailConfig) error {
 			return errors.New("missing 'to' address")
 		}
 
-		if ptr.Deref(config.Smarthost, "") != "" {
-			_, _, err := net.SplitHostPort(*config.Smarthost)
-			if err != nil {
-				return fmt.Errorf("invalid 'smarthost' %s: %w", *config.Smarthost, err)
+		if smarthost := ptr.Deref(config.Smarthost, ""); smarthost != "" {
+			if err := validation.ValidateSmarthost(smarthost); err != nil {
+				return err
 			}
 		}
 
 		if config.Headers != nil {
-			// Header names are case-insensitive, check for collisions.
-			normalizedHeaders := map[string]struct{}{}
+			keys := make([]string, 0, len(config.Headers))
 			for _, v := range config.Headers {
-				normalized := strings.ToLower(v.Key)
-				if _, ok := normalizedHeaders[normalized]; ok {
-					return fmt.Errorf("duplicate header %q", normalized)
-				}
-				normalizedHeaders[normalized] = struct{}{}
+				keys = append(keys, v.Key)
+			}
+			if err := validation.ValidateEmailHeaders(keys); err != nil {
+				return err
 			}
 		}
 	}
@@ -250,23 +245,13 @@ func validateEmailConfig(configs []monitoringv1beta1.EmailConfig) error {
 
 func validateVictorOpsConfigs(configs []monitoringv1beta1.VictorOpsConfig) error {
 	for i, config := range configs {
-
-		// from https://github.com/prometheus/alertmanager/blob/a7f9fdadbecbb7e692d2cd8d3334e3d6de1602e1/config/notifiers.go#L497
-		reservedFields := map[string]struct{}{
-			"routing_key":         {},
-			"message_type":        {},
-			"state_message":       {},
-			"entity_display_name": {},
-			"monitoring_tool":     {},
-			"entity_id":           {},
-			"entity_state":        {},
-		}
-
 		if len(config.CustomFields) > 0 {
+			keys := make([]string, 0, len(config.CustomFields))
 			for _, v := range config.CustomFields {
-				if _, ok := reservedFields[v.Key]; ok {
-					return fmt.Errorf("usage of reserved word %q is not allowed in custom fields", v.Key)
-				}
+				keys = append(keys, v.Key)
+			}
+			if err := validation.ValidateVictorOpsCustomFields(keys); err != nil {
+				return err
 			}
 		}
 
@@ -287,16 +272,15 @@ func validateVictorOpsConfigs(configs []monitoringv1beta1.VictorOpsConfig) error
 
 func validatePushoverConfigs(configs []monitoringv1beta1.PushoverConfig) error {
 	for i, config := range configs {
-		if config.UserKey == nil && config.UserKeyFile == nil {
-			return fmt.Errorf("one of userKey or userKeyFile must be configured")
-		}
-
-		if config.Token == nil && config.TokenFile == nil {
-			return fmt.Errorf("one of token or tokenFile must be configured")
-		}
-
-		if config.HTML != nil && *config.HTML && config.Monospace != nil && *config.Monospace {
-			return fmt.Errorf("html and monospace options are mutually exclusive")
+		if err := validation.ValidatePushoverConfig(
+			config.UserKey != nil,
+			config.UserKeyFile != nil,
+			config.Token != nil,
+			config.TokenFile != nil,
+			config.HTML != nil && *config.HTML,
+			config.Monospace != nil && *config.Monospace,
+		); err != nil {
+			return err
 		}
 
 		if config.URL != "" {
@@ -315,8 +299,12 @@ func validatePushoverConfigs(configs []monitoringv1beta1.PushoverConfig) error {
 
 func validateSnsConfigs(configs []monitoringv1beta1.SNSConfig) error {
 	for i, config := range configs {
-		if (ptr.Deref(config.TargetARN, "") == "") != (ptr.Deref(config.TopicARN, "") == "") != (ptr.Deref(config.PhoneNumber, "") == "") {
-			return fmt.Errorf("[%d]: must provide either a targetARN, topicARN, or phoneNumber for SNS config", i)
+		if err := validation.ValidateSNSConfig(
+			ptr.Deref(config.TargetARN, "") != "",
+			ptr.Deref(config.TopicARN, "") != "",
+			ptr.Deref(config.PhoneNumber, "") != "",
+		); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
 		}
 
 		if config.ApiURL != nil {
@@ -334,12 +322,12 @@ func validateSnsConfigs(configs []monitoringv1beta1.SNSConfig) error {
 
 func validateTelegramConfigs(configs []monitoringv1beta1.TelegramConfig) error {
 	for i, config := range configs {
-		if config.BotToken == nil && config.BotTokenFile == nil {
-			return fmt.Errorf("[%d]: mandatory field botToken or botTokenfile is empty", i)
-		}
-
-		if config.ChatID == 0 {
-			return fmt.Errorf("[%d]: mandatory field %q is empty", i, "chatID")
+		if err := validation.ValidateTelegramConfig(
+			config.BotToken != nil,
+			config.BotTokenFile != nil,
+			config.ChatID,
+		); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
 		}
 
 		if err := validation.ValidateURLPtr((*string)(config.APIURL)); err != nil {
@@ -439,38 +427,23 @@ func validateRoute(r *monitoringv1beta1.Route, receivers, timeIntervals map[stri
 		return nil
 	}
 
-	if r.Receiver == "" {
-		if topLevelRoute {
-			return fmt.Errorf("root route must define a receiver")
-		}
-	} else {
-		if _, found := receivers[r.Receiver]; !found {
-			return fmt.Errorf("receiver %q not found", r.Receiver)
-		}
+	if err := validation.ValidateRouteReceiver(r.Receiver, receivers, topLevelRoute); err != nil {
+		return err
 	}
 
-	if groupLen := len(r.GroupBy); groupLen > 0 {
-		groupedBy := make(map[string]struct{}, groupLen)
-		for _, str := range r.GroupBy {
-			if _, found := groupedBy[str]; found {
-				return fmt.Errorf("duplicate values not permitted in route 'groupBy': %v", r.GroupBy)
-			}
-			groupedBy[str] = struct{}{}
-		}
-		if _, found := groupedBy["..."]; found && groupLen > 1 {
-			return fmt.Errorf("'...' must be a sole value in route 'groupBy': %v", r.GroupBy)
-		}
+	if err := validation.ValidateRouteGroupBy(r.GroupBy); err != nil {
+		return err
 	}
 
 	for _, namedTimeInterval := range r.MuteTimeIntervals {
-		if _, found := timeIntervals[namedTimeInterval]; !found {
-			return fmt.Errorf("time interval %q not found", namedTimeInterval)
+		if err := validation.ValidateTimeIntervalReference(namedTimeInterval, timeIntervals, false); err != nil {
+			return err
 		}
 	}
 
 	for _, namedTimeInterval := range r.ActiveTimeIntervals {
-		if _, found := timeIntervals[namedTimeInterval]; !found {
-			return fmt.Errorf("time interval %q not found", namedTimeInterval)
+		if err := validation.ValidateTimeIntervalReference(namedTimeInterval, timeIntervals, false); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/alertmanager/validation/validation.go
+++ b/pkg/alertmanager/validation/validation.go
@@ -16,7 +16,9 @@ package validation
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"text/template"
 
@@ -91,5 +93,162 @@ func ValidateSecretURL(url string) error {
 		return fmt.Errorf("validate url from string failed with error: %w", err)
 	}
 
+	return nil
+}
+
+// VictorOpsReservedFields contains the set of field names that are reserved
+// and cannot be used in VictorOps custom fields.
+// See: https://github.com/prometheus/alertmanager/blob/a7f9fdadbecbb7e692d2cd8d3334e3d6de1602e1/config/notifiers.go#L497
+var VictorOpsReservedFields = map[string]struct{}{
+	"routing_key":         {},
+	"message_type":        {},
+	"state_message":       {},
+	"entity_display_name": {},
+	"monitoring_tool":     {},
+	"entity_id":           {},
+	"entity_state":        {},
+}
+
+// ValidateVictorOpsCustomFields checks that no custom field uses a reserved name.
+func ValidateVictorOpsCustomFields(customFieldKeys []string) error {
+	for _, key := range customFieldKeys {
+		if _, ok := VictorOpsReservedFields[key]; ok {
+			return fmt.Errorf("usage of reserved word %q is not allowed in custom fields", key)
+		}
+	}
+	return nil
+}
+
+// ValidateEmailHeaders checks for duplicate headers in email configuration.
+// Header names are case-insensitive, so we normalize to lowercase for comparison.
+func ValidateEmailHeaders(headerKeys []string) error {
+	normalizedHeaders := make(map[string]struct{}, len(headerKeys))
+	for _, key := range headerKeys {
+		normalized := strings.ToLower(key)
+		if _, ok := normalizedHeaders[normalized]; ok {
+			return fmt.Errorf("duplicate header %q", normalized)
+		}
+		normalizedHeaders[normalized] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateSmarthost checks that the smarthost string is a valid host:port combination.
+func ValidateSmarthost(smarthost string) error {
+	_, _, err := net.SplitHostPort(smarthost)
+	if err != nil {
+		return fmt.Errorf("invalid 'smarthost' %s: %w", smarthost, err)
+	}
+	return nil
+}
+
+// ValidatePushoverConfig checks that either userKey or userKeyFile is configured,
+// either token or tokenFile is configured, and that HTML and Monospace options
+// are not both enabled (they are mutually exclusive).
+func ValidatePushoverConfig(hasUserKey, hasUserKeyFile, hasToken, hasTokenFile, html, monospace bool) error {
+	if !hasUserKey && !hasUserKeyFile {
+		return fmt.Errorf("one of userKey or userKeyFile must be configured")
+	}
+
+	if !hasToken && !hasTokenFile {
+		return fmt.Errorf("one of token or tokenFile must be configured")
+	}
+
+	if html && monospace {
+		return fmt.Errorf("html and monospace options are mutually exclusive")
+	}
+
+	return nil
+}
+
+// ValidateWebhookConfig checks that either url or urlSecret is configured.
+func ValidateWebhookConfig(hasURL, hasURLSecret bool) error {
+	if !hasURL && !hasURLSecret {
+		return errors.New("one of 'url' or 'urlSecret' must be specified")
+	}
+	return nil
+}
+
+// ValidatePagerDutyConfig checks that either routingKey or serviceKey is configured.
+func ValidatePagerDutyConfig(hasRoutingKey, hasServiceKey bool) error {
+	if !hasRoutingKey && !hasServiceKey {
+		return errors.New("one of 'routingKey' or 'serviceKey' is required")
+	}
+	return nil
+}
+
+// ValidateRouteReceiver checks that a route has a valid receiver reference.
+// For top-level routes, the receiver is required. For child routes, it's optional.
+func ValidateRouteReceiver(receiver string, receivers map[string]struct{}, isTopLevel bool) error {
+	if receiver == "" {
+		if isTopLevel {
+			return errors.New("root route must define a receiver")
+		}
+		return nil
+	}
+	if _, found := receivers[receiver]; !found {
+		return fmt.Errorf("receiver %q not found", receiver)
+	}
+	return nil
+}
+
+// ValidateRouteGroupBy checks the groupBy field for a route.
+// It ensures no duplicates and that "..." is the sole value if present.
+func ValidateRouteGroupBy(groupBy []string) error {
+	if len(groupBy) == 0 {
+		return nil
+	}
+
+	groupedBy := make(map[string]struct{}, len(groupBy))
+	for _, str := range groupBy {
+		if _, found := groupedBy[str]; found {
+			return fmt.Errorf("duplicate values not permitted in route 'groupBy': %v", groupBy)
+		}
+		groupedBy[str] = struct{}{}
+	}
+	if _, found := groupedBy["..."]; found && len(groupBy) > 1 {
+		return fmt.Errorf("'...' must be a sole value in route 'groupBy': %v", groupBy)
+	}
+	return nil
+}
+
+// ValidateTimeIntervalReference checks that a named time interval exists.
+func ValidateTimeIntervalReference(name string, timeIntervals map[string]struct{}, isMute bool) error {
+	if _, found := timeIntervals[name]; !found {
+		if isMute {
+			return fmt.Errorf("mute time interval %q not found", name)
+		}
+		return fmt.Errorf("time interval %q not found", name)
+	}
+	return nil
+}
+
+// ValidateSNSConfig checks that exactly one of targetARN, topicARN, or phoneNumber is configured.
+func ValidateSNSConfig(hasTargetARN, hasTopicARN, hasPhoneNumber bool) error {
+	// XOR logic: exactly one must be true
+	count := 0
+	if hasTargetARN {
+		count++
+	}
+	if hasTopicARN {
+		count++
+	}
+	if hasPhoneNumber {
+		count++
+	}
+	if count != 1 {
+		return errors.New("must provide either a targetARN, topicARN, or phoneNumber for SNS config")
+	}
+	return nil
+}
+
+// ValidateTelegramConfig checks that botToken or botTokenFile is configured and chatID is not zero.
+func ValidateTelegramConfig(hasBotToken, hasBotTokenFile bool, chatID int64) error {
+	if !hasBotToken && !hasBotTokenFile {
+		return errors.New("mandatory field botToken or botTokenfile is empty")
+	}
+	if chatID == 0 {
+		return errors.New("mandatory field 'chatID' is empty")
+	}
 	return nil
 }

--- a/pkg/alertmanager/validation/validation_test.go
+++ b/pkg/alertmanager/validation/validation_test.go
@@ -102,3 +102,338 @@ func TestValidateSecretUrl(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateVictorOpsCustomFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		keys      []string
+		expectErr bool
+	}{
+		{
+			name:      "empty keys is valid",
+			keys:      []string{},
+			expectErr: false,
+		},
+		{
+			name:      "valid custom field",
+			keys:      []string{"my_custom_field"},
+			expectErr: false,
+		},
+		{
+			name:      "reserved field routing_key",
+			keys:      []string{"routing_key"},
+			expectErr: true,
+		},
+		{
+			name:      "reserved field entity_id",
+			keys:      []string{"entity_id"},
+			expectErr: true,
+		},
+		{
+			name:      "mix of valid and reserved",
+			keys:      []string{"valid_field", "message_type"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateVictorOpsCustomFields(tc.keys)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateEmailHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		keys      []string
+		expectErr bool
+	}{
+		{
+			name:      "empty headers is valid",
+			keys:      []string{},
+			expectErr: false,
+		},
+		{
+			name:      "single header is valid",
+			keys:      []string{"Content-Type"},
+			expectErr: false,
+		},
+		{
+			name:      "different headers is valid",
+			keys:      []string{"Content-Type", "X-Custom"},
+			expectErr: false,
+		},
+		{
+			name:      "duplicate headers is invalid",
+			keys:      []string{"Content-Type", "content-type"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEmailHeaders(tc.keys)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidatePushoverConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		hasUserKey     bool
+		hasUserKeyFile bool
+		hasToken       bool
+		hasTokenFile   bool
+		html           bool
+		monospace      bool
+		expectErr      bool
+	}{
+		{
+			name:       "userKey and token present",
+			hasUserKey: true,
+			hasToken:   true,
+			expectErr:  false,
+		},
+		{
+			name:           "userKeyFile and tokenFile present",
+			hasUserKeyFile: true,
+			hasTokenFile:   true,
+			expectErr:      false,
+		},
+		{
+			name:      "missing userKey and userKeyFile",
+			hasToken:  true,
+			expectErr: true,
+		},
+		{
+			name:       "missing token and tokenFile",
+			hasUserKey: true,
+			expectErr:  true,
+		},
+		{
+			name:       "html and monospace both true",
+			hasUserKey: true,
+			hasToken:   true,
+			html:       true,
+			monospace:  true,
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePushoverConfig(tc.hasUserKey, tc.hasUserKeyFile, tc.hasToken, tc.hasTokenFile, tc.html, tc.monospace)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateWebhookConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		hasURL       bool
+		hasURLSecret bool
+		expectErr    bool
+	}{
+		{
+			name:      "has URL",
+			hasURL:    true,
+			expectErr: false,
+		},
+		{
+			name:         "has URLSecret",
+			hasURLSecret: true,
+			expectErr:    false,
+		},
+		{
+			name:      "missing both",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateWebhookConfig(tc.hasURL, tc.hasURLSecret)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidatePagerDutyConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasRoutingKey bool
+		hasServiceKey bool
+		expectErr     bool
+	}{
+		{
+			name:          "has routingKey",
+			hasRoutingKey: true,
+			expectErr:     false,
+		},
+		{
+			name:          "has serviceKey",
+			hasServiceKey: true,
+			expectErr:     false,
+		},
+		{
+			name:      "missing both",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePagerDutyConfig(tc.hasRoutingKey, tc.hasServiceKey)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSmarthost(t *testing.T) {
+	tests := []struct {
+		name      string
+		smarthost string
+		expectErr bool
+	}{
+		{
+			name:      "valid host:port",
+			smarthost: "smtp.example.com:587",
+			expectErr: false,
+		},
+		{
+			name:      "invalid format",
+			smarthost: "invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSmarthost(tc.smarthost)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateRouteGroupBy(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupBy   []string
+		expectErr bool
+	}{
+		{
+			name:      "empty is valid",
+			groupBy:   []string{},
+			expectErr: false,
+		},
+		{
+			name:      "single value is valid",
+			groupBy:   []string{"alertname"},
+			expectErr: false,
+		},
+		{
+			name:      "ellipsis alone is valid",
+			groupBy:   []string{"..."},
+			expectErr: false,
+		},
+		{
+			name:      "duplicate values",
+			groupBy:   []string{"alertname", "alertname"},
+			expectErr: true,
+		},
+		{
+			name:      "ellipsis with other values",
+			groupBy:   []string{"...", "alertname"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRouteGroupBy(tc.groupBy)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateRouteReceiver(t *testing.T) {
+	receivers := map[string]struct{}{
+		"default": {},
+		"slack":   {},
+	}
+
+	tests := []struct {
+		name       string
+		receiver   string
+		isTopLevel bool
+		expectErr  bool
+	}{
+		{
+			name:       "valid receiver",
+			receiver:   "default",
+			isTopLevel: true,
+			expectErr:  false,
+		},
+		{
+			name:       "missing receiver on top-level",
+			receiver:   "",
+			isTopLevel: true,
+			expectErr:  true,
+		},
+		{
+			name:       "missing receiver on child is valid",
+			receiver:   "",
+			isTopLevel: false,
+			expectErr:  false,
+		},
+		{
+			name:       "receiver not found",
+			receiver:   "nonexistent",
+			isTopLevel: true,
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRouteReceiver(tc.receiver, receivers, tc.isTopLevel)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This pr refactors the `AlertmanagerConfig` validation logic to remove duplicated code between the v1alpha1 and v1beta1 apis as suggested in the issue discussion [here](https://github.com/prometheus-operator/prometheus-operator/pull/6007#discussion_r1362743906), this pr consolidates the overlapping logic into a shared package.

*right now i am  focusing on the validation orchestration logic in `pkg/alertmanager/validation`. the type-level validation methods (for example `HTTPConfig.Validate`) under `pkg/apis/monitoring/...` i  intentionally left out and will be handled in a follow-up pr*



<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

related: #6023

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Refactor AlertmanagerConfig validation logic to eliminate code duplication between v1alpha1 and v1beta1 API versions.
```
