### PR TITLE
Feat: add auth_secret_file support for email config in Alertmanager secret config

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2555,6 +2555,17 @@ func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		ec.ImplicitTLS = nil
 	}
 
+	if ec.AuthSecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
+		msg := "'auth_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		ec.AuthSecretFile = ""
+	}
+
+	if ec.AuthSecret != "" && ec.AuthSecretFile != "" {
+		logger.Warn("'auth_secret' and 'auth_secret_file' are mutually exclusive for email receiver config - 'auth_secret' has taken precedence")
+		ec.AuthSecretFile = ""
+	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -5855,6 +5855,38 @@ func TestSanitizeEmailConfig(t *testing.T) {
 			},
 			golden: "test_implicit_tls_is_added_in_email_config_for_supported_versions.golden",
 		},
+		{
+			name:           "Test auth_secret_file is added in email config for supported version",
+			againstVersion: semver.Version{Major: 0, Minor: 31},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						EmailConfigs: []*emailConfig{
+							{
+								AuthSecretFile: "/auth/secret/file",
+							},
+						},
+					},
+				},
+			},
+			golden: "test_auth_secret_file_is_added_in_email_config_for_supported_versions.golden",
+		},
+		{
+			name:           "Test auth_secret_file is dropped in email config for unsupported versions",
+			againstVersion: semver.Version{Major: 0, Minor: 30},
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						EmailConfigs: []*emailConfig{
+							{
+								ImplicitTLS: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			golden: "test_auth_secret_file_is_dropped_in_email_config_for_unsupported_versions.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.in.sanitize(tc.againstVersion, logger)

--- a/pkg/alertmanager/testdata/test_auth_secret_file_is_added_in_email_config_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_auth_secret_file_is_added_in_email_config_for_supported_versions.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  email_configs:
+  - auth_secret_file: /auth/secret/file
+templates: []

--- a/pkg/alertmanager/testdata/test_auth_secret_file_is_dropped_in_email_config_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_auth_secret_file_is_dropped_in_email_config_for_unsupported_versions.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  email_configs:
+  - {}
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -331,6 +331,7 @@ type emailConfig struct {
 	AuthPassword     string            `yaml:"auth_password,omitempty"`
 	AuthPasswordFile string            `yaml:"auth_password_file,omitempty"`
 	AuthSecret       string            `yaml:"auth_secret,omitempty"`
+	AuthSecretFile   string            `yaml:"auth_secret_file,omitempty"`
 	AuthIdentity     string            `yaml:"auth_identity,omitempty"`
 	Headers          map[string]string `yaml:"headers,omitempty"`
 	HTML             *string           `yaml:"html,omitempty"`


### PR DESCRIPTION
## Description

This PR adds a new auth_secret_file config support for email receiver in Alertmanager secret config. This feature is available from Alertmanager 0.31.0 onwards.

https://github.com/prometheus/alertmanager/releases/tag/v0.31.0

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
- Add a new auth_secret_file config support for email receiver in Alertmanager secret config.
```
