### PR TITLE
feat(PrometheusAgent): add RepairPolicy to unblock stuck StatefulSet …

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,4 +1,4 @@
 golang-version=1.25
-kind-version=v0.30.0
-kind-image=kindest/node:v1.34.2
+kind-version=v0.31.0
+kind-image=kindest/node:v1.35.0
 golangci-lint-version=v2.8.0

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -323,6 +323,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PrometheusUTF8MetricsSupport":              testPrometheusUTF8MetricsSupport,
 		"PrometheusUTF8LabelSupport":                testPrometheusUTF8LabelSupport,
 		"StuckStatefulSetRollout":                   testStuckStatefulSetRollout,
+		"AgentStuckStatefulSetRollout":              testAgentStuckStatefulSetRollout,
 		"PromScaleUpWithoutLabels":                  testPromScaleUpWithoutLabels,
 	}
 

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -1009,3 +1009,102 @@ func testDaemonSetInvalidAdditionalScrapeConfigs(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "additionalScrapeConfigs cannot be set when mode is DaemonSet")
 }
+
+// testAgentStuckStatefulSetRollout ensures that when the rollout of a
+// PrometheusAgent statefulset pod gets stuck, it will get unstuck after
+// fixing the spec.
+func testAgentStuckStatefulSetRollout(t *testing.T) {
+	t.Parallel()
+
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	p := framework.MakeBasicPrometheusAgent(ns, "statefulset-rollout", "test", 2)
+
+	pAgent, err := framework.CreatePrometheusAgentAndWaitUntilReady(
+		context.Background(),
+		ns,
+		p,
+	)
+	require.NoError(t, err)
+
+	badImage := "quay.io/prometheus/prometheus:foobar"
+	pAgent, err = framework.PatchPrometheusAgent(
+		context.Background(),
+		pAgent.Name,
+		pAgent.Namespace,
+		monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Image: &badImage,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	var loopError error
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, framework.DefaultTimeout, true, func(_ context.Context) (bool, error) {
+		ctx := context.Background()
+		current, err := framework.MonClientV1alpha1.PrometheusAgents(pAgent.Namespace).Get(ctx, pAgent.Name, metav1.GetOptions{})
+		if err != nil {
+			loopError = fmt.Errorf("failed to get object: %w", err)
+			return false, nil
+		}
+
+		if err := framework.AssertCondition(current.Status.Conditions, monitoringv1.Reconciled, monitoringv1.ConditionTrue); err != nil {
+			loopError = err
+			return false, nil
+		}
+
+		if err := framework.AssertCondition(current.Status.Conditions, monitoringv1.Available, monitoringv1.ConditionDegraded); err != nil {
+			loopError = err
+			return false, nil
+		}
+
+		// The rollout should start from the highest pod ordinal.
+		pod, err := framework.KubeClient.CoreV1().Pods(pAgent.Namespace).Get(ctx, "prom-agent-"+pAgent.Name+"-1", metav1.GetOptions{})
+		if err != nil {
+			loopError = err
+			return false, nil
+		}
+
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Image != badImage {
+				continue
+			}
+
+			if cs.State.Waiting == nil {
+				loopError = fmt.Errorf("container not waiting")
+				return false, nil
+			}
+
+			if cs.State.Waiting.Reason != "ErrImagePull" && cs.State.Waiting.Reason != "ImagePullBackOff" {
+				loopError = fmt.Errorf("container waiting with reason %q", cs.State.Waiting.Reason)
+				return false, nil
+			}
+
+			return true, nil
+		}
+
+		loopError = fmt.Errorf("found no container with image %q", badImage)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("%v: %v", err, loopError)
+	}
+
+	// Fix the bad image and ensure that the resource goes back to ready.
+	_, err = framework.PatchPrometheusAgentAndWaitUntilReady(
+		context.Background(),
+		pAgent.Name,
+		pAgent.Namespace,
+		monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Image: ptr.To(operator.DefaultPrometheusImage),
+			},
+		},
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
…rollouts

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
