### PR TITLE
feat: add jira fields config via parameter to AM secret

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3122,6 +3122,20 @@ func (jc *jiraConfig) sanitize(amVersion semver.Version, logger *slog.Logger) er
 			}
 		}
 	}
+
+	lessThanV0_30 := amVersion.LT(semver.MustParse("0.30.0"))
+	if jc.Summary.EnableUpdate != nil && lessThanV0_30 {
+		msg := "'enable_update' on 'summary' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		jc.Summary.EnableUpdate = nil
+	}
+
+	if jc.Description.EnableUpdate != nil && lessThanV0_30 {
+		msg := "'enable_update' on 'description' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
+		logger.Warn(msg, "current_version", amVersion.String())
+		jc.Description.EnableUpdate = nil
+	}
+
 	if jc.APIURL != "" {
 		if _, err := validation.ValidateURL(jc.APIURL); err != nil {
 			return fmt.Errorf("invalid 'api_url': %w", err)

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -6857,6 +6857,10 @@ func TestSanitizeJiraConfig(t *testing.T) {
 
 	versionAPITypeAllowed := semver.Version{Major: 0, Minor: 29}
 	versionAPITypeNotAllowed := semver.Version{Major: 0, Minor: 28}
+
+	versionEnableUpdateAllowed := semver.Version{Major: 0, Minor: 30}
+	versionEnableUpdateNotAllowed := semver.Version{Major: 0, Minor: 29}
+
 	for _, tc := range []struct {
 		name           string
 		againstVersion semver.Version
@@ -7007,6 +7011,120 @@ func TestSanitizeJiraConfig(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		{
+			name:           "jira_configs with enable_update on summary",
+			againstVersion: versionEnableUpdateAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "http://issues.example.com",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+								Summary: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.summary\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "jira_config_with_enable_update_summary.golden",
+		},
+		{
+			name:           "jira_configs with enable_update on description",
+			againstVersion: versionEnableUpdateAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "http://issues.example.com",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+								Description: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.description\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "jira_config_with_enable_update_description.golden",
+		},
+		{
+			name:           "jira_configs with enable_update on summary version not supported",
+			againstVersion: versionEnableUpdateNotAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "http://issues.example.com",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+								Summary: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.summary\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "jira_config_with_enable_update_summary_version_not_supported.golden",
+		},
+		{
+			name:           "jira_configs with enable_update on description version not supported",
+			againstVersion: versionEnableUpdateNotAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "http://issues.example.com",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+								Description: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.description\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "jira_config_with_enable_update_description_version_not_supported.golden",
+		},
+		{
+			name:           "jira_configs with enable_update on both summary and description version not supported",
+			againstVersion: versionEnableUpdateNotAllowed,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						JiraConfigs: []*jiraConfig{
+							{
+								APIURL:    "http://issues.example.com",
+								Project:   "Monitoring",
+								IssueType: "Bug",
+								Summary: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.summary\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+								Description: jiraFieldConfig{
+									Template:     "{{ template \"jira.default.description\" . }}",
+									EnableUpdate: ptr.To(false),
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "jira_config_with_enable_update_both_version_not_supported.golden",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/alertmanager/testdata/jira_config_with_enable_update_both_version_not_supported.golden
+++ b/pkg/alertmanager/testdata/jira_config_with_enable_update_both_version_not_supported.golden
@@ -1,0 +1,11 @@
+receivers:
+- name: ""
+  jira_configs:
+  - api_url: http://issues.example.com
+    project: Monitoring
+    summary:
+      template: '{{ template "jira.default.summary" . }}'
+    description:
+      template: '{{ template "jira.default.description" . }}'
+    issue_type: Bug
+templates: []

--- a/pkg/alertmanager/testdata/jira_config_with_enable_update_description.golden
+++ b/pkg/alertmanager/testdata/jira_config_with_enable_update_description.golden
@@ -1,0 +1,10 @@
+receivers:
+- name: ""
+  jira_configs:
+  - api_url: http://issues.example.com
+    project: Monitoring
+    description:
+      template: '{{ template "jira.default.description" . }}'
+      enable_update: false
+    issue_type: Bug
+templates: []

--- a/pkg/alertmanager/testdata/jira_config_with_enable_update_description_version_not_supported.golden
+++ b/pkg/alertmanager/testdata/jira_config_with_enable_update_description_version_not_supported.golden
@@ -1,0 +1,9 @@
+receivers:
+- name: ""
+  jira_configs:
+  - api_url: http://issues.example.com
+    project: Monitoring
+    description:
+      template: '{{ template "jira.default.description" . }}'
+    issue_type: Bug
+templates: []

--- a/pkg/alertmanager/testdata/jira_config_with_enable_update_summary.golden
+++ b/pkg/alertmanager/testdata/jira_config_with_enable_update_summary.golden
@@ -1,0 +1,10 @@
+receivers:
+- name: ""
+  jira_configs:
+  - api_url: http://issues.example.com
+    project: Monitoring
+    summary:
+      template: '{{ template "jira.default.summary" . }}'
+      enable_update: false
+    issue_type: Bug
+templates: []

--- a/pkg/alertmanager/testdata/jira_config_with_enable_update_summary_version_not_supported.golden
+++ b/pkg/alertmanager/testdata/jira_config_with_enable_update_summary_version_not_supported.golden
@@ -1,0 +1,9 @@
+receivers:
+- name: ""
+  jira_configs:
+  - api_url: http://issues.example.com
+    project: Monitoring
+    summary:
+      template: '{{ template "jira.default.summary" . }}'
+    issue_type: Bug
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -461,8 +461,8 @@ type jiraConfig struct {
 	SendResolved      *bool             `yaml:"send_resolved,omitempty"`
 	APIURL            string            `yaml:"api_url,omitempty"`
 	Project           string            `yaml:"project,omitempty"`
-	Summary           string            `yaml:"summary,omitempty"`
-	Description       string            `yaml:"description,omitempty"`
+	Summary           jiraFieldConfig   `yaml:"summary,omitempty"`
+	Description       jiraFieldConfig   `yaml:"description,omitempty"`
 	Labels            []string          `yaml:"labels,omitempty"`
 	Priority          string            `yaml:"priority,omitempty"`
 	IssueType         string            `yaml:"issue_type,omitempty"`
@@ -472,6 +472,11 @@ type jiraConfig struct {
 	ReopenDuration    model.Duration    `yaml:"reopen_duration,omitempty"`
 	Fields            map[string]any    `yaml:"fields,omitempty"`
 	APIType           string            `yaml:"api_type,omitempty"`
+}
+
+type jiraFieldConfig struct {
+	Template     string `yaml:"template,omitempty"`
+	EnableUpdate *bool  `yaml:"enable_update,omitempty"`
 }
 
 type rocketchatAttachmentField struct {


### PR DESCRIPTION
## Description

From https://github.com/prometheus/alertmanager/pull/4621 on alertmanager 0.30

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
