### PR TITLE
Replace manual disk cleanup with quick-cleanup

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,10 +26,9 @@ jobs:
       - name: Import environment variables from file
         run: cat ".github/env" >> "$GITHUB_ENV"
       - name: Reclaim disk space
-        run: |
-          docker image prune --force --all
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - name: Install Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/test-prom-version-upgrade.yaml
+++ b/.github/workflows/test-prom-version-upgrade.yaml
@@ -11,10 +11,9 @@ jobs:
     if: github.repository == 'prometheus-operator/prometheus-operator'
     steps:
     - name: Reclaim disk space
-      run: |
-        docker image prune --force --all
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
+      uses: palmsoftware/quick-cleanup@v0
+      with:
+        cleanup-mode: aggressive
     - uses: actions/checkout@v6
     - name: Import environment variables from file
       run: |


### PR DESCRIPTION
## Summary

Replace manual disk cleanup scripts with the shared [`palmsoftware/quick-cleanup`](https://github.com/palmsoftware/quick-cleanup) GitHub Action.

This consolidates the "Reclaim disk space" steps (docker image prune + rm -rf dotnet, android) into a single maintained action across 2 workflows. It also provides automatic Docker storage relocation to the larger `/mnt` partition — a feature none of the manual scripts currently implement.

## Already in use

`quick-cleanup` is already adopted in production workflows across multiple projects:

- [`crc-org/crc`](https://github.com/crc-org/crc/blob/main/.github/workflows/make-rpm.yml#L19) — OpenShift Local (CRC)
- [`palmsoftware/quick-ocp`](https://github.com/palmsoftware/quick-ocp/blob/main/action.yml#L94) — OpenShift cluster deployment action
- [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s/blob/main/action.yml#L509) — Kubernetes cluster deployment action (KinD/Minikube)

## Tracking

- [palmsoftware/quick-cleanup#3](https://github.com/palmsoftware/quick-cleanup/issues/3) — Tracking issue



## Related PRs

- https://github.com/crc-org/crc/pull/5145
- https://github.com/openshift-kni/openperouter/pull/159
- https://github.com/metallb/metallb-operator/pull/537
- https://github.com/prometheus-operator/prometheus-operator/pull/8389
- https://github.com/topolvm/topolvm/pull/1151
- https://github.com/vmware-tanzu/velero/pull/9550

## Changes

- Updated `.github/workflows/publish.yaml` — replaced "Reclaim disk space" block
- Updated `.github/workflows/test-prom-version-upgrade.yaml` — replaced "Reclaim disk space" block

## Benefits

- **Less boilerplate** — replaces manual cleanup across 2 workflows
- **Docker relocation** — automatically moves Docker storage to `/mnt` (larger partition)
- **Adaptive cleanup** — adjusts intensity based on available space
- **Disk reporting** — built-in before/after `df -h` output
- **Maintained upstream** — cleanup targets updated as runner images change
- **Apache 2.0 licensed**