### PR TITLE
Fix: rename implicit_tls to force_implicit_tls for SMTP in Alertmanager secret config

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2561,10 +2561,10 @@ func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 		ec.AuthPasswordFile = ""
 	}
 
-	if ec.ImplicitTLS != nil && amVersion.LT(semver.MustParse("0.31.0")) {
-		msg := "'implicit_tls' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
+	if ec.ForceImplicitTLS != nil && amVersion.LT(semver.MustParse("0.31.0")) {
+		msg := "'force_implicit_tls' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
 		logger.Warn(msg, "current_version", amVersion.String())
-		ec.ImplicitTLS = nil
+		ec.ForceImplicitTLS = nil
 	}
 
 	if ec.AuthSecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -5874,36 +5874,36 @@ func TestSanitizeEmailConfig(t *testing.T) {
 			golden: "test_smtp_auth_password_file_is_dropped_in_email_config_for_unsupported_versions.golden",
 		},
 		{
-			name:           "Test implicit_tls is dropped in email config for unsupported versions",
+			name:           "Test force_implicit_tls is dropped in email config for unsupported versions",
 			againstVersion: semver.Version{Major: 0, Minor: 30},
 			in: &alertmanagerConfig{
 				Receivers: []*receiver{
 					{
 						EmailConfigs: []*emailConfig{
 							{
-								ImplicitTLS: ptr.To(true),
+								ForceImplicitTLS: ptr.To(true),
 							},
 						},
 					},
 				},
 			},
-			golden: "test_implicit_tls_is_dropped_in_email_config_for_unsupported_versions.golden",
+			golden: "test_force_implicit_tls_is_dropped_in_email_config_for_unsupported_versions.golden",
 		},
 		{
-			name:           "Test implicit_tls is added in email config for supported version",
+			name:           "Test force_implicit_tls is added in email config for supported version",
 			againstVersion: semver.Version{Major: 0, Minor: 31},
 			in: &alertmanagerConfig{
 				Receivers: []*receiver{
 					{
 						EmailConfigs: []*emailConfig{
 							{
-								ImplicitTLS: ptr.To(true),
+								ForceImplicitTLS: ptr.To(true),
 							},
 						},
 					},
 				},
 			},
-			golden: "test_implicit_tls_is_added_in_email_config_for_supported_versions.golden",
+			golden: "test_force_implicit_tls_is_added_in_email_config_for_supported_versions.golden",
 		},
 		{
 			name:           "Test auth_secret_file is added in email config for supported version",
@@ -5929,7 +5929,7 @@ func TestSanitizeEmailConfig(t *testing.T) {
 					{
 						EmailConfigs: []*emailConfig{
 							{
-								ImplicitTLS: ptr.To(true),
+								AuthSecretFile: "/auth/secret/file",
 							},
 						},
 					},

--- a/pkg/alertmanager/testdata/test_force_implicit_tls_is_added_in_email_config_for_supported_versions.golden
+++ b/pkg/alertmanager/testdata/test_force_implicit_tls_is_added_in_email_config_for_supported_versions.golden
@@ -1,0 +1,5 @@
+receivers:
+- name: ""
+  email_configs:
+  - force_implicit_tls: true
+templates: []

--- a/pkg/alertmanager/testdata/test_force_implicit_tls_is_dropped_in_email_config_for_unsupported_versions.golden
+++ b/pkg/alertmanager/testdata/test_force_implicit_tls_is_dropped_in_email_config_for_unsupported_versions.golden
@@ -1,5 +1,5 @@
 receivers:
 - name: ""
   email_configs:
-  - implicit_tls: true
+  - {}
 templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -339,7 +339,7 @@ type emailConfig struct {
 	Text             *string           `yaml:"text,omitempty"`
 	RequireTLS       *bool             `yaml:"require_tls,omitempty"`
 	TLSConfig        *tlsConfig        `yaml:"tls_config,omitempty"`
-	ImplicitTLS      *bool             `yaml:"implicit_tls,omitempty"`
+	ForceImplicitTLS *bool             `yaml:"force_implicit_tls,omitempty"`
 }
 
 type pushoverConfig struct {


### PR DESCRIPTION
## Description

The PR #8384 added implicit_tls, which aligned with the configuration document in the Prometheus website. However, the real name should be force_implicit_tls. (Ref: https://github.com/prometheus/alertmanager/pull/4818) This PR is to rename implicit_tls to force_implicit_tls to reflect the name used in the package.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
- Rename implicit_tls to force_implicit_tls for SMTP in Alertmanager secret config
```
