### PR TITLE
feat: support global Telegram bot token

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2242,6 +2242,24 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 		gc.WeChatAPISecretFile = ""
 	}
 
+	if gc.TelegramBotToken != "" && amVersion.LT(semver.MustParse("0.31.0")) {
+		msg := "'telegram_bot_token' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		gc.TelegramBotToken = ""
+	}
+
+	if gc.TelegramBotTokenFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
+		msg := "'telegram_bot_token_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		gc.TelegramBotTokenFile = ""
+	}
+
+	if gc.TelegramBotToken != "" && gc.TelegramBotTokenFile != "" {
+		msg := "'telegram_bot_token' and 'telegram_bot_token_file' are mutually exclusive - 'telegram_bot_token' has taken precedence"
+		logger.Warn(msg)
+		gc.TelegramBotTokenFile = ""
+	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -4033,6 +4033,9 @@ func TestSanitizeConfig(t *testing.T) {
 	jiraGlobalURL, _ := jiraURL.Parse("http://example.com")
 	jiraURL.URL = jiraGlobalURL
 
+	versionGlobalTelegramBotTokenAllowed := semver.Version{Major: 0, Minor: 31}
+	versionGlobalTelegramBotTokenNotAllowed := semver.Version{Major: 0, Minor: 30}
+
 	for _, tc := range []struct {
 		name           string
 		againstVersion semver.Version
@@ -4815,6 +4818,48 @@ func TestSanitizeConfig(t *testing.T) {
 				},
 			},
 			golden: "telegram_config_chat_id_supported.golden",
+		},
+		{
+			name:           "Test telegram_bot_token and telegram_bot_token_file are dropped for unsupported versions",
+			againstVersion: versionGlobalTelegramBotTokenNotAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					TelegramBotToken:     "a",
+					TelegramBotTokenFile: "/b",
+				},
+			},
+			golden: "test_telegram_bot_token_and_telegram_bot_token_file_are_dropped_for_unsupported_versions.golden",
+		},
+		{
+			name:           "Test telegram_bot_token preserved for supported versions",
+			againstVersion: versionGlobalTelegramBotTokenAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					TelegramBotToken: "a",
+				},
+			},
+			golden: "test_telegram_bot_token_preserved_for_supported_versions.golden",
+		},
+		{
+			name:           "Test telegram_bot_token_file preserved for supported versions",
+			againstVersion: versionGlobalTelegramBotTokenAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					TelegramBotTokenFile: "/b",
+				},
+			},
+			golden: "test_telegram_bot_token_file_preserved_for_supported_versions.golden",
+		},
+		{
+			name:           "Test telegram_bot_token takes precedence over telegram_bot_token_file",
+			againstVersion: versionGlobalTelegramBotTokenAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					TelegramBotToken:     "a",
+					TelegramBotTokenFile: "/b",
+				},
+			},
+			golden: "test_telegram_bot_token_takes_precedence_over_telegram_bot_token_file.golden",
 		},
 		{
 			name:           "summary is dropped for unsupported versions for MSTeams config",

--- a/pkg/alertmanager/testdata/test_telegram_bot_token_and_telegram_bot_token_file_are_dropped_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_telegram_bot_token_and_telegram_bot_token_file_are_dropped_for_unsupported_versions.golden
@@ -1,0 +1,2 @@
+global: {}
+templates: []

--- a/pkg/alertmanager/testdata/test_telegram_bot_token_file_preserved_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_telegram_bot_token_file_preserved_for_supported_versions.golden
@@ -1,0 +1,3 @@
+global:
+  telegram_bot_token_file: /b
+templates: []

--- a/pkg/alertmanager/testdata/test_telegram_bot_token_preserved_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_telegram_bot_token_preserved_for_supported_versions.golden
@@ -1,0 +1,3 @@
+global:
+  telegram_bot_token: a
+templates: []

--- a/pkg/alertmanager/testdata/test_telegram_bot_token_takes_precedence_over_telegram_bot_token_file.golden
+++ b/pkg/alertmanager/testdata/test_telegram_bot_token_takes_precedence_over_telegram_bot_token_file.golden
@@ -1,0 +1,3 @@
+global:
+  telegram_bot_token: a
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -68,6 +68,8 @@ type globalConfig struct {
 	VictorOpsAPIKey       string          `yaml:"victorops_api_key,omitempty"`
 	VictorOpsAPIKeyFile   string          `yaml:"victorops_api_key_file,omitempty"`
 	TelegramAPIURL        *config.URL     `yaml:"telegram_api_url,omitempty"`
+	TelegramBotToken      string          `yaml:"telegram_bot_token,omitempty"`
+	TelegramBotTokenFile  string          `yaml:"telegram_bot_token_file,omitempty"`
 	WebexAPIURL           *config.URL     `yaml:"webex_api_url,omitempty"`
 	JiraAPIURL            *config.URL     `yaml:"jira_api_url,omitempty"`
 	RocketChatAPIURL      *config.URL     `yaml:"rocketchat_api_url,omitempty"`


### PR DESCRIPTION
## Description

This pull request adds support for the `telegram_bot_token` field recently introduced in Alertmanager (https://github.com/prometheus/alertmanager/pull/4823).

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
unit tests

## Changelog entry

```release-note
- Add support for the telegram_bot_token field in the Alertmanager global configuration.
```
