### PR TITLE
Fix/v1alpha1 nil error wrap

### DIFF
--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -50,7 +50,7 @@ func validateReceivers(receivers []monitoringv1alpha1.Receiver) (map[string]stru
 
 	for _, receiver := range receivers {
 		if _, found := receiverNames[receiver.Name]; found {
-			return nil, fmt.Errorf("%q receiver is not unique: %w", receiver.Name, err)
+			return nil, fmt.Errorf("%q receiver is not unique", receiver.Name)
 		}
 		receiverNames[receiver.Name] = struct{}{}
 


### PR DESCRIPTION
## Summary

This PR fixes a misleading error message in `validateReceivers()` in `pkg/alertmanager/validation/v1alpha1/validation.go`.

When duplicate receiver names are defined in a `v1alpha1` `AlertmanagerConfig`, the validation returns an error that incorrectly includes `: <nil>`. This happens because a `nil` error is wrapped with `%w`, which produces confusing output.

This change removes the misleading suffix and aligns the behavior with the already-correct `v1beta1` implementation. It also follows Go best practices, where `%w` should only be used with non-nil errors.

---

## Fix

Remove `%w` so a `nil` error is not wrapped.

Changed from:

```go
return nil, fmt.Errorf("%q receiver is not unique: %w", receiver.Name, err)
```

to:

```go
return nil, fmt.Errorf("%q receiver is not unique", receiver.Name)
```

This:

* Eliminates the misleading `: <nil>` suffix
* Matches the `v1beta1` implementation
* Preserves existing validation behavior
* Improves user-facing error clarity

---

## VERIFICATION

* Built the project successfully
* Ran validation package tests:

```bash
go test ./pkg/alertmanager/validation/...
```

* All tests pass
* Duplicate receiver validation still rejects invalid configs
* Error message is now clean and consistent without `<nil>`

---

## Checklist

* [x] `BUGFIX` (non-breaking change which fixes an issue)
* [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
