### PR TITLE
Add field and label selectors for ConfigMap watches

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -54,6 +54,10 @@ Arguments:
     	Config Reloader memory limits. Value "0" disables it and causes no limit to be configured. (default 50Mi)
   -config-reloader-memory-request value
     	Config Reloader memory requests. Value "0" disables it and causes no request to be configured. (default 50Mi)
+  -configmap-field-selector value
+    	Field selector to filter ConfigMaps to watch
+  -configmap-label-selector value
+    	Label selector to filter ConfigMaps to watch
   -controller-id operator.prometheus.io/controller-id
     	Value used by the operator to filter Alertmanager, Prometheus, PrometheusAgent and ThanosRuler objects that it should reconcile. If the value isn't empty, the operator only reconciles objects with an operator.prometheus.io/controller-id annotation of the same value. Otherwise the operator reconciles all objects without the annotation or with an empty annotation value.
   -deny-namespaces value

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -188,6 +188,8 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.ThanosRulerSelector, "thanos-ruler-instance-selector", "Label selector to filter ThanosRuler Custom Resources to watch.")
 	fs.Var(&cfg.SecretListWatchFieldSelector, "secret-field-selector", "Field selector to filter Secrets to watch")
 	fs.Var(&cfg.SecretListWatchLabelSelector, "secret-label-selector", "Label selector to filter Secrets to watch")
+	fs.Var(&cfg.ConfigMapListWatchFieldSelector, "configmap-field-selector", "Field selector to filter ConfigMaps to watch")
+	fs.Var(&cfg.ConfigMapListWatchLabelSelector, "configmap-label-selector", "Label selector to filter ConfigMaps to watch")
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -269,7 +269,10 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 			config.Namespaces.DenyList,
 			c.mdClient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = config.ConfigMapListWatchFieldSelector.String()
+				options.LabelSelector = config.ConfigMapListWatchLabelSelector.String()
+			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -57,11 +57,13 @@ type Config struct {
 	LocalHost string
 
 	// Label and field selectors for resource watchers.
-	PromSelector                 LabelSelector
-	AlertmanagerSelector         LabelSelector
-	ThanosRulerSelector          LabelSelector
-	SecretListWatchFieldSelector FieldSelector
-	SecretListWatchLabelSelector LabelSelector
+	PromSelector                    LabelSelector
+	AlertmanagerSelector            LabelSelector
+	ThanosRulerSelector             LabelSelector
+	SecretListWatchFieldSelector    FieldSelector
+	SecretListWatchLabelSelector    LabelSelector
+	ConfigMapListWatchFieldSelector FieldSelector
+	ConfigMapListWatchLabelSelector LabelSelector
 
 	// Controller id for pod ownership.
 	ControllerID string

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -291,7 +291,10 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = c.ConfigMapListWatchFieldSelector.String()
+				options.LabelSelector = c.ConfigMapListWatchLabelSelector.String()
+			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -338,7 +338,10 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 			c.Namespaces.DenyList,
 			o.mdClient,
 			resyncPeriod,
-			nil,
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = c.ConfigMapListWatchFieldSelector.String()
+				options.LabelSelector = c.ConfigMapListWatchLabelSelector.String()
+			},
 		),
 		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),


### PR DESCRIPTION
## Description

Closes #8095  Closes #7873

Add `--configmap-field-selector` and `--configmap-label-selector` CLI flags to filter which ConfigMaps are watched by the operator's informers.

This mirrors the existing `--secret-field-selector` and `--secret-label-selector` flags. In environments where the operator shares a namespace with noisy controllers (e.g., Istio updating leader election ConfigMaps every ~2 seconds), every ConfigMap update triggers a full reconcile cycle - regenerating Prometheus config, updating secrets and reconciling StatefulSets. This causes unnecessary API server load and wasted compute resources.

With these flags operators can exclude known noisy ConfigMaps:

```
./operator --configmap-field-selector="metadata.name!=istio-leader,metadata.name!=istio-namespace-controller-election"
```

Or include only labeled ConfigMaps:

```
./operator --configmap-label-selector="prometheus-operator.io/managed=true"
```

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- make build - compiles successfully
- make test - all tests pass
- ./operator --help - new flags visible in CLI help
- Manual verification: flags accept valid Kubernetes field/label selector syntax
- Backward compatible: empty selectors (default) match all ConfigMaps

## Changelog entry

```release-note
Add --configmap-field-selector and --configmap-label-selector flags to filter ConfigMaps watched by the operator reducing unnecessary reconciliation from noisy ConfigMap updates.
```
