### PR TITLE
feat(scrapeconfig): add scrape_failure_log_file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* [FEATURE] Add `scrapeFailureLogFile` to the `ScrapeConfig` CRD to enable per-job scrape failure logging with an operator-generated deterministic path. Add `disableScrapeFailureLogFile` to the `Prometheus` and `PrometheusAgent` CRDs to allow platform teams to opt out of the feature. #8426
 * [ENHANCEMENT] Add `--web.tls-curves` CLI argument to the operator and admission-webhook binaries. #8385
 
 ## 0.89.0 / 2026-02-05

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -3008,6 +3008,17 @@ spec:
 
                   It requires Prometheus >= v3.4.0.
                 type: boolean
+              disableScrapeFailureLogFile:
+                description: |-
+                  disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources
+                  from enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.
+                  This is useful in environments where a platform team manages the Prometheus
+                  workload and wants to prevent application teams from writing arbitrary log files
+                  to the Prometheus pod filesystem.
+
+                  When set to true, the `/var/log/prometheus` emptyDir volume is not mounted
+                  (unless `spec.scrapeFailureLogFile` is also set).
+                type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.
                 properties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3765,6 +3765,17 @@ spec:
                   When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
                   disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
                 type: boolean
+              disableScrapeFailureLogFile:
+                description: |-
+                  disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources
+                  from enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.
+                  This is useful in environments where a platform team manages the Prometheus
+                  workload and wants to prevent application teams from writing arbitrary log files
+                  to the Prometheus pod filesystem.
+
+                  When set to true, the `/var/log/prometheus` emptyDir volume is not mounted
+                  (unless `spec.scrapeFailureLogFile` is also set).
+                type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.
                 properties:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -12542,6 +12542,21 @@ spec:
 
                   Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
                 type: boolean
+              scrapeFailureLogFile:
+                description: |-
+                  scrapeFailureLogFile enables logging scrape failures for this job to a file.
+                  When set to true, the operator generates a predictable log file path:
+                  `/var/log/prometheus/scrapeconfig-<namespace>-<name>.log`.
+                  This requires the `/var/log/prometheus` directory to be writable in the
+                  Prometheus pod. The directory is automatically mounted as an emptyDir volume
+                  unless `spec.disableScrapeFailureLogFile` is set to true on the Prometheus resource.
+
+                  Note: this field only applies to ScrapeConfig resources. To disable this
+                  feature cluster-wide, set `spec.disableScrapeFailureLogFile: true` on the
+                  Prometheus/PrometheusAgent resource.
+
+                  It requires Prometheus >= v2.55.0.
+                type: boolean
               scrapeInterval:
                 description: scrapeInterval defines the interval between consecutive
                   scrapes.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -3008,6 +3008,17 @@ spec:
 
                   It requires Prometheus >= v3.4.0.
                 type: boolean
+              disableScrapeFailureLogFile:
+                description: |-
+                  disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources
+                  from enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.
+                  This is useful in environments where a platform team manages the Prometheus
+                  workload and wants to prevent application teams from writing arbitrary log files
+                  to the Prometheus pod filesystem.
+
+                  When set to true, the `/var/log/prometheus` emptyDir volume is not mounted
+                  (unless `spec.scrapeFailureLogFile` is also set).
+                type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.
                 properties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3765,6 +3765,17 @@ spec:
                   When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
                   disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
                 type: boolean
+              disableScrapeFailureLogFile:
+                description: |-
+                  disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources
+                  from enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.
+                  This is useful in environments where a platform team manages the Prometheus
+                  workload and wants to prevent application teams from writing arbitrary log files
+                  to the Prometheus pod filesystem.
+
+                  When set to true, the `/var/log/prometheus` emptyDir volume is not mounted
+                  (unless `spec.scrapeFailureLogFile` is also set).
+                type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.
                 properties:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -12542,6 +12542,21 @@ spec:
 
                   Notice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.
                 type: boolean
+              scrapeFailureLogFile:
+                description: |-
+                  scrapeFailureLogFile enables logging scrape failures for this job to a file.
+                  When set to true, the operator generates a predictable log file path:
+                  `/var/log/prometheus/scrapeconfig-<namespace>-<name>.log`.
+                  This requires the `/var/log/prometheus` directory to be writable in the
+                  Prometheus pod. The directory is automatically mounted as an emptyDir volume
+                  unless `spec.disableScrapeFailureLogFile` is set to true on the Prometheus resource.
+
+                  Note: this field only applies to ScrapeConfig resources. To disable this
+                  feature cluster-wide, set `spec.disableScrapeFailureLogFile: true` on the
+                  Prometheus/PrometheusAgent resource.
+
+                  It requires Prometheus >= v2.55.0.
+                type: boolean
               scrapeInterval:
                 description: scrapeInterval defines the interval between consecutive
                   scrapes.

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -2581,6 +2581,10 @@
                     "description": "convertClassicHistogramsToNHCB defines whether to convert all scraped classic histograms into a native\nhistogram with custom buckets.\n\nIt requires Prometheus >= v3.4.0.",
                     "type": "boolean"
                   },
+                  "disableScrapeFailureLogFile": {
+                    "description": "disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources\nfrom enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.\nThis is useful in environments where a platform team manages the Prometheus\nworkload and wants to prevent application teams from writing arbitrary log files\nto the Prometheus pod filesystem.\n\nWhen set to true, the `/var/log/prometheus` emptyDir volume is not mounted\n(unless `spec.scrapeFailureLogFile` is also set).",
+                    "type": "boolean"
+                  },
                   "dnsConfig": {
                     "description": "dnsConfig defines the DNS configuration for the pods.",
                     "properties": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3228,6 +3228,10 @@
                     "description": "disableCompaction when true, the Prometheus compaction is disabled.\nWhen `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically\ndisables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).",
                     "type": "boolean"
                   },
+                  "disableScrapeFailureLogFile": {
+                    "description": "disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources\nfrom enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.\nThis is useful in environments where a platform team manages the Prometheus\nworkload and wants to prevent application teams from writing arbitrary log files\nto the Prometheus pod filesystem.\n\nWhen set to true, the `/var/log/prometheus` emptyDir volume is not mounted\n(unless `spec.scrapeFailureLogFile` is also set).",
+                    "type": "boolean"
+                  },
                   "dnsConfig": {
                     "description": "dnsConfig defines the DNS configuration for the pods.",
                     "properties": {

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -11669,6 +11669,10 @@
                     "description": "scrapeClassicHistograms defines whether to scrape a classic histogram that is also exposed as a native histogram.\nIt requires Prometheus >= v2.45.0.\n\nNotice: `scrapeClassicHistograms` corresponds to the `always_scrape_classic_histograms` field in the Prometheus configuration.",
                     "type": "boolean"
                   },
+                  "scrapeFailureLogFile": {
+                    "description": "scrapeFailureLogFile enables logging scrape failures for this job to a file.\nWhen set to true, the operator generates a predictable log file path:\n`/var/log/prometheus/scrapeconfig-<namespace>-<name>.log`.\nThis requires the `/var/log/prometheus` directory to be writable in the\nPrometheus pod. The directory is automatically mounted as an emptyDir volume\nunless `spec.disableScrapeFailureLogFile` is set to true on the Prometheus resource.\n\nNote: this field only applies to ScrapeConfig resources. To disable this\nfeature cluster-wide, set `spec.disableScrapeFailureLogFile: true` on the\nPrometheus/PrometheusAgent resource.\n\nIt requires Prometheus >= v2.55.0.",
+                    "type": "boolean"
+                  },
                   "scrapeInterval": {
                     "description": "scrapeInterval defines the interval between consecutive scrapes.",
                     "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -983,6 +983,19 @@ type CommonPrometheusFields struct {
 	// +optional
 	ScrapeFailureLogFile *string `json:"scrapeFailureLogFile,omitempty"`
 
+	// disableScrapeFailureLogFile when set to true prevents ScrapeConfig resources
+	// from enabling per-job scrape failure log files via `spec.scrapeFailureLogFile`.
+	// This is useful in environments where a platform team manages the Prometheus
+	// workload and wants to prevent application teams from writing arbitrary log files
+	// to the Prometheus pod filesystem.
+	//
+	// When set to true, the `/var/log/prometheus` emptyDir volume is not mounted
+	// (unless `spec.scrapeFailureLogFile` is also set).
+	//
+	// +optional
+	//nolint:kubeapilinter
+	DisableScrapeFailureLogFile *bool `json:"disableScrapeFailureLogFile,omitempty"`
+
 	// serviceName defines the name of the service name used by the underlying StatefulSet(s) as the governing service.
 	// If defined, the Service  must be created before the Prometheus/PrometheusAgent resource in the same namespace and it must define a selector that matches the pod labels.
 	// If empty, the operator will create and manage a headless service named `prometheus-operated` for Prometheus resources,

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1213,6 +1213,11 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DisableScrapeFailureLogFile != nil {
+		in, out := &in.DisableScrapeFailureLogFile, &out.DisableScrapeFailureLogFile
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ServiceName != nil {
 		in, out := &in.ServiceName, &out.ServiceName
 		*out = new(string)

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -375,6 +375,22 @@ type ScrapeConfigSpec struct {
 	//
 	// +optional
 	NameEscapingScheme *v1.NameEscapingSchemeOptions `json:"nameEscapingScheme,omitempty"`
+	// scrapeFailureLogFile enables logging scrape failures for this job to a file.
+	// When set to true, the operator generates a predictable log file path:
+	// `/var/log/prometheus/scrapeconfig-<namespace>-<name>.log`.
+	// This requires the `/var/log/prometheus` directory to be writable in the
+	// Prometheus pod. The directory is automatically mounted as an emptyDir volume
+	// unless `spec.disableScrapeFailureLogFile` is set to true on the Prometheus resource.
+	//
+	// Note: this field only applies to ScrapeConfig resources. To disable this
+	// feature cluster-wide, set `spec.disableScrapeFailureLogFile: true` on the
+	// Prometheus/PrometheusAgent resource.
+	//
+	// It requires Prometheus >= v2.55.0.
+	//
+	// +optional
+	//nolint:kubeapilinter
+	ScrapeFailureLogFile *bool `json:"scrapeFailureLogFile,omitempty"`
 	// scrapeClass defines the scrape class to apply.
 	// +kubebuilder:validation:MinLength=1
 	// +optional

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -3154,6 +3154,11 @@ func (in *ScrapeConfigSpec) DeepCopyInto(out *ScrapeConfigSpec) {
 		*out = new(v1.NameEscapingSchemeOptions)
 		**out = **in
 	}
+	if in.ScrapeFailureLogFile != nil {
+		in, out := &in.ScrapeFailureLogFile, &out.ScrapeFailureLogFile
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ScrapeClassName != nil {
 		in, out := &in.ScrapeClassName, &out.ScrapeClassName
 		*out = new(string)

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -123,6 +123,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	ServiceDiscoveryRole                 *monitoringv1.ServiceDiscoveryRole                      `json:"serviceDiscoveryRole,omitempty"`
 	TSDB                                 *TSDBSpecApplyConfiguration                             `json:"tsdb,omitempty"`
 	ScrapeFailureLogFile                 *string                                                 `json:"scrapeFailureLogFile,omitempty"`
+	DisableScrapeFailureLogFile          *bool                                                   `json:"disableScrapeFailureLogFile,omitempty"`
 	ServiceName                          *string                                                 `json:"serviceName,omitempty"`
 	Runtime                              *RuntimeConfigApplyConfiguration                        `json:"runtime,omitempty"`
 	TerminationGracePeriodSeconds        *int64                                                  `json:"terminationGracePeriodSeconds,omitempty"`
@@ -974,6 +975,14 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithTSDB(value *TSDBSpecApply
 // If called multiple times, the ScrapeFailureLogFile field is set to the value of the last call.
 func (b *CommonPrometheusFieldsApplyConfiguration) WithScrapeFailureLogFile(value string) *CommonPrometheusFieldsApplyConfiguration {
 	b.ScrapeFailureLogFile = &value
+	return b
+}
+
+// WithDisableScrapeFailureLogFile sets the DisableScrapeFailureLogFile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DisableScrapeFailureLogFile field is set to the value of the last call.
+func (b *CommonPrometheusFieldsApplyConfiguration) WithDisableScrapeFailureLogFile(value bool) *CommonPrometheusFieldsApplyConfiguration {
+	b.DisableScrapeFailureLogFile = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -900,6 +900,14 @@ func (b *PrometheusSpecApplyConfiguration) WithScrapeFailureLogFile(value string
 	return b
 }
 
+// WithDisableScrapeFailureLogFile sets the DisableScrapeFailureLogFile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DisableScrapeFailureLogFile field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithDisableScrapeFailureLogFile(value bool) *PrometheusSpecApplyConfiguration {
+	b.CommonPrometheusFieldsApplyConfiguration.DisableScrapeFailureLogFile = &value
+	return b
+}
+
 // WithServiceName sets the ServiceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ServiceName field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -888,6 +888,14 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithScrapeFailureLogFile(value s
 	return b
 }
 
+// WithDisableScrapeFailureLogFile sets the DisableScrapeFailureLogFile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DisableScrapeFailureLogFile field is set to the value of the last call.
+func (b *PrometheusAgentSpecApplyConfiguration) WithDisableScrapeFailureLogFile(value bool) *PrometheusAgentSpecApplyConfiguration {
+	b.CommonPrometheusFieldsApplyConfiguration.DisableScrapeFailureLogFile = &value
+	return b
+}
+
 // WithServiceName sets the ServiceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ServiceName field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
@@ -79,6 +79,7 @@ type ScrapeConfigSpecApplyConfiguration struct {
 	v1.ProxyConfigApplyConfiguration           `json:",inline"`
 	NameValidationScheme                       *monitoringv1.NameValidationSchemeOptions `json:"nameValidationScheme,omitempty"`
 	NameEscapingScheme                         *monitoringv1.NameEscapingSchemeOptions   `json:"nameEscapingScheme,omitempty"`
+	ScrapeFailureLogFile                       *bool                                     `json:"scrapeFailureLogFile,omitempty"`
 	ScrapeClassName                            *string                                   `json:"scrapeClass,omitempty"`
 }
 
@@ -704,6 +705,14 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithNameValidationScheme(value moni
 // If called multiple times, the NameEscapingScheme field is set to the value of the last call.
 func (b *ScrapeConfigSpecApplyConfiguration) WithNameEscapingScheme(value monitoringv1.NameEscapingSchemeOptions) *ScrapeConfigSpecApplyConfiguration {
 	b.NameEscapingScheme = &value
+	return b
+}
+
+// WithScrapeFailureLogFile sets the ScrapeFailureLogFile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ScrapeFailureLogFile field is set to the value of the last call.
+func (b *ScrapeConfigSpecApplyConfiguration) WithScrapeFailureLogFile(value bool) *ScrapeConfigSpecApplyConfiguration {
+	b.ScrapeFailureLogFile = &value
 	return b
 }
 

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -288,12 +288,13 @@ func TestScrapeFailureLogFileVolumeMountPresent(t *testing.T) {
 }
 
 func TestScrapeFailureLogFileVolumeMountNotPresent(t *testing.T) {
-	// An emptyDir is only mounted by the Operator if the given
-	// path is only a base filename.
+	// The emptyDir is not mounted when DisableScrapeFailureLogFile is true,
+	// even when a global ScrapeFailureLogFile with a full path is set.
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1alpha1.PrometheusAgent{
 		Spec: monitoringv1alpha1.PrometheusAgentSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ScrapeFailureLogFile: ptr.To("/tmp/file.log"),
+				ScrapeFailureLogFile:        ptr.To("/tmp/file.log"),
+				DisableScrapeFailureLogFile: ptr.To(true),
 			},
 		},
 	})

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -312,8 +312,11 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 		})
 	}
 
-	// scrape failure log file
-	if cpf.ScrapeFailureLogFile != nil && UsesDefaultFileVolume(*cpf.ScrapeFailureLogFile) {
+	// Mount the log directory when the global scrape failure log file uses it,
+	// or when per-ScrapeConfig scrape failure log files are not disabled.
+	needsLogVolume := (cpf.ScrapeFailureLogFile != nil && UsesDefaultFileVolume(*cpf.ScrapeFailureLogFile)) ||
+		!ptr.Deref(cpf.DisableScrapeFailureLogFile, false)
+	if needsLogVolume {
 		volumes = append(volumes, corev1.Volume{
 			Name: DefaultLogFileVolume,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -3004,6 +3004,21 @@ func (cg *ConfigGenerator) appendScrapeFailureLogFile(slice yaml.MapSlice, scrap
 	return cg.WithMinimumVersion("2.55.0").AppendMapItem(slice, "scrape_failure_log_file", logFilePath(*scrapeFailureLogFile))
 }
 
+// appendScrapeConfigFailureLogFile emits scrape_failure_log_file for a ScrapeConfig job.
+// The path is deterministically generated from the namespace and name to prevent
+// application teams from specifying arbitrary paths in the Prometheus pod filesystem.
+// The feature is skipped when disabled at the Prometheus level via DisableScrapeFailureLogFile.
+func (cg *ConfigGenerator) appendScrapeConfigFailureLogFile(slice yaml.MapSlice, namespace, name string, enabled *bool) yaml.MapSlice {
+	if !ptr.Deref(enabled, false) {
+		return slice
+	}
+	if ptr.Deref(cg.prom.GetCommonPrometheusFields().DisableScrapeFailureLogFile, false) {
+		return slice
+	}
+	logFile := fmt.Sprintf("scrapeconfig-%s-%s.log", namespace, name)
+	return cg.WithMinimumVersion("2.55.0").AppendMapItem(slice, "scrape_failure_log_file", filepath.Join(DefaultLogDirectory, logFile))
+}
+
 func (cg *ConfigGenerator) appendRuleFiles(slice yaml.MapSlice, ruleFiles []string, ruleSelector *metav1.LabelSelector) yaml.MapSlice {
 	if ruleSelector != nil {
 		ruleFilePaths := []string{}
@@ -4834,6 +4849,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 		cfg = append(cfg, yaml.MapItem{Key: "metric_relabel_configs", Value: generateRelabelConfig(metricRelabelings)})
 	}
 
+	cfg = cg.appendScrapeConfigFailureLogFile(cfg, sc.Namespace, sc.Name, sc.Spec.ScrapeFailureLogFile)
 	cfg = cg.appendNameValidationScheme(cfg, sc.Spec.NameValidationScheme)
 	cfg = cg.appendNameEscapingScheme(cfg, sc.Spec.NameEscapingScheme)
 

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -5310,6 +5310,81 @@ func TestScrapeConfigBodySizeLimit(t *testing.T) {
 	golden.Assert(t, string(cfg), "ScrapeConfigBodySizeLimit.golden")
 }
 
+func TestScrapeConfigScrapeFailureLogFile(t *testing.T) {
+	for _, tc := range []struct {
+		scenario                    string
+		prometheusVersion           string
+		scrapeFailureLogFile        *bool
+		disableScrapeFailureLogFile *bool
+		golden                      string
+	}{
+		{
+			scenario:             "scrape_failure_log_file enabled",
+			prometheusVersion:    "v2.55.0",
+			scrapeFailureLogFile: ptr.To(true),
+			golden:               "ScrapeConfigScrapeFailureLogFile.golden",
+		},
+		{
+			scenario:             "scrape_failure_log_file unsupported version",
+			prometheusVersion:    "v2.54.0",
+			scrapeFailureLogFile: ptr.To(true),
+			golden:               "ScrapeConfigScrapeFailureLogFileUnsupportedVersion.golden",
+		},
+		{
+			scenario:          "scrape_failure_log_file not set",
+			prometheusVersion: "v2.55.0",
+			golden:            "ScrapeConfigScrapeFailureLogFileNotSet.golden",
+		},
+		{
+			scenario:                    "scrape_failure_log_file disabled by workload owner",
+			prometheusVersion:           "v2.55.0",
+			scrapeFailureLogFile:        ptr.To(true),
+			disableScrapeFailureLogFile: ptr.To(true),
+			golden:                      "ScrapeConfigScrapeFailureLogFileDisabledByOwner.golden",
+		},
+	} {
+		t.Run(tc.scenario, func(t *testing.T) {
+			p := defaultPrometheus()
+			p.Spec.CommonPrometheusFields.Version = tc.prometheusVersion
+			p.Spec.CommonPrometheusFields.DisableScrapeFailureLogFile = tc.disableScrapeFailureLogFile
+
+			scrapeConfig := monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testscrapeconfig1",
+					Namespace: "default",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					StaticConfigs: []monitoringv1alpha1.StaticConfig{
+						{
+							Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+						},
+					},
+					ScrapeFailureLogFile: tc.scrapeFailureLogFile,
+				},
+			}
+
+			cg := mustNewConfigGenerator(t, p)
+			cfg, err := cg.GenerateServerConfiguration(
+				p,
+				nil,
+				nil,
+				nil,
+				map[string]*monitoringv1alpha1.ScrapeConfig{
+					"testscrapeconfig1": &scrapeConfig,
+				},
+				&assets.StoreBuilder{},
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+
+			require.NoError(t, err)
+			golden.Assert(t, string(cfg), tc.golden)
+		})
+	}
+}
+
 func TestMatchExpressionsServiceMonitor(t *testing.T) {
 	p := defaultPrometheus()
 

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -458,8 +458,13 @@ func buildServerArgs(cg *prompkg.ConfigGenerator, p *monitoringv1.Prometheus) []
 
 // appendServerVolumes returns a set of volumes to be mounted on the statefulset spec that are specific to Prometheus Server.
 func appendServerVolumes(p *monitoringv1.Prometheus, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, ruleConfigMapNames []string) ([]corev1.Volume, []corev1.VolumeMount) {
-	// not mount 2 emptyDir volumes at the same mountpath
-	if volume, ok := queryLogFileVolume(p.Spec.QueryLogFile); ok && p.Spec.ScrapeFailureLogFile == nil {
+	// Only add the query log file volume when the log directory isn't already
+	// mounted by BuildCommonVolumes. The log directory is mounted whenever
+	// per-ScrapeConfig failure logs are not disabled or when the global
+	// ScrapeFailureLogFile uses the default volume.
+	logDirAlreadyMounted := (p.Spec.ScrapeFailureLogFile != nil && prompkg.UsesDefaultFileVolume(*p.Spec.ScrapeFailureLogFile)) ||
+		!ptr.Deref(p.Spec.DisableScrapeFailureLogFile, false)
+	if volume, ok := queryLogFileVolume(p.Spec.QueryLogFile); ok && !logDirAlreadyMounted {
 		volumes = append(volumes, volume)
 	}
 
@@ -485,8 +490,7 @@ func appendServerVolumes(p *monitoringv1.Prometheus, volumes []corev1.Volume, vo
 		})
 	}
 
-	// Prevent mounting 2 emptyDir volumes at the same mountpath
-	if vmount, ok := queryLogFileVolumeMount(p.Spec.QueryLogFile); ok && p.Spec.ScrapeFailureLogFile == nil {
+	if vmount, ok := queryLogFileVolumeMount(p.Spec.QueryLogFile); ok && !logDirAlreadyMounted {
 		volumeMounts = append(volumeMounts, vmount)
 	}
 

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -318,6 +318,11 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 									MountPath: "/etc/prometheus/secrets/test-secret1",
 								},
 								{
+									Name:      prompkg.DefaultLogFileVolume,
+									ReadOnly:  false,
+									MountPath: prompkg.DefaultLogDirectory,
+								},
+								{
 									Name:      "rules-configmap-one",
 									ReadOnly:  true,
 									MountPath: "/etc/prometheus/rules/rules-configmap-one",
@@ -370,6 +375,12 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: "test-secret1",
 								},
+							},
+						},
+						{
+							Name: prompkg.DefaultLogFileVolume,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 						{
@@ -2004,11 +2015,14 @@ func TestQueryLogFileVolumeMountPresent(t *testing.T) {
 }
 
 func TestQueryLogFileVolumeMountNotPresent(t *testing.T) {
-	// An emptyDir is only mounted by the Operator if the given
-	// path is only a base filename.
+	// The emptyDir is not mounted when DisableScrapeFailureLogFile is true
+	// and the QueryLogFile uses a full path (no base filename).
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			QueryLogFile: "/tmp/test.log",
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				DisableScrapeFailureLogFile: ptr.To(true),
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -2070,12 +2084,13 @@ func TestScrapeFailureLogFileVolumeMountPresent(t *testing.T) {
 }
 
 func TestScrapeFailureLogFileVolumeMountNotPresent(t *testing.T) {
-	// An emptyDir is only mounted by the Operator if the given
-	// path is only a base filename.
+	// The emptyDir is not mounted when DisableScrapeFailureLogFile is true,
+	// even when a global ScrapeFailureLogFile with a full path is set.
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ScrapeFailureLogFile: ptr.To("/tmp/file.log"),
+				ScrapeFailureLogFile:        ptr.To("/tmp/file.log"),
+				DisableScrapeFailureLogFile: ptr.To(true),
 			},
 		},
 	})

--- a/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFile.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFile.golden
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  static_configs:
+  - targets:
+    - localhost:9090
+    labels: {}
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  scrape_failure_log_file: /var/log/prometheus/scrapeconfig-default-testscrapeconfig1.log

--- a/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileDisabledByOwner.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileDisabledByOwner.golden
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  static_configs:
+  - targets:
+    - localhost:9090
+    labels: {}
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileNotSet.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileNotSet.golden
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  static_configs:
+  - targets:
+    - localhost:9090
+    labels: {}
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileUnsupportedVersion.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigScrapeFailureLogFileUnsupportedVersion.golden
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: scrapeConfig/default/testscrapeconfig1
+  static_configs:
+  - targets:
+    - localhost:9090
+    labels: {}
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -309,6 +309,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"RelabelConfigCRDValidation":                testRelabelConfigCRDValidation,
 		"PromReconcileStatusWhenInvalidRuleCreated": testPromReconcileStatusWhenInvalidRuleCreated,
 		"ScrapeConfigCreation":                      testScrapeConfigCreation,
+		"ScrapeConfigScrapeFailureLogFile":          testScrapeConfigScrapeFailureLogFile,
 		"CreatePrometheusAgent":                     testCreatePrometheusAgent,
 		"PrometheusAgentAndServerNameColision":      testAgentAndServerNameColision,
 		"ScrapeConfigKubeNode":                      testScrapeConfigKubernetesNodeRole,

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -16,6 +16,8 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
 
 // testScrapeConfigCreation tests multiple ScrapeConfig definitions.
@@ -5030,4 +5033,121 @@ var EurekaSDTestCases = []scrapeCRDTestCase{
 		},
 		expectedError: true,
 	},
+}
+
+// testScrapeConfigScrapeFailureLogFile verifies that when a ScrapeConfig enables
+// scrape failure logging, the operator generates a deterministic log file path in the
+// Prometheus configuration and mounts the log directory in the pod.
+// It also verifies that the workload owner can disable the feature via
+// spec.disableScrapeFailureLogFile on the Prometheus resource.
+func testScrapeConfigScrapeFailureLogFile(t *testing.T) {
+	skipPrometheusTests(t)
+	t.Parallel()
+
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	_, err := framework.CreateOrUpdatePrometheusOperator(
+		context.Background(),
+		ns,
+		[]string{ns},
+		nil,
+		[]string{ns},
+		nil,
+		false,
+		true,
+		true,
+	)
+	require.NoError(t, err)
+
+	t.Run("log file path generated and log dir mounted", func(t *testing.T) {
+		p := framework.MakeBasicPrometheus(ns, "prom-log", "group", 1)
+		p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{"role": "scrapeconfig"},
+		}
+		_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
+		require.NoError(t, err)
+
+		sc := framework.MakeBasicScrapeConfig(ns, "scrape-config-log")
+		sc.Spec.StaticConfigs = []monitoringv1alpha1.StaticConfig{
+			{Targets: []monitoringv1alpha1.Target{"localhost:9090"}},
+		}
+		sc.Spec.ScrapeFailureLogFile = ptr.To(true)
+		_, err = framework.CreateScrapeConfig(context.Background(), ns, sc)
+		require.NoError(t, err)
+
+		expectedLogFile := fmt.Sprintf(
+			"scrape_failure_log_file: /var/log/prometheus/scrapeconfig-%s-%s.log",
+			ns, "scrape-config-log",
+		)
+		podName := "prometheus-prom-log-0"
+
+		// Wait until the config contains the expected scrape_failure_log_file entry.
+		require.Eventually(t, func() bool {
+			stdout, _, execErr := framework.ExecWithOptions(context.Background(), testFramework.ExecOptions{
+				Command:       []string{"/bin/sh", "-c", "cat /etc/prometheus/config_out/prometheus.env.yaml"},
+				Namespace:     ns,
+				PodName:       podName,
+				ContainerName: "prometheus",
+				CaptureStdout: true,
+				CaptureStderr: true,
+			})
+			if execErr != nil {
+				return false
+			}
+			return strings.Contains(stdout, expectedLogFile)
+		}, 3*time.Minute, 5*time.Second, "expected scrape_failure_log_file entry not found in Prometheus config")
+
+		// Verify the log directory is mounted in the pod.
+		stdout, _, err := framework.ExecWithOptions(context.Background(), testFramework.ExecOptions{
+			Command:       []string{"/bin/sh", "-c", "test -d /var/log/prometheus && echo ok"},
+			Namespace:     ns,
+			PodName:       podName,
+			ContainerName: "prometheus",
+			CaptureStdout: true,
+			CaptureStderr: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "ok", stdout, "expected /var/log/prometheus to be mounted in the Prometheus pod")
+	})
+
+	t.Run("disabled by workload owner", func(t *testing.T) {
+		p := framework.MakeBasicPrometheus(ns, "prom-log-disabled", "group", 1)
+		p.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{"role": "scrapeconfig"},
+		}
+		p.Spec.DisableScrapeFailureLogFile = ptr.To(true)
+		_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
+		require.NoError(t, err)
+
+		sc := framework.MakeBasicScrapeConfig(ns, "scrape-config-log-disabled")
+		sc.Spec.StaticConfigs = []monitoringv1alpha1.StaticConfig{
+			{Targets: []monitoringv1alpha1.Target{"localhost:9090"}},
+		}
+		sc.Spec.ScrapeFailureLogFile = ptr.To(true)
+		_, err = framework.CreateScrapeConfig(context.Background(), ns, sc)
+		require.NoError(t, err)
+
+		podName := "prometheus-prom-log-disabled-0"
+
+		// Wait for the config to be rendered and verify no scrape_failure_log_file is present.
+		require.Eventually(t, func() bool {
+			stdout, _, execErr := framework.ExecWithOptions(context.Background(), testFramework.ExecOptions{
+				Command:       []string{"/bin/sh", "-c", "cat /etc/prometheus/config_out/prometheus.env.yaml"},
+				Namespace:     ns,
+				PodName:       podName,
+				ContainerName: "prometheus",
+				CaptureStdout: true,
+				CaptureStderr: true,
+			})
+			if execErr != nil {
+				return false
+			}
+			// The config must be rendered (job is present) but must not contain scrape_failure_log_file.
+			return strings.Contains(stdout, "scrape-config-log-disabled") &&
+				!strings.Contains(stdout, "scrape_failure_log_file")
+		}, 3*time.Minute, 5*time.Second, "unexpected scrape_failure_log_file found in Prometheus config when feature is disabled")
+	})
 }


### PR DESCRIPTION
Fixes #8425

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add scrape_failure_log_file support in ScrapeConfig CRD
```
