### PR TITLE
Feat: add smtp_auth_secret_file for Alertmanager global config secret config

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2260,6 +2260,18 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 		gc.TelegramBotTokenFile = ""
 	}
 
+	if gc.SMTPAuthSecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
+		msg := "'smtp_auth_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		gc.SMTPAuthSecretFile = ""
+	}
+
+	if gc.SMTPAuthSecret != "" && gc.SMTPAuthSecretFile != "" {
+		msg := "'smtp_auth_secret' and 'smtp_auth_secret_file' are mutually exclusive - 'smtp_auth_secret_file' has taken precedence"
+		logger.Warn(msg)
+		gc.SMTPAuthSecretFile = ""
+	}
+
 	return nil
 }
 

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2267,7 +2267,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 	}
 
 	if gc.SMTPAuthSecret != "" && gc.SMTPAuthSecretFile != "" {
-		msg := "'smtp_auth_secret' and 'smtp_auth_secret_file' are mutually exclusive - 'smtp_auth_secret_file' has taken precedence"
+		msg := "'smtp_auth_secret' and 'smtp_auth_secret_file' are mutually exclusive - 'smtp_auth_secret' has taken precedence"
 		logger.Warn(msg)
 		gc.SMTPAuthSecretFile = ""
 	}

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -4033,6 +4033,9 @@ func TestSanitizeConfig(t *testing.T) {
 	versionGlobalTelegramBotTokenAllowed := semver.Version{Major: 0, Minor: 31}
 	versionGlobalTelegramBotTokenNotAllowed := semver.Version{Major: 0, Minor: 30}
 
+	versionGlobalSMTPAuthSecretFileAllowed := semver.Version{Major: 0, Minor: 31}
+	versionGlobalSMTPAuthSecretFileNotAllowed := semver.Version{Major: 0, Minor: 30}
+
 	for _, tc := range []struct {
 		name           string
 		againstVersion semver.Version
@@ -4065,6 +4068,37 @@ func TestSanitizeConfig(t *testing.T) {
 				},
 			},
 			golden: "test_smtp_tls_config_is_added_for_supported_versions.golden",
+		},
+		{
+			name:           "Test smtp_auth_secret_file is added for supported versions",
+			againstVersion: versionGlobalSMTPAuthSecretFileAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					SMTPAuthSecretFile: "/smtp/auth/secret/file",
+				},
+			},
+			golden: "test_smtp_auth_secret_file_is_added_for_supported_versions.golden",
+		},
+		{
+			name:           "Test smtp_auth_secret_file is dropped for unsupported versions",
+			againstVersion: versionGlobalSMTPAuthSecretFileNotAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					SMTPAuthSecretFile: "/smtp/auth/secret/file",
+				},
+			},
+			golden: "test_smtp_auth_secret_file_is_dropped_for_unsupported_versions.golden",
+		},
+		{
+			name:           "Test smtp_auth_secret takes precedence over smtp_auth_secret_file",
+			againstVersion: versionGlobalSMTPAuthSecretFileAllowed,
+			in: &alertmanagerConfig{
+				Global: &globalConfig{
+					SMTPAuthSecret:     "authsecret12345",
+					SMTPAuthSecretFile: "/smtp/auth/secret/file",
+				},
+			},
+			golden: "test_smtp_auth_secret_takes_precedence_over_smtp_auth_secret_file.golden",
 		},
 		{
 			name:           "Test slack_api_url takes precedence in global config",

--- a/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_added_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_added_for_supported_versions.golden
@@ -1,0 +1,3 @@
+global:
+  smtp_auth_secret_file: /smtp/auth/secret/file
+templates: []

--- a/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_dropped_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_dropped_for_unsupported_versions.golden
@@ -1,0 +1,1 @@
+templates: []

--- a/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_dropped_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_smtp_auth_secret_file_is_dropped_for_unsupported_versions.golden
@@ -1,1 +1,2 @@
+global: {}
 templates: []

--- a/pkg/alertmanager/testdata/test_smtp_auth_secret_takes_precedence_over_smtp_auth_secret_file.golden
+++ b/pkg/alertmanager/testdata/test_smtp_auth_secret_takes_precedence_over_smtp_auth_secret_file.golden
@@ -1,0 +1,3 @@
+global:
+  smtp_auth_secret: authsecret12345
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -50,6 +50,7 @@ type globalConfig struct {
 	SMTPAuthPassword      string          `yaml:"smtp_auth_password,omitempty"`
 	SMTPAuthPasswordFile  string          `yaml:"smtp_auth_password_file,omitempty"`
 	SMTPAuthSecret        string          `yaml:"smtp_auth_secret,omitempty"`
+	SMTPAuthSecretFile    string          `yaml:"smtp_auth_secret_file,omitempty"`
 	SMTPAuthIdentity      string          `yaml:"smtp_auth_identity,omitempty"`
 	SMTPRequireTLS        *bool           `yaml:"smtp_require_tls,omitempty"`
 	SMTPTLSConfig         *tlsConfig      `yaml:"smtp_tls_config,omitempty"`


### PR DESCRIPTION
## Description

Add the smtp_auth_secret_file config for Alertmanager global config.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
- Add the smtp_auth_secret_file config for Alertmanager global config
```
