### PR TITLE
chore: Add standardization of import as aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - godot
     - godoclint
     - iface
+    - importas
     - iotamixing
     - modernize
     - nilnesserr
@@ -32,6 +33,43 @@ linters:
       exclude-functions:
         # Any error in HTTP handlers is handled by the server itself.
         - (net/http.ResponseWriter).Write
+    importas:
+      alias:
+        # Kubernetes
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/discovery/v1
+          alias: discoveryv1
+        - pkg: k8s.io/api/events/v1
+          alias: eventsv1
+        - pkg: k8s.io/api/storage/v1
+          alias: storagev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        - pkg: k8s.io/component-base/logs/api/v1
+          alias: logsv1
+        - pkg: k8s.io/client-go/kubernetes/typed/core/v1
+          alias: typedcorev1
+        - pkg: k8s.io/client-go/kubernetes/typed/authorization/v1
+          alias: typedauthv1
+        # Controller Runtime
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        # Prometheus Operator
+        - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1
+          alias: monitoringv1
+        - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1
+          alias: monitoringv1alpha1
+        - pkg: github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1
+          alias: monitoringv1beta1
     modernize:
       disable:
         - omitzero

--- a/cmd/po-rule-migration/main.go
+++ b/cmd/po-rule-migration/main.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"path/filepath"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
@@ -71,7 +71,7 @@ func main() {
 		log.Fatalf("failed to read file '%v': %v", ruleConfigMapName, err.Error())
 	}
 
-	configMap := v1.ConfigMap{}
+	configMap := corev1.ConfigMap{}
 
 	err = k8sYAML.NewYAMLOrJSONDecoder(file, 100).Decode(&configMap)
 	if err != nil {
@@ -99,7 +99,7 @@ func main() {
 // CMToRule takes a rule ConfigMap and transforms it to possibly multiple
 // rule file crds. It is used in `cmd/po-rule-cm-to-rule-file-crds`. Thereby it
 // needs to be public.
-func CMToRule(cm *v1.ConfigMap) ([]monitoringv1.PrometheusRule, error) {
+func CMToRule(cm *corev1.ConfigMap) ([]monitoringv1.PrometheusRule, error) {
 	rules := []monitoringv1.PrometheusRule{}
 
 	for name, content := range cm.Data {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -30,7 +30,7 @@ import (
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
@@ -408,14 +408,14 @@ func (cb *ConfigBuilder) AddAlertmanagerConfigs(ctx context.Context, amConfigs m
 	return cb.cfg.sanitize(cb.amVersion, cb.logger)
 }
 
-func (cb *ConfigBuilder) getValidURLFromSecret(ctx context.Context, namespace string, selector v1.SecretKeySelector) (string, error) {
+func (cb *ConfigBuilder) getValidURLFromSecret(ctx context.Context, namespace string, selector corev1.SecretKeySelector) (string, error) {
 	return cb.getFromSecretWithValidation(ctx, namespace, selector, func(url string) error {
 		_, err := validation.ValidateURL(url)
 		return err
 	})
 }
 
-func (cb *ConfigBuilder) getFromSecretWithValidation(ctx context.Context, namespace string, selector v1.SecretKeySelector, validFn func(string) error) (string, error) {
+func (cb *ConfigBuilder) getFromSecretWithValidation(ctx context.Context, namespace string, selector corev1.SecretKeySelector, validFn func(string) error) (string, error) {
 	url, err := cb.store.GetSecretKey(ctx, namespace, selector)
 	if err != nil {
 		return "", fmt.Errorf("failed to get URL: %w", err)

--- a/pkg/alertmanager/clustertlsconfig/config.go
+++ b/pkg/alertmanager/clustertlsconfig/config.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -108,7 +108,7 @@ func New(mountingDir string, a *monitoringv1.Alertmanager) (*Config, error) {
 // or "cluster-tls-client-config-" respectively, for server and client credentials.
 // The server and client TLS credentials are mounted in different paths: ~/{mountingDir}/server-tls/
 // and ~/{mountingDir}/client-tls/ respectively.
-func (c Config) GetMountParameters() (*monitoringv1.Argument, []v1.Volume, []v1.VolumeMount, error) {
+func (c Config) GetMountParameters() (*monitoringv1.Argument, []corev1.Volume, []corev1.VolumeMount, error) {
 	destinationPath := path.Join(c.mountingDir, ConfigFileKey)
 
 	var arg *monitoringv1.Argument
@@ -117,11 +117,11 @@ func (c Config) GetMountParameters() (*monitoringv1.Argument, []v1.Volume, []v1.
 		arg = c.makeArg(destinationPath)
 	}
 
-	var volumes []v1.Volume
+	var volumes []corev1.Volume
 	cfgVolume := c.makeVolume()
 	volumes = append(volumes, cfgVolume)
 
-	var mounts []v1.VolumeMount
+	var mounts []corev1.VolumeMount
 	cfgMount := c.makeVolumeMount(destinationPath)
 	mounts = append(mounts, cfgMount)
 
@@ -179,11 +179,11 @@ func (c Config) makeArg(filePath string) *monitoringv1.Argument {
 
 // makeVolume() creates a Volume with volumeName = "cluster-tls-config" which stores
 // the secret which contains the cluster TLS config.
-func (c Config) makeVolume() v1.Volume {
-	return v1.Volume{
+func (c Config) makeVolume() corev1.Volume {
+	return corev1.Volume{
 		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				SecretName: c.secretName,
 			},
 		},
@@ -192,8 +192,8 @@ func (c Config) makeVolume() v1.Volume {
 
 // makeVolumeMount() creates a VolumeMount, mounting the cluster_tls_config.yaml SubPath
 // to the given filePath.
-func (c Config) makeVolumeMount(filePath string) v1.VolumeMount {
-	return v1.VolumeMount{
+func (c Config) makeVolumeMount(filePath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
 		Name:      volumeName,
 		SubPath:   ConfigFileKey,
 		ReadOnly:  true,

--- a/pkg/alertmanager/clustertlsconfig/config_test.go
+++ b/pkg/alertmanager/clustertlsconfig/config_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -44,15 +44,15 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -61,23 +61,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					InsecureSkipVerify: ptr.To(true),
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.KeySecret",
@@ -91,15 +91,15 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -108,23 +108,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					InsecureSkipVerify: ptr.To(true),
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "cert.pem",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -138,22 +138,22 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
 					},
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.client_ca",
@@ -163,23 +163,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					InsecureSkipVerify: ptr.To(true),
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -193,23 +193,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.keySecret",
@@ -224,23 +224,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					InsecureSkipVerify: ptr.To(true),
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -260,23 +260,23 @@ func TestCreateOrUpdateClusterTLSConfigSecret(t *testing.T) {
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					InsecureSkipVerify: ptr.To(true),
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "cert.pem",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "cert.pem",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -314,23 +314,23 @@ func TestGetMountParameters(t *testing.T) {
 	ts := []struct {
 		name             string
 		clusterTLSConfig *monitoringv1.ClusterTLSConfig
-		expectedVolumes  []v1.Volume
-		expectedMounts   []v1.VolumeMount
+		expectedVolumes  []corev1.Volume
+		expectedMounts   []corev1.VolumeMount
 	}{
 		{
 			name:             "cluster tls config not defined",
 			clusterTLSConfig: nil,
-			expectedVolumes: []v1.Volume{
+			expectedVolumes: []corev1.Volume{
 				{
 					Name: "cluster-tls-config",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "alertmanager-test-cluster-tls-config",
 						},
 					},
 				},
 			},
-			expectedMounts: []v1.VolumeMount{
+			expectedMounts: []corev1.VolumeMount{
 				{
 					Name:             "cluster-tls-config",
 					ReadOnly:         true,
@@ -345,23 +345,23 @@ func TestGetMountParameters(t *testing.T) {
 			name: "cluster tls config completely defined",
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "some-secret",
 						},
 						Key: "tls.key",
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.client_ca",
@@ -369,23 +369,23 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 				ClientTLS: monitoringv1.SafeTLSConfig{
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "some-secret",
 						},
 						Key: "tls.key",
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.client_ca",
@@ -393,65 +393,65 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 			},
-			expectedVolumes: []v1.Volume{
+			expectedVolumes: []corev1.Volume{
 				{
 					Name: "cluster-tls-config",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "alertmanager-test-cluster-tls-config",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-server-config-secret-key-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-server-config-secret-cert-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-server-config-secret-client-ca-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-client-config-secret-key-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-client-config-secret-cert-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "cluster-tls-client-config-secret-client-ca-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 			},
-			expectedMounts: []v1.VolumeMount{
+			expectedMounts: []corev1.VolumeMount{
 				{
 					Name:             "cluster-tls-config",
 					ReadOnly:         true,

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -30,12 +30,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	typedauthv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -82,7 +82,7 @@ type Operator struct {
 	kclient    kubernetes.Interface
 	mdClient   metadata.Interface
 	mclient    monitoringclient.Interface
-	ssarClient authv1.SelfSubjectAccessReviewInterface
+	ssarClient typedauthv1.SelfSubjectAccessReviewInterface
 
 	controllerID string
 
@@ -256,7 +256,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 				options.LabelSelector = config.SecretListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceSecrets)),
 		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
@@ -274,7 +274,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 				options.LabelSelector = config.ConfigMapListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),
 	)
 	if err != nil {
@@ -314,7 +314,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 		c.logger.Debug("creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
-			&v1.Namespace{},
+			&corev1.Namespace{},
 			resyncPeriod,
 			cache.Indexers{},
 		), nil
@@ -440,7 +440,7 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 		c.logger.Error(fmt.Sprintf("get namespace to enqueue Alertmanager instances failed: namespace %q does not exist", nsName))
 		return
 	}
-	ns := nsObject.(*v1.Namespace)
+	ns := nsObject.(*corev1.Namespace)
 
 	err = c.alrtInfs.ListAll(labels.Everything(), func(obj any) {
 		// Check for Alertmanager instances in the namespace.
@@ -528,8 +528,8 @@ func alertmanagerKeyToStatefulSetKey(key string) string {
 }
 
 func (c *Operator) handleNamespaceUpdate(oldo, curo any) {
-	old := oldo.(*v1.Namespace)
-	cur := curo.(*v1.Namespace)
+	old := oldo.(*corev1.Namespace)
+	cur := curo.(*corev1.Namespace)
 
 	c.logger.Debug("update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
@@ -966,7 +966,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 }
 
 func (c *Operator) createOrUpdateGeneratedConfigSecret(ctx context.Context, am *monitoringv1.Alertmanager, conf []byte, additionalData map[string][]byte) error {
-	generatedConfigSecret := &v1.Secret{
+	generatedConfigSecret := &corev1.Secret{
 		Data: map[string][]byte{},
 	}
 
@@ -1010,7 +1010,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 		}
 
 		err = cache.ListAll(c.nsAlrtCfgInf.GetStore(), amConfigNSSelector, func(obj any) {
-			namespaces = append(namespaces, obj.(*v1.Namespace).Name)
+			namespaces = append(namespaces, obj.(*corev1.Namespace).Name)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list namespaces: %w", err)
@@ -1061,7 +1061,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 				"namespace", am.Namespace,
 				"alertmanager", am.Name,
 			)
-			eventRecorder.Eventf(amc, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
+			eventRecorder.Eventf(amc, corev1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingAlertmanagerConfigResourcesAction, "AlertmanagerConfig %s was rejected due to invalid configuration: %v", amc.GetName(), err)
 			continue
 		}
 
@@ -1568,7 +1568,7 @@ func checkPushoverConfigs(
 	store *assets.StoreBuilder,
 	amVersion semver.Version,
 ) error {
-	checkSecret := func(secret *v1.SecretKeySelector, name string) error {
+	checkSecret := func(secret *corev1.SecretKeySelector, name string) error {
 		if secret == nil {
 			return fmt.Errorf("mandatory field %s is empty", name)
 		}
@@ -1803,8 +1803,8 @@ func configureHTTPConfigInStore(ctx context.Context, httpConfig *monitoringv1alp
 	return store.AddOAuth2(ctx, namespace, httpConfig.OAuth2)
 }
 
-func (c *Operator) newTLSAssetSecret(am *monitoringv1.Alertmanager) *v1.Secret {
-	s := &v1.Secret{
+func (c *Operator) newTLSAssetSecret(am *monitoringv1.Alertmanager) *corev1.Secret {
+	s := &corev1.Secret{
 		Data: make(map[string][]byte),
 	}
 
@@ -1835,7 +1835,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, a *monitor
 		return fmt.Errorf("failed to initialize web config: %w", err)
 	}
 
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	operator.UpdateObject(
 		s,
 		operator.WithLabels(c.config.Labels),
@@ -1861,7 +1861,7 @@ func (c *Operator) createOrUpdateClusterTLSConfigSecret(ctx context.Context, a *
 		return fmt.Errorf("failed to generate the configuration: %w", err)
 	}
 
-	s := &v1.Secret{
+	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterTLSConfig.GetSecretName(),
 		},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authorization/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,9 +57,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				},
 				Spec: monitoringv1.AlertmanagerSpec{
 					Version: "v0.0.1",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("200Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 					},
 				},
@@ -70,9 +70,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				},
 				Spec: monitoringv1.AlertmanagerSpec{
 					Version: "v0.0.1",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("100Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
 						},
 					},
 				},
@@ -88,9 +88,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 			a: monitoringv1.Alertmanager{
 				Spec: monitoringv1.AlertmanagerSpec{
 					Version: "v0.0.1",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("200Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 					},
 				},
@@ -98,9 +98,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 			b: monitoringv1.Alertmanager{
 				Spec: monitoringv1.AlertmanagerSpec{
 					Version: "v0.0.1",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("100Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
 						},
 					},
 				},
@@ -205,7 +205,7 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -366,8 +366,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					Receivers: []monitoringv1alpha1.Receiver{{
 						Name: "recv1",
 						PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-							ServiceKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+							ServiceKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 								Key:                  "not-existing",
 							},
 						}},
@@ -389,8 +389,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					Receivers: []monitoringv1alpha1.Receiver{{
 						Name: "recv1",
 						PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-							ServiceKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+							ServiceKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 								Key:                  "key1",
 							},
 						}},
@@ -412,8 +412,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					Receivers: []monitoringv1alpha1.Receiver{{
 						Name: "recv1",
 						PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-							RoutingKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+							RoutingKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 								Key:                  "not-existing",
 							},
 						}},
@@ -435,8 +435,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 					Receivers: []monitoringv1alpha1.Receiver{{
 						Name: "recv1",
 						PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-							RoutingKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+							RoutingKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 								Key:                  "key1",
 							},
 						}},
@@ -567,8 +567,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 							{
-								URLSecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								URLSecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "key1",
 								},
 							},
@@ -592,8 +592,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 							{
-								URLSecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								URLSecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "template-url",
 								},
 							},
@@ -617,8 +617,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 							{
-								URLSecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								URLSecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "not-existing",
 								},
 							},
@@ -642,8 +642,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 							{
-								URLSecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								URLSecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "invalid-template-url",
 								},
 							},
@@ -713,8 +713,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						WeChatConfigs: []monitoringv1alpha1.WeChatConfig{
 							{
 								CorpID: ptr.To("testingCorpID"),
-								APISecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								APISecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "not-existing",
 								},
 							},
@@ -739,8 +739,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						WeChatConfigs: []monitoringv1alpha1.WeChatConfig{
 							{
 								CorpID: ptr.To("testingCorpID"),
-								APISecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								APISecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "key1",
 								},
 							},
@@ -1140,8 +1140,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						SlackConfigs: []monitoringv1alpha1.SlackConfig{
 							{
-								APIURL: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								APIURL: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "invalid-url",
 								},
 							},
@@ -1253,8 +1253,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						DiscordConfigs: []monitoringv1alpha1.DiscordConfig{
 							{
-								APIURL: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								APIURL: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "invalid-url",
 								},
 							},
@@ -1302,8 +1302,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						MSTeamsConfigs: []monitoringv1alpha1.MSTeamsConfig{
 							{
-								WebhookURL: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "not-existing-secret"},
+								WebhookURL: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "not-existing-secret"},
 									Key:                  "url",
 								},
 							},
@@ -1327,8 +1327,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						MSTeamsConfigs: []monitoringv1alpha1.MSTeamsConfig{
 							{
-								WebhookURL: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								WebhookURL: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "not-existing",
 								},
 							},
@@ -1352,8 +1352,8 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 						Name: "recv1",
 						MSTeamsConfigs: []monitoringv1alpha1.MSTeamsConfig{
 							{
-								WebhookURL: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+								WebhookURL: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
 									Key:                  "key1",
 								},
 							},
@@ -1480,7 +1480,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1506,7 +1506,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1529,7 +1529,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1553,7 +1553,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1576,7 +1576,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1602,7 +1602,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1627,7 +1627,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1652,7 +1652,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				},
 			},
 			objects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "amconfig",
 						Namespace: "test",
@@ -1683,7 +1683,7 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 				operator.Config{
 					Namespaces: operator.Namespaces{
 						AlertmanagerConfigAllowList: map[string]struct{}{
-							v1.NamespaceAll: {},
+							corev1.NamespaceAll: {},
 						},
 						AlertmanagerAllowList: map[string]struct{}{
 							"foo": {},

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -101,10 +101,10 @@ func makeStatefulSet(logger *slog.Logger, am *monitoringv1.Alertmanager, config 
 		am.Spec.Retention = defaultRetention
 	}
 	if am.Spec.Resources.Requests == nil {
-		am.Spec.Resources.Requests = v1.ResourceList{}
+		am.Spec.Resources.Requests = corev1.ResourceList{}
 	}
-	if _, ok := am.Spec.Resources.Requests[v1.ResourceMemory]; !ok {
-		am.Spec.Resources.Requests[v1.ResourceMemory] = resource.MustParse("200Mi")
+	if _, ok := am.Spec.Resources.Requests[corev1.ResourceMemory]; !ok {
+		am.Spec.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("200Mi")
 	}
 
 	spec, err := makeStatefulSetSpec(logger, am, config, tlsSecrets)
@@ -133,25 +133,25 @@ func makeStatefulSet(logger *slog.Logger, am *monitoringv1.Alertmanager, config 
 	storageSpec := am.Spec.Storage
 	switch {
 	case storageSpec == nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(am.Name),
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 
 	case storageSpec.EmptyDir != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(am.Name),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				EmptyDir: storageSpec.EmptyDir,
 			},
 		})
 
 	case storageSpec.Ephemeral != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(am.Name),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				Ephemeral: storageSpec.Ephemeral,
 			},
 		})
@@ -162,7 +162,7 @@ func makeStatefulSet(logger *slog.Logger, am *monitoringv1.Alertmanager, config 
 			pvcTemplate.Name = volumeName(am.Name)
 		}
 		if storageSpec.VolumeClaimTemplate.Spec.AccessModes == nil {
-			pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+			pvcTemplate.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
@@ -180,33 +180,33 @@ func makeStatefulSet(logger *slog.Logger, am *monitoringv1.Alertmanager, config 
 	return statefulset, nil
 }
 
-func makeStatefulSetService(a *monitoringv1.Alertmanager, config Config) *v1.Service {
+func makeStatefulSetService(a *monitoringv1.Alertmanager, config Config) *corev1.Service {
 	if a.Spec.PortName == "" {
 		a.Spec.PortName = defaultPortName
 	}
 
-	svc := &v1.Service{
-		Spec: v1.ServiceSpec{
-			ClusterIP:                v1.ClusterIPNone,
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			ClusterIP:                corev1.ClusterIPNone,
 			PublishNotReadyAddresses: true,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       a.Spec.PortName,
 					Port:       alertmanagerWebPort,
 					TargetPort: intstr.FromString(a.Spec.PortName),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       "tcp-mesh",
 					Port:       alertmanagerMeshPort,
 					TargetPort: intstr.FromString(alertmanagerMeshTCPPortName),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       "udp-mesh",
 					Port:       alertmanagerMeshPort,
 					TargetPort: intstr.FromString(alertmanagerMeshUDPPortName),
-					Protocol:   v1.ProtocolUDP,
+					Protocol:   corev1.ProtocolUDP,
 				},
 			},
 			Selector: map[string]string{
@@ -354,30 +354,30 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 
 	isHTTPS := a.Spec.Web != nil && a.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("0.22.0"))
 
-	livenessProbeHandler := v1.ProbeHandler{
-		HTTPGet: &v1.HTTPGetAction{
+	livenessProbeHandler := corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
 			Path: path.Clean(webRoutePrefix + "/-/healthy"),
 			Port: intstr.FromString(a.Spec.PortName),
 		},
 	}
 
-	readinessProbeHandler := v1.ProbeHandler{
-		HTTPGet: &v1.HTTPGetAction{
+	readinessProbeHandler := corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
 			Path: path.Clean(webRoutePrefix + "/-/ready"),
 			Port: intstr.FromString(a.Spec.PortName),
 		},
 	}
 
-	var livenessProbe *v1.Probe
-	var readinessProbe *v1.Probe
+	var livenessProbe *corev1.Probe
+	var readinessProbe *corev1.Probe
 	if !a.Spec.ListenLocal {
-		livenessProbe = &v1.Probe{
+		livenessProbe = &corev1.Probe{
 			ProbeHandler:     livenessProbeHandler,
 			TimeoutSeconds:   probeTimeoutSeconds,
 			FailureThreshold: 10,
 		}
 
-		readinessProbe = &v1.Probe{
+		readinessProbe = &corev1.Probe{
 			ProbeHandler:        readinessProbeHandler,
 			InitialDelaySeconds: 3,
 			TimeoutSeconds:      3,
@@ -386,8 +386,8 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		}
 
 		if isHTTPS {
-			livenessProbe.HTTPGet.Scheme = v1.URISchemeHTTPS
-			readinessProbe.HTTPGet.Scheme = v1.URISchemeHTTPS
+			livenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+			readinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
 		}
 	}
 
@@ -408,7 +408,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 
 	podAnnotations[operator.DefaultContainerAnnotationKey] = "alertmanager"
 
-	var operatorInitContainers []v1.Container
+	var operatorInitContainers []corev1.Container
 
 	var clusterPeerDomain string
 	if config.ClusterDomain != "" {
@@ -428,24 +428,24 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.peer", Value: peer})
 	}
 
-	ports := []v1.ContainerPort{
+	ports := []corev1.ContainerPort{
 		{
 			Name:          alertmanagerMeshTCPPortName,
 			ContainerPort: alertmanagerMeshPort,
-			Protocol:      v1.ProtocolTCP,
+			Protocol:      corev1.ProtocolTCP,
 		},
 		{
 			Name:          alertmanagerMeshUDPPortName,
 			ContainerPort: alertmanagerMeshPort,
-			Protocol:      v1.ProtocolUDP,
+			Protocol:      corev1.ProtocolUDP,
 		},
 	}
 	if !a.Spec.ListenLocal {
-		ports = append([]v1.ContainerPort{
+		ports = append([]corev1.ContainerPort{
 			{
 				Name:          a.Spec.PortName,
 				ContainerPort: alertmanagerWebPort,
-				Protocol:      v1.ProtocolTCP,
+				Protocol:      corev1.ProtocolTCP,
 			},
 		}, ports...)
 	}
@@ -455,11 +455,11 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 	// regular rolling update.
 	amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.reconnect-timeout", Value: "5m"})
 
-	volumes := []v1.Volume{
+	volumes := []corev1.Volume{
 		{
 			Name: alertmanagerConfigVolumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: generatedConfigSecretName(a.Name),
 				},
 			},
@@ -467,10 +467,10 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		tlsSecrets.Volume(tlsAssetsVolumeName),
 		{
 			Name: alertmanagerConfigOutVolumeName,
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
 					// tmpfs is used here to avoid writing sensitive data into disk.
-					Medium: v1.StorageMediumMemory,
+					Medium: corev1.StorageMediumMemory,
 				},
 			},
 		},
@@ -483,7 +483,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		}
 	}
 
-	amVolumeMounts := []v1.VolumeMount{
+	amVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      alertmanagerConfigVolumeName,
 			MountPath: alertmanagerConfigDir,
@@ -508,7 +508,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 	var configReloaderWebConfigFile string
 
 	watchedDirectories := []string{alertmanagerConfigDir}
-	configReloaderVolumeMounts := []v1.VolumeMount{
+	configReloaderVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      alertmanagerConfigVolumeName,
 			MountPath: alertmanagerConfigDir,
@@ -522,7 +522,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 
 	amCfg := a.Spec.AlertmanagerConfiguration
 	if amCfg != nil && len(amCfg.Templates) > 0 {
-		sources := []v1.VolumeProjection{}
+		sources := []corev1.VolumeProjection{}
 		keys := sets.Set[string]{}
 		for _, v := range amCfg.Templates {
 			if v.ConfigMap != nil {
@@ -530,12 +530,12 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 					logger.Debug(fmt.Sprintf("skipping %q due to duplicate key %q", v.ConfigMap.Key, v.ConfigMap.Name))
 					continue
 				}
-				sources = append(sources, v1.VolumeProjection{
-					ConfigMap: &v1.ConfigMapProjection{
-						LocalObjectReference: v1.LocalObjectReference{
+				sources = append(sources, corev1.VolumeProjection{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: v.ConfigMap.Name,
 						},
-						Items: []v1.KeyToPath{{
+						Items: []corev1.KeyToPath{{
 							Key:  v.ConfigMap.Key,
 							Path: v.ConfigMap.Key,
 						}},
@@ -548,12 +548,12 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 					logger.Debug(fmt.Sprintf("skipping %q due to duplicate key %q", v.Secret.Key, v.Secret.Name))
 					continue
 				}
-				sources = append(sources, v1.VolumeProjection{
-					Secret: &v1.SecretProjection{
-						LocalObjectReference: v1.LocalObjectReference{
+				sources = append(sources, corev1.VolumeProjection{
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: v.Secret.Name,
 						},
-						Items: []v1.KeyToPath{{
+						Items: []corev1.KeyToPath{{
 							Key:  v.Secret.Key,
 							Path: v.Secret.Key,
 						}},
@@ -562,20 +562,20 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 				keys.Insert(v.Secret.Key)
 			}
 		}
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: "notification-templates",
-			VolumeSource: v1.VolumeSource{
-				Projected: &v1.ProjectedVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
 					Sources: sources,
 				},
 			},
 		})
-		amVolumeMounts = append(amVolumeMounts, v1.VolumeMount{
+		amVolumeMounts = append(amVolumeMounts, corev1.VolumeMount{
 			Name:      alertmanagerTemplatesVolumeName,
 			ReadOnly:  true,
 			MountPath: alertmanagerTemplatesDir,
 		})
-		configReloaderVolumeMounts = append(configReloaderVolumeMounts, v1.VolumeMount{
+		configReloaderVolumeMounts = append(configReloaderVolumeMounts, corev1.VolumeMount{
 			Name:      alertmanagerTemplatesVolumeName,
 			ReadOnly:  true,
 			MountPath: alertmanagerTemplatesDir,
@@ -590,16 +590,16 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 			return nil, err
 		}
 
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: s,
 				},
 			},
 		})
 		mountPath := path.Join(secretsDir, s)
-		mount := v1.VolumeMount{
+		mount := corev1.VolumeMount{
 			Name:      name,
 			ReadOnly:  true,
 			MountPath: mountPath,
@@ -616,18 +616,18 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 			return nil, err
 		}
 
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: c,
 					},
 				},
 			},
 		})
 		mountPath := path.Join(configmapsDir, c)
-		mount := v1.VolumeMount{
+		mount := corev1.VolumeMount{
 			Name:      name,
 			ReadOnly:  true,
 			MountPath: mountPath,
@@ -698,7 +698,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		return nil, err
 	}
 
-	defaultContainers := []v1.Container{
+	defaultContainers := []corev1.Container{
 		{
 			Args:            containerArgs,
 			Name:            "alertmanager",
@@ -709,25 +709,25 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 			LivenessProbe:   livenessProbe,
 			ReadinessProbe:  readinessProbe,
 			Resources:       a.Spec.Resources,
-			SecurityContext: &v1.SecurityContext{
+			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 				ReadOnlyRootFilesystem:   ptr.To(true),
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
 				},
 			},
-			Env: []v1.EnvVar{
+			Env: []corev1.EnvVar{
 				{
 					// Necessary for '--cluster.listen-address' flag
 					Name: "POD_IP",
-					ValueFrom: &v1.EnvVarSource{
-						FieldRef: &v1.ObjectFieldSelector{
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
 							FieldPath: "status.podIP",
 						},
 					},
 				},
 			},
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		},
 		operator.CreateConfigReloader(
 			"config-reloader",
@@ -792,12 +792,12 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,
 				Annotations: podAnnotations,
 			},
-			Spec: v1.PodSpec{
+			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken:  a.Spec.AutomountServiceAccountToken,
 				NodeSelector:                  a.Spec.NodeSelector,
 				PriorityClassName:             a.Spec.PriorityClassName,
@@ -819,7 +819,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 	}
 
 	if a.Spec.HostNetwork {
-		spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+		spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	k8s.UpdateDNSPolicy(&spec.Template.Spec, a.Spec.DNSPolicy)
 	k8s.UpdateDNSConfig(&spec.Template.Spec, a.Spec.DNSConfig)

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -179,8 +179,8 @@ func TestStatefulSetPVC(t *testing.T) {
 		EmbeddedObjectMetadata: monitoringv1.EmbeddedObjectMetadata{
 			Annotations: annotations,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			StorageClassName: &storageClass,
 		},
 	}
@@ -210,8 +210,8 @@ func TestStatefulEmptyDir(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	emptyDir := v1.EmptyDirVolumeSource{
-		Medium: v1.StorageMediumMemory,
+	emptyDir := corev1.EmptyDirVolumeSource{
+		Medium: corev1.StorageMediumMemory,
 	}
 
 	sset, err := makeStatefulSet(nil, &monitoringv1.Alertmanager{
@@ -242,10 +242,10 @@ func TestStatefulSetEphemeral(t *testing.T) {
 
 	storageClass := "storageclass"
 
-	ephemeral := v1.EphemeralVolumeSource{
-		VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
-			Spec: v1.PersistentVolumeClaimSpec{
-				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+	ephemeral := corev1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				StorageClassName: &storageClass,
 			},
 		},
@@ -307,14 +307,14 @@ func TestListenTLS(t *testing.T) {
 			Web: &monitoringv1.AlertmanagerWebSpec{
 				WebConfigFileFields: monitoringv1.WebConfigFileFields{
 					TLSConfig: &monitoringv1.WebTLSConfig{
-						KeySecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						KeySecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 						},
 						Cert: monitoringv1.SecretOrConfigMap{
-							ConfigMap: &v1.ConfigMapKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ConfigMap: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "some-configmap",
 								},
 							},
@@ -326,9 +326,9 @@ func TestListenTLS(t *testing.T) {
 	}, defaultTestConfig, "", &operator.ShardedSecret{})
 	require.NoError(t, err)
 
-	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
-		return v1.ProbeHandler{
-			HTTPGet: &v1.HTTPGetAction{
+	expectedProbeHandler := func(probePath string) corev1.ProbeHandler {
+		return corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
 				Path:   probePath,
 				Port:   intstr.FromString("web"),
 				Scheme: "HTTPS",
@@ -337,7 +337,7 @@ func TestListenTLS(t *testing.T) {
 	}
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
-	expectedLivenessProbe := &v1.Probe{
+	expectedLivenessProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		FailureThreshold: 10,
@@ -345,7 +345,7 @@ func TestListenTLS(t *testing.T) {
 	require.Equal(t, expectedLivenessProbe, actualLivenessProbe, "Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
-	expectedReadinessProbe := &v1.Probe{
+	expectedReadinessProbe := &corev1.Probe{
 		ProbeHandler:        expectedProbeHandler("/-/ready"),
 		InitialDelaySeconds: 3,
 		TimeoutSeconds:      3,
@@ -761,8 +761,8 @@ func TestMakeStatefulSetSpecNotificationTemplates(t *testing.T) {
 			AlertmanagerConfiguration: &monitoringv1.AlertmanagerConfiguration{
 				Templates: []monitoringv1.SecretOrConfigMap{
 					{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "template1",
 							},
 							Key: "template1.tmpl",
@@ -1005,7 +1005,7 @@ func TestTerminationPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, c := range sset.Spec.Template.Spec.Containers {
-		require.Equal(t, v1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy, "Unexpected TermintationMessagePolicy. Expected %v got %v", v1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy)
+		require.Equal(t, corev1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy, "Unexpected TermintationMessagePolicy. Expected %v got %v", corev1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy)
 	}
 }
 
@@ -1091,28 +1091,28 @@ func TestPodTemplateConfig(t *testing.T) {
 	nodeSelector := map[string]string{
 		"foo": "bar",
 	}
-	affinity := v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{},
-		PodAffinity: &v1.PodAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+	affinity := corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+		PodAffinity: &corev1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
-					PodAffinityTerm: v1.PodAffinityTerm{
+					PodAffinityTerm: corev1.PodAffinityTerm{
 						Namespaces: []string{"foo"},
 					},
 					Weight: 100,
 				},
 			},
 		},
-		PodAntiAffinity: &v1.PodAntiAffinity{},
+		PodAntiAffinity: &corev1.PodAntiAffinity{},
 	}
 
-	tolerations := []v1.Toleration{
+	tolerations := []corev1.Toleration{
 		{
 			Key: "key",
 		},
 	}
 	userid := int64(1234)
-	securityContext := v1.PodSecurityContext{
+	securityContext := corev1.PodSecurityContext{
 		RunAsUser: &userid,
 	}
 	priorityClassName := "foo"
@@ -1123,12 +1123,12 @@ func TestPodTemplateConfig(t *testing.T) {
 			IP:        "1.1.1.1",
 		},
 	}
-	imagePullSecrets := []v1.LocalObjectReference{
+	imagePullSecrets := []corev1.LocalObjectReference{
 		{
 			Name: "registry-secret",
 		},
 	}
-	imagePullPolicy := v1.PullAlways
+	imagePullPolicy := corev1.PullAlways
 	hostUsers := true
 	hostNetwork := false
 
@@ -1179,7 +1179,7 @@ func TestPodHostNetworkConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, sset.Spec.Template.Spec.HostNetwork, "expected hostNetwork to be true")
-	require.Equal(t, v1.DNSClusterFirstWithHostNet, sset.Spec.Template.Spec.DNSPolicy,
+	require.Equal(t, corev1.DNSClusterFirstWithHostNet, sset.Spec.Template.Spec.DNSPolicy,
 		"expected DNSPolicy to be ClusterFirstWithHostNet when hostNetwork is enabled")
 }
 
@@ -1298,16 +1298,16 @@ func TestMakeStatefulSetSpecTemplatesUniqueness(t *testing.T) {
 					AlertmanagerConfiguration: &monitoringv1.AlertmanagerConfiguration{
 						Templates: []monitoringv1.SecretOrConfigMap{
 							{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "template1",
 									},
 									Key: "template1.tmpl",
 								},
 							},
 							{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "template2",
 									},
 									Key: "template1.tmpl",
@@ -1326,16 +1326,16 @@ func TestMakeStatefulSetSpecTemplatesUniqueness(t *testing.T) {
 					AlertmanagerConfiguration: &monitoringv1.AlertmanagerConfiguration{
 						Templates: []monitoringv1.SecretOrConfigMap{
 							{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "template1",
 									},
 									Key: "template1.tmpl",
 								},
 							},
 							{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "template2",
 									},
 									Key: "template2.tmpl",
@@ -1354,8 +1354,8 @@ func TestMakeStatefulSetSpecTemplatesUniqueness(t *testing.T) {
 					AlertmanagerConfiguration: &monitoringv1.AlertmanagerConfiguration{
 						Templates: []monitoringv1.SecretOrConfigMap{
 							{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "template1",
 									},
 									Key: "template1.tmpl",
@@ -1482,12 +1482,12 @@ func TestStatefulSetDNSPolicyAndDNSConfig(t *testing.T) {
 	}, defaultTestConfig, "", &operator.ShardedSecret{})
 	require.NoError(t, err)
 
-	require.Equal(t, v1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected dns policy to match")
+	require.Equal(t, corev1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected dns policy to match")
 	require.Equal(t,
-		&v1.PodDNSConfig{
+		&corev1.PodDNSConfig{
 			Nameservers: []string{"8.8.8.8"},
 			Searches:    []string{"custom.search"},
-			Options: []v1.PodDNSConfigOption{
+			Options: []corev1.PodDNSConfigOption{
 				{
 					Name:  "ndots",
 					Value: ptr.To("5"),

--- a/pkg/assets/interface.go
+++ b/pkg/assets/interface.go
@@ -15,7 +15,7 @@
 package assets
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -24,7 +24,7 @@ import (
 // It will return an error if the key selector didn't match.
 type StoreGetter interface {
 	GetSecretOrConfigMapKey(key monitoringv1.SecretOrConfigMap) (string, error)
-	GetConfigMapKey(key v1.ConfigMapKeySelector) (string, error)
-	GetSecretKey(key v1.SecretKeySelector) ([]byte, error)
+	GetConfigMapKey(key corev1.ConfigMapKeySelector) (string, error)
+	GetSecretKey(key corev1.SecretKeySelector) ([]byte, error)
 	TLSAsset(key any) string
 }

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -66,7 +66,7 @@ hvBlhCknnq89u57O41ID6Mqxz3bRxNxpkqhfMyVWcVU=
 
 func TestGetSecretKey(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -120,8 +120,8 @@ func TestGetSecretKey(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
-			sel := v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			sel := corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: tc.selectedName,
 				},
 				Key: tc.selectedKey,
@@ -143,7 +143,7 @@ func TestGetSecretKey(t *testing.T) {
 
 func TestAddBasicAuth(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -231,14 +231,14 @@ func TestAddBasicAuth(t *testing.T) {
 			store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 			basicAuth := &monitoringv1.BasicAuth{
-				Username: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				Username: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: tc.selectedUserName,
 					},
 					Key: tc.selectedUserKey,
 				},
-				Password: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				Password: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: tc.selectedPasswordName,
 					},
 					Key: tc.selectedPasswordKey,
@@ -269,7 +269,7 @@ func TestAddBasicAuth(t *testing.T) {
 
 func TestProxyCongfig(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -327,10 +327,10 @@ func TestProxyCongfig(t *testing.T) {
 			store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 			proxyConfig := monitoringv1.ProxyConfig{
-				ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+				ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 					"header": {
 						{
-							LocalObjectReference: v1.LocalObjectReference{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: tc.selectedName,
 							},
 							Key: tc.selectedKey,
@@ -358,7 +358,7 @@ func TestProxyCongfig(t *testing.T) {
 
 func TestAddTLSConfig(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm",
 				Namespace: "ns1",
@@ -369,7 +369,7 @@ func TestAddTLSConfig(t *testing.T) {
 				"cmKey":  keyPEM,
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -400,23 +400,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -434,23 +434,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -468,23 +468,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -502,23 +502,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -534,23 +534,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "secretCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -566,23 +566,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -598,23 +598,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -630,23 +630,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "cm",
 							},
 							Key: "cmCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "cmCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -662,23 +662,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "cmKey",
@@ -694,16 +694,16 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
@@ -720,15 +720,15 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCA",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -744,23 +744,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "wrongKey",
@@ -776,23 +776,23 @@ func TestAddTLSConfig(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "invalidCA",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "secretCert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "secretKey",
@@ -835,7 +835,7 @@ func TestAddTLSConfig(t *testing.T) {
 
 func TestAddAuthorization(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -894,8 +894,8 @@ func TestAddAuthorization(t *testing.T) {
 			sel := &monitoringv1.Authorization{
 				SafeAuthorization: monitoringv1.SafeAuthorization{
 					Type: tc.authType,
-					Credentials: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: tc.selectedName},
 						Key: tc.selectedKey,
 					},
@@ -926,7 +926,7 @@ func TestAddAuthorization(t *testing.T) {
 
 func TestAddAuthorizationNoCredentials(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -958,7 +958,7 @@ func TestAddSigV4(t *testing.T) {
 		secretKey = "secretKey"
 	)
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1044,16 +1044,16 @@ func TestAddSigV4(t *testing.T) {
 
 			sigV4 := monitoringv1.Sigv4{}
 			if tc.accessKey != "" {
-				sigV4.AccessKey = &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				sigV4.AccessKey = &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: tc.selectedName,
 					},
 					Key: tc.accessKey,
 				}
 			}
 			if tc.secretKey != "" {
-				sigV4.SecretKey = &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				sigV4.SecretKey = &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: tc.selectedName,
 					},
 					Key: tc.secretKey,
@@ -1088,7 +1088,7 @@ func TestAddAzureOAuth(t *testing.T) {
 		clientSecret = "clientSecretKey"
 	)
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1147,8 +1147,8 @@ func TestAddAzureOAuth(t *testing.T) {
 			azureAD := monitoringv1.AzureAD{}
 			azureOAuth := monitoringv1.AzureOAuth{}
 			if tc.secretKey != "" {
-				azureOAuth.ClientSecret = v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				azureOAuth.ClientSecret = corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: tc.selectedName,
 					},
 					Key: tc.secretKey,
@@ -1173,7 +1173,7 @@ func TestAddAzureOAuth(t *testing.T) {
 
 func TestUpdateObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1186,8 +1186,8 @@ func TestUpdateObject(t *testing.T) {
 	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 	// Add the secret to the store by fetching it
-	sel := v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	sel := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "secret",
 		},
 		Key: "key1",
@@ -1197,7 +1197,7 @@ func TestUpdateObject(t *testing.T) {
 	require.Equal(t, "val1", val)
 
 	// Update the secret object
-	updatedSecret := &v1.Secret{
+	updatedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "ns1",
@@ -1221,7 +1221,7 @@ func TestUpdateObject(t *testing.T) {
 
 func TestDeleteObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1230,7 +1230,7 @@ func TestDeleteObject(t *testing.T) {
 				"key1": []byte("val1"),
 			},
 		},
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm",
 				Namespace: "ns1",
@@ -1243,8 +1243,8 @@ func TestDeleteObject(t *testing.T) {
 	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 	// Add secret and configmap to the store by fetching them
-	secretSel := v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	secretSel := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "secret",
 		},
 		Key: "key1",
@@ -1253,8 +1253,8 @@ func TestDeleteObject(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "val1", val)
 
-	cmSel := v1.ConfigMapKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	cmSel := corev1.ConfigMapKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "cm",
 		},
 		Key: "cmKey",
@@ -1263,7 +1263,7 @@ func TestDeleteObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try deleting the secret object
-	secretObj := &v1.Secret{
+	secretObj := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "ns1",
@@ -1281,7 +1281,7 @@ func TestDeleteObject(t *testing.T) {
 	require.Error(t, err)
 
 	// Try deleting the configmap object (should not error even if it doesn't exist in the client)
-	cmObj := &v1.ConfigMap{
+	cmObj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cm",
 			Namespace: "ns1",
@@ -1304,7 +1304,7 @@ func TestDeleteObject(t *testing.T) {
 
 func TestGetObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1313,7 +1313,7 @@ func TestGetObject(t *testing.T) {
 				"key1": []byte("val1"),
 			},
 		},
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm",
 				Namespace: "ns1",
@@ -1326,8 +1326,8 @@ func TestGetObject(t *testing.T) {
 	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 	// Add secret and configmap to the store by fetching them
-	secretSel := v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	secretSel := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "secret",
 		},
 		Key: "key1",
@@ -1335,8 +1335,8 @@ func TestGetObject(t *testing.T) {
 	_, err := store.GetSecretKey(context.Background(), "ns1", secretSel)
 	require.NoError(t, err)
 
-	cmSel := v1.ConfigMapKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	cmSel := corev1.ConfigMapKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "cm",
 		},
 		Key: "cmKey",
@@ -1345,7 +1345,7 @@ func TestGetObject(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test getting existing secret
-	secretObj := &v1.Secret{
+	secretObj := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "ns1",
@@ -1355,14 +1355,14 @@ func TestGetObject(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.NotNil(t, obj)
-	secret, ok := obj.(*v1.Secret)
+	secret, ok := obj.(*corev1.Secret)
 	require.True(t, ok)
 	require.Equal(t, "secret", secret.Name)
 	require.Equal(t, "ns1", secret.Namespace)
 	require.Equal(t, []byte("val1"), secret.Data["key1"])
 
 	// Test getting existing configmap
-	cmObj := &v1.ConfigMap{
+	cmObj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cm",
 			Namespace: "ns1",
@@ -1372,14 +1372,14 @@ func TestGetObject(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.NotNil(t, obj)
-	cm, ok := obj.(*v1.ConfigMap)
+	cm, ok := obj.(*corev1.ConfigMap)
 	require.True(t, ok)
 	require.Equal(t, "cm", cm.Name)
 	require.Equal(t, "ns1", cm.Namespace)
 	require.Equal(t, "cmVal", cm.Data["cmKey"])
 
 	// Test getting non-existing object
-	nonExistingSecret := &v1.Secret{
+	nonExistingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "notfound",
 			Namespace: "ns1",
@@ -1399,7 +1399,7 @@ func TestGetObject(t *testing.T) {
 
 func TestAddObject(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -1408,7 +1408,7 @@ func TestAddObject(t *testing.T) {
 				"key1": []byte("val1"),
 			},
 		},
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm",
 				Namespace: "ns1",
@@ -1421,7 +1421,7 @@ func TestAddObject(t *testing.T) {
 	store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 	// Add a secret object
-	secretObj := &v1.Secret{
+	secretObj := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret2",
 			Namespace: "ns1",
@@ -1438,14 +1438,14 @@ func TestAddObject(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.NotNil(t, obj)
-	secret, ok := obj.(*v1.Secret)
+	secret, ok := obj.(*corev1.Secret)
 	require.True(t, ok)
 	require.Equal(t, "secret2", secret.Name)
 	require.Equal(t, "ns1", secret.Namespace)
 	require.Equal(t, []byte("val2"), secret.Data["key2"])
 
 	// Add a configmap object
-	cmObj := &v1.ConfigMap{
+	cmObj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cm2",
 			Namespace: "ns1",
@@ -1462,7 +1462,7 @@ func TestAddObject(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.NotNil(t, obj)
-	cm, ok := obj.(*v1.ConfigMap)
+	cm, ok := obj.(*corev1.ConfigMap)
 	require.True(t, ok)
 	require.Equal(t, "cm2", cm.Name)
 	require.Equal(t, "ns1", cm.Namespace)

--- a/pkg/assets/tls.go
+++ b/pkg/assets/tls.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -42,7 +42,7 @@ type tlsAssetKey struct {
 }
 
 // tlsAssetKeyFromSecretSelector returns a tlsAssetKey struct from a secret key selector.
-func tlsAssetKeyFromSecretSelector(ns string, sel *v1.SecretKeySelector) tlsAssetKey {
+func tlsAssetKeyFromSecretSelector(ns string, sel *corev1.SecretKeySelector) tlsAssetKey {
 	return tlsAssetKeyFromSelector(
 		ns,
 		monitoringv1.SecretOrConfigMap{
@@ -172,9 +172,9 @@ func (s *StoreBuilder) TLSAssets() map[string][]byte {
 
 		var b []byte
 		switch v := obj.(type) {
-		case *v1.ConfigMap:
+		case *corev1.ConfigMap:
 			b = []byte(v.Data[tak.key])
-		case *v1.Secret:
+		case *corev1.Secret:
 			b = v.Data[tak.key]
 		}
 

--- a/pkg/assets/tracker_test.go
+++ b/pkg/assets/tracker_test.go
@@ -19,20 +19,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestHasRefTo(t *testing.T) {
 	c := fake.NewSimpleClientset(
-		&v1.Pod{
+		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod",
 				Namespace: "ns1",
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "ns1",
@@ -41,7 +41,7 @@ func TestHasRefTo(t *testing.T) {
 				"key1": []byte("val1"),
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret2",
 				Namespace: "ns1",
@@ -50,7 +50,7 @@ func TestHasRefTo(t *testing.T) {
 				"key1": []byte("val1"),
 			},
 		},
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cm",
 				Namespace: "ns1",
@@ -69,8 +69,8 @@ func TestHasRefTo(t *testing.T) {
 	_, err := store.GetSecretKey(
 		context.Background(),
 		"ns1",
-		v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "secret",
 			},
 			Key: "key1",
@@ -81,8 +81,8 @@ func TestHasRefTo(t *testing.T) {
 	_, err = store.GetSecretKey(
 		context.Background(),
 		"ns1",
-		v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "nosecret",
 			},
 			Key: "key1",
@@ -93,8 +93,8 @@ func TestHasRefTo(t *testing.T) {
 	_, err = store.GetConfigMapKey(
 		context.Background(),
 		"ns1",
-		v1.ConfigMapKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "cm",
 			},
 			Key: "cmCA",
@@ -105,8 +105,8 @@ func TestHasRefTo(t *testing.T) {
 	_, err = store.GetConfigMapKey(
 		context.Background(),
 		"ns1",
-		v1.ConfigMapKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "nocm",
 			},
 			Key: "key1",
@@ -122,7 +122,7 @@ func TestHasRefTo(t *testing.T) {
 	_, err = c.CoreV1().Secrets("ns1").Get(context.Background(), "nosecret", metav1.GetOptions{})
 	require.Error(t, err)
 	require.True(t, refTracker.Has(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nosecret",
 				Namespace: "ns1",
@@ -137,7 +137,7 @@ func TestHasRefTo(t *testing.T) {
 	_, err = c.CoreV1().Secrets("ns1").Get(context.Background(), "nocm", metav1.GetOptions{})
 	require.Error(t, err)
 	require.True(t, refTracker.Has(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nocm",
 				Namespace: "ns1",

--- a/pkg/informers/informers.go
+++ b/pkg/informers/informers.go
@@ -19,7 +19,7 @@ import (
 	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -85,8 +85,8 @@ func NewInformersForResourceWithTransform(ifs FactoriesForNamespaces, resource s
 	}, nil
 }
 
-func partialObjectMetadataStrip(obj any) (*v1.PartialObjectMetadata, error) {
-	partialMeta, ok := obj.(*v1.PartialObjectMetadata)
+func partialObjectMetadataStrip(obj any) (*metav1.PartialObjectMetadata, error) {
+	partialMeta, ok := obj.(*metav1.PartialObjectMetadata)
 	if !ok {
 		// Don't do anything if the cast isn't successful.
 		// The object might be of type "cache.DeletedFinalStateUnknown".
@@ -124,7 +124,7 @@ func PartialObjectMetadataStrip(gvk schema.GroupVersionKind) cache.TransformFunc
 			return obj, nil
 		}
 
-		partialMeta.TypeMeta = v1.TypeMeta{
+		partialMeta.TypeMeta = metav1.TypeMeta{
 			Kind:       gvk.Kind,
 			APIVersion: gvk.GroupVersion().String(),
 		}
@@ -215,18 +215,18 @@ func (w *ForResource) Get(name string) (runtime.Object, error) {
 // then it returns it and a tweak function filtering denied namespaces using a field selector.
 //
 // Else, denied namespaces are ignored and just the set of allowed namespaces is returned.
-func newInformerOptions(allowedNamespaces, deniedNamespaces map[string]struct{}, tweaks func(*v1.ListOptions)) (func(*v1.ListOptions), []string) {
+func newInformerOptions(allowedNamespaces, deniedNamespaces map[string]struct{}, tweaks func(*metav1.ListOptions)) (func(*metav1.ListOptions), []string) {
 	if tweaks == nil {
-		tweaks = func(*v1.ListOptions) {} // nop
+		tweaks = func(*metav1.ListOptions) {} // nop
 	}
 
 	var namespaces []string
 
 	if listwatch.IsAllNamespaces(allowedNamespaces) {
-		return func(options *v1.ListOptions) {
+		return func(options *metav1.ListOptions) {
 			tweaks(options)
 			listwatch.DenyTweak(options, "metadata.namespace", deniedNamespaces)
-		}, []string{v1.NamespaceAll}
+		}, []string{metav1.NamespaceAll}
 	}
 
 	for ns := range allowedNamespaces {

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -24,7 +24,7 @@ import (
 	promversion "github.com/prometheus/common/version"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authorization/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +33,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	clientauthv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedauthv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
@@ -127,7 +127,7 @@ type ResourceAttribute struct {
 // the requirements aren't met.
 func IsAllowed(
 	ctx context.Context,
-	ssarClient clientauthv1.SelfSubjectAccessReviewInterface,
+	ssarClient typedauthv1.SelfSubjectAccessReviewInterface,
 	namespaces []string,
 	attributes ...ResourceAttribute,
 ) (bool, []error, error) {
@@ -136,7 +136,7 @@ func IsAllowed(
 	}
 
 	if len(namespaces) == 0 {
-		namespaces = []string{v1.NamespaceAll}
+		namespaces = []string{corev1.NamespaceAll}
 	}
 
 	var missingPermissions []error
@@ -182,7 +182,7 @@ func IsAllowed(
 					}
 
 					switch ns {
-					case v1.NamespaceAll:
+					case corev1.NamespaceAll:
 						reason = fmt.Errorf("missing %q permission on resource %q (group: %q) for all namespaces", verb, resource, ra.Group)
 					default:
 						reason = fmt.Errorf("missing %q permission on resource %q (group: %q) for namespace %q", verb, resource, ra.Group, ns)
@@ -216,7 +216,7 @@ func UpdateDaemonSet(ctx context.Context, dmsClient clientappsv1.DaemonSetInterf
 }
 
 // CreateOrUpdateSecret merges metadata of existing Secret with new one and updates it.
-func CreateOrUpdateSecret(ctx context.Context, secretClient clientv1.SecretInterface, desired *v1.Secret) error {
+func CreateOrUpdateSecret(ctx context.Context, secretClient typedcorev1.SecretInterface, desired *corev1.Secret) error {
 	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existingSecret, err := secretClient.Get(ctx, desired.Name, metav1.GetOptions{})
@@ -229,7 +229,7 @@ func CreateOrUpdateSecret(ctx context.Context, secretClient clientv1.SecretInter
 			return err
 		}
 
-		mutated := existingSecret.DeepCopyObject().(*v1.Secret)
+		mutated := existingSecret.DeepCopyObject().(*corev1.Secret)
 		mergeMetadata(&desired.ObjectMeta, mutated.ObjectMeta)
 		if apiequality.Semantic.DeepEqual(existingSecret, desired) {
 			return nil
@@ -240,7 +240,7 @@ func CreateOrUpdateSecret(ctx context.Context, secretClient clientv1.SecretInter
 }
 
 // CreateOrUpdateConfigMap merges metadata of existing ConfigMap with new one and updates it.
-func CreateOrUpdateConfigMap(ctx context.Context, cmClient clientv1.ConfigMapInterface, desired *v1.ConfigMap) error {
+func CreateOrUpdateConfigMap(ctx context.Context, cmClient typedcorev1.ConfigMapInterface, desired *corev1.ConfigMap) error {
 	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existingCM, err := cmClient.Get(ctx, desired.Name, metav1.GetOptions{})
@@ -253,7 +253,7 @@ func CreateOrUpdateConfigMap(ctx context.Context, cmClient clientv1.ConfigMapInt
 			return err
 		}
 
-		mutated := existingCM.DeepCopyObject().(*v1.ConfigMap)
+		mutated := existingCM.DeepCopyObject().(*corev1.ConfigMap)
 		mergeMetadata(&desired.ObjectMeta, mutated.ObjectMeta)
 		if apiequality.Semantic.DeepEqual(existingCM, desired) {
 			return nil

--- a/pkg/k8s/merge.go
+++ b/pkg/k8s/merge.go
@@ -18,16 +18,16 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 // MergePatchContainers adds patches to base using a strategic merge patch and
 // iterating by container name, failing on the first error.
-func MergePatchContainers(base, patches []v1.Container) ([]v1.Container, error) {
-	var out []v1.Container
+func MergePatchContainers(base, patches []corev1.Container) ([]corev1.Container, error) {
+	var out []corev1.Container
 
-	containersByName := make(map[string]v1.Container)
+	containersByName := make(map[string]corev1.Container)
 	for _, c := range patches {
 		containersByName[c.Name] = c
 	}
@@ -52,12 +52,12 @@ func MergePatchContainers(base, patches []v1.Container) ([]v1.Container, error) 
 		}
 
 		// Calculate the patch result.
-		jsonResult, err := strategicpatch.StrategicMergePatch(containerBytes, patchBytes, v1.Container{})
+		jsonResult, err := strategicpatch.StrategicMergePatch(containerBytes, patchBytes, corev1.Container{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate merge patch for container %s: %w", container.Name, err)
 		}
 
-		var patchResult v1.Container
+		var patchResult corev1.Container
 		if err := json.Unmarshal(jsonResult, &patchResult); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal merged container %s: %w", container.Name, err)
 		}

--- a/pkg/k8s/merge_test.go
+++ b/pkg/k8s/merge_test.go
@@ -19,94 +19,94 @@ import (
 
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestPodLabelsAnnotations(t *testing.T) {
-	build := func(name, image string, ports ...v1.ContainerPort) v1.Container {
-		return v1.Container{
+	build := func(name, image string, ports ...corev1.ContainerPort) corev1.Container {
+		return corev1.Container{
 			Name:  name,
 			Image: image,
 			Ports: ports,
 		}
 	}
 
-	port1A := v1.ContainerPort{
+	port1A := corev1.ContainerPort{
 		Name:          "portA",
 		ContainerPort: 1,
 	}
-	port1B := v1.ContainerPort{
+	port1B := corev1.ContainerPort{
 		Name:          "portB",
 		ContainerPort: 1,
 	}
-	port2A := v1.ContainerPort{
+	port2A := corev1.ContainerPort{
 		Name:          "portA",
 		ContainerPort: 2,
 	}
 
 	testCases := []struct {
 		name    string
-		base    []v1.Container
-		patches []v1.Container
-		result  []v1.Container
+		base    []corev1.Container
+		patches []corev1.Container
+		result  []corev1.Container
 	}{
 		// sanity checks
 		{
 			name: "everything nil",
 		}, {
 			name:   "no patch",
-			base:   []v1.Container{build("c1", "image:A")},
-			result: []v1.Container{build("c1", "image:A")},
+			base:   []corev1.Container{build("c1", "image:A")},
+			result: []corev1.Container{build("c1", "image:A")},
 		}, {
 			name:    "no Base",
-			patches: []v1.Container{build("c1", "image:A")},
-			result:  []v1.Container{build("c1", "image:A")},
+			patches: []corev1.Container{build("c1", "image:A")},
+			result:  []corev1.Container{build("c1", "image:A")},
 		}, {
 			name:    "no conflict",
-			base:    []v1.Container{build("c1", "image:A")},
-			patches: []v1.Container{build("c2", "image:A")},
-			result:  []v1.Container{build("c1", "image:A"), build("c2", "image:A")},
+			base:    []corev1.Container{build("c1", "image:A")},
+			patches: []corev1.Container{build("c2", "image:A")},
+			result:  []corev1.Container{build("c1", "image:A"), build("c2", "image:A")},
 		}, {
 			name:    "no conflict with port",
-			base:    []v1.Container{build("c1", "image:A", port1A)},
-			patches: []v1.Container{build("c2", "image:A", port1B)},
-			result:  []v1.Container{build("c1", "image:A", port1A), build("c2", "image:A", port1B)},
+			base:    []corev1.Container{build("c1", "image:A", port1A)},
+			patches: []corev1.Container{build("c2", "image:A", port1B)},
+			result:  []corev1.Container{build("c1", "image:A", port1A), build("c2", "image:A", port1B)},
 		},
 		// string conflicts
 		{
 			name:    "one conflict",
-			base:    []v1.Container{build("c1", "image:A")},
-			patches: []v1.Container{build("c1", "image:B")},
-			result:  []v1.Container{build("c1", "image:B")},
+			base:    []corev1.Container{build("c1", "image:A")},
+			patches: []corev1.Container{build("c1", "image:B")},
+			result:  []corev1.Container{build("c1", "image:B")},
 		}, {
 			name:    "one conflict with ports",
-			base:    []v1.Container{build("c1", "image:A", port1A)},
-			patches: []v1.Container{build("c1", "image:B", port1A)},
-			result:  []v1.Container{build("c1", "image:B", port1A)},
+			base:    []corev1.Container{build("c1", "image:A", port1A)},
+			patches: []corev1.Container{build("c1", "image:B", port1A)},
+			result:  []corev1.Container{build("c1", "image:B", port1A)},
 		}, {
 			name:    "out of order conflict",
-			base:    []v1.Container{build("c1", "image:A"), build("c2", "image:A")},
-			patches: []v1.Container{build("c2", "image:B"), build("c1", "image:B")},
-			result:  []v1.Container{build("c1", "image:B"), build("c2", "image:B")},
+			base:    []corev1.Container{build("c1", "image:A"), build("c2", "image:A")},
+			patches: []corev1.Container{build("c2", "image:B"), build("c1", "image:B")},
+			result:  []corev1.Container{build("c1", "image:B"), build("c2", "image:B")},
 		},
 		// struct conflict
 		{
 			name:    "port name conflict",
-			base:    []v1.Container{build("c1", "image:A", port1A)},
-			patches: []v1.Container{build("c1", "image:A", port2A)},
-			result:  []v1.Container{build("c1", "image:A", port2A, port1A)}, // port ordering doesn't matter here
+			base:    []corev1.Container{build("c1", "image:A", port1A)},
+			patches: []corev1.Container{build("c1", "image:A", port2A)},
+			result:  []corev1.Container{build("c1", "image:A", port2A, port1A)}, // port ordering doesn't matter here
 		},
 		{
 			name:    "port value conflict",
-			base:    []v1.Container{build("c1", "image:A", port1A)},
-			patches: []v1.Container{build("c1", "image:A", port1B)},
-			result:  []v1.Container{build("c1", "image:A", port1B)}, // port ordering doesn't matter here
+			base:    []corev1.Container{build("c1", "image:A", port1A)},
+			patches: []corev1.Container{build("c1", "image:A", port1B)},
+			result:  []corev1.Container{build("c1", "image:A", port1B)}, // port ordering doesn't matter here
 		},
 		{
 			name:    "empty image, add port",
-			base:    []v1.Container{build("c1", "image:A")},
-			patches: []v1.Container{build("c1", "", port1A)},
-			result:  []v1.Container{build("c1", "image:A", port1A)},
+			base:    []corev1.Container{build("c1", "image:A")},
+			patches: []corev1.Container{build("c1", "", port1A)},
+			result:  []corev1.Container{build("c1", "image:A", port1A)},
 		},
 	}
 
@@ -119,8 +119,8 @@ func TestPodLabelsAnnotations(t *testing.T) {
 }
 
 func TestMergePatchContainersOrderPreserved(t *testing.T) {
-	build := func(name, image string) v1.Container {
-		return v1.Container{
+	build := func(name, image string) corev1.Container {
+		return corev1.Container{
 			Name:  name,
 			Image: image,
 		}
@@ -128,11 +128,11 @@ func TestMergePatchContainersOrderPreserved(t *testing.T) {
 
 	for range 10 {
 		result, err := MergePatchContainers(
-			[]v1.Container{
+			[]corev1.Container{
 				build("c1", "image:base"),
 				build("c2", "image:base"),
 			},
-			[]v1.Container{
+			[]corev1.Container{
 				build("c1", "image:A"),
 				build("c3", "image:B"),
 				build("c4", "image:C"),
@@ -144,7 +144,7 @@ func TestMergePatchContainersOrderPreserved(t *testing.T) {
 
 		diff := pretty.Compare(
 			result,
-			[]v1.Container{
+			[]corev1.Container{
 				build("c1", "image:A"),
 				build("c2", "image:base"),
 				build("c3", "image:B"),

--- a/pkg/k8s/network.go
+++ b/pkg/k8s/network.go
@@ -18,19 +18,19 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientdiscoveryv1 "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	"k8s.io/client-go/util/retry"
 )
 
 // CreateOrUpdateService creates or updates a Service resource.
-func CreateOrUpdateService(ctx context.Context, sclient clientv1.ServiceInterface, svc *v1.Service) (*v1.Service, error) {
-	var ret *v1.Service
+func CreateOrUpdateService(ctx context.Context, sclient typedcorev1.ServiceInterface, svc *corev1.Service) (*corev1.Service, error) {
+	var ret *corev1.Service
 
 	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -76,7 +76,7 @@ func mergeOwnerReferences(oldObj []metav1.OwnerReference, newObj []metav1.OwnerR
 // CreateOrUpdateEndpoints creates or updates an Endpoints resource.
 //
 //nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
-func CreateOrUpdateEndpoints(ctx context.Context, eclient clientv1.EndpointsInterface, eps *v1.Endpoints) error {
+func CreateOrUpdateEndpoints(ctx context.Context, eclient typedcorev1.EndpointsInterface, eps *corev1.Endpoints) error {
 	// As stated in the RetryOnConflict's documentation, the returned error shouldn't be wrapped.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		endpoints, err := eclient.Get(ctx, eps.Name, metav1.GetOptions{})
@@ -132,7 +132,7 @@ func CreateOrUpdateEndpointSlice(ctx context.Context, c clientdiscoveryv1.Endpoi
 // labels.
 // If it is not selected, fail the reconciliation
 // Warning: the function will panic if the resource's ServiceName is nil..
-func EnsureCustomGoverningService(ctx context.Context, namespace string, serviceName string, svcClient clientv1.ServiceInterface, selectorLabels map[string]string) error {
+func EnsureCustomGoverningService(ctx context.Context, namespace string, serviceName string, svcClient typedcorev1.ServiceInterface, selectorLabels map[string]string) error {
 	// Check if the custom governing service is defined in the same namespace and selects the Prometheus pod.
 	svc, err := svcClient.Get(ctx, serviceName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/k8s/pod.go
+++ b/pkg/k8s/pod.go
@@ -17,23 +17,23 @@ package k8s
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 // PodRunningAndReady returns whether a pod is running and each container has
 // passed it's ready state.
-func PodRunningAndReady(pod v1.Pod) (bool, error) {
+func PodRunningAndReady(pod corev1.Pod) (bool, error) {
 	switch pod.Status.Phase {
-	case v1.PodFailed, v1.PodSucceeded:
+	case corev1.PodFailed, corev1.PodSucceeded:
 		return false, fmt.Errorf("pod completed with phase %s", pod.Status.Phase)
-	case v1.PodRunning:
+	case corev1.PodRunning:
 		for _, cond := range pod.Status.Conditions {
-			if cond.Type != v1.PodReady {
+			if cond.Type != corev1.PodReady {
 				continue
 			}
-			return cond.Status == v1.ConditionTrue, nil
+			return cond.Status == corev1.ConditionTrue, nil
 		}
 		return false, fmt.Errorf("pod ready condition not found")
 	}
@@ -41,18 +41,18 @@ func PodRunningAndReady(pod v1.Pod) (bool, error) {
 }
 
 // UpdateDNSConfig updates the DNS configuration in a Pod spec.
-func UpdateDNSConfig(podSpec *v1.PodSpec, config *monitoringv1.PodDNSConfig) {
+func UpdateDNSConfig(podSpec *corev1.PodSpec, config *monitoringv1.PodDNSConfig) {
 	if config == nil {
 		return
 	}
 
-	dnsConfig := v1.PodDNSConfig{
+	dnsConfig := corev1.PodDNSConfig{
 		Nameservers: config.Nameservers,
 		Searches:    config.Searches,
 	}
 
 	for _, opt := range config.Options {
-		dnsConfig.Options = append(dnsConfig.Options, v1.PodDNSConfigOption{
+		dnsConfig.Options = append(dnsConfig.Options, corev1.PodDNSConfigOption{
 			Name:  opt.Name,
 			Value: opt.Value,
 		})
@@ -62,10 +62,10 @@ func UpdateDNSConfig(podSpec *v1.PodSpec, config *monitoringv1.PodDNSConfig) {
 }
 
 // UpdateDNSPolicy updates the DNS policy in a Pod spec.
-func UpdateDNSPolicy(podSpec *v1.PodSpec, dnsPolicy *monitoringv1.DNSPolicy) {
+func UpdateDNSPolicy(podSpec *corev1.PodSpec, dnsPolicy *monitoringv1.DNSPolicy) {
 	if dnsPolicy == nil {
 		return
 	}
 
-	podSpec.DNSPolicy = v1.DNSPolicy(*dnsPolicy)
+	podSpec.DNSPolicy = corev1.DNSPolicy(*dnsPolicy)
 }

--- a/pkg/k8s/pod_test.go
+++ b/pkg/k8s/pod_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -40,7 +40,7 @@ func TestConvertToK8sDNSConfig(t *testing.T) {
 		},
 	}
 
-	var spec v1.PodSpec
+	var spec corev1.PodSpec
 	UpdateDNSConfig(&spec, monitoringDNSConfig)
 
 	// Verify the conversion matches the original content

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -19,17 +19,17 @@ import (
 	"fmt"
 	"log/slog"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/ptr"
 )
 
 // LoadSecretRef returns the data from a secret key reference.
 // If the reference is set as optional and the secret or key isn't found, the
 // function returns no error.
-func LoadSecretRef(ctx context.Context, logger *slog.Logger, client clientv1.SecretInterface, sks *v1.SecretKeySelector) ([]byte, error) {
+func LoadSecretRef(ctx context.Context, logger *slog.Logger, client typedcorev1.SecretInterface, sks *corev1.SecretKeySelector) ([]byte, error) {
 	if sks == nil {
 		return nil, nil
 	}

--- a/pkg/k8s/secrets_test.go
+++ b/pkg/k8s/secrets_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
@@ -43,7 +42,7 @@ func TestLoadSecretRef(t *testing.T) {
 
 	for _, tc := range []struct {
 		name     string
-		ref      *v1.SecretKeySelector
+		ref      *corev1.SecretKeySelector
 		expected []byte
 		err      bool
 	}{
@@ -52,8 +51,8 @@ func TestLoadSecretRef(t *testing.T) {
 		},
 		{
 			name: "valid ref",
-			ref: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ref: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "secret",
 				},
 				Key: "key1",
@@ -62,8 +61,8 @@ func TestLoadSecretRef(t *testing.T) {
 		},
 		{
 			name: "missing secret",
-			ref: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ref: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "secret2",
 				},
 				Key: "key1",
@@ -72,8 +71,8 @@ func TestLoadSecretRef(t *testing.T) {
 		},
 		{
 			name: "missing key",
-			ref: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ref: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "secret",
 				},
 				Key: "key2",
@@ -82,8 +81,8 @@ func TestLoadSecretRef(t *testing.T) {
 		},
 		{
 			name: "missing optional secret",
-			ref: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ref: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "secret2",
 				},
 				Key:      "key1",
@@ -93,8 +92,8 @@ func TestLoadSecretRef(t *testing.T) {
 		},
 		{
 			name: "missing optional key",
-			ref: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ref: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "secret",
 				},
 				Key:      "key2",

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -246,25 +246,25 @@ func (c *Controller) Run(ctx context.Context) error {
 // 2. NodeExternalIP
 //
 // Copied from github.com/prometheus/prometheus/discovery/kubernetes/node.go.
-func (c *Controller) nodeAddress(node v1.Node) (string, map[v1.NodeAddressType][]string, error) {
-	m := map[v1.NodeAddressType][]string{}
+func (c *Controller) nodeAddress(node corev1.Node) (string, map[corev1.NodeAddressType][]string, error) {
+	m := map[corev1.NodeAddressType][]string{}
 	for _, a := range node.Status.Addresses {
 		m[a.Type] = append(m[a.Type], a.Address)
 	}
 
 	switch c.nodeAddressPriority {
 	case "internal":
-		if addresses, ok := m[v1.NodeInternalIP]; ok {
+		if addresses, ok := m[corev1.NodeInternalIP]; ok {
 			return addresses[0], m, nil
 		}
-		if addresses, ok := m[v1.NodeExternalIP]; ok {
+		if addresses, ok := m[corev1.NodeExternalIP]; ok {
 			return addresses[0], m, nil
 		}
 	case "external":
-		if addresses, ok := m[v1.NodeExternalIP]; ok {
+		if addresses, ok := m[corev1.NodeExternalIP]; ok {
 			return addresses[0], m, nil
 		}
-		if addresses, ok := m[v1.NodeInternalIP]; ok {
+		if addresses, ok := m[corev1.NodeInternalIP]; ok {
 			return addresses[0], m, nil
 		}
 	}
@@ -276,9 +276,9 @@ func (c *Controller) nodeAddress(node v1.Node) (string, map[v1.NodeAddressType][
 // condition is Unknown then that node's kubelet has not recently sent any node
 // status, so we should not add this node to the kubelet endpoint and scrape
 // it.
-func nodeReadyConditionKnown(node v1.Node) bool {
+func nodeReadyConditionKnown(node corev1.Node) bool {
 	for _, c := range node.Status.Conditions {
-		if c.Type == v1.NodeReady && c.Status != v1.ConditionUnknown {
+		if c.Type == corev1.NodeReady && c.Status != corev1.ConditionUnknown {
 			return true
 		}
 	}
@@ -301,7 +301,7 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 			Ready: ptr.To(true),
 		},
 		NodeName: ptr.To(na.name),
-		TargetRef: &v1.ObjectReference{
+		TargetRef: &corev1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
 			UID:        na.uid,
@@ -310,11 +310,11 @@ func (na *nodeAddress) discoveryV1Endpoint() discoveryv1.Endpoint {
 	}
 }
 
-func (na *nodeAddress) v1EndpointAddress() v1.EndpointAddress {
-	return v1.EndpointAddress{
+func (na *nodeAddress) v1EndpointAddress() corev1.EndpointAddress {
+	return corev1.EndpointAddress{
 		IP:       na.ipAddress,
 		NodeName: ptr.To(na.name),
-		TargetRef: &v1.ObjectReference{
+		TargetRef: &corev1.ObjectReference{
 			Kind:       "Node",
 			Name:       na.name,
 			UID:        na.uid,
@@ -323,7 +323,7 @@ func (na *nodeAddress) v1EndpointAddress() v1.EndpointAddress {
 	}
 }
 
-func (c *Controller) getNodeAddresses(nodes []v1.Node) ([]nodeAddress, []error) {
+func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []error) {
 	var (
 		addresses         = make([]nodeAddress, 0, len(nodes))
 		readyKnownNodes   = map[string]string{}
@@ -394,7 +394,7 @@ func (c *Controller) sync(ctx context.Context) {
 
 	// Sort the nodes slice by their name.
 	nodes := nodeList.Items
-	slices.SortStableFunc(nodes, func(a, b v1.Node) int {
+	slices.SortStableFunc(nodes, func(a, b corev1.Node) int {
 		return strings.Compare(a.Name, b.Name)
 	})
 	c.logger.Debug("Nodes retrieved from the Kubernetes API", "num_nodes", len(nodes))
@@ -434,7 +434,7 @@ func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress)
 	c.logger.Debug("Sync endpoints")
 
 	//nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
-	eps := &v1.Endpoints{
+	eps := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.kubeletObjectName,
 			Annotations: c.annotations,
@@ -445,9 +445,9 @@ func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress)
 			}),
 		},
 		//nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
-		Subsets: []v1.EndpointSubset{
+		Subsets: []corev1.EndpointSubset{
 			{
-				Addresses: make([]v1.EndpointAddress, len(addresses)),
+				Addresses: make([]corev1.EndpointAddress, len(addresses)),
 				Ports:     c.endpointPorts(),
 			},
 		},
@@ -472,10 +472,10 @@ func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress)
 	return nil
 }
 
-func (c *Controller) syncService(ctx context.Context) (*v1.Service, error) {
+func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 	c.logger.Debug("Sync service")
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.kubeletObjectName,
 			Annotations: c.annotations,
@@ -485,9 +485,9 @@ func (c *Controller) syncService(ctx context.Context) (*v1.Service, error) {
 				operator.ManagedByLabelKey:       operator.ManagedByLabelValue,
 			}),
 		},
-		Spec: v1.ServiceSpec{
-			Type:      v1.ServiceTypeClusterIP,
-			ClusterIP: v1.ClusterIPNone,
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
 			Ports:     c.servicePorts(),
 		},
 	}
@@ -496,7 +496,7 @@ func (c *Controller) syncService(ctx context.Context) (*v1.Service, error) {
 	return k8s.CreateOrUpdateService(ctx, c.kclient.CoreV1().Services(c.kubeletObjectNamespace), svc)
 }
 
-func (c *Controller) syncEndpointSlice(ctx context.Context, svc *v1.Service, addresses []nodeAddress) error {
+func (c *Controller) syncEndpointSlice(ctx context.Context, svc *corev1.Service, addresses []nodeAddress) error {
 	c.logger.Debug("Sync endpointslice")
 
 	// Get the list of endpointslice objects associated to the service.
@@ -667,8 +667,8 @@ func (c *Controller) fullCapacity(eps []discoveryv1.Endpoint) bool {
 
 // servicePorts returns the list of ServicePort for the kubelet Service.
 // If httpMetricsEnabled is false, the insecure HTTP port (10255) is excluded.
-func (c *Controller) servicePorts() []v1.ServicePort {
-	ports := []v1.ServicePort{
+func (c *Controller) servicePorts() []corev1.ServicePort {
+	ports := []corev1.ServicePort{
 		{
 			Name: httpsPortName,
 			Port: httpsPort,
@@ -680,7 +680,7 @@ func (c *Controller) servicePorts() []v1.ServicePort {
 	}
 
 	if c.httpMetricsEnabled {
-		ports = append(ports, v1.ServicePort{
+		ports = append(ports, corev1.ServicePort{
 			Name: httpPortName,
 			Port: httpPort,
 		})
@@ -691,8 +691,8 @@ func (c *Controller) servicePorts() []v1.ServicePort {
 
 // endpointPorts returns the list of EndpointPort for the kubelet Endpoints.
 // If httpMetricsEnabled is false, the insecure HTTP port (10255) is excluded.
-func (c *Controller) endpointPorts() []v1.EndpointPort {
-	ports := []v1.EndpointPort{
+func (c *Controller) endpointPorts() []corev1.EndpointPort {
+	ports := []corev1.EndpointPort{
 		{
 			Name: httpsPortName,
 			Port: httpsPort,
@@ -704,7 +704,7 @@ func (c *Controller) endpointPorts() []v1.EndpointPort {
 	}
 
 	if c.httpMetricsEnabled {
-		ports = append(ports, v1.EndpointPort{
+		ports = append(ports, corev1.EndpointPort{
 			Name: httpPortName,
 			Port: httpPort,
 		})

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,28 +39,28 @@ import (
 func TestGetNodeAddresses(t *testing.T) {
 	for _, c := range []struct {
 		name              string
-		nodes             []v1.Node
+		nodes             []corev1.Node
 		expectedAddresses []string
 		expectedErrors    int
 	}{
 		{
 			name: "simple",
-			nodes: []v1.Node{
+			nodes: []corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-0",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.1",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionTrue,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},
@@ -72,22 +72,22 @@ func TestGetNodeAddresses(t *testing.T) {
 		{
 			// Replicates #1815
 			name: "missing ip on one node",
-			nodes: []v1.Node{
+			nodes: []corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-0",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "node-0",
-								Type:    v1.NodeHostName,
+								Type:    corev1.NodeHostName,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionTrue,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},
@@ -96,17 +96,17 @@ func TestGetNodeAddresses(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-1",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.1",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionTrue,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},
@@ -117,22 +117,22 @@ func TestGetNodeAddresses(t *testing.T) {
 		},
 		{
 			name: "not ready node unique ip",
-			nodes: []v1.Node{
+			nodes: []corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-0",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.1",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionTrue,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},
@@ -141,17 +141,17 @@ func TestGetNodeAddresses(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-1",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.2",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionUnknown,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionUnknown,
 							},
 						},
 					},
@@ -160,17 +160,17 @@ func TestGetNodeAddresses(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-2",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.3",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionFalse,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
 							},
 						},
 					},
@@ -181,22 +181,22 @@ func TestGetNodeAddresses(t *testing.T) {
 		},
 		{
 			name: "not ready node duplicate ip",
-			nodes: []v1.Node{
+			nodes: []corev1.Node{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-0",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.1",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionTrue,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
 							},
 						},
 					},
@@ -205,17 +205,17 @@ func TestGetNodeAddresses(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-1",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.1",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionUnknown,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionUnknown,
 							},
 						},
 					},
@@ -224,17 +224,17 @@ func TestGetNodeAddresses(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-2",
 					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
 							{
 								Address: "10.0.0.3",
-								Type:    v1.NodeInternalIP,
+								Type:    corev1.NodeInternalIP,
 							},
 						},
-						Conditions: []v1.NodeCondition{
+						Conditions: []corev1.NodeCondition{
 							{
-								Type:   v1.NodeReady,
-								Status: v1.ConditionFalse,
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
 							},
 						},
 					},
@@ -258,26 +258,26 @@ func TestGetNodeAddresses(t *testing.T) {
 }
 
 func TestNodeAddressPriority(t *testing.T) {
-	nodes := []v1.Node{
+	nodes := []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-0",
 			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
 						Address: "192.168.0.100",
-						Type:    v1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 					},
 					{
 						Address: "203.0.113.100",
-						Type:    v1.NodeExternalIP,
+						Type:    corev1.NodeExternalIP,
 					},
 				},
-				Conditions: []v1.NodeCondition{
+				Conditions: []corev1.NodeCondition{
 					{
-						Type:   v1.NodeReady,
-						Status: v1.ConditionTrue,
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -287,21 +287,21 @@ func TestNodeAddressPriority(t *testing.T) {
 				Name:      "node-1",
 				Namespace: "abc",
 			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
 						Address: "104.27.131.189",
-						Type:    v1.NodeExternalIP,
+						Type:    corev1.NodeExternalIP,
 					},
 					{
 						Address: "192.168.1.100",
-						Type:    v1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 					},
 				},
-				Conditions: []v1.NodeCondition{
+				Conditions: []corev1.NodeCondition{
 					{
-						Type:   v1.NodeReady,
-						Status: v1.ConditionTrue,
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
 					},
 				},
 			},
@@ -535,23 +535,23 @@ func TestSync(t *testing.T) {
 	})
 }
 
-func newNode(name, address string) *v1.Node {
-	return &v1.Node{
+func newNode(name, address string) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			UID:  types.UID(name + "-" + address),
 		},
-		Status: v1.NodeStatus{
-			Addresses: []v1.NodeAddress{
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
 				{
 					Address: address,
-					Type:    v1.NodeInternalIP,
+					Type:    corev1.NodeInternalIP,
 				},
 			},
-			Conditions: []v1.NodeCondition{
+			Conditions: []corev1.NodeCondition{
 				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
 				},
 			},
 		},

--- a/pkg/listwatch/namespace_denylist.go
+++ b/pkg/listwatch/namespace_denylist.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,7 +177,7 @@ func newDenylistWatch(l *slog.Logger, denylist map[string]struct{}, next watch.I
 // If the object is itself a namespace, it returns the object's
 // name.
 func getNamespace(obj metav1.Object) string {
-	if _, ok := obj.(*v1.Namespace); ok {
+	if _, ok := obj.(*corev1.Namespace); ok {
 		return obj.GetName()
 	}
 	return obj.GetNamespace()

--- a/pkg/listwatch/namespace_denylist_test.go
+++ b/pkg/listwatch/namespace_denylist_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -59,8 +59,8 @@ func newUnstructured(namespace string) *unstructured.Unstructured {
 		}}
 }
 
-func newNamespace(name string) *v1.Namespace {
-	return &v1.Namespace{
+func newNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},

--- a/pkg/operator/argument_test.go
+++ b/pkg/operator/argument_test.go
@@ -19,23 +19,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 func TestBuildArgs(t *testing.T) {
 	for _, tc := range []struct {
-		a   []v1.Argument
-		b   []v1.Argument
+		a   []monitoringv1.Argument
+		b   []monitoringv1.Argument
 		exp []string
 		err bool
 	}{
 		{
-			a: []v1.Argument{
+			a: []monitoringv1.Argument{
 				{Name: "test", Value: "value"},
 				{Name: "test2-test", Value: "value2"},
 				{Name: "test3.test", Value: "value3"},
 			},
-			b: []v1.Argument{
+			b: []monitoringv1.Argument{
 				{Name: "addtest", Value: "value"},
 				{Name: "addtest2-test", Value: "value2"},
 				{Name: "addtest3.test", Value: "value3"},
@@ -50,22 +50,22 @@ func TestBuildArgs(t *testing.T) {
 			},
 		},
 		{
-			a: []v1.Argument{
+			a: []monitoringv1.Argument{
 				{Name: "test", Value: "value"},
 				{Name: "test2", Value: "value2"},
 			},
-			b: []v1.Argument{
+			b: []monitoringv1.Argument{
 				{Name: "addtest", Value: "value"},
 				{Name: "test2", Value: "value3"},
 			},
 			err: true,
 		},
 		{
-			a: []v1.Argument{
+			a: []monitoringv1.Argument{
 				{Name: "test", Value: "value"},
 				{Name: "test2", Value: ""},
 			},
-			b: []v1.Argument{
+			b: []monitoringv1.Argument{
 				{Name: "addtest", Value: "value"},
 				{Name: "no-test2", Value: ""},
 			},

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -142,23 +142,23 @@ type ContainerConfig struct {
 	EnableProbes   bool
 }
 
-func (cc ContainerConfig) ResourceRequirements() v1.ResourceRequirements {
-	resources := v1.ResourceRequirements{
-		Limits:   v1.ResourceList{},
-		Requests: v1.ResourceList{},
+func (cc ContainerConfig) ResourceRequirements() corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
 	}
 
 	if cc.CPURequests.String() != "0" {
-		resources.Requests[v1.ResourceCPU] = cc.CPURequests.q
+		resources.Requests[corev1.ResourceCPU] = cc.CPURequests.q
 	}
 	if cc.CPULimits.String() != "0" {
-		resources.Limits[v1.ResourceCPU] = cc.CPULimits.q
+		resources.Limits[corev1.ResourceCPU] = cc.CPULimits.q
 	}
 	if cc.MemoryRequests.String() != "0" {
-		resources.Requests[v1.ResourceMemory] = cc.MemoryRequests.q
+		resources.Requests[corev1.ResourceMemory] = cc.MemoryRequests.q
 	}
 	if cc.MemoryLimits.String() != "0" {
-		resources.Limits[v1.ResourceMemory] = cc.MemoryLimits.q
+		resources.Limits[corev1.ResourceMemory] = cc.MemoryLimits.q
 	}
 
 	return resources
@@ -286,7 +286,7 @@ func (n *Namespaces) Finalize() error {
 	}
 
 	if len(n.AllowList) == 0 {
-		n.AllowList = StringSet{v1.NamespaceAll: struct{}{}}
+		n.AllowList = StringSet{corev1.NamespaceAll: struct{}{}}
 	}
 
 	if len(n.PrometheusAllowList) == 0 {
@@ -390,7 +390,7 @@ func (s StringSet) isAllNamespace() bool {
 		return false
 	}
 
-	_, found := s[v1.NamespaceAll]
+	_, found := s[corev1.NamespaceAll]
 	return found
 }
 

--- a/pkg/operator/config_reloader_test.go
+++ b/pkg/operator/config_reloader_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -101,18 +101,18 @@ func TestCreateInitConfigReloaderEnableProbes(t *testing.T) {
 
 func TestCreateInitConfigReloader(t *testing.T) {
 	initContainerName := "init-config-reloader"
-	expectedImagePullPolicy := v1.PullAlways
+	expectedImagePullPolicy := corev1.PullAlways
 	var container = CreateConfigReloader(
 		initContainerName,
 		ReloaderConfig(reloaderConfig),
 		InitContainer(),
-		ImagePullPolicy(v1.PullAlways),
+		ImagePullPolicy(corev1.PullAlways),
 	)
 
-	assert.NotContains(t, container.Env, v1.EnvVar{
+	assert.NotContains(t, container.Env, corev1.EnvVar{
 		Name: NodeNameEnvVar,
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 		},
 	})
 
@@ -158,7 +158,7 @@ func TestCreateConfigReloader(t *testing.T) {
 	configEnvsubstFile := "configEnvsubstFile"
 	watchedDirectories := []string{"directory1", "directory2"}
 	shard := int32(1)
-	expectedImagePullPolicy := v1.PullAlways
+	expectedImagePullPolicy := corev1.PullAlways
 	var container = CreateConfigReloader(
 		containerName,
 		ReloaderConfig(reloaderConfig),
@@ -242,14 +242,14 @@ func TestCreateConfigReloaderForDaemonSet(t *testing.T) {
 		WithDaemonSetMode(),
 	)
 
-	assert.Contains(t, container.Env, v1.EnvVar{
+	assert.Contains(t, container.Env, corev1.EnvVar{
 		Name: NodeNameEnvVar,
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 		},
 	})
 
-	assert.Contains(t, container.Env, v1.EnvVar{
+	assert.Contains(t, container.Env, corev1.EnvVar{
 		Name:  ShardEnvVar,
 		Value: strconv.Itoa(0),
 	})

--- a/pkg/operator/config_reloader_test_lib.go
+++ b/pkg/operator/config_reloader_test_lib.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -40,7 +40,7 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 	for _, tc := range []struct {
 		name              string
 		reloaderConfig    ContainerConfig
-		expectedResources v1.ResourceRequirements
+		expectedResources corev1.ResourceRequirements
 	}{
 		{
 			name: "no_resources",
@@ -51,9 +51,9 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("0")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits:   v1.ResourceList{},
-				Requests: v1.ResourceList{},
+			expectedResources: corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{},
+				Requests: corev1.ResourceList{},
 			},
 		},
 		{
@@ -65,12 +65,12 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("50Mi")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
-				Requests: v1.ResourceList{},
+				Requests: corev1.ResourceList{},
 			},
 		},
 		{
@@ -82,11 +82,11 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("0")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			},
 		},
@@ -99,12 +99,12 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("50Mi")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			},
 		},
@@ -117,13 +117,13 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("50Mi")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			},
 		},
@@ -136,13 +136,13 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("50Mi")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			},
 		},
@@ -155,12 +155,12 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("0")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("100m"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("100m"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
 				},
 			},
 		},
@@ -173,13 +173,13 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("50Mi")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("100m"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
 				},
 			},
 		},
@@ -192,13 +192,13 @@ func TestSidecarsResources(t *testing.T, makeStatefulSet func(reloaderConfig Con
 				MemoryLimits:   Quantity{q: resource.MustParse("0")},
 				Image:          DefaultReloaderTestConfig.ReloaderConfig.Image,
 			},
-			expectedResources: v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceCPU: resource.MustParse("100m"),
+			expectedResources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
 				},
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("100m"),
-					v1.ResourceMemory: resource.MustParse("50Mi"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
 				},
 			},
 		},

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestMap(t *testing.T) {
@@ -243,13 +243,13 @@ func TestMergeAllowLists(t *testing.T) {
 	}{
 		{
 			a: StringSet{
-				v1.NamespaceAll: struct{}{},
+				corev1.NamespaceAll: struct{}{},
 			},
 			b: StringSet{
 				"foo": struct{}{},
 			},
 			exp: StringSet{
-				v1.NamespaceAll: struct{}{},
+				corev1.NamespaceAll: struct{}{},
 			},
 		},
 		{
@@ -257,10 +257,10 @@ func TestMergeAllowLists(t *testing.T) {
 				"foo": struct{}{},
 			},
 			b: StringSet{
-				v1.NamespaceAll: struct{}{},
+				corev1.NamespaceAll: struct{}{},
 			},
 			exp: StringSet{
-				v1.NamespaceAll: struct{}{},
+				corev1.NamespaceAll: struct{}{},
 			},
 		},
 		{

--- a/pkg/operator/factory_test.go
+++ b/pkg/operator/factory_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -33,13 +33,13 @@ var _ = Owner(&fakeOwner{})
 func TestUpdateObject(t *testing.T) {
 	for _, tc := range []struct {
 		opts []ObjectOption
-		o    *v1.Secret
+		o    *corev1.Secret
 
-		exp *v1.Secret
+		exp *corev1.Secret
 	}{
 		{
-			o: &v1.Secret{},
-			exp: &v1.Secret{
+			o: &corev1.Secret{},
+			exp: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app.kubernetes.io/managed-by": "prometheus-operator",
@@ -67,7 +67,7 @@ func TestUpdateObject(t *testing.T) {
 					},
 				),
 			},
-			o: &v1.Secret{
+			o: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"annotation1": "val1", "annotation2": "val2"},
 					Labels:      map[string]string{"managed-by": "prometheus-operator2", "label2": "val2"},
@@ -81,7 +81,7 @@ func TestUpdateObject(t *testing.T) {
 					},
 				},
 			},
-			exp: &v1.Secret{
+			exp: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"annotation1": "val1",

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -564,12 +564,12 @@ func WaitForNamedCacheSync(ctx context.Context, controllerName string, logger *s
 
 // ConfigMapGVK returns the GroupVersionKind representing ConfigMap objects.
 func ConfigMapGVK() schema.GroupVersionKind {
-	return v1.SchemeGroupVersion.WithKind("ConfigMap")
+	return corev1.SchemeGroupVersion.WithKind("ConfigMap")
 }
 
 // SecretGVK returns the GroupVersionKind representing Secret objects.
 func SecretGVK() schema.GroupVersionKind {
-	return v1.SchemeGroupVersion.WithKind("Secret")
+	return corev1.SchemeGroupVersion.WithKind("Secret")
 }
 
 // SelectNamespacesFromCache returns the selected namespaces from the informer's cache.
@@ -586,7 +586,7 @@ func SelectNamespacesFromCache(obj metav1.Object, sel *metav1.LabelSelector, nsI
 
 	var ns []string
 	err = cache.ListAll(nsInfs.GetStore(), labelSelector, func(obj any) {
-		ns = append(ns, obj.(*v1.Namespace).Name)
+		ns = append(ns, obj.(*corev1.Namespace).Name)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list namespaces: %w", err)

--- a/pkg/operator/prober.go
+++ b/pkg/operator/prober.go
@@ -17,12 +17,12 @@ package operator
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ExecAction returns an ExecAction probing the given URL.
-func ExecAction(u string) *v1.ExecAction {
-	return &v1.ExecAction{
+func ExecAction(u string) *corev1.ExecAction {
+	return &corev1.ExecAction{
 		Command: []string{
 			"sh",
 			"-c",

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -27,10 +27,10 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
@@ -58,7 +58,7 @@ const (
 // maximum `Data` size of a ConfigMap seems to differ between environments.
 // This is probably due to different meta data sizes which count into the
 // overall maximum size of a ConfigMap. Thereby lets leave a large buffer.
-var MaxConfigMapDataSize = int(float64(v1.MaxSecretSize) * 0.5)
+var MaxConfigMapDataSize = int(float64(corev1.MaxSecretSize) * 0.5)
 
 // PrometheusRuleSelector selects PrometheusRule resources and translates them
 // to Prometheus/Thanos configuration format.
@@ -282,7 +282,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (PrometheusRuleSe
 				"prometheusrule", promRule.Name,
 				"namespace", promRule.Namespace,
 			)
-			prs.eventRecorder.Eventf(promRule, v1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
+			prs.eventRecorder.Eventf(promRule, corev1.EventTypeWarning, InvalidConfigurationEvent, selectingPrometheusRuleResourcesAction, "PrometheusRule %s was rejected due to invalid configuration: %v", promRule.Name, err)
 			reason = InvalidConfigurationEvent
 		} else {
 			marshalRules[ruleName] = content
@@ -315,7 +315,7 @@ func (prs *PrometheusRuleSelector) Select(namespaces []string) (PrometheusRuleSe
 type PrometheusRuleSyncer struct {
 	namePrefix string
 	opts       []ObjectOption
-	cmClient   clientv1.ConfigMapInterface
+	cmClient   typedcorev1.ConfigMapInterface
 	cmSelector labels.Set
 
 	logger *slog.Logger
@@ -324,7 +324,7 @@ type PrometheusRuleSyncer struct {
 func NewPrometheusRuleSyncer(
 	logger *slog.Logger,
 	namePrefix string,
-	cmClient clientv1.ConfigMapInterface,
+	cmClient typedcorev1.ConfigMapInterface,
 	cmSelector labels.Set,
 	options []ObjectOption,
 ) *PrometheusRuleSyncer {
@@ -420,7 +420,7 @@ func (prs *PrometheusRuleSyncer) Sync(ctx context.Context, rules map[string]stri
 	return configMapNames(configMaps), nil
 }
 
-func configMapNames(cms []v1.ConfigMap) []string {
+func configMapNames(cms []corev1.ConfigMap) []string {
 	return slices.Sorted(slices.Values(slices.Collect(func(yield func(string) bool) {
 		for _, cm := range cms {
 			if !yield(cm.Name) {
@@ -444,7 +444,7 @@ type bucket struct {
 // simplicity should be sufficient.
 //
 // [1] https://en.wikipedia.org/wiki/Bin_packing_problem#First-fit_algorithm
-func (prs *PrometheusRuleSyncer) makeConfigMapsFromRules(rules map[string]string) ([]v1.ConfigMap, error) {
+func (prs *PrometheusRuleSyncer) makeConfigMapsFromRules(rules map[string]string) ([]corev1.ConfigMap, error) {
 	var (
 		i       int
 		buckets = []bucket{{rules: map[string]string{}}}
@@ -462,9 +462,9 @@ func (prs *PrometheusRuleSyncer) makeConfigMapsFromRules(rules map[string]string
 		buckets[i].size += len(rules[filename])
 	}
 
-	configMaps := make([]v1.ConfigMap, 0, len(buckets))
+	configMaps := make([]corev1.ConfigMap, 0, len(buckets))
 	for i, bucket := range buckets {
-		cm := v1.ConfigMap{
+		cm := corev1.ConfigMap{
 			Data: bucket.rules,
 		}
 

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -692,7 +692,7 @@ func createUTF8Rule() *monitoringv1.PrometheusRule {
 func TestPrometheusRuleSync(t *testing.T) {
 	c := fake.NewClientset(
 		// This configmap should be left untouched.
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "prometheus-bar-rulefiles-0",
 				Namespace: "monitoring",

--- a/pkg/operator/sharded_secret.go
+++ b/pkg/operator/sharded_secret.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	sortutil "github.com/prometheus-operator/prometheus-operator/internal/sortutil"
 	"github.com/prometheus-operator/prometheus-operator/pkg/k8s"
@@ -31,18 +31,18 @@ import (
 // MaxSecretDataSizeBytes is the maximum data size that a single secret shard
 // may use. This is lower than v1.MaxSecretSize in order to reserve space for
 // metadata and the rest of the secret k8s object.
-const MaxSecretDataSizeBytes = v1.MaxSecretSize - 50_000
+const MaxSecretDataSizeBytes = corev1.MaxSecretSize - 50_000
 
 // ShardedSecret can shard Secret data across multiple k8s Secrets.
 // This is used to circumvent the size limitation of k8s Secrets.
 type ShardedSecret struct {
-	template     *v1.Secret
+	template     *corev1.Secret
 	data         map[string][]byte
-	secretShards []*v1.Secret
+	secretShards []*corev1.Secret
 }
 
 // updateSecrets updates the concrete Secrets from the stored data.
-func (s *ShardedSecret) updateSecrets(ctx context.Context, sClient corev1.SecretInterface) error {
+func (s *ShardedSecret) updateSecrets(ctx context.Context, sClient typedcorev1.SecretInterface) error {
 	secrets := s.shard()
 
 	for _, secret := range secrets {
@@ -56,8 +56,8 @@ func (s *ShardedSecret) updateSecrets(ctx context.Context, sClient corev1.Secret
 }
 
 // shard does the in-memory sharding of the secret data.
-func (s *ShardedSecret) shard() []*v1.Secret {
-	s.secretShards = []*v1.Secret{}
+func (s *ShardedSecret) shard() []*corev1.Secret {
+	s.secretShards = []*corev1.Secret{}
 
 	currentIndex := 0
 	secretSize := 0
@@ -82,7 +82,7 @@ func (s *ShardedSecret) shard() []*v1.Secret {
 }
 
 // newSecretAt creates a new Kubernetes object at the given shard index.
-func (s *ShardedSecret) newSecretAt(index int) *v1.Secret {
+func (s *ShardedSecret) newSecretAt(index int) *corev1.Secret {
 	newShardSecret := s.template.DeepCopy()
 	newShardSecret.Name = s.secretNameAt(index)
 	newShardSecret.Data = make(map[string][]byte)
@@ -93,7 +93,7 @@ func (s *ShardedSecret) newSecretAt(index int) *v1.Secret {
 // cleanupExcessSecretShards removes excess secret shards that are no longer in use.
 // It also tries to remove a non-sharded secret that exactly matches the name
 // prefix in order to make sure that operator version upgrades run smoothly.
-func (s *ShardedSecret) cleanupExcessSecretShards(ctx context.Context, sClient corev1.SecretInterface, lastSecretIndex int) error {
+func (s *ShardedSecret) cleanupExcessSecretShards(ctx context.Context, sClient typedcorev1.SecretInterface, lastSecretIndex int) error {
 	for i := lastSecretIndex + 1; ; i++ {
 		secretName := s.secretNameAt(i)
 		err := sClient.Delete(ctx, secretName, metav1.DeleteOptions{})
@@ -121,21 +121,21 @@ func (s *ShardedSecret) Hash() (uint64, error) {
 
 // Volume returns a v1.Volume object with all TLS assets ready to be mounted in a container.
 // It must be called after UpdateSecrets().
-func (s *ShardedSecret) Volume(name string) v1.Volume {
-	volume := v1.Volume{
+func (s *ShardedSecret) Volume(name string) corev1.Volume {
+	volume := corev1.Volume{
 		Name: name,
-		VolumeSource: v1.VolumeSource{
-			Projected: &v1.ProjectedVolumeSource{
-				Sources: []v1.VolumeProjection{},
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{},
 			},
 		},
 	}
 
 	for i := 0; i < len(s.secretShards); i++ {
 		volume.Projected.Sources = append(volume.Projected.Sources,
-			v1.VolumeProjection{
-				Secret: &v1.SecretProjection{
-					LocalObjectReference: v1.LocalObjectReference{Name: s.secretNameAt(i)},
+			corev1.VolumeProjection{
+				Secret: &corev1.SecretProjection{
+					LocalObjectReference: corev1.LocalObjectReference{Name: s.secretNameAt(i)},
 				},
 			})
 	}
@@ -143,7 +143,7 @@ func (s *ShardedSecret) Volume(name string) v1.Volume {
 	return volume
 }
 
-func ReconcileShardedSecret(ctx context.Context, data map[string][]byte, client kubernetes.Interface, template *v1.Secret) (*ShardedSecret, error) {
+func ReconcileShardedSecret(ctx context.Context, data map[string][]byte, client kubernetes.Interface, template *corev1.Secret) (*ShardedSecret, error) {
 	shardedSecret := &ShardedSecret{
 		template: template,
 		data:     data,

--- a/pkg/operator/sharded_secret_test.go
+++ b/pkg/operator/sharded_secret_test.go
@@ -17,7 +17,7 @@ package operator
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -70,7 +70,7 @@ func TestShardedSecret(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			template := &v1.Secret{
+			template := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namePrefix,
 				},

--- a/pkg/operator/statefulset_reporter.go
+++ b/pkg/operator/statefulset_reporter.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -30,19 +30,19 @@ import (
 )
 
 // Pod is an alias for the Kubernetes v1.Pod type.
-type Pod v1.Pod
+type Pod corev1.Pod
 
 // Ready returns true if the pod is ready.
 func (p *Pod) Ready() bool {
-	if p.Status.Phase != v1.PodRunning {
+	if p.Status.Phase != corev1.PodRunning {
 		return false
 	}
 
 	for _, cond := range p.Status.Conditions {
-		if cond.Type != v1.PodReady {
+		if cond.Type != corev1.PodReady {
 			continue
 		}
-		return cond.Status == v1.ConditionTrue
+		return cond.Status == corev1.ConditionTrue
 	}
 
 	return false
@@ -50,14 +50,14 @@ func (p *Pod) Ready() bool {
 
 // Message returns a human-readable and terse message about the state of the pod.
 func (p *Pod) Message() string {
-	for _, condType := range []v1.PodConditionType{
-		v1.PodScheduled,    // Check first that the pod is scheduled.
-		v1.PodInitialized,  // Then that init containers have been started successfully.
-		v1.ContainersReady, // Then that all containers are ready.
-		v1.PodReady,        // And finally that the pod is ready.
+	for _, condType := range []corev1.PodConditionType{
+		corev1.PodScheduled,    // Check first that the pod is scheduled.
+		corev1.PodInitialized,  // Then that init containers have been started successfully.
+		corev1.ContainersReady, // Then that all containers are ready.
+		corev1.PodReady,        // And finally that the pod is ready.
 	} {
 		for _, cond := range p.Status.Conditions {
-			if cond.Type == condType && cond.Status == v1.ConditionFalse {
+			if cond.Type == condType && cond.Status == corev1.ConditionFalse {
 				return cond.Message
 			}
 		}

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -15,14 +15,14 @@
 package operator
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-func MakeVolumeClaimTemplate(e monitoringv1.EmbeddedPersistentVolumeClaim) *v1.PersistentVolumeClaim {
-	pvc := v1.PersistentVolumeClaim{
+func MakeVolumeClaimTemplate(e monitoringv1.EmbeddedPersistentVolumeClaim) *corev1.PersistentVolumeClaim {
+	pvc := corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: e.APIVersion,
 			Kind:       e.Kind,
@@ -39,12 +39,12 @@ func MakeVolumeClaimTemplate(e monitoringv1.EmbeddedPersistentVolumeClaim) *v1.P
 }
 
 // MakeHostAliases converts array of monitoringv1 HostAlias to array of corev1 HostAlias.
-func MakeHostAliases(input []monitoringv1.HostAlias) []v1.HostAlias {
+func MakeHostAliases(input []monitoringv1.HostAlias) []corev1.HostAlias {
 	if len(input) == 0 {
 		return nil
 	}
 
-	output := make([]v1.HostAlias, len(input))
+	output := make([]corev1.HostAlias, len(input))
 
 	for i, in := range input {
 		output[i].Hostnames = in.Hostnames

--- a/pkg/operator/types_test.go
+++ b/pkg/operator/types_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -26,7 +26,7 @@ import (
 func TestMakeHostAliases(t *testing.T) {
 	cases := []struct {
 		input    []monitoringv1.HostAlias
-		expected []v1.HostAlias
+		expected []corev1.HostAlias
 	}{
 		{
 			input:    nil,
@@ -43,7 +43,7 @@ func TestMakeHostAliases(t *testing.T) {
 					Hostnames: []string{"foo.com"},
 				},
 			},
-			expected: []v1.HostAlias{
+			expected: []corev1.HostAlias{
 				{
 					IP:        "1.1.1.1",
 					Hostnames: []string{"foo.com"},

--- a/pkg/prometheus/agent/daemonset.go
+++ b/pkg/prometheus/agent/daemonset.go
@@ -19,7 +19,7 @@ import (
 	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -128,7 +128,7 @@ func makeDaemonSetSpec(
 	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
 	finalLabels := c.Labels.Merge(podLabels)
 
-	var additionalContainers, operatorInitContainers []v1.Container
+	var additionalContainers, operatorInitContainers []corev1.Container
 
 	var watchedDirectories []string
 
@@ -153,7 +153,7 @@ func makeDaemonSetSpec(
 		return nil, err
 	}
 
-	operatorContainers := append([]v1.Container{
+	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "prometheus",
 			Image:                    pImagePath,
@@ -165,12 +165,12 @@ func makeDaemonSetSpec(
 			LivenessProbe:            livenessProbe,
 			ReadinessProbe:           readinessProbe,
 			Resources:                cpf.Resources,
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			SecurityContext: &v1.SecurityContext{
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
 				},
 			},
 		},
@@ -195,12 +195,12 @@ func makeDaemonSetSpec(
 			MatchLabels: finalSelectorLabels,
 		},
 		MinReadySeconds: ptr.Deref(cpf.MinReadySeconds, 0),
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,
 				Annotations: podAnnotations,
 			},
-			Spec: v1.PodSpec{
+			Spec: corev1.PodSpec{
 				ShareProcessNamespace:         prompkg.ShareProcessNamespace(p),
 				Containers:                    containers,
 				InitContainers:                initContainers,
@@ -223,7 +223,7 @@ func makeDaemonSetSpec(
 	}
 
 	if cpf.HostNetwork {
-		spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+		spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	k8s.UpdateDNSPolicy(&spec.Template.Spec, cpf.DNSPolicy)
 	k8s.UpdateDNSConfig(&spec.Template.Spec, cpf.DNSConfig)

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mitchellh/hashstructure"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -296,7 +296,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 				options.LabelSelector = c.ConfigMapListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),
 	)
 	if err != nil {
@@ -314,7 +314,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 				options.LabelSelector = c.SecretListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceSecrets)),
 		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
@@ -380,7 +380,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		logger.Debug("creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
-			&v1.Namespace{}, resyncPeriod, cache.Indexers{},
+			&corev1.Namespace{}, resyncPeriod, cache.Indexers{},
 		), nil
 	}
 
@@ -1067,7 +1067,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitor
 		return fmt.Errorf("failed to initialize web config: %w", err)
 	}
 
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	operator.UpdateObject(
 		s,
 		operator.WithLabels(c.config.Labels),
@@ -1105,7 +1105,7 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		c.logger.Error(fmt.Sprintf("get namespace to enqueue Prometheus instances failed: namespace %q does not exist", nsName))
 		return
 	}
-	ns := nsObject.(*v1.Namespace)
+	ns := nsObject.(*corev1.Namespace)
 
 	err = c.promInfs.ListAll(labels.Everything(), func(obj any) {
 		// Check for Prometheus Agent instances in the namespace.
@@ -1184,8 +1184,8 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 }
 
 func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
-	old := oldo.(*v1.Namespace)
-	cur := curo.(*v1.Namespace)
+	old := oldo.(*corev1.Namespace)
+	cur := curo.(*corev1.Namespace)
 
 	c.logger.Debug("update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 

--- a/pkg/prometheus/agent/statefulset.go
+++ b/pkg/prometheus/agent/statefulset.go
@@ -19,7 +19,7 @@ import (
 	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -86,25 +86,25 @@ func makeStatefulSet(
 	storageSpec := cpf.Storage
 	switch {
 	case storageSpec == nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 
 	case storageSpec.EmptyDir != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				EmptyDir: storageSpec.EmptyDir,
 			},
 		})
 
 	case storageSpec.Ephemeral != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				Ephemeral: storageSpec.Ephemeral,
 			},
 		})
@@ -115,7 +115,7 @@ func makeStatefulSet(
 			pvcTemplate.Name = prompkg.VolumeName(p)
 		}
 		if storageSpec.VolumeClaimTemplate.Spec.AccessModes == nil {
-			pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+			pvcTemplate.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
@@ -202,7 +202,7 @@ func makeStatefulSetSpec(
 	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
 	finalLabels := c.Labels.Merge(podLabels)
 
-	var additionalContainers, operatorInitContainers []v1.Container
+	var additionalContainers, operatorInitContainers []corev1.Container
 
 	var watchedDirectories []string
 
@@ -227,7 +227,7 @@ func makeStatefulSetSpec(
 		return nil, err
 	}
 
-	operatorContainers := append([]v1.Container{
+	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "prometheus",
 			Image:                    pImagePath,
@@ -239,12 +239,12 @@ func makeStatefulSetSpec(
 			LivenessProbe:            livenessProbe,
 			ReadinessProbe:           readinessProbe,
 			Resources:                cpf.Resources,
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			SecurityContext: &v1.SecurityContext{
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
 				},
 			},
 		},
@@ -264,7 +264,7 @@ func makeStatefulSetSpec(
 		return nil, fmt.Errorf("failed to merge containers spec: %w", err)
 	}
 
-	spec := v1.PodSpec{
+	spec := corev1.PodSpec{
 		ShareProcessNamespace:         prompkg.ShareProcessNamespace(p),
 		Containers:                    containers,
 		InitContainers:                initContainers,
@@ -285,7 +285,7 @@ func makeStatefulSetSpec(
 	}
 
 	if cpf.HostNetwork {
-		spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+		spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	k8s.UpdateDNSPolicy(&spec, cpf.DNSPolicy)
 	k8s.UpdateDNSConfig(&spec, cpf.DNSConfig)
@@ -305,7 +305,7 @@ func makeStatefulSetSpec(
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,
 				Annotations: podAnnotations,

--- a/pkg/prometheus/agent/statefulset_test.go
+++ b/pkg/prometheus/agent/statefulset_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -156,7 +156,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 						CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 							MaxSkew:           1,
 							TopologyKey:       "kubernetes.io/hostname",
-							WhenUnsatisfiable: v1.DoNotSchedule,
+							WhenUnsatisfiable: corev1.DoNotSchedule,
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"app": "prometheus",
@@ -167,10 +167,10 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 				},
 			},
 		},
-		tsc: v1.TopologySpreadConstraint{
+		tsc: corev1.TopologySpreadConstraint{
 			MaxSkew:           1,
 			TopologyKey:       "kubernetes.io/hostname",
-			WhenUnsatisfiable: v1.DoNotSchedule,
+			WhenUnsatisfiable: corev1.DoNotSchedule,
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":                          "prometheus",
@@ -211,7 +211,7 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 
 func TestStatefulSetDNSPolicyAndDNSConfig(t *testing.T) {
 	// Monitoring DNS settings
-	monitoringDNSPolicy := v1.DNSClusterFirst
+	monitoringDNSPolicy := corev1.DNSClusterFirst
 	monitoringDNSConfig := &monitoringv1.PodDNSConfig{
 		Nameservers: []string{"8.8.8.8", "8.8.4.4"},
 		Searches:    []string{"custom.search"},
@@ -239,7 +239,7 @@ func TestStatefulSetDNSPolicyAndDNSConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Validate the DNS Policy
-	require.Equal(t, v1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected DNS policy to match")
+	require.Equal(t, corev1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected DNS policy to match")
 
 	// Validate the DNS Config
 	require.NotNil(t, sset.Spec.Template.Spec.DNSConfig, "expected DNS config to be set")

--- a/pkg/prometheus/agent/test_utils.go
+++ b/pkg/prometheus/agent/test_utils.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -43,14 +43,14 @@ func makeSpecForTestListenTLS() monitoringv1alpha1.PrometheusAgentSpec {
 			Web: &monitoringv1.PrometheusWebSpec{
 				WebConfigFileFields: monitoringv1.WebConfigFileFields{
 					TLSConfig: &monitoringv1.WebTLSConfig{
-						KeySecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						KeySecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 						},
 						Cert: monitoringv1.SecretOrConfigMap{
-							ConfigMap: &v1.ConfigMapKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ConfigMap: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "some-configmap",
 								},
 							},
@@ -62,7 +62,7 @@ func makeSpecForTestListenTLS() monitoringv1alpha1.PrometheusAgentSpec {
 	}
 }
 
-func testCorrectArgs(t *testing.T, actualArgs []string, actualContainers []v1.Container) {
+func testCorrectArgs(t *testing.T, actualArgs []string, actualContainers []corev1.Container) {
 	expectedConfigReloaderReloadURL := "--reload-url=https://localhost:9090/-/reload"
 	require.True(t, slices.Contains(actualArgs, expectedConfigReloaderReloadURL))
 
@@ -83,7 +83,7 @@ func testCorrectArgs(t *testing.T, actualArgs []string, actualContainers []v1.Co
 type testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels struct {
 	name string
 	spec monitoringv1alpha1.PrometheusAgentSpec
-	tsc  v1.TopologySpreadConstraint
+	tsc  corev1.TopologySpreadConstraint
 }
 
 func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []testcaseForTestPodTopologySpreadConstraintWithAdditionalLabels {
@@ -97,16 +97,16 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 							},
 						},
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"app": "prometheus",
@@ -129,10 +129,10 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app": "prometheus",
@@ -150,7 +150,7 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"app": "prometheus",
@@ -161,10 +161,10 @@ func createTestCasesForTestPodTopologySpreadConstraintWithAdditionalLabels() []t
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app":                          "prometheus",

--- a/pkg/prometheus/collector.go
+++ b/pkg/prometheus/collector.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 var (
@@ -68,12 +68,12 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range c.stores {
 		for _, p := range s.List() {
-			c.collectPrometheus(ch, p.(v1.PrometheusInterface))
+			c.collectPrometheus(ch, p.(monitoringv1.PrometheusInterface))
 		}
 	}
 }
 
-func (c *Collector) collectPrometheus(ch chan<- prometheus.Metric, p v1.PrometheusInterface) {
+func (c *Collector) collectPrometheus(ch chan<- prometheus.Metric, p monitoringv1.PrometheusInterface) {
 	namespace := p.GetObjectMeta().GetNamespace()
 	name := p.GetObjectMeta().GetName()
 	replicas := float64(*ReplicasNumberPtr(p))

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"path/filepath"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -140,13 +140,13 @@ func compress(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func MakeConfigurationSecret(p monitoringv1.PrometheusInterface, config Config, data []byte) (*v1.Secret, error) {
+func MakeConfigurationSecret(p monitoringv1.PrometheusInterface, config Config, data []byte) (*corev1.Secret, error) {
 	promConfig, err := compress(data)
 	if err != nil {
 		return nil, err
 	}
 
-	s := &v1.Secret{
+	s := &corev1.Secret{
 		Data: map[string][]byte{
 			ConfigFilename: promConfig,
 		},
@@ -217,14 +217,14 @@ func logFilePath(logFile string) string {
 }
 
 // BuildCommonVolumes returns a set of volumes to be mounted on the spec that are common between Prometheus Server and Agent.
-func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator.ShardedSecret, statefulSet bool) ([]v1.Volume, []v1.VolumeMount, error) {
+func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator.ShardedSecret, statefulSet bool) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	cpf := p.GetCommonPrometheusFields()
 
-	volumes := []v1.Volume{
+	volumes := []corev1.Volume{
 		{
 			Name: "config",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: ConfigSecretName(p),
 				},
 			},
@@ -232,16 +232,16 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 		tlsSecrets.Volume("tls-assets"),
 		{
 			Name: "config-out",
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
 					// tmpfs is used here to avoid writing sensitive data into disk.
-					Medium: v1.StorageMediumMemory,
+					Medium: corev1.StorageMediumMemory,
 				},
 			},
 		},
 	}
 
-	promVolumeMounts := []v1.VolumeMount{
+	promVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-out",
 			ReadOnly:  true,
@@ -256,7 +256,7 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 
 	// Only StatefulSet needs this.
 	if statefulSet {
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+		promVolumeMounts = append(promVolumeMounts, corev1.VolumeMount{
 			Name:      VolumeClaimName(p, cpf),
 			MountPath: StorageDir,
 			SubPath:   SubPathForStorage(cpf.Storage),
@@ -273,15 +273,15 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 			return nil, nil, err
 		}
 
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: s,
 				},
 			},
 		})
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+		promVolumeMounts = append(promVolumeMounts, corev1.VolumeMount{
 			Name:      name,
 			ReadOnly:  true,
 			MountPath: secretsDir + s,
@@ -295,17 +295,17 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 			return nil, nil, err
 		}
 
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: c,
 					},
 				},
 			},
 		})
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+		promVolumeMounts = append(promVolumeMounts, corev1.VolumeMount{
 			Name:      name,
 			ReadOnly:  true,
 			MountPath: configmapsDir + c,
@@ -314,13 +314,13 @@ func BuildCommonVolumes(p monitoringv1.PrometheusInterface, tlsSecrets *operator
 
 	// scrape failure log file
 	if cpf.ScrapeFailureLogFile != nil && UsesDefaultFileVolume(*cpf.ScrapeFailureLogFile) {
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: DefaultLogFileVolume,
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
-		promVolumeMounts = append(promVolumeMounts, v1.VolumeMount{
+		promVolumeMounts = append(promVolumeMounts, corev1.VolumeMount{
 			Name:      DefaultLogFileVolume,
 			ReadOnly:  false,
 			MountPath: DefaultLogDirectory,
@@ -344,10 +344,10 @@ func BuildConfigReloader(
 	p monitoringv1.PrometheusInterface,
 	c Config,
 	initContainer bool,
-	mounts []v1.VolumeMount,
+	mounts []corev1.VolumeMount,
 	watchedDirectories []string,
 	opts ...operator.ReloaderOption,
-) v1.Container {
+) corev1.Container {
 	cpf := p.GetCommonPrometheusFields()
 
 	reloaderOptions := []operator.ReloaderOption{
@@ -406,13 +406,13 @@ func ShareProcessNamespace(p monitoringv1.PrometheusInterface) *bool {
 	)
 }
 
-func MakeK8sTopologySpreadConstraint(selectorLabels map[string]string, tscs []monitoringv1.TopologySpreadConstraint) []v1.TopologySpreadConstraint {
+func MakeK8sTopologySpreadConstraint(selectorLabels map[string]string, tscs []monitoringv1.TopologySpreadConstraint) []corev1.TopologySpreadConstraint {
 
-	coreTscs := make([]v1.TopologySpreadConstraint, 0, len(tscs))
+	coreTscs := make([]corev1.TopologySpreadConstraint, 0, len(tscs))
 
 	for _, tsc := range tscs {
 		if tsc.AdditionalLabelSelectors == nil {
-			coreTscs = append(coreTscs, v1.TopologySpreadConstraint(tsc.CoreV1TopologySpreadConstraint))
+			coreTscs = append(coreTscs, corev1.TopologySpreadConstraint(tsc.CoreV1TopologySpreadConstraint))
 			continue
 		}
 
@@ -429,28 +429,28 @@ func MakeK8sTopologySpreadConstraint(selectorLabels map[string]string, tscs []mo
 			tsc.LabelSelector.MatchLabels[key] = value
 		}
 
-		coreTscs = append(coreTscs, v1.TopologySpreadConstraint(tsc.CoreV1TopologySpreadConstraint))
+		coreTscs = append(coreTscs, corev1.TopologySpreadConstraint(tsc.CoreV1TopologySpreadConstraint))
 	}
 
 	return coreTscs
 }
 
-func MakeContainerPorts(cpf monitoringv1.CommonPrometheusFields) []v1.ContainerPort {
+func MakeContainerPorts(cpf monitoringv1.CommonPrometheusFields) []corev1.ContainerPort {
 	if cpf.ListenLocal {
 		return nil
 	}
 
-	return []v1.ContainerPort{
+	return []corev1.ContainerPort{
 		{
 			Name:          cpf.PortName,
 			ContainerPort: 9090,
-			Protocol:      v1.ProtocolTCP,
+			Protocol:      corev1.ProtocolTCP,
 		},
 	}
 }
 
-func CreateConfigReloaderVolumeMounts() []v1.VolumeMount {
-	return []v1.VolumeMount{
+func CreateConfigReloaderVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
 		{
 			Name:      "config",
 			MountPath: ConfDir,
@@ -465,7 +465,7 @@ func CreateConfigReloaderVolumeMounts() []v1.VolumeMount {
 func BuildWebconfig(
 	cpf monitoringv1.CommonPrometheusFields,
 	p monitoringv1.PrometheusInterface,
-) (monitoringv1.Argument, []v1.Volume, []v1.VolumeMount, error) {
+) (monitoringv1.Argument, []corev1.Volume, []corev1.VolumeMount, error) {
 	var fields monitoringv1.WebConfigFileFields
 	if cpf.Web != nil {
 		fields = cpf.Web.WebConfigFileFields
@@ -480,17 +480,17 @@ func BuildWebconfig(
 }
 
 // BuildStatefulSetService returns a governing service to be used for a statefulset.
-func BuildStatefulSetService(name string, selector map[string]string, p monitoringv1.PrometheusInterface, config Config) *v1.Service {
+func BuildStatefulSetService(name string, selector map[string]string, p monitoringv1.PrometheusInterface, config Config) *corev1.Service {
 	cpf := p.GetCommonPrometheusFields()
 	portName := DefaultPortName
 	if cpf.PortName != "" {
 		portName = cpf.PortName
 	}
 
-	svc := &v1.Service{
-		Spec: v1.ServiceSpec{
-			ClusterIP: v1.ClusterIPNone,
-			Ports: []v1.ServicePort{
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
 				{
 					Name:       portName,
 					Port:       9090,

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -66,8 +66,8 @@ func statefulSetNameFromPrometheusName(p monitoringv1.PrometheusInterface, name 
 	return fmt.Sprintf("%s-%s-shard-%d", Prefix(p), name, shard)
 }
 
-func NewTLSAssetSecret(p monitoringv1.PrometheusInterface, config Config) *v1.Secret {
-	s := &v1.Secret{
+func NewTLSAssetSecret(p monitoringv1.PrometheusInterface, config Config) *corev1.Secret {
+	s := &corev1.Secret{
 		Data: map[string][]byte{},
 	}
 

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -123,8 +123,8 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "00000000-0000-0000-0000-000000000000",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",
@@ -189,8 +189,8 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "00000000-0000-0000-0000-000000000000",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",
@@ -209,8 +209,8 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "invalid",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",
@@ -287,8 +287,8 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "00000000-0000-0000-0000-000000000000",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",
@@ -354,8 +354,8 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "00000000-0000-0000-0000-000000000000",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -33,7 +33,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -1262,25 +1262,25 @@ func (cg *ConfigGenerator) BuildPodMetadata() (map[string]string, map[string]str
 // Prometheus is effectively ready.
 // We don't want to use the /-/healthy handler here because it returns OK as
 // soon as the web server is started (irrespective of the WAL replay).
-func (cg *ConfigGenerator) BuildProbes() (*v1.Probe, *v1.Probe, *v1.Probe) {
+func (cg *ConfigGenerator) BuildProbes() (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	readyProbeHandler := cg.buildProbeHandler("/-/ready")
 	startupPeriodSeconds, startupFailureThreshold := getStatupProbePeriodSecondsAndFailureThreshold(cg.prom.GetCommonPrometheusFields().MaximumStartupDurationSeconds)
 
-	startupProbe := &v1.Probe{
+	startupProbe := &corev1.Probe{
 		ProbeHandler:     readyProbeHandler,
 		TimeoutSeconds:   ProbeTimeoutSeconds,
 		PeriodSeconds:    startupPeriodSeconds,
 		FailureThreshold: startupFailureThreshold,
 	}
 
-	readinessProbe := &v1.Probe{
+	readinessProbe := &corev1.Probe{
 		ProbeHandler:     readyProbeHandler,
 		TimeoutSeconds:   ProbeTimeoutSeconds,
 		PeriodSeconds:    5,
 		FailureThreshold: 3,
 	}
 
-	livenessProbe := &v1.Probe{
+	livenessProbe := &corev1.Probe{
 		ProbeHandler:     cg.buildProbeHandler("/-/healthy"),
 		TimeoutSeconds:   ProbeTimeoutSeconds,
 		PeriodSeconds:    5,
@@ -1290,11 +1290,11 @@ func (cg *ConfigGenerator) BuildProbes() (*v1.Probe, *v1.Probe, *v1.Probe) {
 	return startupProbe, readinessProbe, livenessProbe
 }
 
-func (cg *ConfigGenerator) buildProbeHandler(probePath string) v1.ProbeHandler {
+func (cg *ConfigGenerator) buildProbeHandler(probePath string) corev1.ProbeHandler {
 	cpf := cg.prom.GetCommonPrometheusFields()
 
 	probePath = path.Clean(cpf.WebRoutePrefix() + probePath)
-	handler := v1.ProbeHandler{}
+	handler := corev1.ProbeHandler{}
 	if cpf.ListenLocal {
 		probeURL := url.URL{
 			Scheme: "http",
@@ -1306,12 +1306,12 @@ func (cg *ConfigGenerator) buildProbeHandler(probePath string) v1.ProbeHandler {
 		return handler
 	}
 
-	handler.HTTPGet = &v1.HTTPGetAction{
+	handler.HTTPGet = &corev1.HTTPGetAction{
 		Path: probePath,
 		Port: intstr.FromString(cpf.PortName),
 	}
 	if cpf.Web != nil && cpf.Web.TLSConfig != nil && cg.IsCompatible() {
-		handler.HTTPGet.Scheme = v1.URISchemeHTTPS
+		handler.HTTPGet.Scheme = corev1.URISchemeHTTPS
 	}
 
 	return handler

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/v3/golden"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -898,14 +898,14 @@ func TestK8SSDConfigGeneration(t *testing.T) {
 			apiServerConfig: &monitoringv1.APIServerConfig{
 				Host: "example.com",
 				BasicAuth: &monitoringv1.BasicAuth{
-					Username: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Username: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo",
 						},
 						Key: "username",
 					},
-					Password: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Password: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo",
 						},
 						Key: "password",
@@ -913,7 +913,7 @@ func TestK8SSDConfigGeneration(t *testing.T) {
 				},
 			},
 			store: assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -939,23 +939,23 @@ func TestK8SSDConfigGeneration(t *testing.T) {
 				TLSConfig: &monitoringv1.TLSConfig{
 					SafeTLSConfig: monitoringv1.SafeTLSConfig{
 						CA: monitoringv1.SecretOrConfigMap{
-							Secret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "ca",
 							},
 						},
 						Cert: monitoringv1.SecretOrConfigMap{
-							Secret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "cert",
 							},
 						},
-						KeySecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						KeySecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "private-key",
@@ -1078,14 +1078,14 @@ func TestAlertmanagerBasicAuth(t *testing.T) {
 							Namespace: ptr.To("default"),
 							Port:      intstr.FromString("web"),
 							BasicAuth: &monitoringv1.BasicAuth{
-								Username: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Username: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "foo",
 									},
 									Key: "username",
 								},
-								Password: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Password: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "foo",
 									},
 									Key: "password",
@@ -1106,7 +1106,7 @@ func TestAlertmanagerBasicAuth(t *testing.T) {
 			nil,
 			nil,
 			assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -1156,14 +1156,14 @@ func TestAlertmanagerSigv4(t *testing.T) {
 					Sigv4: &monitoringv1.Sigv4{
 						Profile: "profilename",
 						RoleArn: "arn:aws:iam::123456789012:instance-profile/prometheus",
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "sigv4-secret",
 							},
 							Key: "access-key",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "sigv4-secret",
 							},
 							Key: "secret-key",
@@ -1182,7 +1182,7 @@ func TestAlertmanagerSigv4(t *testing.T) {
 			nil,
 			nil,
 			assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sigv4-secret",
 						Namespace: "default",
@@ -2613,15 +2613,15 @@ func TestTargetLabels(t *testing.T) {
 func TestEndpointOAuth2(t *testing.T) {
 	oauth2 := monitoringv1.OAuth2{
 		ClientID: monitoringv1.SecretOrConfigMap{
-			ConfigMap: &v1.ConfigMapKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ConfigMap: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "oauth2",
 				},
 				Key: "client_id",
 			},
 		},
-		ClientSecret: v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		ClientSecret: corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "oauth2",
 			},
 			Key: "client_secret",
@@ -2635,8 +2635,8 @@ func TestEndpointOAuth2(t *testing.T) {
 		TLSConfig: &monitoringv1.SafeTLSConfig{
 			InsecureSkipVerify: ptr.To(true),
 			CA: monitoringv1.SecretOrConfigMap{
-				Secret: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "tls",
 					},
 					Key: "ca2",
@@ -2647,10 +2647,10 @@ func TestEndpointOAuth2(t *testing.T) {
 			ProxyURL:             ptr.To("http://no-proxy.com"),
 			NoProxy:              ptr.To("0.0.0.0"),
 			ProxyFromEnvironment: ptr.To(false),
-			ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+			ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 				"header": {
 					{
-						LocalObjectReference: v1.LocalObjectReference{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo",
 						},
 						Key: "proxy-header",
@@ -2661,7 +2661,7 @@ func TestEndpointOAuth2(t *testing.T) {
 	}
 
 	s := assets.NewTestStoreBuilder(
-		&v1.ConfigMap{
+		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "oauth2",
 				Namespace: "default",
@@ -2670,7 +2670,7 @@ func TestEndpointOAuth2(t *testing.T) {
 				"client_id": "test_client_id",
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "oauth2",
 				Namespace: "default",
@@ -2679,7 +2679,7 @@ func TestEndpointOAuth2(t *testing.T) {
 				"client_secret": []byte("test_client_secret"),
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "secret",
 				Namespace: "default",
@@ -2691,7 +2691,7 @@ func TestEndpointOAuth2(t *testing.T) {
 				"Password":     []byte("password"),
 			},
 		},
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "default",
@@ -3011,9 +3011,9 @@ func generateTestConfig(t *testing.T, version string) ([]byte, error) {
 						"group": "group1",
 					},
 				},
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("400Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
 				RemoteWrite: []monitoringv1.RemoteWriteSpec{{
@@ -3743,15 +3743,15 @@ func TestRemoteReadConfig(t *testing.T) {
 				URL: "http://example.com",
 				OAuth2: &monitoringv1.OAuth2{
 					ClientID: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "oauth2",
 							},
 							Key: "client_id",
 						},
 					},
-					ClientSecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "oauth2",
 						},
 						Key: "client_secret",
@@ -3769,15 +3769,15 @@ func TestRemoteReadConfig(t *testing.T) {
 				URL: "http://example.com",
 				OAuth2: &monitoringv1.OAuth2{
 					ClientID: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "oauth2",
 							},
 							Key: "client_id",
 						},
 					},
-					ClientSecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "oauth2",
 						},
 						Key: "client_secret",
@@ -3842,8 +3842,8 @@ func TestRemoteReadConfig(t *testing.T) {
 				URL: "http://example.com",
 				Authorization: &monitoringv1.Authorization{
 					SafeAuthorization: monitoringv1.SafeAuthorization{
-						Credentials: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "auth",
 							},
 							Key: "bearer",
@@ -3861,10 +3861,10 @@ func TestRemoteReadConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
@@ -3882,7 +3882,7 @@ func TestRemoteReadConfig(t *testing.T) {
 			p.Spec.RemoteRead = []monitoringv1.RemoteReadSpec{tc.remoteRead}
 
 			s := assets.NewTestStoreBuilder(
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -3891,7 +3891,7 @@ func TestRemoteReadConfig(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -3900,7 +3900,7 @@ func TestRemoteReadConfig(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth",
 						Namespace: "default",
@@ -3909,7 +3909,7 @@ func TestRemoteReadConfig(t *testing.T) {
 						"bearer": []byte("secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -4044,15 +4044,15 @@ func TestRemoteWriteConfig(t *testing.T) {
 				URL: "http://example.com",
 				OAuth2: &monitoringv1.OAuth2{
 					ClientID: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "oauth2",
 							},
 							Key: "client_id",
 						},
 					},
-					ClientSecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "oauth2",
 						},
 						Key: "client_secret",
@@ -4086,8 +4086,8 @@ func TestRemoteWriteConfig(t *testing.T) {
 					OAuth: &monitoringv1.AzureOAuth{
 						TenantID: "00000000-a12b-3cd4-e56f-000000000000",
 						ClientID: "00000000-0000-0000-0000-000000000000",
-						ClientSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "azure-oauth-secret",
 							},
 							Key: "secret-key",
@@ -4143,8 +4143,8 @@ func TestRemoteWriteConfig(t *testing.T) {
 				URL: "http://example.com",
 				Authorization: &monitoringv1.Authorization{
 					SafeAuthorization: monitoringv1.SafeAuthorization{
-						Credentials: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "auth",
 							},
 							Key: "token",
@@ -4161,14 +4161,14 @@ func TestRemoteWriteConfig(t *testing.T) {
 				Sigv4: &monitoringv1.Sigv4{
 					Profile: "profilename",
 					RoleArn: "arn:aws:iam::123456789012:instance-profile/prometheus",
-					AccessKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					AccessKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "access-key",
 					},
-					SecretKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "secret-key",
@@ -4318,10 +4318,10 @@ func TestRemoteWriteConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
@@ -4341,16 +4341,16 @@ func TestRemoteWriteConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "bar",
 								},
 								Key: "proxy-header",
@@ -4413,14 +4413,14 @@ func TestRemoteWriteConfig(t *testing.T) {
 				Sigv4: &monitoringv1.Sigv4{
 					Profile: "profilename",
 					RoleArn: "arn:aws:iam::123456789012:instance-profile/prometheus",
-					AccessKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					AccessKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "access-key",
 					},
-					SecretKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "secret-key",
@@ -4452,14 +4452,14 @@ func TestRemoteWriteConfig(t *testing.T) {
 				Sigv4: &monitoringv1.Sigv4{
 					Profile: "profilename",
 					RoleArn: "arn:aws:iam::123456789012:instance-profile/prometheus",
-					AccessKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					AccessKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "access-key",
 					},
-					SecretKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "sigv4-secret",
 						},
 						Key: "secret-key",
@@ -4528,7 +4528,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 			p.Spec.CommonPrometheusFields.Secrets = []string{"sigv4-secret"}
 
 			store := assets.NewTestStoreBuilder(
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -4537,7 +4537,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -4547,7 +4547,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"token":        []byte("value"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
 						Namespace: "default",
@@ -4557,7 +4557,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"token":        []byte("value1"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -4566,7 +4566,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth",
 						Namespace: "default",
@@ -4575,7 +4575,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"token": []byte("secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sigv4-secret",
 						Namespace: "default",
@@ -4585,7 +4585,7 @@ func TestRemoteWriteConfig(t *testing.T) {
 						"secret-key": []byte("secret-key"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "azure-oauth-secret",
 						Namespace: "default",
@@ -4918,10 +4918,10 @@ func TestLabelValueLengthLimits(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "proxy-header",
@@ -4950,7 +4950,7 @@ func TestLabelValueLengthLimits(t *testing.T) {
 			}
 
 			s := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -6104,10 +6104,10 @@ func TestProbeSpecConfig(t *testing.T) {
 						ProxyURL:             ptr.To("http://no-proxy.com"),
 						NoProxy:              ptr.To("0.0.0.0"),
 						ProxyFromEnvironment: ptr.To(false),
-						ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+						ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 							"header": {
 								{
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "foo",
 									},
 									Key: "proxy-header",
@@ -6218,7 +6218,7 @@ func TestProbeSpecConfig(t *testing.T) {
 			}
 
 			s := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -6375,10 +6375,10 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "proxy-header",
@@ -6445,14 +6445,14 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			name: "basic_auth",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				BasicAuth: &monitoringv1.BasicAuth{
-					Username: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Username: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo",
 						},
 						Key: "username",
 					},
-					Password: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Password: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo",
 						},
 						Key: "password",
@@ -6462,14 +6462,14 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					{
 						URL: "http://localhost:9100/sd.json",
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username-sd",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password-sd",
@@ -6484,8 +6484,8 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			name: "authorization",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				Authorization: &monitoringv1.SafeAuthorization{
-					Credentials: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "auth",
 						},
 						Key: "scrape-key",
@@ -6495,8 +6495,8 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					{
 						URL: "http://localhost:9100/sd.json",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "auth",
 								},
 								Key: "http-sd-key",
@@ -6512,23 +6512,23 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				TLSConfig: &monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "cert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls",
 						},
 						Key: "private-key",
@@ -6540,8 +6540,8 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(false),
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca2",
@@ -6559,23 +6559,23 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				TLSConfig: &monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "cert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls",
 						},
 						Key: "private-key",
@@ -6587,8 +6587,8 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca2",
@@ -6687,10 +6687,10 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
@@ -6708,22 +6708,22 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "token",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "bar",
 								},
 								Key: "proxy-header",
@@ -6731,13 +6731,13 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						},
 						"token": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "token",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "bar",
 								},
 								Key: "token",
@@ -6758,10 +6758,10 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "proxy-header",
@@ -6904,15 +6904,15 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				OAuth2: &monitoringv1.OAuth2{
 					ClientID: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "oauth2",
 							},
 							Key: "client_id",
 						},
 					},
-					ClientSecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "oauth2",
 						},
 						Key: "client_secret",
@@ -6933,15 +6933,15 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				OAuth2: &monitoringv1.OAuth2{
 					ClientID: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "oauth2",
 							},
 							Key: "client_id",
 						},
 					},
-					ClientSecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "oauth2",
 						},
 						Key: "client_secret",
@@ -7044,7 +7044,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 			cg.inlineTLSConfig = tc.inlineTLSConfig
 
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -7058,7 +7058,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						"password-sd":  []byte("http-sd-alice"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bar",
 						Namespace: "default",
@@ -7068,7 +7068,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						"token":        []byte("bar-value"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth",
 						Namespace: "default",
@@ -7078,7 +7078,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						"http-sd-key": []byte("http-sd-secret"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7087,7 +7087,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7096,7 +7096,7 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "tls",
 						Namespace: "default",
@@ -7146,10 +7146,10 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "proxy-header",
@@ -7169,14 +7169,14 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 					{
 						URL: "http://localhost:9100/sd.json",
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Password",
@@ -7193,8 +7193,8 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 					{
 						URL: "http://localhost:9100/sd.json",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -7212,15 +7212,15 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 						URL: "http://localhost:9100/sd.json",
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -7244,23 +7244,23 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 						URL: "http://localhost:9100/sd.json",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -7274,7 +7274,7 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -7286,7 +7286,7 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 						"Password":     []byte("password"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7295,7 +7295,7 @@ func TestScrapeConfigSpecConfigWithHTTPSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7357,10 +7357,10 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -7477,14 +7477,14 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role:      monitoringv1alpha1.KubernetesRoleNode,
 						APIServer: ptr.To("https://kubernetes.default.svc"),
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Password",
@@ -7502,8 +7502,8 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						Role:      monitoringv1alpha1.KubernetesRoleNode,
 						APIServer: ptr.To("https://kubernetes.default.svc"),
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -7522,15 +7522,15 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						APIServer: ptr.To("https://kubernetes.default.svc"),
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -7555,23 +7555,23 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						APIServer: ptr.To("https://kubernetes.default.svc"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -7584,7 +7584,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -7596,7 +7596,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						"Password":     []byte("password"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7605,7 +7605,7 @@ func TestScrapeConfigSpecConfigWithKubernetesSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7680,10 +7680,10 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "proxy-header",
@@ -7693,8 +7693,8 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						},
 						FollowRedirects: ptr.To(true),
 						EnableHttp2:     ptr.To(true),
-						TokenRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						TokenRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "foo",
 							},
 							Key: "token",
@@ -7722,14 +7722,14 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 					{
 						Server: "localhost:8500",
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -7746,8 +7746,8 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 					{
 						Server: "localhost:8500",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "auth",
 								},
 								Key: "token",
@@ -7765,15 +7765,15 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						Server: "localhost:8500",
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -7797,23 +7797,23 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						Server: "localhost:8500",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -7879,7 +7879,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -7891,7 +7891,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						"password":     []byte("consul-sd-alice"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7900,7 +7900,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -7909,7 +7909,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth",
 						Namespace: "default",
@@ -7958,7 +7958,7 @@ func TestScrapeConfigSpecConfigWithConsulSD(t *testing.T) {
 }
 
 func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
-	sec := &v1.Secret{
+	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "aws-access-api",
 			Namespace: "default",
@@ -7981,14 +7981,14 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "aws-access-api",
 							},
 							Key: "accessKey",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "aws-access-api",
 							},
 							Key: "secretKey",
@@ -8070,14 +8070,14 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 				EC2SDConfigs: []monitoringv1alpha1.EC2SDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong-secret-name",
 							},
 							Key: "accessKey",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "aws-access-api",
 							},
 							Key: "secretKey",
@@ -8104,10 +8104,10 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -8131,23 +8131,23 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 						Region: ptr.To("us-east-1"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -8169,23 +8169,23 @@ func TestScrapeConfigSpecConfigWithEC2SD(t *testing.T) {
 						Region: ptr.To("us-east-1"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -8253,8 +8253,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
 						TenantID:             ptr.To("BBBB222B-B2B2-2B22-B222-2BB2222BB2B2"),
 						ClientID:             ptr.To("333333CC-3C33-3333-CCC3-33C3CCCCC33C"),
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "clientSecret",
@@ -8313,8 +8313,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
 				AzureSDConfigs: []monitoringv1alpha1.AzureSDConfig{
 					{
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong-secret-name",
 							},
 							Key: "clientSecret",
@@ -8332,8 +8332,8 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						SubscriptionID:       "11AAAA11-A11A-111A-A111-1111A1111A11",
 						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -8343,10 +8343,10 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -8370,37 +8370,37 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "key",
 							},
 						},
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -8420,15 +8420,15 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeSDK),
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -8455,7 +8455,7 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -8467,7 +8467,7 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						"clientSecret": []byte("my-secret"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -8476,7 +8476,7 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -8485,7 +8485,7 @@ func TestScrapeConfigSpecConfigWithAzureSD(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -8624,7 +8624,7 @@ func TestScrapeConfigSpecConfigWithGCESD(t *testing.T) {
 }
 
 func TestScrapeConfigSpecConfigWithOpenStackSD(t *testing.T) {
-	sec := &v1.Secret{
+	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "openstack-access-secret",
 			Namespace: "default",
@@ -8649,8 +8649,8 @@ func TestScrapeConfigSpecConfigWithOpenStackSD(t *testing.T) {
 						Region:           "region-1",
 						IdentityEndpoint: ptr.To("http://identity.example.com:5000/v2.0"),
 						Username:         ptr.To("nova-user-1"),
-						Password: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Password: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "openstack-access-secret",
 							},
 							Key: "password",
@@ -8670,8 +8670,8 @@ func TestScrapeConfigSpecConfigWithOpenStackSD(t *testing.T) {
 					{
 						Role:   monitoringv1alpha1.OpenStackRoleInstance,
 						Region: "region-1",
-						ApplicationCredentialSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ApplicationCredentialSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "openstack-access-secret",
 							},
 							Key: "invalid-key",
@@ -8737,8 +8737,8 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 				DigitalOceanSDConfigs: []monitoringv1alpha1.DigitalOceanSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -8748,10 +8748,10 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -8775,15 +8775,15 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 					{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -8806,8 +8806,8 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 				DigitalOceanSDConfigs: []monitoringv1alpha1.DigitalOceanSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -8815,23 +8815,23 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -8845,7 +8845,7 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -8856,7 +8856,7 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -8865,7 +8865,7 @@ func TestScrapeConfigSpecConfigWithDigitalOceanSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -8921,8 +8921,8 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 					{
 						Host: "hostAddress",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -8932,10 +8932,10 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -8958,23 +8958,23 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -8993,15 +8993,15 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						Host: "hostAddress",
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -9021,23 +9021,23 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -9062,37 +9062,37 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
 							},
 						},
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -9118,37 +9118,37 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
 							},
 						},
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -9175,37 +9175,37 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
 							},
 						},
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -9220,7 +9220,7 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -9231,7 +9231,7 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -9240,7 +9240,7 @@ func TestScrapeConfigSpecConfigWithDockerSDConfig(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -9296,8 +9296,8 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 				LinodeSDConfigs: []monitoringv1alpha1.LinodeSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -9307,10 +9307,10 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -9325,23 +9325,23 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 						EnableHTTP2:     ptr.To(true),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -9359,15 +9359,15 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 					{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -9384,23 +9384,23 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 						EnableHTTP2:     ptr.To(true),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -9414,7 +9414,7 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -9425,7 +9425,7 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -9434,7 +9434,7 @@ func TestScrapeConfigSpecConfigWithLinodeSDConfig(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -9491,10 +9491,10 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -9522,10 +9522,10 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -9554,10 +9554,10 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -9582,14 +9582,14 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 					{
 						Role: "hcloud",
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "Password",
@@ -9606,8 +9606,8 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 					{
 						Role: "hcloud",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "token",
@@ -9625,15 +9625,15 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						Role: "hcloud",
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -9657,23 +9657,23 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						Role: "hcloud",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -9687,7 +9687,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -9699,7 +9699,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						"Password":     []byte("password"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -9708,7 +9708,7 @@ func TestScrapeConfigSpecConfigWithHetznerSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -10232,8 +10232,8 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 				KumaSDConfigs: []monitoringv1alpha1.KumaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -10243,10 +10243,10 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -10272,15 +10272,15 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 					{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -10303,8 +10303,8 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 				KumaSDConfigs: []monitoringv1alpha1.KumaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -10312,23 +10312,23 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "key",
@@ -10345,8 +10345,8 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 				KumaSDConfigs: []monitoringv1alpha1.KumaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -10354,23 +10354,23 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "key",
@@ -10386,7 +10386,7 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -10397,7 +10397,7 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -10406,7 +10406,7 @@ func TestScrapeConfigSpecConfigWithKumaSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -10668,23 +10668,23 @@ func TestServiceMonitorScrapeClassWithDefaultTLS(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tls",
 							},
 							Key: "cert",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls",
 						},
 						Key: "private-key",
@@ -10710,14 +10710,14 @@ func TestServiceMonitorScrapeClassWithDefaultTLS(t *testing.T) {
 			tlsConfig: &monitoringv1.TLSConfig{
 				SafeTLSConfig: monitoringv1.SafeTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret-cert",
 							},
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key",
@@ -10783,23 +10783,23 @@ func TestPodMonitorScrapeClassWithDefaultTLS(t *testing.T) {
 			},
 			tlsConfig: &monitoringv1.SafeTLSConfig{
 				CA: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls",
 						},
 						Key: "ca",
 					},
 				},
 				Cert: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls",
 						},
 						Key: "cert",
 					},
 				},
-				KeySecret: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "tls",
 					},
 					Key: "private-key",
@@ -10823,14 +10823,14 @@ func TestPodMonitorScrapeClassWithDefaultTLS(t *testing.T) {
 			},
 			tlsConfig: &monitoringv1.SafeTLSConfig{
 				Cert: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret-cert",
 						},
 					},
 				},
-				KeySecret: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "secret",
 					},
 					Key: "key",
@@ -11065,8 +11065,8 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 				EurekaSDConfigs: []monitoringv1alpha1.EurekaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11076,10 +11076,10 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11103,15 +11103,15 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 					{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -11134,8 +11134,8 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 				EurekaSDConfigs: []monitoringv1alpha1.EurekaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11143,23 +11143,23 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -11173,7 +11173,7 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -11184,7 +11184,7 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11193,7 +11193,7 @@ func TestScrapeConfigSpecConfigWithEurekaSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11246,8 +11246,8 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 				NomadSDConfigs: []monitoringv1alpha1.NomadSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11257,10 +11257,10 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11288,15 +11288,15 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 					{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -11319,8 +11319,8 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 				NomadSDConfigs: []monitoringv1alpha1.NomadSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11328,23 +11328,23 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "key",
@@ -11358,7 +11358,7 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -11369,7 +11369,7 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11378,7 +11378,7 @@ func TestScrapeConfigSpecConfigWithNomadSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11433,8 +11433,8 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						Host: "https://www.example.com",
 						Role: "Nodes",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11444,10 +11444,10 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11478,14 +11478,14 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						Host: "http://www.example.com",
 						Role: "Tasks",
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -11495,10 +11495,10 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11523,15 +11523,15 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						Role: "Nodes",
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -11555,8 +11555,8 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						Host: "acp://www.example.com",
 						Role: "Nodes",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11564,23 +11564,23 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -11593,7 +11593,7 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -11604,7 +11604,7 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11613,7 +11613,7 @@ func TestScrapeConfigSpecConfigWithDockerswarmSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11668,8 +11668,8 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						URL:   "https://www.example.com",
 						Query: "vhost", // This is not a valid PuppetDB query, just a mock.
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11679,10 +11679,10 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11707,14 +11707,14 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						URL:   "http://www.example.com",
 						Query: "vhost", // This is not a valid PuppetDB query, just a mock.
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -11724,10 +11724,10 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11752,15 +11752,15 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						Query: "vhost", // This is not a valid PuppetDB query, just a mock.
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -11784,8 +11784,8 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						URL:   "https://www.example.com",
 						Query: "vhost", // This is not a valid PuppetDB query, just a mock.
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11793,23 +11793,23 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -11822,7 +11822,7 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -11833,7 +11833,7 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11842,7 +11842,7 @@ func TestScrapeConfigSpecConfigWithPuppetDBSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -11896,14 +11896,14 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 					{
 						Region:   ptr.To("us-east-1"),
 						Endpoint: ptr.To("https://lightsail.us-east-1.amazonaws.com/"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "aws-access-api",
 							},
 							Key: "accessKey",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "aws-access-api",
 							},
 							Key: "secretKey",
@@ -11938,8 +11938,8 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						Region:   ptr.To("us-east-1"),
 						Endpoint: ptr.To("https://lightsail.us-east-1.amazonaws.com/"),
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -11949,10 +11949,10 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -11976,14 +11976,14 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						Region:   ptr.To("us-east-1"),
 						Endpoint: ptr.To("https://lightsail.us-east-1.amazonaws.com/"),
 						BasicAuth: &monitoringv1.BasicAuth{
-							Username: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Username: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "username",
 							},
-							Password: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Password: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "foo",
 								},
 								Key: "password",
@@ -11993,10 +11993,10 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -12022,15 +12022,15 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "oauth2",
 									},
 									Key: "client_id",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "oauth2",
 								},
 								Key: "client_secret",
@@ -12055,8 +12055,8 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						Region:   ptr.To("us-east-1"),
 						Endpoint: ptr.To("https://lightsail.us-east-1.amazonaws.com/"),
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -12064,23 +12064,23 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -12094,7 +12094,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -12105,7 +12105,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12114,7 +12114,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12123,7 +12123,7 @@ func TestScrapeConfigSpecConfigWithLightSailSD(t *testing.T) {
 						"client_secret": []byte("client-secret"),
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "aws-access-api",
 						Namespace: "default",
@@ -12178,14 +12178,14 @@ func TestScrapeConfigSpecConfigWithOVHCloudSD(t *testing.T) {
 				OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 					{
 						ApplicationKey: "application-key",
-						ApplicationSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ApplicationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "as",
 						},
-						ConsumerKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConsumerKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "ck",
@@ -12201,7 +12201,7 @@ func TestScrapeConfigSpecConfigWithOVHCloudSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -12255,8 +12255,8 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "SCWABCDEFGH123456789",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "credential",
@@ -12272,10 +12272,10 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -12296,8 +12296,8 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "SCWABCDEFGH123456789",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "credential",
@@ -12306,23 +12306,23 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 						Role:      monitoringv1alpha1.ScalewayRoleInstance,
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -12335,7 +12335,7 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 		}} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -12346,7 +12346,7 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12355,7 +12355,7 @@ func TestScrapeConfigSpecConfigWithScalewaySD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12409,8 +12409,8 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 					{
 						DataCenterID: "11111111-1111-1111-1111-111111111111",
 						Authorization: monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -12420,10 +12420,10 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "proxy-header",
@@ -12447,8 +12447,8 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 					{
 						DataCenterID: "11111111-1111-1111-1111-111111111111",
 						Authorization: monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "credential",
@@ -12456,23 +12456,23 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "tls",
 								},
 								Key: "private-key",
@@ -12486,7 +12486,7 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := assets.NewTestStoreBuilder(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "default",
@@ -12497,7 +12497,7 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 						"credential":   []byte("00000000-0000-0000-0000-000000000000"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12506,7 +12506,7 @@ func TestScrapeConfigSpecConfigWithIonosSD(t *testing.T) {
 						"client_id": "client-id",
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "oauth2",
 						Namespace: "default",
@@ -12862,13 +12862,13 @@ func TestScrapeClassAuthorization(t *testing.T) {
 
 	safeAuthz := &monitoringv1.SafeAuthorization{
 		Type: authType,
-		Credentials: &v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{Name: secretName},
+		Credentials: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
 			Key:                  secretKey,
 		},
 	}
 
-	authzSecret := &v1.Secret{
+	authzSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: secretNamespace,
@@ -13382,10 +13382,10 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "proxy-header",
@@ -13408,23 +13408,23 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",
@@ -13446,23 +13446,23 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",
@@ -13512,7 +13512,7 @@ func TestGenerateAlertmanagerConfig(t *testing.T) {
 				nil,
 				nil,
 				assets.NewTestStoreBuilder(
-					&v1.Secret{
+					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "foo",
 							Namespace: "default",
@@ -13553,23 +13553,23 @@ func TestAlertmanagerTLSConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",
@@ -13594,23 +13594,23 @@ func TestAlertmanagerTLSConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",
@@ -13635,23 +13635,23 @@ func TestAlertmanagerTLSConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",
@@ -13676,23 +13676,23 @@ func TestAlertmanagerTLSConfig(t *testing.T) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "ca",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tls",
 										},
 										Key: "cert",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "tls",
 									},
 									Key: "private-key",

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/blang/semver/v4"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -151,7 +151,7 @@ func selectObjects[T operator.ConfigurationResource](
 			rejected++
 			reason = operator.InvalidConfiguration
 			logger.Warn("skipping object", "error", err.Error(), "object", namespaceAndName)
-			rs.eventRecorder.Eventf(obj, v1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
+			rs.eventRecorder.Eventf(obj, corev1.EventTypeWarning, operator.InvalidConfigurationEvent, selectingConfigurationResourcesAction, "%q was rejected due to invalid configuration: %v", namespaceAndName, err)
 		} else {
 			valid = append(valid, namespaceAndName)
 		}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
@@ -149,10 +149,10 @@ func TestSelectProbes(t *testing.T) {
 					ProxyURL:             ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -169,10 +169,10 @@ func TestSelectProbes(t *testing.T) {
 				ps.ProberSpec.ProxyConfig = monitoringv1.ProxyConfig{
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					ProxyFromEnvironment: ptr.To(true),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -189,10 +189,10 @@ func TestSelectProbes(t *testing.T) {
 				ps.ProberSpec.ProxyConfig = monitoringv1.ProxyConfig{
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(true),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -209,10 +209,10 @@ func TestSelectProbes(t *testing.T) {
 				ps.ProberSpec.ProxyConfig = monitoringv1.ProxyConfig{
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					ProxyFromEnvironment: ptr.To(true),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "invalid_key",
@@ -228,10 +228,10 @@ func TestSelectProbes(t *testing.T) {
 			updateSpec: func(ps *monitoringv1.ProbeSpec) {
 				ps.ProberSpec.ProxyConfig = monitoringv1.ProxyConfig{
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -249,10 +249,10 @@ func TestSelectProbes(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -430,7 +430,7 @@ func TestSelectProbes(t *testing.T) {
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "test",
@@ -709,24 +709,24 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									CA: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
 									},
 									Cert: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "cert",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
 									},
-									KeySecret: &v1.SecretKeySelector{
+									KeySecret: &corev1.SecretKeySelector{
 										Key: "key",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 									},
@@ -747,9 +747,9 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									CA: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
@@ -774,15 +774,15 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									CA: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
-										ConfigMap: &v1.ConfigMapKeySelector{
+										ConfigMap: &corev1.ConfigMapKeySelector{
 											Key: "ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "configmap",
 											},
 										},
@@ -804,9 +804,9 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									CA: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "invalid_ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
@@ -828,9 +828,9 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									Cert: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "cert",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
@@ -851,9 +851,9 @@ func TestSelectServiceMonitors(t *testing.T) {
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
-									KeySecret: &v1.SecretKeySelector{
+									KeySecret: &corev1.SecretKeySelector{
 										Key: "key",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 									},
@@ -874,16 +874,16 @@ func TestSelectServiceMonitors(t *testing.T) {
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									Cert: monitoringv1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "invalid_ca",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "secret",
 											},
 										},
 									},
-									KeySecret: &v1.SecretKeySelector{
+									KeySecret: &corev1.SecretKeySelector{
 										Key: "key",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 									},
@@ -904,10 +904,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -929,10 +929,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "invalid_key",
@@ -954,10 +954,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -978,10 +978,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1002,10 +1002,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1024,10 +1024,10 @@ func TestSelectServiceMonitors(t *testing.T) {
 				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						ProxyConfig: monitoringv1.ProxyConfig{
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1107,7 +1107,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "test",
@@ -1120,7 +1120,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 						"key1":       []byte("val1"),
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "configmap",
 						Namespace: "test",
@@ -1297,10 +1297,10 @@ func TestSelectPodMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1322,10 +1322,10 @@ func TestSelectPodMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "invalid_key",
@@ -1347,10 +1347,10 @@ func TestSelectPodMonitors(t *testing.T) {
 							ProxyURL:             ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1371,10 +1371,10 @@ func TestSelectPodMonitors(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1395,10 +1395,10 @@ func TestSelectPodMonitors(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1417,10 +1417,10 @@ func TestSelectPodMonitors(t *testing.T) {
 				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
 					HTTPConfigWithProxy: monitoringv1.HTTPConfigWithProxy{
 						ProxyConfig: monitoringv1.ProxyConfig{
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1500,7 +1500,7 @@ func TestSelectPodMonitors(t *testing.T) {
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "test",
@@ -1669,10 +1669,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1687,10 +1687,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			scenario: "invalid proxy config with proxyConnectHeaders but no proxyUrl defined or proxyFromEnvironment set to true",
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.ProxyConfig = monitoringv1.ProxyConfig{
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1707,10 +1707,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ProxyConfig = monitoringv1.ProxyConfig{
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					ProxyFromEnvironment: ptr.To(true),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1727,10 +1727,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ProxyConfig = monitoringv1.ProxyConfig{
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(true),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1748,16 +1748,16 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "invalid-key",
@@ -1784,22 +1784,22 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
 							},
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1817,10 +1817,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					ProxyURL:             ptr.To("http://no-proxy.com"),
 					NoProxy:              ptr.To("0.0.0.0"),
 					ProxyFromEnvironment: ptr.To(false),
-					ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+					ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 						"header": {
 							{
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "invalid-key",
@@ -1875,10 +1875,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1901,10 +1901,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -1925,8 +1925,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						URL: "http://example.com",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -1945,8 +1945,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						URL: "http://example.com",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -1967,10 +1967,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "invalid-key",
@@ -1991,8 +1991,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						URL: "http://example.com",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -2011,8 +2011,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -2030,8 +2030,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -2050,24 +2050,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -2085,9 +2085,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Role: monitoringv1alpha1.KubernetesRoleNode,
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -2108,10 +2108,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -2133,10 +2133,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -2346,8 +2346,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{
 					{
 						Server: "example.com",
-						TokenRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						TokenRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -2363,8 +2363,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{
 					{
 						Server: "example.com",
-						TokenRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						TokenRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong",
 							},
 							Key: "key1",
@@ -2417,8 +2417,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{
 					{
 						Server: "example.com",
-						TokenRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						TokenRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -2429,10 +2429,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "foo",
 										},
 										Key: "invalid-key",
@@ -2453,24 +2453,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "server",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -2488,9 +2488,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "server",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -2509,24 +2509,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "server",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -2544,9 +2544,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "server",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -2659,14 +2659,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key2",
@@ -2693,14 +2693,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.EC2SDConfigs = []monitoringv1alpha1.EC2SDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong",
 							},
 							Key: "key2",
@@ -2718,24 +2718,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Region: ptr.To("us-east-1"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -2753,24 +2753,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Region: ptr.To("us-east-1"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -2791,9 +2791,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Region: ptr.To("us-east-1"),
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -2814,10 +2814,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -2838,8 +2838,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TenantID: ptr.To("BBBB222B-B2B2-2B22-B222-2BB2222BB2B2"),
 						ClientID: ptr.To("333333CC-3C33-3333-CCC3-33C3CCCCC33C"),
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -2869,8 +2869,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeOAuth),
 						ClientID:             ptr.To("333333CC-3C33-3333-CCC3-33C3CCCCC33C"),
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -2887,8 +2887,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						AuthenticationMethod: ptr.To(monitoringv1alpha1.AuthMethodTypeOAuth),
 						TenantID:             ptr.To("BBBB222B-B2B2-2B22-B222-2BB2222BB2B2"),
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -2967,32 +2967,32 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						SubscriptionID: "11111111-1111-1111-1111-111111111111",
 						TenantID:       ptr.To("BBBB222B-B2B2-2B22-B222-2BB2222BB2B2"),
 						ClientID:       ptr.To("333333CC-3C33-3333-CCC3-33C3CCCCC33C"),
-						ClientSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ClientSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3009,9 +3009,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3029,14 +3029,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Role:   monitoringv1alpha1.OpenStackRoleInstance,
 						Region: "RegionOne",
-						Password: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Password: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						ApplicationCredentialSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ApplicationCredentialSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key2",
@@ -3051,8 +3051,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.OpenStackSDConfigs = []monitoringv1alpha1.OpenStackSDConfig{
 					{
-						Password: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Password: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "invalid",
 							},
 							Key: "key1",
@@ -3067,8 +3067,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.OpenStackSDConfigs = []monitoringv1alpha1.OpenStackSDConfig{
 					{
-						ApplicationCredentialSecret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ApplicationCredentialSecret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key3",
@@ -3123,24 +3123,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3158,9 +3158,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3178,8 +3178,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.DigitalOceanSDConfigs = []monitoringv1alpha1.DigitalOceanSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -3199,24 +3199,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "http://example.com",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3234,9 +3234,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Server: "http://example.com",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3268,10 +3268,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3291,8 +3291,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Server: "http://example.com",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3310,24 +3310,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3344,9 +3344,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3366,10 +3366,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3388,8 +3388,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.EurekaSDConfigs = []monitoringv1alpha1.EurekaSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3409,24 +3409,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Host: "hostAddress",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3444,9 +3444,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Host: "hostAddress",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3464,8 +3464,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Host: "hostAddress",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -3483,8 +3483,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Host: "hostAddress",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3502,24 +3502,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3536,9 +3536,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3555,8 +3555,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LinodeSDConfigs = []monitoringv1alpha1.LinodeSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -3573,8 +3573,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LinodeSDConfigs = []monitoringv1alpha1.LinodeSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3592,8 +3592,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Role: "hcloud",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key1",
@@ -3611,8 +3611,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						Role: "hcloud",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3631,24 +3631,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Role: "hcloud",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3666,9 +3666,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						Role: "hcloud",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3689,10 +3689,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3714,10 +3714,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3737,24 +3737,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3771,9 +3771,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3793,10 +3793,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3815,8 +3815,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.NomadSDConfigs = []monitoringv1alpha1.NomadSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3834,24 +3834,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3868,9 +3868,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3890,10 +3890,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -3912,8 +3912,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.DockerSwarmSDConfigs = []monitoringv1alpha1.DockerSwarmSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -3932,24 +3932,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						URL: "https://example.com",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -3967,9 +3967,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						URL: "https://example.com",
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -3990,10 +3990,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4013,8 +4013,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						URL: "https://example.com",
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -4043,24 +4043,24 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "cert",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
+							KeySecret: &corev1.SecretKeySelector{
 								Key: "key",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 							},
@@ -4077,9 +4077,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -4100,10 +4100,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4124,10 +4124,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4146,8 +4146,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LightSailSDConfigs = []monitoringv1alpha1.LightSailSDConfig{
 					{
 						Authorization: &monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -4165,14 +4165,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LightSailSDConfigs = []monitoringv1alpha1.LightSailSDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key2",
@@ -4199,14 +4199,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LightSailSDConfigs = []monitoringv1alpha1.LightSailSDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong",
 							},
 							Key: "key1",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key2",
@@ -4222,14 +4222,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.LightSailSDConfigs = []monitoringv1alpha1.LightSailSDConfig{
 					{
 						Region: ptr.To("us-east-1"),
-						AccessKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						AccessKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						SecretKey: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong",
 							},
 							Key: "key2",
@@ -4245,14 +4245,14 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.OVHCloudSDConfigs = []monitoringv1alpha1.OVHCloudSDConfig{
 					{
 						ApplicationKey: "ApplicationKey",
-						ApplicationSecret: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ApplicationSecret: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
 						},
-						ConsumerKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConsumerKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key2",
@@ -4270,8 +4270,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ScalewaySDConfigs = []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "AccessKey",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key1",
@@ -4295,8 +4295,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.ScalewaySDConfigs = []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "AccessKey",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "wrong",
 							},
 							Key: "key1",
@@ -4316,10 +4316,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4339,9 +4339,9 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
+								Secret: &corev1.SecretKeySelector{
 									Key: "invalid_ca",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 								},
@@ -4359,23 +4359,23 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 									Key: "ca",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 									Key: "cert",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "secret",
 								},
 								Key: "key",
@@ -4393,8 +4393,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 					{
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
 									},
 									Key: "invalid-ca",
@@ -4415,10 +4415,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							NoProxy:              ptr.To("0.0.0.0"),
 							ProxyFromEnvironment: ptr.To(false),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4439,10 +4439,10 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						ProxyConfig: monitoringv1.ProxyConfig{
 							ProxyURL:             ptr.To("http://no-proxy.com"),
 							ProxyFromEnvironment: ptr.To(true),
-							ProxyConnectHeader: map[string][]v1.SecretKeySelector{
+							ProxyConnectHeader: map[string][]corev1.SecretKeySelector{
 								"header": {
 									{
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "secret",
 										},
 										Key: "key1",
@@ -4461,8 +4461,8 @@ func TestSelectScrapeConfigs(t *testing.T) {
 				sc.IonosSDConfigs = []monitoringv1alpha1.IonosSDConfig{
 					{
 						Authorization: monitoringv1.SafeAuthorization{
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "wrong",
 								},
 								Key: "key1",
@@ -4502,7 +4502,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret",
 						Namespace: "test",
@@ -4516,7 +4516,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 						"key":        key,
 					},
 				},
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "configmap",
 						Namespace: "test",
@@ -4586,7 +4586,7 @@ func TestSelectScrapeConfigs(t *testing.T) {
 
 func TestSelectPodMonitorsWithInvalidAuthentication(t *testing.T) {
 	storeBuilder := assets.NewTestStoreBuilder(
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "default",
@@ -4596,8 +4596,8 @@ func TestSelectPodMonitorsWithInvalidAuthentication(t *testing.T) {
 			},
 		},
 	)
-	secretKey := v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	secretKey := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "foo",
 		},
 		Key: "secret",

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mitchellh/hashstructure"
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -343,7 +343,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 				options.LabelSelector = c.ConfigMapListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceConfigMaps)),
 		informers.PartialObjectMetadataStrip(operator.ConfigMapGVK()),
 	)
 	if err != nil {
@@ -361,7 +361,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 				options.LabelSelector = c.SecretListWatchLabelSelector.String()
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceSecrets)),
 		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
 	)
 	if err != nil {
@@ -401,7 +401,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		o.logger.Debug("creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
-			&v1.Namespace{}, resyncPeriod, cache.Indexers{},
+			&corev1.Namespace{}, resyncPeriod, cache.Indexers{},
 		), nil
 	}
 
@@ -664,7 +664,7 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		)
 		return
 	}
-	ns := nsObject.(*v1.Namespace)
+	ns := nsObject.(*corev1.Namespace)
 
 	err = c.promInfs.ListAll(labels.Everything(), func(obj any) {
 		// Check for Prometheus instances in the namespace.
@@ -761,8 +761,8 @@ func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 }
 
 func (c *Operator) handleMonitorNamespaceUpdate(oldo, curo any) {
-	old := oldo.(*v1.Namespace)
-	cur := curo.(*v1.Namespace)
+	old := oldo.(*corev1.Namespace)
+	cur := curo.(*corev1.Namespace)
 
 	c.logger.Debug("update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
@@ -930,7 +930,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		)
 
 		if p.Spec.Thanos != nil {
-			svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
+			svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
 				Name:       "grpc",
 				Port:       10901,
 				TargetPort: intstr.FromString("grpc"),
@@ -1495,7 +1495,7 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitor
 		return fmt.Errorf("failed to initialize web config: %w", err)
 	}
 
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	operator.UpdateObject(
 		s,
 		operator.WithLabels(c.config.Labels),

--- a/pkg/prometheus/server/operator_test.go
+++ b/pkg/prometheus/server/operator_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -49,9 +49,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						Version: "v1.7.0",
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceMemory: resource.MustParse("200Mi"),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
 						},
 					},
@@ -64,9 +64,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						Version: "v1.7.0",
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceMemory: resource.MustParse("100Mi"),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
 							},
 						},
 					},
@@ -82,9 +82,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						Version: "v1.7.0",
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceMemory: resource.MustParse("200Mi"),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
 						},
 					},
@@ -94,9 +94,9 @@ func TestCreateStatefulSetInputHash(t *testing.T) {
 				Spec: monitoringv1.PrometheusSpec{
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						Version: "v1.7.0",
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceMemory: resource.MustParse("100Mi"),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
 							},
 						},
 					},

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -91,25 +91,25 @@ func makeStatefulSet(
 	storageSpec := cpf.Storage
 	switch {
 	case storageSpec == nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 
 	case storageSpec.EmptyDir != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				EmptyDir: storageSpec.EmptyDir,
 			},
 		})
 
 	case storageSpec.Ephemeral != nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: prompkg.VolumeName(p),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				Ephemeral: storageSpec.Ephemeral,
 			},
 		})
@@ -120,7 +120,7 @@ func makeStatefulSet(
 			pvcTemplate.Name = prompkg.VolumeName(p)
 		}
 		if storageSpec.VolumeClaimTemplate.Spec.AccessModes == nil {
-			pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+			pvcTemplate.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
@@ -215,7 +215,7 @@ func makeStatefulSetSpec(
 	finalSelectorLabels := c.Labels.Merge(podSelectorLabels)
 	finalLabels := c.Labels.Merge(podLabels)
 
-	var additionalContainers, operatorInitContainers []v1.Container
+	var additionalContainers, operatorInitContainers []corev1.Container
 
 	thanosContainer, thanosVolumes, err := createThanosContainer(p, c)
 	if err != nil {
@@ -252,7 +252,7 @@ func makeStatefulSetSpec(
 	if len(ruleConfigMapNames) != 0 {
 		for _, name := range ruleConfigMapNames {
 			mountPath := prompkg.RulesDir + "/" + name
-			configReloaderVolumeMounts = append(configReloaderVolumeMounts, v1.VolumeMount{
+			configReloaderVolumeMounts = append(configReloaderVolumeMounts, corev1.VolumeMount{
 				Name:      name,
 				MountPath: mountPath,
 			})
@@ -281,13 +281,13 @@ func makeStatefulSetSpec(
 		return nil, err
 	}
 
-	var envVars []v1.EnvVar
+	var envVars []corev1.EnvVar
 	// For higher Prometheus version its set with runtime field in configuration
 	if p.Spec.Runtime != nil && p.Spec.Runtime.GoGC != nil && !cg.WithMinimumVersion("2.53.0").IsCompatible() {
-		envVars = append(envVars, v1.EnvVar{Name: "GOGC", Value: fmt.Sprintf("%d", *p.Spec.Runtime.GoGC)})
+		envVars = append(envVars, corev1.EnvVar{Name: "GOGC", Value: fmt.Sprintf("%d", *p.Spec.Runtime.GoGC)})
 	}
 
-	operatorContainers := append([]v1.Container{
+	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "prometheus",
 			Image:                    pImagePath,
@@ -300,12 +300,12 @@ func makeStatefulSetSpec(
 			LivenessProbe:            livenessProbe,
 			ReadinessProbe:           readinessProbe,
 			Resources:                cpf.Resources,
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			SecurityContext: &v1.SecurityContext{
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &corev1.SecurityContext{
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
 				},
 			},
 		},
@@ -340,12 +340,12 @@ func makeStatefulSetSpec(
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalSelectorLabels,
 		},
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,
 				Annotations: podAnnotations,
 			},
-			Spec: v1.PodSpec{
+			Spec: corev1.PodSpec{
 				ShareProcessNamespace:         prompkg.ShareProcessNamespace(p),
 				Containers:                    containers,
 				InitContainers:                initContainers,
@@ -368,7 +368,7 @@ func makeStatefulSetSpec(
 	}
 
 	if cpf.HostNetwork {
-		spec.Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+		spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	k8s.UpdateDNSPolicy(&spec.Template.Spec, cpf.DNSPolicy)
 	k8s.UpdateDNSConfig(&spec.Template.Spec, cpf.DNSConfig)
@@ -457,18 +457,18 @@ func buildServerArgs(cg *prompkg.ConfigGenerator, p *monitoringv1.Prometheus) []
 }
 
 // appendServerVolumes returns a set of volumes to be mounted on the statefulset spec that are specific to Prometheus Server.
-func appendServerVolumes(p *monitoringv1.Prometheus, volumes []v1.Volume, volumeMounts []v1.VolumeMount, ruleConfigMapNames []string) ([]v1.Volume, []v1.VolumeMount) {
+func appendServerVolumes(p *monitoringv1.Prometheus, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, ruleConfigMapNames []string) ([]corev1.Volume, []corev1.VolumeMount) {
 	// not mount 2 emptyDir volumes at the same mountpath
 	if volume, ok := queryLogFileVolume(p.Spec.QueryLogFile); ok && p.Spec.ScrapeFailureLogFile == nil {
 		volumes = append(volumes, volume)
 	}
 
 	for _, name := range ruleConfigMapNames {
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
 					Optional: ptr.To(true),
@@ -478,7 +478,7 @@ func appendServerVolumes(p *monitoringv1.Prometheus, volumes []v1.Volume, volume
 	}
 
 	for _, name := range ruleConfigMapNames {
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      name,
 			MountPath: prompkg.RulesDir + "/" + name,
 			ReadOnly:  true,
@@ -493,13 +493,13 @@ func appendServerVolumes(p *monitoringv1.Prometheus, volumes []v1.Volume, volume
 	return volumes, volumeMounts
 }
 
-func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Container, []v1.Volume, error) {
+func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*corev1.Container, []corev1.Volume, error) {
 	if p.Spec.Thanos == nil {
 		return nil, nil, nil
 	}
 
 	var (
-		container *v1.Container
+		container *corev1.Container
 		cpf       = p.GetCommonPrometheusFields()
 		thanos    = p.Spec.Thanos
 	)
@@ -545,19 +545,19 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 		}
 	}
 
-	container = &v1.Container{
+	container = &corev1.Container{
 		Name:                     "thanos-sidecar",
 		Image:                    thanosImage,
 		ImagePullPolicy:          cpf.ImagePullPolicy,
-		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-		SecurityContext: &v1.SecurityContext{
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 			ReadOnlyRootFilesystem:   ptr.To(true),
-			Capabilities: &v1.Capabilities{
-				Drop: []v1.Capability{"ALL"},
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
 			},
 		},
-		Ports: []v1.ContainerPort{
+		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",
 				ContainerPort: 10902,
@@ -571,7 +571,7 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 	}
 
 	for _, thanosSideCarVM := range thanos.VolumeMounts {
-		container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      thanosSideCarVM.Name,
 			MountPath: thanosSideCarVM.MountPath,
 		})
@@ -582,9 +582,9 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config-file", Value: *thanos.ObjectStorageConfigFile})
 		} else {
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "objstore.config", Value: "$(OBJSTORE_CONFIG)"})
-			container.Env = append(container.Env, v1.EnvVar{
+			container.Env = append(container.Env, corev1.EnvVar{
 				Name: "OBJSTORE_CONFIG",
-				ValueFrom: &v1.EnvVarSource{
+				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: thanos.ObjectStorageConfig,
 				},
 			})
@@ -594,7 +594,7 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 		thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tsdb.path", Value: prompkg.StorageDir})
 		container.VolumeMounts = append(
 			container.VolumeMounts,
-			v1.VolumeMount{
+			corev1.VolumeMount{
 				Name:      volName,
 				MountPath: prompkg.StorageDir,
 				SubPath:   prompkg.SubPathForStorage(cpf.Storage),
@@ -607,9 +607,9 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config-file", Value: thanos.TracingConfigFile})
 		} else {
 			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "tracing.config", Value: "$(TRACING_CONFIG)"})
-			container.Env = append(container.Env, v1.EnvVar{
+			container.Env = append(container.Env, corev1.EnvVar{
 				Name: "TRACING_CONFIG",
-				ValueFrom: &v1.EnvVarSource{
+				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: thanos.TracingConfig,
 				},
 			})
@@ -649,20 +649,20 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 
 	// set prometheus.http-client-config
 	// ref: https://thanos.io/tip/components/sidecar.md/#prometheus-http-client
-	var volumes []v1.Volume
+	var volumes []corev1.Volume
 	if thanosVersion.GTE(semver.MustParse(thanosSupportedVersionHTTPClientFlag)) {
 		thanosArgs = append(thanosArgs, monitoringv1.Argument{
 			Name:  "prometheus.http-client-file",
 			Value: filepath.Join(thanosConfigDir, thanosPrometheusHTTPClientConfigFileName),
 		})
-		container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      thanosPrometheusHTTPClientConfigSecretNameSuffix,
 			MountPath: thanosConfigDir,
 		})
-		volumes = append(volumes, v1.Volume{
+		volumes = append(volumes, corev1.Volume{
 			Name: thanosPrometheusHTTPClientConfigSecretNameSuffix,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: thanosPrometheusHTTPClientConfigSecretName(p),
 				},
 			},
@@ -678,27 +678,27 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*v1.Co
 	return container, volumes, nil
 }
 
-func queryLogFileVolumeMount(queryLogFile string) (v1.VolumeMount, bool) {
+func queryLogFileVolumeMount(queryLogFile string) (corev1.VolumeMount, bool) {
 	if !prompkg.UsesDefaultFileVolume(queryLogFile) {
-		return v1.VolumeMount{}, false
+		return corev1.VolumeMount{}, false
 	}
 
-	return v1.VolumeMount{
+	return corev1.VolumeMount{
 		Name:      prompkg.DefaultLogFileVolume,
 		ReadOnly:  false,
 		MountPath: prompkg.DefaultLogDirectory,
 	}, true
 }
 
-func queryLogFileVolume(queryLogFile string) (v1.Volume, bool) {
+func queryLogFileVolume(queryLogFile string) (corev1.Volume, bool) {
 	if !prompkg.UsesDefaultFileVolume(queryLogFile) {
-		return v1.Volume{}, false
+		return corev1.Volume{}, false
 	}
 
-	return v1.Volume{
+	return corev1.Volume{
 		Name: prompkg.DefaultLogFileVolume,
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{},
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}, true
 }

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -180,8 +180,8 @@ func TestStatefulSetPVC(t *testing.T) {
 		EmbeddedObjectMetadata: monitoringv1.EmbeddedObjectMetadata{
 			Annotations: annotations,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			StorageClassName: &storageClass,
 		},
 	}
@@ -213,8 +213,8 @@ func TestStatefulSetEmptyDir(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	emptyDir := v1.EmptyDirVolumeSource{
-		Medium: v1.StorageMediumMemory,
+	emptyDir := corev1.EmptyDirVolumeSource{
+		Medium: corev1.StorageMediumMemory,
 	}
 
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
@@ -247,10 +247,10 @@ func TestStatefulSetEphemeral(t *testing.T) {
 
 	storageClass := "storageclass"
 
-	ephemeral := v1.EphemeralVolumeSource{
-		VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
-			Spec: v1.PersistentVolumeClaimSpec{
-				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+	ephemeral := corev1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				StorageClassName: &storageClass,
 			},
 		},
@@ -292,11 +292,11 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 
 	expected := &appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
-			Template: v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config-out",
 									ReadOnly:  true,
@@ -331,23 +331,23 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 							},
 						},
 					},
-					Volumes: []v1.Volume{
+					Volumes: []corev1.Volume{
 						{
 							Name: "config",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: prompkg.ConfigSecretName(&p),
 								},
 							},
 						},
 						{
 							Name: "tls-assets",
-							VolumeSource: v1.VolumeSource{
-								Projected: &v1.ProjectedVolumeSource{
-									Sources: []v1.VolumeProjection{
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
 										{
-											Secret: &v1.SecretProjection{
-												LocalObjectReference: v1.LocalObjectReference{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
 													Name: prompkg.TLSAssetsSecretName(&p) + "-0",
 												},
 											},
@@ -358,25 +358,25 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 						},
 						{
 							Name: "config-out",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{
-									Medium: v1.StorageMediumMemory,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
 								},
 							},
 						},
 						{
 							Name: "secret-test-secret1",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "test-secret1",
 								},
 							},
 						},
 						{
 							Name: "rules-configmap-one",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "rules-configmap-one",
 									},
 									Optional: ptr.To(true),
@@ -385,16 +385,16 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 						},
 						{
 							Name: "web-config",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "prometheus-volume-init-test-web-config",
 								},
 							},
 						},
 						{
 							Name: "prometheus-volume-init-test-db",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -412,7 +412,7 @@ func TestStatefulSetVolumeInitial(t *testing.T) {
 		context.Background(),
 		map[string][]byte{},
 		fake.NewSimpleClientset(),
-		&v1.Secret{
+		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      prompkg.TLSAssetsSecretName(&p),
 				Namespace: "test",
@@ -482,9 +482,9 @@ func TestListenLocal(t *testing.T) {
 
 	require.True(t, found, "Prometheus not listening on loopback when it should.")
 
-	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
-		return v1.ProbeHandler{
-			Exec: &v1.ExecAction{
+	expectedProbeHandler := func(probePath string) corev1.ProbeHandler {
+		return corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
 				Command: []string{
 					`sh`,
 					`-c`,
@@ -495,7 +495,7 @@ func TestListenLocal(t *testing.T) {
 	}
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
-	expectedStartupProbe := &v1.Probe{
+	expectedStartupProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
@@ -504,7 +504,7 @@ func TestListenLocal(t *testing.T) {
 	require.Equal(t, expectedStartupProbe, actualStartupProbe, "Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
-	expectedLivenessProbe := &v1.Probe{
+	expectedLivenessProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
@@ -513,7 +513,7 @@ func TestListenLocal(t *testing.T) {
 	require.Equal(t, expectedLivenessProbe, actualLivenessProbe, "Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
-	expectedReadinessProbe := &v1.Probe{
+	expectedReadinessProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
@@ -531,14 +531,14 @@ func TestListenTLS(t *testing.T) {
 				Web: &monitoringv1.PrometheusWebSpec{
 					WebConfigFileFields: monitoringv1.WebConfigFileFields{
 						TLSConfig: &monitoringv1.WebTLSConfig{
-							KeySecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "some-secret",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "some-configmap",
 									},
 								},
@@ -552,9 +552,9 @@ func TestListenTLS(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	expectedProbeHandler := func(probePath string) v1.ProbeHandler {
-		return v1.ProbeHandler{
-			HTTPGet: &v1.HTTPGetAction{
+	expectedProbeHandler := func(probePath string) corev1.ProbeHandler {
+		return corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
 				Path:   probePath,
 				Port:   intstr.FromString("web"),
 				Scheme: "HTTPS",
@@ -563,7 +563,7 @@ func TestListenTLS(t *testing.T) {
 	}
 
 	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
-	expectedStartupProbe := &v1.Probe{
+	expectedStartupProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
@@ -572,7 +572,7 @@ func TestListenTLS(t *testing.T) {
 	require.Equal(t, expectedStartupProbe, actualStartupProbe, "Startup probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedStartupProbe, actualStartupProbe)
 
 	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
-	expectedLivenessProbe := &v1.Probe{
+	expectedLivenessProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
@@ -581,7 +581,7 @@ func TestListenTLS(t *testing.T) {
 	require.Equal(t, expectedLivenessProbe, actualLivenessProbe, "Liveness probe doesn't match expected. \n\nExpected: %+v\n\nGot: %+v", expectedLivenessProbe, actualLivenessProbe)
 
 	actualReadinessProbe := sset.Spec.Template.Spec.Containers[0].ReadinessProbe
-	expectedReadinessProbe := &v1.Probe{
+	expectedReadinessProbe := &corev1.Probe{
 		ProbeHandler:     expectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
@@ -947,14 +947,14 @@ func TestThanosResourcesNotSet(t *testing.T) {
 }
 
 func TestThanosResourcesSet(t *testing.T) {
-	expected := v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("125m"),
-			v1.ResourceMemory: resource.MustParse("75Mi"),
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("125m"),
+			corev1.ResourceMemory: resource.MustParse("75Mi"),
 		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("50Mi"),
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
 		},
 	}
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
@@ -996,7 +996,7 @@ func TestThanosObjectStorage(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
-				ObjectStorageConfig: &v1.SecretKeySelector{
+				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
 				},
 				BlockDuration: "2h",
@@ -1123,7 +1123,7 @@ func TestThanosBlockDuration(t *testing.T) {
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
 				BlockDuration: "1h",
-				ObjectStorageConfig: &v1.SecretKeySelector{
+				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
 				},
 			},
@@ -1148,8 +1148,8 @@ func TestThanosWithNamedPVC(t *testing.T) {
 		EmbeddedObjectMetadata: monitoringv1.EmbeddedObjectMetadata{
 			Name: testKey,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			StorageClassName: &storageClass,
 		},
 	}
@@ -1163,7 +1163,7 @@ func TestThanosWithNamedPVC(t *testing.T) {
 			},
 			Thanos: &monitoringv1.ThanosSpec{
 				BlockDuration: "1h",
-				ObjectStorageConfig: &v1.SecretKeySelector{
+				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
 				},
 			},
@@ -1190,7 +1190,7 @@ func TestThanosTracing(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
-				TracingConfig: &v1.SecretKeySelector{
+				TracingConfig: &corev1.SecretKeySelector{
 					Key: testKey,
 				},
 			},
@@ -1224,17 +1224,17 @@ func TestThanosSideCarVolumes(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Volumes: []v1.Volume{
+				Volumes: []corev1.Volume{
 					{
 						Name: testVolume,
-						VolumeSource: v1.VolumeSource{
-							EmptyDir: &v1.EmptyDirVolumeSource{},
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
 				},
 			},
 			Thanos: &monitoringv1.ThanosSpec{
-				VolumeMounts: []v1.VolumeMount{
+				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      testVolume,
 						MountPath: testVolumeMountPath,
@@ -1416,7 +1416,7 @@ func TestAdditionalContainers(t *testing.T) {
 	addSset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Containers: []v1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "extra-container",
 					},
@@ -1434,7 +1434,7 @@ func TestAdditionalContainers(t *testing.T) {
 	modSset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Containers: []v1.Container{
+				Containers: []corev1.Container{
 					{
 						Name:  existingContainerName,
 						Image: containerImage,
@@ -1644,7 +1644,7 @@ func TestTerminationPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, c := range sset.Spec.Template.Spec.Containers {
-		require.Equal(t, v1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy, "Unexpected TermintationMessagePolicy. Expected %v got %v", v1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy)
+		require.Equal(t, corev1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy, "Unexpected TermintationMessagePolicy. Expected %v got %v", corev1.TerminationMessageFallbackToLogsOnError, c.TerminationMessagePolicy)
 	}
 }
 
@@ -2205,28 +2205,28 @@ func TestPodTemplateConfig(t *testing.T) {
 	nodeSelector := map[string]string{
 		"foo": "bar",
 	}
-	affinity := v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{},
-		PodAffinity: &v1.PodAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+	affinity := corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+		PodAffinity: &corev1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
-					PodAffinityTerm: v1.PodAffinityTerm{
+					PodAffinityTerm: corev1.PodAffinityTerm{
 						Namespaces: []string{"foo"},
 					},
 					Weight: 100,
 				},
 			},
 		},
-		PodAntiAffinity: &v1.PodAntiAffinity{},
+		PodAntiAffinity: &corev1.PodAntiAffinity{},
 	}
 
-	tolerations := []v1.Toleration{
+	tolerations := []corev1.Toleration{
 		{
 			Key: "key",
 		},
 	}
 	userid := int64(1234)
-	securityContext := v1.PodSecurityContext{
+	securityContext := corev1.PodSecurityContext{
 		RunAsUser: &userid,
 	}
 	priorityClassName := "foo"
@@ -2237,8 +2237,8 @@ func TestPodTemplateConfig(t *testing.T) {
 			IP:        "1.1.1.1",
 		},
 	}
-	imagePullPolicy := v1.PullAlways
-	imagePullSecrets := []v1.LocalObjectReference{
+	imagePullPolicy := corev1.PullAlways
+	imagePullSecrets := []corev1.LocalObjectReference{
 		{
 			Name: "registry-secret",
 		},
@@ -2771,7 +2771,7 @@ func TestPodHostNetworkConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, hostNetwork, sset.Spec.Template.Spec.HostNetwork, "expected hostNetwork configuration to match but failed")
-	require.Equal(t, v1.DNSClusterFirstWithHostNet, sset.Spec.Template.Spec.DNSPolicy, "expected DNSPolicy configuration to match due to hostNetwork but failed")
+	require.Equal(t, corev1.DNSClusterFirstWithHostNet, sset.Spec.Template.Spec.DNSPolicy, "expected DNSPolicy configuration to match due to hostNetwork but failed")
 }
 
 func TestPersistentVolumeClaimRetentionPolicy(t *testing.T) {
@@ -2796,7 +2796,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		spec monitoringv1.PrometheusSpec
-		tsc  v1.TopologySpreadConstraint
+		tsc  corev1.TopologySpreadConstraint
 	}{
 		{
 			name: "without labelSelector and additionalLabels",
@@ -2807,16 +2807,16 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 							},
 						},
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 			},
 		},
 		{
@@ -2828,7 +2828,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"app": "prometheus",
@@ -2839,10 +2839,10 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app": "prometheus",
@@ -2860,7 +2860,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"app": "prometheus",
@@ -2871,10 +2871,10 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app":                            "prometheus",
@@ -2898,7 +2898,7 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 							CoreV1TopologySpreadConstraint: monitoringv1.CoreV1TopologySpreadConstraint{
 								MaxSkew:           1,
 								TopologyKey:       "kubernetes.io/hostname",
-								WhenUnsatisfiable: v1.DoNotSchedule,
+								WhenUnsatisfiable: corev1.DoNotSchedule,
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"app": "prometheus",
@@ -2909,10 +2909,10 @@ func TestPodTopologySpreadConstraintWithAdditionalLabels(t *testing.T) {
 					},
 				},
 			},
-			tsc: v1.TopologySpreadConstraint{
+			tsc: corev1.TopologySpreadConstraint{
 				MaxSkew:           1,
 				TopologyKey:       "kubernetes.io/hostname",
-				WhenUnsatisfiable: v1.DoNotSchedule,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app":                            "prometheus",
@@ -3088,46 +3088,46 @@ func TestAutomountServiceAccountToken(t *testing.T) {
 func TestDNSPolicyAndDNSConfig(t *testing.T) {
 	tests := []struct {
 		name              string
-		dnsPolicy         v1.DNSPolicy
-		dnsConfig         *v1.PodDNSConfig
-		expectedDNSPolicy v1.DNSPolicy
-		expectedDNSConfig *v1.PodDNSConfig
+		dnsPolicy         corev1.DNSPolicy
+		dnsConfig         *corev1.PodDNSConfig
+		expectedDNSPolicy corev1.DNSPolicy
+		expectedDNSConfig *corev1.PodDNSConfig
 	}{
 		{
 			name:              "Default DNSPolicy and DNSConfig",
-			dnsPolicy:         v1.DNSClusterFirst,
+			dnsPolicy:         corev1.DNSClusterFirst,
 			dnsConfig:         nil,
-			expectedDNSPolicy: v1.DNSClusterFirst,
+			expectedDNSPolicy: corev1.DNSClusterFirst,
 			expectedDNSConfig: nil,
 		},
 		{
 			name:              "Custom DNSPolicy",
-			dnsPolicy:         v1.DNSDefault,
+			dnsPolicy:         corev1.DNSDefault,
 			dnsConfig:         nil,
-			expectedDNSPolicy: v1.DNSDefault,
+			expectedDNSPolicy: corev1.DNSDefault,
 			expectedDNSConfig: nil,
 		},
 		{
 			name:      "Custom DNSConfig",
-			dnsPolicy: v1.DNSClusterFirst,
-			dnsConfig: &v1.PodDNSConfig{
+			dnsPolicy: corev1.DNSClusterFirst,
+			dnsConfig: &corev1.PodDNSConfig{
 				Nameservers: []string{"8.8.8.8", "8.8.4.4"},
 				Searches:    []string{"custom.svc.cluster.local"},
 			},
-			expectedDNSPolicy: v1.DNSClusterFirst,
-			expectedDNSConfig: &v1.PodDNSConfig{
+			expectedDNSPolicy: corev1.DNSClusterFirst,
+			expectedDNSConfig: &corev1.PodDNSConfig{
 				Nameservers: []string{"8.8.8.8", "8.8.4.4"},
 				Searches:    []string{"custom.svc.cluster.local"},
 			},
 		},
 		{
 			name:      "Custom DNS Policy with Search Domains",
-			dnsPolicy: v1.DNSDefault,
-			dnsConfig: &v1.PodDNSConfig{
+			dnsPolicy: corev1.DNSDefault,
+			dnsConfig: &corev1.PodDNSConfig{
 				Searches: []string{"kitsos.com", "kitsos.org"},
 			},
-			expectedDNSPolicy: v1.DNSDefault,
-			expectedDNSConfig: &v1.PodDNSConfig{
+			expectedDNSPolicy: corev1.DNSDefault,
+			expectedDNSConfig: &corev1.PodDNSConfig{
 				Searches: []string{"kitsos.com", "kitsos.org"},
 			},
 		},

--- a/pkg/prometheus/server/thanos_sidecar_config.go
+++ b/pkg/prometheus/server/thanos_sidecar_config.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -34,7 +34,7 @@ const (
 // buildPrometheusHTTPClientConfigSecret returns a kubernetes secret with the HTTP configuration for the Thanos sidecar
 // to communicated with prometheus server.
 // https://thanos.io/tip/components/sidecar.md/#prometheus-http-client
-func buildPrometheusHTTPClientConfigSecret(p *monitoringv1.Prometheus) (*v1.Secret, error) {
+func buildPrometheusHTTPClientConfigSecret(p *monitoringv1.Prometheus) (*corev1.Secret, error) {
 	dataYaml := yaml.MapSlice{}
 	dataYaml = append(dataYaml, yaml.MapItem{
 		Key: "tls_config",
@@ -51,7 +51,7 @@ func buildPrometheusHTTPClientConfigSecret(p *monitoringv1.Prometheus) (*v1.Secr
 		return nil, err
 	}
 
-	return &v1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      thanosPrometheusHTTPClientConfigSecretName(p),
 			Namespace: p.Namespace,

--- a/pkg/prometheus/test_utils.go
+++ b/pkg/prometheus/test_utils.go
@@ -18,15 +18,15 @@ import (
 	"fmt"
 	"log/slog"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
 )
 
-func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
-	return v1.ProbeHandler{
-		HTTPGet: &v1.HTTPGetAction{
+func makeExpectedProbeHandler(probePath string) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
 			Path:   probePath,
 			Port:   intstr.FromString("web"),
 			Scheme: "HTTPS",
@@ -34,8 +34,8 @@ func makeExpectedProbeHandler(probePath string) v1.ProbeHandler {
 	}
 }
 
-func MakeExpectedStartupProbe() *v1.Probe {
-	return &v1.Probe{
+func MakeExpectedStartupProbe() *corev1.Probe {
+	return &corev1.Probe{
 		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    15,
@@ -43,8 +43,8 @@ func MakeExpectedStartupProbe() *v1.Probe {
 	}
 }
 
-func MakeExpectedLivenessProbe() *v1.Probe {
-	return &v1.Probe{
+func MakeExpectedLivenessProbe() *corev1.Probe {
+	return &corev1.Probe{
 		ProbeHandler:     makeExpectedProbeHandler("/-/healthy"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,
@@ -52,8 +52,8 @@ func MakeExpectedLivenessProbe() *v1.Probe {
 	}
 }
 
-func MakeExpectedReadinessProbe() *v1.Probe {
-	return &v1.Probe{
+func MakeExpectedReadinessProbe() *corev1.Probe {
+	return &corev1.Probe{
 		ProbeHandler:     makeExpectedProbeHandler("/-/ready"),
 		TimeoutSeconds:   3,
 		PeriodSeconds:    5,

--- a/pkg/thanos/collector.go
+++ b/pkg/thanos/collector.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
 
-	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 var (
@@ -50,12 +50,12 @@ func (c *thanosRulerCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *thanosRulerCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range c.stores {
 		for _, tr := range s.List() {
-			c.collectThanos(ch, tr.(*v1.ThanosRuler))
+			c.collectThanos(ch, tr.(*monitoringv1.ThanosRuler))
 		}
 	}
 }
 
-func (c *thanosRulerCollector) collectThanos(ch chan<- prometheus.Metric, tr *v1.ThanosRuler) {
+func (c *thanosRulerCollector) collectThanos(ch chan<- prometheus.Metric, tr *monitoringv1.ThanosRuler) {
 	replicas := float64(minReplicas)
 	if tr.Spec.Replicas != nil {
 		replicas = float64(*tr.Spec.Replicas)

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -191,7 +191,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 				options.LabelSelector = labelThanosRulerName
 			},
 		),
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceConfigMaps)),
+		corev1.SchemeGroupVersion.WithResource(string(corev1.ResourceConfigMaps)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating configmap informers: %w", err)
@@ -275,7 +275,7 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		o.logger.Debug("creating namespace informer", "privileged", privileged)
 		return cache.NewSharedIndexInformer(
 			o.metrics.NewInstrumentedListerWatcher(lw),
-			&v1.Namespace{},
+			&corev1.Namespace{},
 			resyncPeriod,
 			cache.Indexers{},
 		), nil
@@ -422,8 +422,8 @@ func thanosKeyToStatefulSetKey(key string) string {
 }
 
 func (o *Operator) handleNamespaceUpdate(oldo, curo any) {
-	old := oldo.(*v1.Namespace)
-	cur := curo.(*v1.Namespace)
+	old := oldo.(*corev1.Namespace)
+	cur := curo.(*corev1.Namespace)
 
 	o.logger.Debug("update handler", "namespace", cur.GetName(), "old", old.ResourceVersion, "cur", cur.ResourceVersion)
 
@@ -786,7 +786,7 @@ func (o *Operator) enqueueForNamespace(store cache.Store, nsName string) {
 		)
 		return
 	}
-	ns := nsObject.(*v1.Namespace)
+	ns := nsObject.(*corev1.Namespace)
 
 	err = o.thanosRulerInfs.ListAll(labels.Everything(), func(obj any) {
 		// Check for ThanosRuler instances in the namespace.
@@ -836,7 +836,7 @@ func (o *Operator) createOrUpdateWebConfigSecret(ctx context.Context, tr *monito
 		return fmt.Errorf("failed to initialize the web config: %w", err)
 	}
 
-	s := &v1.Secret{}
+	s := &corev1.Secret{}
 	operator.UpdateObject(
 		s,
 		operator.WithLabels(o.config.Labels),
@@ -874,8 +874,8 @@ func applyConfigurationFromThanosRuler(a *monitoringv1.ThanosRuler) *monitoringv
 	return monitoringv1ac.ThanosRuler(a.Name, a.Namespace).WithStatus(trac)
 }
 
-func newTLSAssetSecret(tr *monitoringv1.ThanosRuler, config Config) *v1.Secret {
-	s := &v1.Secret{
+func newTLSAssetSecret(tr *monitoringv1.ThanosRuler, config Config) *corev1.Secret {
+	s := &corev1.Secret{
 		Data: map[string][]byte{},
 	}
 
@@ -917,7 +917,7 @@ func labelSelectorForStatefulSets() string {
 func (o *Operator) createOrUpdateRulerConfigSecret(ctx context.Context, store *assets.StoreBuilder, tr *monitoringv1.ThanosRuler) error {
 	sClient := o.kclient.CoreV1().Secrets(tr.GetNamespace())
 
-	s := &v1.Secret{
+	s := &corev1.Secret{
 		Data: map[string][]byte{},
 	}
 

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -60,10 +60,10 @@ var (
 func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapNames []string, inputHash string, tlsSecrets *operator.ShardedSecret) (*appsv1.StatefulSet, error) {
 
 	if tr.Spec.Resources.Requests == nil {
-		tr.Spec.Resources.Requests = v1.ResourceList{}
+		tr.Spec.Resources.Requests = corev1.ResourceList{}
 	}
-	if _, ok := tr.Spec.Resources.Requests[v1.ResourceMemory]; !ok {
-		tr.Spec.Resources.Requests[v1.ResourceMemory] = resource.MustParse("200Mi")
+	if _, ok := tr.Spec.Resources.Requests[corev1.ResourceMemory]; !ok {
+		tr.Spec.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("200Mi")
 	}
 
 	spec, err := makeStatefulSetSpec(tr, config, ruleConfigMapNames, tlsSecrets)
@@ -92,27 +92,27 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapN
 	storageSpec := tr.Spec.Storage
 	switch {
 	case storageSpec == nil:
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(tr.Name),
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 
 	case storageSpec.EmptyDir != nil:
 		emptyDir := storageSpec.EmptyDir
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(tr.Name),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				EmptyDir: emptyDir,
 			},
 		})
 
 	case storageSpec.Ephemeral != nil:
 		ephemeral := storageSpec.Ephemeral
-		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, v1.Volume{
+		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: volumeName(tr.Name),
-			VolumeSource: v1.VolumeSource{
+			VolumeSource: corev1.VolumeSource{
 				Ephemeral: ephemeral,
 			},
 		})
@@ -123,7 +123,7 @@ func makeStatefulSet(tr *monitoringv1.ThanosRuler, config Config, ruleConfigMapN
 			pvcTemplate.Name = volumeName(tr.Name)
 		}
 		if storageSpec.VolumeClaimTemplate.Spec.AccessModes == nil {
-			pvcTemplate.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+			pvcTemplate.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		} else {
 			pvcTemplate.Spec.AccessModes = storageSpec.VolumeClaimTemplate.Spec.AccessModes
 		}
@@ -193,11 +193,11 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "enable-feature", Value: strings.Join(efs, ",")})
 	}
 
-	trEnvVars := []v1.EnvVar{
+	trEnvVars := []corev1.EnvVar{
 		{
 			Name: "POD_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 			},
 		},
 	}
@@ -213,21 +213,21 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "alert.label-drop", Value: lb})
 	}
 
-	ports := []v1.ContainerPort{
+	ports := []corev1.ContainerPort{
 		{
 			Name:          "grpc",
 			ContainerPort: 10901,
-			Protocol:      v1.ProtocolTCP,
+			Protocol:      corev1.ProtocolTCP,
 		},
 	}
 	if tr.Spec.ListenLocal {
 		trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "http-address", Value: "localhost:10902"})
 	} else {
 		ports = append(ports,
-			v1.ContainerPort{
+			corev1.ContainerPort{
 				Name:          tr.Spec.PortName,
 				ContainerPort: 10902,
-				Protocol:      v1.ProtocolTCP,
+				Protocol:      corev1.ProtocolTCP,
 			})
 	}
 
@@ -243,8 +243,8 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	trVolumes, trVolumeMounts, fullPath := mountSecretKey(
 		nil,
 		nil,
-		&v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		&corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: rulerConfigSecretName(tr.Name),
 			},
 			Key: rwConfigFile,
@@ -295,7 +295,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	trVolumes = append(trVolumes, tlsSecrets.Volume("tls-assets"))
-	trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
+	trVolumeMounts = append(trVolumeMounts, corev1.VolumeMount{
 		Name:      "tls-assets",
 		ReadOnly:  true,
 		MountPath: tlsAssetsDir,
@@ -342,16 +342,16 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	containerArgs = append([]string{"rule"}, containerArgs...)
 
 	var configReloaderWebConfigFile string
-	var additionalContainers []v1.Container
+	var additionalContainers []corev1.Container
 	if len(ruleConfigMapNames) != 0 {
 		var (
 			watchedDirectories         []string
-			configReloaderVolumeMounts []v1.VolumeMount
+			configReloaderVolumeMounts []corev1.VolumeMount
 		)
 
 		for _, name := range ruleConfigMapNames {
 			mountPath := rulesDir + "/" + name
-			configReloaderVolumeMounts = append(configReloaderVolumeMounts, v1.VolumeMount{
+			configReloaderVolumeMounts = append(configReloaderVolumeMounts, corev1.VolumeMount{
 				Name:      name,
 				MountPath: mountPath,
 			})
@@ -426,24 +426,24 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			storageVolName = tr.Spec.Storage.VolumeClaimTemplate.Name
 		}
 	}
-	trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
+	trVolumeMounts = append(trVolumeMounts, corev1.VolumeMount{
 		Name:      storageVolName,
 		MountPath: storageDir,
 	})
 
 	for _, name := range ruleConfigMapNames {
-		trVolumes = append(trVolumes, v1.Volume{
+		trVolumes = append(trVolumes, corev1.Volume{
 			Name: name,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
 					Optional: ptr.To(true),
 				},
 			},
 		})
-		trVolumeMounts = append(trVolumeMounts, v1.VolumeMount{
+		trVolumeMounts = append(trVolumeMounts, corev1.VolumeMount{
 			Name:      name,
 			MountPath: rulesDir + "/" + name,
 			ReadOnly:  true,
@@ -452,7 +452,7 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 
 	trVolumeMounts = append(trVolumeMounts, tr.Spec.VolumeMounts...)
 
-	operatorContainers := append([]v1.Container{
+	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "thanos-ruler",
 			Image:                    trImagePath,
@@ -462,12 +462,12 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 			VolumeMounts:             trVolumeMounts,
 			Resources:                tr.Spec.Resources,
 			Ports:                    ports,
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			SecurityContext: &v1.SecurityContext{
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 				ReadOnlyRootFilesystem:   ptr.To(true),
-				Capabilities: &v1.Capabilities{
-					Drop: []v1.Capability{"ALL"},
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
 				},
 			},
 		},
@@ -493,12 +493,12 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		Selector: &metav1.LabelSelector{
 			MatchLabels: finalLabels,
 		},
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      finalLabels,
 				Annotations: podAnnotations,
 			},
-			Spec: v1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeSelector:                  tr.Spec.NodeSelector,
 				PriorityClassName:             tr.Spec.PriorityClassName,
 				ServiceAccountName:            tr.Spec.ServiceAccountName,
@@ -523,26 +523,26 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	return &spec, nil
 }
 
-func makeStatefulSetService(tr *monitoringv1.ThanosRuler, config Config) *v1.Service {
+func makeStatefulSetService(tr *monitoringv1.ThanosRuler, config Config) *corev1.Service {
 	if tr.Spec.PortName == "" {
 		tr.Spec.PortName = defaultPortName
 	}
 
-	svc := &v1.Service{
-		Spec: v1.ServiceSpec{
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
 			ClusterIP: "None",
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       tr.Spec.PortName,
 					Port:       10902,
 					TargetPort: intstr.FromString(tr.Spec.PortName),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       "grpc",
 					Port:       10901,
 					TargetPort: intstr.FromString("grpc"),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				},
 			},
 			Selector: map[string]string{
@@ -581,15 +581,15 @@ func webConfigSecretName(name string) string {
 
 // mountSecretKey adds the secret key to the mounted volumes and returns the
 // full path of the file on disk.
-func mountSecretKey(vols []v1.Volume, vmounts []v1.VolumeMount, secretSelector *v1.SecretKeySelector, volumeName string) ([]v1.Volume, []v1.VolumeMount, string) {
+func mountSecretKey(vols []corev1.Volume, vmounts []corev1.VolumeMount, secretSelector *corev1.SecretKeySelector, volumeName string) ([]corev1.Volume, []corev1.VolumeMount, string) {
 	mountpath := filepath.Join(configDir, volumeName)
 
-	return append(vols, v1.Volume{
+	return append(vols, corev1.Volume{
 			Name: volumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: secretSelector.Name,
-					Items: []v1.KeyToPath{
+					Items: []corev1.KeyToPath{
 						{
 							Key:  secretSelector.Key,
 							Path: secretSelector.Key,
@@ -598,7 +598,7 @@ func mountSecretKey(vols []v1.Volume, vmounts []v1.VolumeMount, secretSelector *
 				},
 			},
 		}),
-		append(vmounts, v1.VolumeMount{
+		append(vmounts, corev1.VolumeMount{
 			Name:      volumeName,
 			MountPath: mountpath,
 			ReadOnly:  true,

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -129,11 +129,11 @@ func TestThanosDefaultBaseImageFlag(t *testing.T) {
 func TestStatefulSetVolumes(t *testing.T) {
 	expected := &appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
-			Template: v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "remote-write-config",
 									ReadOnly:  true,
@@ -166,13 +166,13 @@ func TestStatefulSetVolumes(t *testing.T) {
 							},
 						},
 					},
-					Volumes: []v1.Volume{
+					Volumes: []corev1.Volume{
 						{
 							Name: "remote-write-config",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "thanos-ruler-foo-config",
-									Items: []v1.KeyToPath{
+									Items: []corev1.KeyToPath{
 										{
 											Key:  "remote-write.yaml",
 											Path: "remote-write.yaml",
@@ -183,25 +183,25 @@ func TestStatefulSetVolumes(t *testing.T) {
 						},
 						{
 							Name: "tls-assets",
-							VolumeSource: v1.VolumeSource{
-								Projected: &v1.ProjectedVolumeSource{
-									Sources: []v1.VolumeProjection{},
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{},
 								},
 							},
 						},
 						{
 							Name: "web-config",
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
 									SecretName: "thanos-ruler-foo-web-config",
 								},
 							},
 						},
 						{
 							Name: "rules-configmap-one",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "rules-configmap-one",
 									},
 									Optional: ptr.To(true),
@@ -210,14 +210,14 @@ func TestStatefulSetVolumes(t *testing.T) {
 						},
 						{
 							Name: "thanos-ruler-foo-data",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 						{
 							Name: "additional-volume",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -232,17 +232,17 @@ func TestStatefulSetVolumes(t *testing.T) {
 		},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			Volumes: []v1.Volume{
+			Volumes: []corev1.Volume{
 				{
 					Name: "additional-volume",
-					VolumeSource: v1.VolumeSource{
-						EmptyDir: &v1.EmptyDirVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium: "",
 						},
 					},
 				},
 			},
-			VolumeMounts: []v1.VolumeMount{
+			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "additional-volume",
 					ReadOnly:  false,
@@ -270,8 +270,8 @@ func TestTracing(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			TracingConfig: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			TracingConfig: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key: secretKey,
@@ -321,7 +321,7 @@ func TestTracingFile(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints:    emptyQueryEndpoints,
 			TracingConfigFile: testPath,
-			TracingConfig: &v1.SecretKeySelector{
+			TracingConfig: &corev1.SecretKeySelector{
 				Key: testKey,
 			},
 		},
@@ -362,8 +362,8 @@ func TestObjectStorage(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			ObjectStorageConfig: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			ObjectStorageConfig: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key: secretKey,
@@ -413,7 +413,7 @@ func TestObjectStorageFile(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints:          emptyQueryEndpoints,
 			ObjectStorageConfigFile: &testPath,
-			ObjectStorageConfig: &v1.SecretKeySelector{
+			ObjectStorageConfig: &corev1.SecretKeySelector{
 				Key: testKey,
 			},
 		},
@@ -454,8 +454,8 @@ func TestAlertRelabel(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{},
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			AlertRelabelConfigs: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			AlertRelabelConfigs: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key: secretKey,
@@ -505,7 +505,7 @@ func TestAlertRelabelFile(t *testing.T) {
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints:         emptyQueryEndpoints,
 			AlertRelabelConfigFile: &testPath,
-			AlertRelabelConfigs: &v1.SecretKeySelector{
+			AlertRelabelConfigs: &corev1.SecretKeySelector{
 				Key: testKey,
 			},
 		},
@@ -634,7 +634,7 @@ func TestAdditionalContainers(t *testing.T) {
 	addSset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			Containers: []v1.Container{
+			Containers: []corev1.Container{
 				{
 					Name: "extra-container",
 				},
@@ -651,7 +651,7 @@ func TestAdditionalContainers(t *testing.T) {
 	modSset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
 		Spec: monitoringv1.ThanosRulerSpec{
 			QueryEndpoints: emptyQueryEndpoints,
-			Containers: []v1.Container{
+			Containers: []corev1.Container{
 				{
 					Name:  existingContainerName,
 					Image: containerImage,
@@ -696,28 +696,28 @@ func TestPodTemplateConfig(t *testing.T) {
 	nodeSelector := map[string]string{
 		"foo": "bar",
 	}
-	affinity := v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{},
-		PodAffinity: &v1.PodAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+	affinity := corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+		PodAffinity: &corev1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
-					PodAffinityTerm: v1.PodAffinityTerm{
+					PodAffinityTerm: corev1.PodAffinityTerm{
 						Namespaces: []string{"foo"},
 					},
 					Weight: 100,
 				},
 			},
 		},
-		PodAntiAffinity: &v1.PodAntiAffinity{},
+		PodAntiAffinity: &corev1.PodAntiAffinity{},
 	}
 
-	tolerations := []v1.Toleration{
+	tolerations := []corev1.Toleration{
 		{
 			Key: "key",
 		},
 	}
 	userid := int64(1234)
-	securityContext := v1.PodSecurityContext{
+	securityContext := corev1.PodSecurityContext{
 		RunAsUser: &userid,
 	}
 	priorityClassName := "foo"
@@ -728,12 +728,12 @@ func TestPodTemplateConfig(t *testing.T) {
 			IP:        "1.1.1.1",
 		},
 	}
-	imagePullSecrets := []v1.LocalObjectReference{
+	imagePullSecrets := []corev1.LocalObjectReference{
 		{
 			Name: "registry-secret",
 		},
 	}
-	imagePullPolicy := v1.PullAlways
+	imagePullPolicy := corev1.PullAlways
 
 	additionalArgs := []monitoringv1.Argument{
 		{Name: "additional.arg", Value: "additional-arg-value"},
@@ -862,8 +862,8 @@ func TestStatefulSetPVC(t *testing.T) {
 		EmbeddedObjectMetadata: monitoringv1.EmbeddedObjectMetadata{
 			Annotations: annotations,
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			StorageClassName: &storageClass,
 		},
 	}
@@ -894,8 +894,8 @@ func TestStatefulEmptyDir(t *testing.T) {
 		"testannotation": "testannotationvalue",
 	}
 
-	emptyDir := v1.EmptyDirVolumeSource{
-		Medium: v1.StorageMediumMemory,
+	emptyDir := corev1.EmptyDirVolumeSource{
+		Medium: corev1.StorageMediumMemory,
 	}
 
 	sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
@@ -927,10 +927,10 @@ func TestStatefulSetEphemeral(t *testing.T) {
 
 	storageClass := "storageclass"
 
-	ephemeral := v1.EphemeralVolumeSource{
-		VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
-			Spec: v1.PersistentVolumeClaimSpec{
-				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+	ephemeral := corev1.EphemeralVolumeSource{
+		VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				StorageClassName: &storageClass,
 			},
 		},
@@ -1008,11 +1008,11 @@ func TestStatefulSetDNSPolicyAndDNSConfig(t *testing.T) {
 	}, defaultTestConfig, nil, "", &operator.ShardedSecret{})
 	require.NoError(t, err)
 
-	require.Equal(t, v1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected DNS policy to match")
-	require.Equal(t, &v1.PodDNSConfig{
+	require.Equal(t, corev1.DNSClusterFirst, sset.Spec.Template.Spec.DNSPolicy, "expected DNS policy to match")
+	require.Equal(t, &corev1.PodDNSConfig{
 		Nameservers: []string{"8.8.8.8"},
 		Searches:    []string{"custom.search"},
-		Options: []v1.PodDNSConfigOption{
+		Options: []corev1.PodDNSConfigOption{
 			{
 				Name:  "ndots",
 				Value: ptr.To("5"),

--- a/pkg/webconfig/config.go
+++ b/pkg/webconfig/config.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
-	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -66,11 +66,11 @@ func New(mountingDir string, secretName string, configFileFields monitoringv1.We
 // and the associated TLS files.
 // In addition, GetMountParameters returns a web.config.file command line option pointing
 // to the file in the volume mount.
-func (c Config) GetMountParameters() (monitoringv1.Argument, []v1.Volume, []v1.VolumeMount, error) {
+func (c Config) GetMountParameters() (monitoringv1.Argument, []corev1.Volume, []corev1.VolumeMount, error) {
 	destinationPath := path.Join(c.mountingDir, configFile)
 
-	var volumes []v1.Volume
-	var mounts []v1.VolumeMount
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
 
 	arg := c.makeArg(destinationPath)
 	cfgVolume := c.makeVolume()
@@ -98,7 +98,7 @@ func (c Config) GetMountParameters() (monitoringv1.Argument, []v1.Volume, []v1.V
 // data for the web config file.
 // The format of the web config file is available in the official prometheus documentation:
 // https://prometheus.io/docs/prometheus/latest/configuration/https/#https-and-authentication
-func (c Config) CreateOrUpdateWebConfigSecret(ctx context.Context, secretClient clientv1.SecretInterface, s *v1.Secret) error {
+func (c Config) CreateOrUpdateWebConfigSecret(ctx context.Context, secretClient typedcorev1.SecretInterface, s *corev1.Secret) error {
 	data, err := c.generateConfigFileContents()
 	if err != nil {
 		return err
@@ -258,19 +258,19 @@ func (c Config) makeArg(filePath string) monitoringv1.Argument {
 	return monitoringv1.Argument{Name: "web.config.file", Value: filePath}
 }
 
-func (c Config) makeVolume() v1.Volume {
-	return v1.Volume{
+func (c Config) makeVolume() corev1.Volume {
+	return corev1.Volume{
 		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				SecretName: c.secretName,
 			},
 		},
 	}
 }
 
-func (c Config) makeVolumeMount(filePath string) v1.VolumeMount {
-	return v1.VolumeMount{
+func (c Config) makeVolumeMount(filePath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
 		Name:      volumeName,
 		SubPath:   configFile,
 		ReadOnly:  true,

--- a/pkg/webconfig/config_test.go
+++ b/pkg/webconfig/config_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
@@ -45,15 +45,15 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 			webConfigFileFields: monitoringv1.WebConfigFileFields{
 				TLSConfig: &monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -67,15 +67,15 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 			webConfigFileFields: monitoringv1.WebConfigFileFields{
 				TLSConfig: &monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
@@ -89,22 +89,22 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 			webConfigFileFields: monitoringv1.WebConfigFileFields{
 				TLSConfig: &monitoringv1.WebTLSConfig{
 					Cert: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.key",
 					},
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						ConfigMap: &v1.ConfigMapKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-configmap",
 							},
 							Key: "tls.client_ca",
@@ -119,23 +119,23 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 			webConfigFileFields: monitoringv1.WebConfigFileFields{
 				TLSConfig: &monitoringv1.WebTLSConfig{
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.ca",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "test-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
 						Key: "tls.keySecret",
@@ -186,7 +186,7 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 			require.NoError(t, err)
 
 			var (
-				s            = v1.Secret{}
+				s            = corev1.Secret{}
 				secretClient = fake.NewSimpleClientset().CoreV1().Secrets("default")
 			)
 			err = config.CreateOrUpdateWebConfigSecret(context.Background(), secretClient, &s)
@@ -203,22 +203,22 @@ func TestCreateOrUpdateWebConfigSecret(t *testing.T) {
 func TestGetMountParameters(t *testing.T) {
 	ts := []struct {
 		webConfigFileFields monitoringv1.WebConfigFileFields
-		expectedVolumes     []v1.Volume
-		expectedMounts      []v1.VolumeMount
+		expectedVolumes     []corev1.Volume
+		expectedMounts      []corev1.VolumeMount
 	}{
 		{
 			webConfigFileFields: monitoringv1.WebConfigFileFields{},
-			expectedVolumes: []v1.Volume{
+			expectedVolumes: []corev1.Volume{
 				{
 					Name: "web-config",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "web-config",
 						},
 					},
 				},
 			},
-			expectedMounts: []v1.VolumeMount{
+			expectedMounts: []corev1.VolumeMount{
 				{
 					Name:             "web-config",
 					ReadOnly:         true,
@@ -232,23 +232,23 @@ func TestGetMountParameters(t *testing.T) {
 		{
 			webConfigFileFields: monitoringv1.WebConfigFileFields{
 				TLSConfig: &monitoringv1.WebTLSConfig{
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "some-secret",
 						},
 						Key: "tls.key",
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.crt",
 						},
 					},
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "some-secret",
 							},
 							Key: "tls.client_ca",
@@ -256,41 +256,41 @@ func TestGetMountParameters(t *testing.T) {
 					},
 				},
 			},
-			expectedVolumes: []v1.Volume{
+			expectedVolumes: []corev1.Volume{
 				{
 					Name: "web-config",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "web-config",
 						},
 					},
 				},
 				{
 					Name: "web-config-tls-secret-key-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "web-config-tls-secret-cert-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 				{
 					Name: "web-config-tls-secret-client-ca-some-secret-3556f148",
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: "some-secret",
 						},
 					},
 				},
 			},
-			expectedMounts: []v1.VolumeMount{
+			expectedMounts: []corev1.VolumeMount{
 				{
 					Name:             "web-config",
 					ReadOnly:         true,

--- a/test/e2e/alertmanager_instance_namespaces_test.go
+++ b/test/e2e/alertmanager_instance_namespaces_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -72,7 +72,7 @@ func testAlertmanagerInstanceNamespacesAllNs(t *testing.T) {
 	}
 
 	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.Background(), "alertmanager-instance", metav1.GetOptions{})
-	if !api_errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 }
@@ -195,7 +195,7 @@ func testAlertmanagerInstanceNamespacesAllowList(t *testing.T) {
 
 	// Check that the Alertmanager resource created in the "allowed" namespace hasn't been reconciled.
 	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.Background(), "alertmanager-instance", metav1.GetOptions{})
-	if !api_errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not to find an Alertmanager statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -81,16 +81,16 @@ func testAlertmanagerWithStatefulsetCreationFailure(t *testing.T) {
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{
 			TLSConfig: &monitoringv1.WebTLSConfig{
 				Cert: monitoringv1.SecretOrConfigMap{
-					ConfigMap: &v1.ConfigMapKeySelector{},
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ConfigMap: &corev1.ConfigMapKeySelector{},
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls-cert",
 						},
 						Key: "tls.crt",
 					},
 				},
-				KeySecret: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "tls-cert",
 					},
 					Key: "tls.key",
@@ -216,11 +216,11 @@ func testAMStorageUpdate(t *testing.T) {
 							"test": "testAMStorageUpdate",
 						},
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
-						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-						Resources: v1.VolumeResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse("200Mi"),
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("200Mi"),
 							},
 						},
 					},
@@ -246,11 +246,11 @@ func testAMStorageUpdate(t *testing.T) {
 							"test": "testAMStorageUpdate",
 						},
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
+					Spec: corev1.PersistentVolumeClaimSpec{
 						StorageClassName: ptr.To("unknown-storage-class"),
-						Resources: v1.VolumeResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse("200Mi"),
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("200Mi"),
 							},
 						},
 					},
@@ -288,7 +288,7 @@ func testAMExposingWithKubernetesAPI(t *testing.T) {
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	alertmanager := framework.MakeBasicAlertmanager(ns, "test-alertmanager", 1)
-	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
+	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", corev1.ServiceTypeClusterIP)
 
 	_, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), alertmanager)
 	require.NoError(t, err)
@@ -312,7 +312,7 @@ func testAMClusterInitialization(t *testing.T) {
 
 	amClusterSize := 3
 	alertmanager := framework.MakeBasicAlertmanager(ns, "test", int32(amClusterSize))
-	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", v1.ServiceTypeClusterIP)
+	alertmanagerService := framework.MakeAlertmanagerService(alertmanager.Name, "alertmanager-service", corev1.ServiceTypeClusterIP)
 
 	_, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), alertmanager)
 	require.NoError(t, err)
@@ -379,23 +379,23 @@ func testAMClusterGossipSilences(t *testing.T) {
 			clusterTLSConfig: &monitoringv1.ClusterTLSConfig{
 				ServerTLS: monitoringv1.WebTLSConfig{
 					ClientCA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: secretName,
 							},
 							Key: "ca.crt",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: secretName,
 							},
 							Key: "cert.pem",
 						},
 					},
-					KeySecret: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: secretName,
 						},
 						Key: "key.pem",
@@ -404,23 +404,23 @@ func testAMClusterGossipSilences(t *testing.T) {
 				},
 				ClientTLS: monitoringv1.SafeTLSConfig{
 					CA: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: secretName,
 							},
 							Key: "ca.crt",
 						},
 					},
 					Cert: monitoringv1.SecretOrConfigMap{
-						Secret: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: secretName,
 							},
 							Key: "cert.pem",
 						},
 					},
-					KeySecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					KeySecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: secretName,
 						},
 						Key: "key.pem",
@@ -552,7 +552,7 @@ An Alert test
 </body>
 `
 
-	cfg := &v1.Secret{
+	cfg := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("alertmanager-%s", alertmanager.Name),
 		},
@@ -563,7 +563,7 @@ An Alert test
 
 	templateFileKey := "test-emails.tmpl"
 	templateSecretFileKey := "test-emails-secret.tmpl"
-	templateCfg := &v1.ConfigMap{
+	templateCfg := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: templateResourceName,
 		},
@@ -571,7 +571,7 @@ An Alert test
 			templateFileKey: template,
 		},
 	}
-	templateSecret := &v1.Secret{
+	templateSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: templateResourceName,
 		},
@@ -676,7 +676,7 @@ An Alert test
 </body>
 `
 
-	cfg := &v1.Secret{
+	cfg := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("alertmanager-%s", alertmanager.Name),
 		},
@@ -721,18 +721,18 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 					"app.kubernetes.io/name": "alertmanager-webhook",
 				},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app.kubernetes.io/name": "alertmanager-webhook",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "webhook-server",
 							Image: "quay.io/prometheus-operator/prometheus-alertmanager-test-webhook:latest",
-							Ports: []v1.ContainerPort{
+							Ports: []corev1.ContainerPort{
 								{
 									Name:          "web",
 									ContainerPort: 5001,
@@ -744,13 +744,13 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 			},
 		},
 	}
-	whsvc := &v1.Service{
+	whsvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "alertmanager-webhook",
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       5001,
@@ -776,8 +776,8 @@ func testAMZeroDowntimeRollingDeployment(t *testing.T) {
 	require.NoError(t, err)
 
 	alertmanager := framework.MakeBasicAlertmanager(ns, "rolling-deploy", 3)
-	amsvc := framework.MakeAlertmanagerService(alertmanager.Name, "test", v1.ServiceTypeClusterIP)
-	amcfg := &v1.Secret{
+	amsvc := framework.MakeAlertmanagerService(alertmanager.Name, "test", corev1.ServiceTypeClusterIP)
+	amcfg := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("alertmanager-%s", alertmanager.Name),
 		},
@@ -1017,7 +1017,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// reuse the secret for pagerduty, wechat and sns
 	testingSecret := "testing-secret"
 	testingSecretKey := "testing-secret-key"
-	testingKeySecret := &v1.Secret{
+	testingKeySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testingSecret,
 		},
@@ -1031,7 +1031,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	// telegram secret
 	telegramTestingSecret := "telegram-testing-secret"
 	telegramTestingbotTokenKey := "telegram-testing-bottoken-key"
-	telegramTestingKeySecret := &v1.Secret{
+	telegramTestingKeySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: telegramTestingSecret,
 		},
@@ -1042,7 +1042,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), telegramTestingKeySecret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	apiKeySecret := &v1.Secret{
+	apiKeySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "og-receiver-api-key",
 		},
@@ -1053,7 +1053,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), apiKeySecret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	slackAPIURLSecret := &v1.Secret{
+	slackAPIURLSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "s-receiver-api-url",
 		},
@@ -1065,7 +1065,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	require.NoError(t, err)
 
 	webexAPIToken := "super-secret-token"
-	webexAPITokenSecret := &v1.Secret{
+	webexAPITokenSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "webex-api-token",
 		},
@@ -1090,16 +1090,16 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			Receivers: []monitoringv1alpha1.Receiver{{
 				Name: "e2e",
 				OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{{
-					APIKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					APIKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "og-receiver-api-key",
 						},
 						Key: "api-key",
 					},
 				}},
 				PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-					RoutingKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					RoutingKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1107,8 +1107,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					URL: ptr.To(monitoringv1alpha1.URL("https://pagerduty.example.com")),
 				}},
 				SlackConfigs: []monitoringv1alpha1.SlackConfig{{
-					APIURL: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					APIURL: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "s-receiver-api-url",
 						},
 						Key: "api-url",
@@ -1134,8 +1134,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					URL: ptr.To("http://test.url"),
 				}},
 				WeChatConfigs: []monitoringv1alpha1.WeChatConfig{{
-					APISecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					APISecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1149,14 +1149,14 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					Smarthost: ptr.To("example.com:25"),
 					From:      ptr.To("admin@example.com"),
 					To:        ptr.To("test@example.com"),
-					AuthPassword: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					AuthPassword: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
 					},
-					AuthSecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					AuthSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1170,8 +1170,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					HTML: ptr.To(""),
 				}},
 				VictorOpsConfigs: []monitoringv1alpha1.VictorOpsConfig{{
-					APIKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					APIKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1179,14 +1179,14 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					RoutingKey: "abc",
 				}},
 				PushoverConfigs: []monitoringv1alpha1.PushoverConfig{{
-					UserKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					UserKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
 					},
-					Token: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Token: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1194,8 +1194,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 				}},
 				TelegramConfigs: []monitoringv1alpha1.TelegramConfig{{
 					APIURL: ptr.To(monitoringv1alpha1.URL("https://telegram.api.url")),
-					BotToken: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					BotToken: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: telegramTestingSecret,
 						},
 						Key: telegramTestingbotTokenKey,
@@ -1207,14 +1207,14 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 						ApiURL: ptr.To("https://sns.us-east-2.amazonaws.com"),
 						Sigv4: &monitoringv1.Sigv4{
 							Region: "us-east-2",
-							AccessKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							AccessKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: testingSecret,
 								},
 								Key: testingSecretKey,
 							},
-							SecretKey: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							SecretKey: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: testingSecret,
 								},
 								Key: testingSecretKey,
@@ -1236,8 +1236,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					HTTPConfig: &monitoringv1alpha1.HTTPConfig{
 						Authorization: &monitoringv1.SafeAuthorization{
 							Type: "Bearer",
-							Credentials: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "webex-api-token",
 								},
 								Key: "api-token",
@@ -1394,8 +1394,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			Receivers: []monitoringv1alpha1.Receiver{{
 				Name: "e2e",
 				PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-					RoutingKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					RoutingKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: "non-existing-key",
@@ -1423,8 +1423,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			Receivers: []monitoringv1alpha1.Receiver{{
 				Name: "e2e",
 				PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-					RoutingKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					RoutingKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: testingSecretKey,
@@ -1454,8 +1454,8 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 			Receivers: []monitoringv1alpha1.Receiver{{
 				Name: "e2e",
 				PagerDutyConfigs: []monitoringv1alpha1.PagerDutyConfig{{
-					RoutingKey: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					RoutingKey: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: testingSecret,
 						},
 						Key: "non-existing-key",
@@ -1849,7 +1849,7 @@ inhibit_rules:
   - test!=dropped
   - expect=~this-value
 `
-	amConfig := &v1.Secret{
+	amConfig := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "amconfig",
 		},
@@ -1924,15 +1924,15 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 				},
 				Hello:        ptr.To("smtp.example.org"),
 				AuthUsername: ptr.To("dev@smtp.example.org"),
-				AuthPassword: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				AuthPassword: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "smtp-auth",
 					},
 					Key: "password",
 				},
 				AuthIdentity: ptr.To("dev@smtp.example.org"),
-				AuthSecret: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				AuthSecret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "smtp-auth",
 					},
 					Key: "secret",
@@ -1945,15 +1945,15 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 					HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
 						OAuth2: &monitoringv1.OAuth2{
 							ClientID: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "webhook-client-id",
 									},
 									Key: "test",
 								},
 							},
-							ClientSecret: v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "webhook-client-secret",
 								},
 								Key: "test",
@@ -1971,16 +1971,16 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 		},
 		Templates: []monitoringv1.SecretOrConfigMap{
 			{
-				Secret: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "template1",
 					},
 					Key: "template1.tmpl",
 				},
 			},
 			{
-				ConfigMap: &v1.ConfigMapKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				ConfigMap: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "template2",
 					},
 					Key: "template2.tmpl",
@@ -1989,7 +1989,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 		},
 	}
 
-	cm := v1.ConfigMap{
+	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "webhook-client-id",
 			Namespace: ns,
@@ -1998,7 +1998,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"test": "clientID",
 		},
 	}
-	smtp := v1.Secret{
+	smtp := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "smtp-auth",
 			Namespace: ns,
@@ -2008,7 +2008,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"secret":   []byte("secret"),
 		},
 	}
-	sec := v1.Secret{
+	sec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "webhook-client-secret",
 			Namespace: ns,
@@ -2017,7 +2017,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"test": []byte("clientSecret"),
 		},
 	}
-	tpl1 := v1.Secret{
+	tpl1 := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "template1",
 		},
@@ -2025,7 +2025,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"template1.tmpl": []byte(`template1`),
 		},
 	}
-	tpl2 := v1.ConfigMap{
+	tpl2 := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "template2",
 		},
@@ -2279,15 +2279,15 @@ func testAMWeb(t *testing.T) {
 	am.Spec.Web = &monitoringv1.AlertmanagerWebSpec{
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{
 			TLSConfig: &monitoringv1.WebTLSConfig{
-				KeySecret: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "web-tls",
 					},
 					Key: "tls.key",
 				},
 				Cert: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "web-tls",
 						},
 						Key: "tls.crt",
@@ -2851,14 +2851,14 @@ func testAlertManagerServiceName(t *testing.T) {
 	ns := framework.CreateNamespace(ctx, t, testCtx)
 	name := "test-servicename"
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", name),
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 9090,

--- a/test/e2e/denylist_test.go
+++ b/test/e2e/denylist_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,7 +63,7 @@ func testDenyPrometheus(t *testing.T) {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
 		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.Background(), "prometheus-denied", metav1.GetOptions{})
-		if !api_errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}
 	}
@@ -103,18 +103,18 @@ func testDenyServiceMonitor(t *testing.T) {
 						"prometheus": "denied",
 					},
 				},
-				Template: v1.PodTemplateSpec{
+				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"prometheus": "denied",
 						},
 					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
 							{
 								Name:  "echoserver",
 								Image: "k8s.gcr.io/echoserver:1.10",
-								Ports: []v1.ContainerPort{
+								Ports: []corev1.ContainerPort{
 									{
 										Name:          "web",
 										ContainerPort: 8443,
@@ -131,7 +131,7 @@ func testDenyServiceMonitor(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService("denied", "denied", v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService("denied", "denied", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), denied, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -153,7 +153,7 @@ func testDenyServiceMonitor(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService("allowed", "allowed", v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService("allowed", "allowed", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowed, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -228,7 +228,7 @@ func testDenyThanosRuler(t *testing.T) {
 		// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied thanos ruler.
 		// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
 		sts, err := framework.KubeClient.AppsV1().StatefulSets(denied).Get(context.Background(), "thanosruler-denied", metav1.GetOptions{})
-		if !api_errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 		}
 	}

--- a/test/e2e/prometheus_instance_namespaces_test.go
+++ b/test/e2e/prometheus_instance_namespaces_test.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -62,7 +62,7 @@ func testPrometheusInstanceNamespacesAllNs(t *testing.T) {
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
 	sts, err := framework.KubeClient.AppsV1().StatefulSets(nonInstanceNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
-	if !api_errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 }
@@ -136,7 +136,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakeEchoService("denied", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakeEchoService("denied", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), deniedNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -181,7 +181,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService("instance", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -192,7 +192,7 @@ func testPrometheusInstanceNamespacesDenyList(t *testing.T) {
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
 	sts, err := framework.KubeClient.AppsV1().StatefulSets(deniedNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
-	if !api_errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 
@@ -284,7 +284,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService("instance", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -308,7 +308,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakeEchoService("allowed", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -339,7 +339,7 @@ func testPrometheusInstanceNamespacesAllowList(t *testing.T) {
 	// this is not ideal, as we cannot really find out if prometheus operator did not reconcile the denied prometheus.
 	// nevertheless it is very likely that it reconciled it as the allowed prometheus is up.
 	sts, err := framework.KubeClient.AppsV1().StatefulSets(allowedNs).Get(context.Background(), "prometheus-instance", metav1.GetOptions{})
-	if !api_errors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected not to find a Prometheus statefulset, but did: %v/%v", sts.Namespace, sts.Name)
 	}
 
@@ -434,7 +434,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService("instance", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService("instance", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), instanceNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {
@@ -453,7 +453,7 @@ func testPrometheusInstanceNamespacesNamespaceNotFound(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakeEchoService("allowed", "monitored", v1.ServiceTypeClusterIP)
+		svc := framework.MakeEchoService("allowed", "monitored", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), allowedNs, svc); err != nil {
 			t.Fatal(fmt.Errorf("creating prometheus service failed: %w", err))
 		} else {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -37,7 +37,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,16 +88,16 @@ func deployInstrumentedApplicationWithTLS(name, ns string) error {
 	}
 
 	dep.Spec.Template.Spec.Containers[0].Args = []string{"--cert-path=/etc/certs"}
-	dep.Spec.Template.Spec.Volumes = []v1.Volume{{
+	dep.Spec.Template.Spec.Volumes = []corev1.Volume{{
 		Name: "tls-certs",
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				SecretName: testFramework.ServerTLSSecret,
 			},
 		},
 	}}
 
-	dep.Spec.Template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+	dep.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      dep.Spec.Template.Spec.Volumes[0].Name,
 			MountPath: "/etc/certs",
@@ -108,16 +108,16 @@ func deployInstrumentedApplicationWithTLS(name, ns string) error {
 		return fmt.Errorf("failed to create app deployment: %w", err)
 	}
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dep.Name,
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "mtls",
 					Port: 8081,
@@ -146,23 +146,23 @@ func deployInstrumentedApplicationWithTLS(name, ns string) error {
 						SafeTLSConfig: monitoringv1.SafeTLSConfig{
 							ServerName: ptr.To("caandserver.com"),
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: testFramework.ScrapingTLSSecret,
 									},
 									Key: testFramework.CAKey,
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: testFramework.ScrapingTLSSecret,
 									},
 									Key: testFramework.CertKey,
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: testFramework.ScrapingTLSSecret,
 								},
 								Key: testFramework.PrivateKey,
@@ -185,7 +185,7 @@ func deployInstrumentedApplicationWithTLS(name, ns string) error {
 // instance scraping targets and remote-writing samples to the second one.
 // The 1st returned value is the scraping Prometheus service.
 // The 2nd returned value is the receiver Prometheus service.
-func createRemoteWriteStack(name, ns string, prwtc testFramework.PromRemoteWriteTestConfig) (*v1.Service, *v1.Service, error) {
+func createRemoteWriteStack(name, ns string, prwtc testFramework.PromRemoteWriteTestConfig) (*corev1.Service, *corev1.Service, error) {
 	// Prometheus instance with remote-write receiver enabled.
 	receiverName := fmt.Sprintf("%s-%s", name, "receiver")
 	rwReceiver := framework.MakeBasicPrometheus(ns, receiverName, receiverName, 1)
@@ -195,7 +195,7 @@ func createRemoteWriteStack(name, ns string, prwtc testFramework.PromRemoteWrite
 		return nil, nil, err
 	}
 
-	rwReceiverService := framework.MakePrometheusService(receiverName, receiverName, v1.ServiceTypeClusterIP)
+	rwReceiverService := framework.MakePrometheusService(receiverName, receiverName, corev1.ServiceTypeClusterIP)
 	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, rwReceiverService); err != nil {
 		return nil, nil, err
 	}
@@ -207,7 +207,7 @@ func createRemoteWriteStack(name, ns string, prwtc testFramework.PromRemoteWrite
 		return nil, nil, err
 	}
 
-	prometheusService := framework.MakePrometheusService(name, name, v1.ServiceTypeClusterIP)
+	prometheusService := framework.MakePrometheusService(name, name, corev1.ServiceTypeClusterIP)
 	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, prometheusService); err != nil {
 		return nil, nil, err
 	}
@@ -217,7 +217,7 @@ func createRemoteWriteStack(name, ns string, prwtc testFramework.PromRemoteWrite
 
 func createServiceAccountSecret(t *testing.T, saName, ns string) {
 	// Create the secret object
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName + "-sa-secret",
 			Namespace: ns,
@@ -225,7 +225,7 @@ func createServiceAccountSecret(t *testing.T, saName, ns string) {
 				"kubernetes.io/service-account.name": saName,
 			},
 		},
-		Type: v1.SecretTypeServiceAccountToken,
+		Type: corev1.SecretTypeServiceAccountToken,
 	}
 
 	// Create the secret
@@ -889,9 +889,9 @@ func testPromResourceUpdate(t *testing.T) {
 
 	p := framework.MakeBasicPrometheus(ns, name, name, 1)
 
-	p.Spec.Resources = v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("100Mi"),
+	p.Spec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}
 	p, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
@@ -922,9 +922,9 @@ func testPromResourceUpdate(t *testing.T) {
 		ns,
 		monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("200Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
 					},
 				},
 			},
@@ -982,11 +982,11 @@ func testPromStorageLabelsAnnotations(t *testing.T) {
 					"test-annotation": "bar",
 				},
 			},
-			Spec: v1.PersistentVolumeClaimSpec{
-				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-				Resources: v1.VolumeResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceStorage: resource.MustParse("200Mi"),
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("200Mi"),
 					},
 				},
 			},
@@ -1062,11 +1062,11 @@ func testPromStorageUpdate(t *testing.T) {
 								"test": "testPromStorageUpdate",
 							},
 						},
-						Spec: v1.PersistentVolumeClaimSpec{
-							AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-							Resources: v1.VolumeResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse("200Mi"),
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("200Mi"),
 								},
 							},
 						},
@@ -1094,11 +1094,11 @@ func testPromStorageUpdate(t *testing.T) {
 								"test": "testPromStorageUpdate",
 							},
 						},
-						Spec: v1.PersistentVolumeClaimSpec{
+						Spec: corev1.PersistentVolumeClaimSpec{
 							StorageClassName: ptr.To("unknown-storage-class"),
-							Resources: v1.VolumeResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse("200Mi"),
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("200Mi"),
 								},
 							},
 						},
@@ -1155,17 +1155,17 @@ func testPromReloadConfig(t *testing.T) {
 			p := framework.MakeBasicPrometheus(ns, name, name, 1)
 			p.Spec.ServiceMonitorSelector = nil
 			p.Spec.PodMonitorSelector = nil
-			p.Spec.AdditionalScrapeConfigs = &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			p.Spec.AdditionalScrapeConfigs = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: fmt.Sprintf("additional-config-%s", name),
 				},
 				Key: "config.yaml",
 			}
 			p.Spec.ReloadStrategy = ptr.To(tc.reloadStrategy)
 
-			svc := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 
-			cfg := &v1.Secret{
+			cfg := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("additional-config-%s", name),
 				},
@@ -1227,7 +1227,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 
 	prometheusName := "test"
 	group := "additional-config-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
 	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
@@ -1239,7 +1239,7 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
   static_configs:
   - targets: ["localhost:9090"]
 `
-	secret := v1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "additional-scrape-configs",
 		},
@@ -1253,8 +1253,8 @@ func testPromAdditionalScrapeConfig(t *testing.T) {
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	p.Spec.AdditionalScrapeConfigs = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	p.Spec.AdditionalScrapeConfigs = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "additional-scrape-configs",
 		},
 		Key: "prometheus-additional.yaml",
@@ -1284,7 +1284,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 
 	prometheusName := "test"
 	group := "additional-alert-config-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
 	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
@@ -1297,7 +1297,7 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
   static_configs:
   - targets: ["localhost:9093"]
 `
-	secret := v1.Secret{
+	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "additional-alert-configs",
 		},
@@ -1311,8 +1311,8 @@ func testPromAdditionalAlertManagerConfig(t *testing.T) {
 	}
 
 	p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
-	p.Spec.AdditionalAlertManagerConfigs = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	p.Spec.AdditionalAlertManagerConfigs = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "additional-alert-configs",
 		},
 		Key: "prometheus-additional.yaml",
@@ -1378,7 +1378,7 @@ func testPromReloadRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
@@ -1436,7 +1436,7 @@ func testPromMultiplePrometheusRulesSameNS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
@@ -1492,7 +1492,7 @@ func testPromMultiplePrometheusRulesDifferentNS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), rootNS, pSVC); err != nil {
 		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
@@ -1559,7 +1559,7 @@ func testPromRulesExceedingConfigMapLimit(t *testing.T) {
 	require.NoError(t, err)
 	generation := sts.Generation
 
-	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+	pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC)
 	require.NoError(t, err)
 
@@ -1835,7 +1835,7 @@ func testPromOnlyUpdatedOnRelevantChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	pSVC := framework.MakePrometheusService(prometheus.Name, name, corev1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC); err != nil {
 		t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 	} else {
@@ -2008,16 +2008,16 @@ func testPromPreserveUserAddedMetadata(t *testing.T) {
 	}
 }
 
-func asService(t *testing.T, object metav1.Object) *v1.Service {
-	svc, ok := object.(*v1.Service)
+func asService(t *testing.T, object metav1.Object) *corev1.Service {
+	svc, ok := object.(*corev1.Service)
 	if !ok {
 		t.Fatalf("expected service got %T", object)
 	}
 	return svc
 }
 
-func asEndpoints(t *testing.T, object metav1.Object) *v1.Endpoints {
-	endpoints, ok := object.(*v1.Endpoints)
+func asEndpoints(t *testing.T, object metav1.Object) *corev1.Endpoints {
+	endpoints, ok := object.(*corev1.Endpoints)
 	if !ok {
 		t.Fatalf("expected endpoints got %T", object)
 	}
@@ -2032,8 +2032,8 @@ func asStatefulSet(t *testing.T, object metav1.Object) *appsv1.StatefulSet {
 	return sset
 }
 
-func asSecret(t *testing.T, object metav1.Object) *v1.Secret {
-	sec, ok := object.(*v1.Secret)
+func asSecret(t *testing.T, object metav1.Object) *corev1.Secret {
+	sec, ok := object.(*corev1.Secret)
 	if !ok {
 		t.Fatalf("expected secret set got %T", object)
 	}
@@ -2126,7 +2126,7 @@ func testPromDiscovery(t *testing.T) {
 
 			prometheusName := "test"
 			group := "servicediscovery-test"
-			svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 			s := framework.MakeBasicServiceMonitor(group)
 			if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
@@ -2179,7 +2179,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 			t.Fatal(err)
 		} else {
@@ -2203,7 +2203,7 @@ func testPromSharedResourcesReconciliation(t *testing.T) {
 
 	// Delete the service monitors and check that both Prometheus instances are updated.
 	for _, prometheusName := range []string{"test", "test2"} {
-		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), v1.ServiceTypeClusterIP)
+		svc := framework.MakePrometheusService(prometheusName, fmt.Sprintf("reconcile-%s", prometheusName), corev1.ServiceTypeClusterIP)
 
 		if err := framework.WaitForActiveTargets(context.Background(), ns, svc.Name, 0); err != nil {
 			t.Fatalf("Validating Prometheus active targets failed for %s: %v", prometheusName, err)
@@ -2220,7 +2220,7 @@ func testShardingProvisioning(t *testing.T) {
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
 	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
@@ -2295,7 +2295,7 @@ func testResharding(t *testing.T) {
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
 	if _, err := framework.MonClientV1.ServiceMonitors(ns).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
@@ -2394,8 +2394,8 @@ func testPromAlertmanagerDiscovery(t *testing.T) {
 			prometheusName := "test"
 			alertmanagerName := "test"
 			group := "servicediscovery-test"
-			svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
-			amsvc := framework.MakeAlertmanagerService(alertmanagerName, group, v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
+			amsvc := framework.MakeAlertmanagerService(alertmanagerName, group, corev1.ServiceTypeClusterIP)
 
 			p := framework.MakeBasicPrometheus(ns, prometheusName, group, 1)
 			framework.AddAlertingToPrometheus(p, ns, alertmanagerName)
@@ -2445,7 +2445,7 @@ func testPromExposingWithKubernetesAPI(t *testing.T) {
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
 	basicPrometheus := framework.MakeBasicPrometheus(ns, "basic-prometheus", "test-group", 1)
-	service := framework.MakePrometheusService(basicPrometheus.Name, "test-group", v1.ServiceTypeClusterIP)
+	service := framework.MakePrometheusService(basicPrometheus.Name, "test-group", corev1.ServiceTypeClusterIP)
 
 	if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, basicPrometheus); err != nil {
 		t.Fatal("Creating prometheus failed: ", err)
@@ -2472,7 +2472,7 @@ func testPromDiscoverTargetPort(t *testing.T) {
 
 	prometheusName := "test"
 	group := "servicediscovery-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	targetPort := intstr.FromInt(9090)
 	sm := &monitoringv1.ServiceMonitor{
@@ -2543,7 +2543,7 @@ func testPromOpMatchPromAndServMonInDiffNSs(t *testing.T) {
 	prometheusJobName := serviceMonitorNSName + "/" + group
 
 	prometheusName := "test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	s := framework.MakeBasicServiceMonitor(group)
 
@@ -2594,7 +2594,7 @@ func testThanos(t *testing.T) {
 	prom, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom)
 	require.NoError(t, err)
 
-	promSvc := framework.MakePrometheusService(prom.Name, "test-group", v1.ServiceTypeClusterIP)
+	promSvc := framework.MakePrometheusService(prom.Name, "test-group", corev1.ServiceTypeClusterIP)
 	_, err = framework.KubeClient.CoreV1().Services(ns).Create(context.Background(), promSvc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -2657,12 +2657,12 @@ func testPromGetAuthSecret(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		secret         *v1.Secret
+		secret         *corev1.Secret
 		serviceMonitor func() *monitoringv1.ServiceMonitor
 	}{
 		{
 			name: "basic-auth",
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -2674,14 +2674,14 @@ func testPromGetAuthSecret(t *testing.T) {
 			serviceMonitor: func() *monitoringv1.ServiceMonitor {
 				sm := framework.MakeBasicServiceMonitor(name)
 				sm.Spec.Endpoints[0].BasicAuth = &monitoringv1.BasicAuth{
-					Username: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Username: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: name,
 						},
 						Key: "user",
 					},
-					Password: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Password: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: name,
 						},
 						Key: "password",
@@ -2693,7 +2693,7 @@ func testPromGetAuthSecret(t *testing.T) {
 		},
 		{
 			name: "bearer-token",
-			secret: &v1.Secret{
+			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -2703,8 +2703,8 @@ func testPromGetAuthSecret(t *testing.T) {
 			},
 			serviceMonitor: func() *monitoringv1.ServiceMonitor {
 				sm := framework.MakeBasicServiceMonitor(name)
-				sm.Spec.Endpoints[0].BearerTokenSecret = &v1.SecretKeySelector{ //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
-					LocalObjectReference: v1.LocalObjectReference{
+				sm.Spec.Endpoints[0].BearerTokenSecret = &corev1.SecretKeySelector{ //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
 					Key: "bearertoken",
@@ -2749,16 +2749,16 @@ func testPromGetAuthSecret(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			svc := &v1.Service{
+			svc := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 					Labels: map[string]string{
 						"group": name,
 					},
 				},
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeLoadBalancer,
-					Ports: []v1.ServicePort{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
 						{
 							Name: "web",
 							Port: 8080,
@@ -2856,7 +2856,7 @@ func testOperatorNSScope(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), mainNS, pSVC); err != nil {
 			t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 		} else {
@@ -2922,7 +2922,7 @@ func testOperatorNSScope(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", v1.ServiceTypeClusterIP)
+		pSVC := framework.MakePrometheusService(p.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 		if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), prometheusNS, pSVC); err != nil {
 			t.Fatal(fmt.Errorf("creating Prometheus service failed: %w", err))
 		} else {
@@ -2988,8 +2988,8 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 					HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 						HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
-							BearerTokenSecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							BearerTokenSecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: name,
 								},
 								Key: "bearer-token",
@@ -3058,23 +3058,23 @@ func testPromArbitraryFSAcc(t *testing.T) {
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: ptr.To(true),
 								CA: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: name,
 										},
 										Key: "cert.pem",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									Secret: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: name,
 										},
 										Key: "cert.pem",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "key.pem",
@@ -3099,23 +3099,23 @@ func testPromArbitraryFSAcc(t *testing.T) {
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: ptr.To(true),
 								CA: monitoringv1.SecretOrConfigMap{
-									ConfigMap: &v1.ConfigMapKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									ConfigMap: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: name,
 										},
 										Key: "cert.pem",
 									},
 								},
 								Cert: monitoringv1.SecretOrConfigMap{
-									ConfigMap: &v1.ConfigMapKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{
+									ConfigMap: &corev1.ConfigMapKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: name,
 										},
 										Key: "cert.pem",
 									},
 								},
-								KeySecret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "key.pem",
@@ -3151,7 +3151,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				t.Fatalf("failed to load key.pem: %v", err)
 			}
 
-			tlsCertsSecret := &v1.Secret{
+			tlsCertsSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -3166,7 +3166,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tlsCertsConfigMap := &v1.ConfigMap{
+			tlsCertsConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -3197,7 +3197,7 @@ func testPromArbitraryFSAcc(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			svc := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(prometheusCRD.Name, name, corev1.ServiceTypeClusterIP)
 			if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc); err != nil {
 				t.Fatal(err)
 			}
@@ -3225,18 +3225,18 @@ func testPromArbitraryFSAcc(t *testing.T) {
 func mountTLSFiles(p *monitoringv1.Prometheus, secretName string) {
 	volumeName := secretName
 	p.Spec.Volumes = append(p.Spec.Volumes,
-		v1.Volume{
+		corev1.Volume{
 			Name: volumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: secretName,
 				},
 			},
 		})
-	p.Spec.Containers = []v1.Container{
+	p.Spec.Containers = []corev1.Container{
 		{
 			Name: "prometheus",
-			VolumeMounts: []v1.VolumeMount{
+			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      volumeName,
 					MountPath: "/etc/ca-certificates",
@@ -3271,7 +3271,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		t.Fatalf("failed to load key.pem: %v", err)
 	}
 
-	tlsCertsSecret := &v1.Secret{
+	tlsCertsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -3292,18 +3292,18 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 
 	simple.Spec.Template.Spec.Containers[0].Args = []string{"--cert-path=/etc/certs"}
 
-	simple.Spec.Template.Spec.Volumes = []v1.Volume{
+	simple.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{
 			Name: "tls-certs",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: tlsCertsSecret.Name,
 				},
 			},
 		},
 	}
 
-	simple.Spec.Template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+	simple.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      simple.Spec.Template.Spec.Volumes[0].Name,
 			MountPath: "/etc/certs",
@@ -3314,16 +3314,16 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		t.Fatal("Creating simple basic auth app failed: ", err)
 	}
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 8080,
@@ -3359,15 +3359,15 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 						SafeTLSConfig: monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: tlsCertsSecret.Name,
 									},
 									Key: "cert.pem",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: tlsCertsSecret.Name,
 								},
 								Key: "key.pem",
@@ -3389,7 +3389,7 @@ func testPromTLSConfigViaSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, v1.ServiceTypeClusterIP)
+	promSVC := framework.MakePrometheusService(prometheusCRD.Name, name, corev1.ServiceTypeClusterIP)
 
 	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, promSVC); err != nil {
 		t.Fatal(err)
@@ -3446,7 +3446,7 @@ func testPromStaticProbe(t *testing.T) {
 
 	prometheusName := "test"
 	group := "probe-test"
-	svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 	proberURL := blackboxExporterName + ":9115"
 	targets := []string{svc.Name + ":9090"}
@@ -3522,14 +3522,14 @@ func testPromSecurePodMonitor(t *testing.T) {
 					HTTPConfig: monitoringv1.HTTPConfig{
 						HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
 							BasicAuth: &monitoringv1.BasicAuth{
-								Username: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Username: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "user",
 								},
-								Password: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Password: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "password",
@@ -3550,8 +3550,8 @@ func testPromSecurePodMonitor(t *testing.T) {
 				HTTPConfigWithProxy: monitoringv1.HTTPConfigWithProxy{
 					HTTPConfig: monitoringv1.HTTPConfig{
 						HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
-							BearerTokenSecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							BearerTokenSecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: name,
 								},
 								Key: "bearer-token",
@@ -3575,23 +3575,23 @@ func testPromSecurePodMonitor(t *testing.T) {
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),
 							CA: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "cert.pem",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								Secret: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "cert.pem",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: name,
 								},
 								Key: "key.pem",
@@ -3612,23 +3612,23 @@ func testPromSecurePodMonitor(t *testing.T) {
 						TLSConfig: &monitoringv1.SafeTLSConfig{
 							InsecureSkipVerify: ptr.To(true),
 							CA: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "cert.pem",
 								},
 							},
 							Cert: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 									Key: "cert.pem",
 								},
 							},
-							KeySecret: &v1.SecretKeySelector{
-								LocalObjectReference: v1.LocalObjectReference{
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: name,
 								},
 								Key: "key.pem",
@@ -3662,7 +3662,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 				t.Fatalf("failed to load key.pem: %v", err)
 			}
 
-			secret := &v1.Secret{
+			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -3679,7 +3679,7 @@ func testPromSecurePodMonitor(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tlsCertsConfigMap := &v1.ConfigMap{
+			tlsCertsConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
 				},
@@ -3697,18 +3697,18 @@ func testPromSecurePodMonitor(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			simple.Spec.Template.Spec.Volumes = []v1.Volume{
+			simple.Spec.Template.Spec.Volumes = []corev1.Volume{
 				{
 					Name: name,
-					VolumeSource: v1.VolumeSource{
-						Secret: &v1.SecretVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
 							SecretName: name,
 						},
 					},
 				},
 			}
 
-			simple.Spec.Template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+			simple.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 				{
 					Name:      name,
 					MountPath: "/etc/ca-certificates",
@@ -3767,15 +3767,15 @@ func testPromWebWithThanosSidecar(t *testing.T) {
 	prom.Spec.Web = &monitoringv1.PrometheusWebSpec{
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{
 			TLSConfig: &monitoringv1.WebTLSConfig{
-				KeySecret: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "web-tls",
 					},
 					Key: "tls.key",
 				},
 				Cert: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "web-tls",
 						},
 						Key: "tls.crt",
@@ -4135,7 +4135,7 @@ func testPromEnforcedNamespaceLabel(t *testing.T) {
 
 			prometheusName := "test"
 			group := "servicediscovery-test"
-			svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 			s := framework.MakeBasicServiceMonitor(group)
 			s.Spec.Endpoints[0].RelabelConfigs = tc.relabelConfigs
@@ -4280,7 +4280,7 @@ func testPromNamespaceEnforcementExclusion(t *testing.T) {
 
 			prometheusName := "test"
 			group := "servicediscovery-test"
-			svc := framework.MakePrometheusService(prometheusName, group, v1.ServiceTypeClusterIP)
+			svc := framework.MakePrometheusService(prometheusName, group, corev1.ServiceTypeClusterIP)
 
 			s := framework.MakeBasicServiceMonitor(group)
 			s.Spec.Endpoints[0].RelabelConfigs = tc.relabelConfigs
@@ -4379,9 +4379,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4395,9 +4395,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4411,9 +4411,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4427,9 +4427,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4444,9 +4444,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4461,9 +4461,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4480,9 +4480,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					ScrapeInterval: "0",
@@ -4496,9 +4496,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					ScrapeInterval: "30s",
@@ -4512,9 +4512,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					ScrapeInterval: "1h30m15s",
@@ -4528,9 +4528,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					ScrapeInterval: "600",
@@ -4545,9 +4545,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					ScrapeInterval: "60ss",
@@ -4562,9 +4562,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					Web: &monitoringv1.PrometheusWebSpec{
@@ -4580,9 +4580,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					Web: &monitoringv1.PrometheusWebSpec{
@@ -4599,9 +4599,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4617,9 +4617,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4636,9 +4636,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					DNSPolicy: ptr.To(monitoringv1.DNSPolicy("ClusterFirst")),
@@ -4662,9 +4662,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 					DNSPolicy: ptr.To(monitoringv1.DNSPolicy("InvalidPolicy")),
@@ -4681,9 +4681,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4709,9 +4709,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -4738,9 +4738,9 @@ func testPrometheusCRDValidation(t *testing.T) {
 					Replicas:           &replicas,
 					Version:            operator.DefaultPrometheusVersion,
 					ServiceAccountName: "prometheus",
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("400Mi"),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
 						},
 					},
 				},
@@ -5128,7 +5128,7 @@ func testPromDegradedConditionStatus(t *testing.T) {
 		ns,
 		monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Containers: []v1.Container{{
+				Containers: []corev1.Container{{
 					Name:  "bad-image",
 					Image: "quay.io/prometheus-operator/invalid-image",
 				}},
@@ -5260,9 +5260,9 @@ func testPromStrategicMergePatch(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: ns},
-		Type:       v1.SecretType("Opaque"),
+		Type:       corev1.SecretType("Opaque"),
 		Data:       map[string][]byte{},
 	}
 	_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
@@ -5270,7 +5270,7 @@ func testPromStrategicMergePatch(t *testing.T) {
 		t.Fatalf("failed to create secret: %s", err)
 	}
 
-	configmap := &v1.ConfigMap{
+	configmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "configmap", Namespace: ns},
 		Data:       map[string]string{},
 	}
@@ -5282,11 +5282,11 @@ func testPromStrategicMergePatch(t *testing.T) {
 	p := framework.MakeBasicPrometheus(ns, "test", "", 1)
 	p.Spec.Secrets = []string{secret.Name}
 	p.Spec.ConfigMaps = []string{configmap.Name}
-	p.Spec.Containers = []v1.Container{{
+	p.Spec.Containers = []corev1.Container{{
 		Name:  "sidecar",
 		Image: "nginx",
 		// Ensure that the sidecar container can mount the additional secret and configmap.
-		VolumeMounts: []v1.VolumeMount{{
+		VolumeMounts: []corev1.VolumeMount{{
 			Name:      "secret-" + secret.Name,
 			MountPath: "/tmp/secret",
 		}, {
@@ -5314,16 +5314,16 @@ func testPrometheusWithStatefulsetCreationFailure(t *testing.T) {
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{
 			TLSConfig: &monitoringv1.WebTLSConfig{
 				Cert: monitoringv1.SecretOrConfigMap{
-					ConfigMap: &v1.ConfigMapKeySelector{},
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ConfigMap: &corev1.ConfigMapKeySelector{},
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "tls-cert",
 						},
 						Key: "tls.crt",
 					},
 				},
-				KeySecret: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "tls-cert",
 					},
 					Key: "tls.key",
@@ -5401,14 +5401,14 @@ func testPrometheusServiceName(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	name := "test-servicename"
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", name),
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 9090,
@@ -5524,16 +5524,16 @@ func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 	framework.CreateDeployment(context.Background(), ns2, simple)
 	require.NoError(t, err)
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: simple.Spec.Template.ObjectMeta.Labels,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 8080,
@@ -5547,15 +5547,15 @@ func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 	sm := framework.MakeBasicServiceMonitor(name)
 	sm.Spec.Endpoints[0].Interval = monitoringv1.Duration("1s")
 	sm.Spec.Endpoints[0].BasicAuth = &monitoringv1.BasicAuth{
-		Username: v1.SecretKeySelector{
+		Username: corev1.SecretKeySelector{
 			Key: "user",
-			LocalObjectReference: v1.LocalObjectReference{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "auth",
 			},
 		},
-		Password: v1.SecretKeySelector{
+		Password: corev1.SecretKeySelector{
 			Key: "pass",
-			LocalObjectReference: v1.LocalObjectReference{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "auth",
 			},
 		},
@@ -5584,7 +5584,7 @@ func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 	require.Empty(t, targets)
 
 	// Create the secret and wait for the target to be discovered.
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "auth",
 			Namespace: ns2,
@@ -5593,7 +5593,7 @@ func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 			"user": "user",
 			"pass": "pass",
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	secret, err = framework.KubeClient.CoreV1().Secrets(ns2).Create(ctx, secret, metav1.CreateOptions{})
@@ -5643,20 +5643,20 @@ func testPrometheusUTF8MetricsSupport(t *testing.T) {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "instrumented-sample-app"},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "instrumented-sample-app",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
 						Name:  "instrumented-sample-app",
 						Image: "quay.io/prometheus-operator/instrumented-sample-app:latest",
-						Ports: []v1.ContainerPort{{
+						Ports: []corev1.ContainerPort{{
 							Name:          "web",
 							ContainerPort: 8080,
-							Protocol:      v1.ProtocolTCP,
+							Protocol:      corev1.ProtocolTCP,
 						}},
 					}},
 				},
@@ -5666,7 +5666,7 @@ func testPrometheusUTF8MetricsSupport(t *testing.T) {
 	_, err = framework.KubeClient.AppsV1().Deployments(ns).Create(context.Background(), deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	service := &v1.Service{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "utf8-test-service",
 			Namespace: ns,
@@ -5675,8 +5675,8 @@ func testPrometheusUTF8MetricsSupport(t *testing.T) {
 				"group": "test-app",
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports:    []v1.ServicePort{{Name: "web", Port: 8080, TargetPort: intstr.FromInt(8080)}},
+		Spec: corev1.ServiceSpec{
+			Ports:    []corev1.ServicePort{{Name: "web", Port: 8080, TargetPort: intstr.FromInt(8080)}},
 			Selector: map[string]string{"app": "instrumented-sample-app"},
 		},
 	}
@@ -5700,12 +5700,12 @@ func testPrometheusUTF8MetricsSupport(t *testing.T) {
 					HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 						HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
 							BasicAuth: &monitoringv1.BasicAuth{
-								Username: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "basic-auth"},
+								Username: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "basic-auth"},
 									Key:                  "username",
 								},
-								Password: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "basic-auth"},
+								Password: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "basic-auth"},
 									Key:                  "password",
 								},
 							},
@@ -5716,12 +5716,12 @@ func testPrometheusUTF8MetricsSupport(t *testing.T) {
 		},
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic-auth",
 			Namespace: ns,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
 			"username": "user",
 			"password": "pass",
@@ -5874,20 +5874,20 @@ func testPrometheusUTF8LabelSupport(t *testing.T) {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.name": "instrumented-sample-app"},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app.name": "instrumented-sample-app",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
 						Name:  "instrumented-sample-app",
 						Image: "quay.io/prometheus-operator/instrumented-sample-app:latest",
-						Ports: []v1.ContainerPort{{
+						Ports: []corev1.ContainerPort{{
 							Name:          "web",
 							ContainerPort: 8080,
-							Protocol:      v1.ProtocolTCP,
+							Protocol:      corev1.ProtocolTCP,
 						}},
 					}},
 				},
@@ -5897,7 +5897,7 @@ func testPrometheusUTF8LabelSupport(t *testing.T) {
 	_, err := framework.KubeClient.AppsV1().Deployments(ns).Create(context.Background(), deployment, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	service := &v1.Service{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "utf8-test-service",
 			Namespace: ns,
@@ -5907,8 +5907,8 @@ func testPrometheusUTF8LabelSupport(t *testing.T) {
 				"cluster":  "dev",
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports:    []v1.ServicePort{{Name: "web", Port: 8080, TargetPort: intstr.FromInt(8080)}},
+		Spec: corev1.ServiceSpec{
+			Ports:    []corev1.ServicePort{{Name: "web", Port: 8080, TargetPort: intstr.FromInt(8080)}},
 			Selector: map[string]string{"app.name": "instrumented-sample-app"},
 		},
 	}
@@ -5937,12 +5937,12 @@ func testPrometheusUTF8LabelSupport(t *testing.T) {
 					HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 						HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
 							BasicAuth: &monitoringv1.BasicAuth{
-								Username: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "basic-auth"},
+								Username: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "basic-auth"},
 									Key:                  "username",
 								},
-								Password: v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{Name: "basic-auth"},
+								Password: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "basic-auth"},
 									Key:                  "password",
 								},
 							},
@@ -5953,12 +5953,12 @@ func testPrometheusUTF8LabelSupport(t *testing.T) {
 		},
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic-auth",
 			Namespace: ns,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
 			"username": "user",
 			"password": "pass",

--- a/test/e2e/prometheusagent_test.go
+++ b/test/e2e/prometheusagent_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -139,11 +139,11 @@ func testAgentCheckStorageClass(t *testing.T) {
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				Storage: &monitoringv1.StorageSpec{
 					VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-						Spec: v1.PersistentVolumeClaimSpec{
+						Spec: corev1.PersistentVolumeClaimSpec{
 							StorageClassName: ptr.To("unknown-storage-class"),
-							Resources: v1.VolumeResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse("200Mi"),
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("200Mi"),
 								},
 							},
 						},
@@ -214,9 +214,9 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 	name := "test"
 	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	p.Spec.Resources = v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("100Mi"),
+	p.Spec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}
 
@@ -236,9 +236,9 @@ func testPromAgentDaemonSetResourceUpdate(t *testing.T) {
 		ns,
 		monitoringv1alpha1.PrometheusAgentSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("200Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
 					},
 				},
 			},
@@ -286,9 +286,9 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	name := "test"
 	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	p.Spec.Resources = v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("100Mi"),
+	p.Spec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}
 
@@ -302,9 +302,9 @@ func testPromAgentReconcileDaemonSetResourceUpdate(t *testing.T) {
 	res := dms.Spec.Template.Spec.Containers[0].Resources
 	require.Equal(t, res, p.Spec.Resources)
 
-	dms.Spec.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("200Mi"),
+	dms.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
 	framework.KubeClient.AppsV1().DaemonSets(ns).Update(ctx, dms, metav1.UpdateOptions{})
@@ -394,7 +394,7 @@ func testPrometheusAgentDaemonSetSelectPodMonitor(t *testing.T) {
 	require.NoError(t, err)
 
 	var pollErr error
-	var paPods *v1.PodList
+	var paPods *corev1.PodList
 	var firstTargetIP string
 	var secondTargetIP string
 
@@ -594,14 +594,14 @@ func testPrometheusAgentSSetServiceName(t *testing.T) {
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 	name := "test-agent-servicename"
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", name),
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 9090,
@@ -716,11 +716,11 @@ func testDaemonSetInvalidStorage(t *testing.T) {
 	// storage should not be set in Daemonsets
 	p.Spec.CommonPrometheusFields.Storage = &monitoringv1.StorageSpec{
 		VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-			Spec: v1.PersistentVolumeClaimSpec{
+			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: ptr.To("standard"),
-				Resources: v1.VolumeResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceStorage: resource.MustParse("200Mi"),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("200Mi"),
 					},
 				},
 			},
@@ -998,8 +998,8 @@ func testDaemonSetInvalidAdditionalScrapeConfigs(t *testing.T) {
 	name := "test-invalid-additional-scrape-configs"
 	p := framework.MakeBasicPrometheusAgentDaemonSet(ns, name)
 
-	p.Spec.AdditionalScrapeConfigs = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	p.Spec.AdditionalScrapeConfigs = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: "test-secret",
 		},
 		Key: "key",

--- a/test/e2e/scrapeconfig_test.go
+++ b/test/e2e/scrapeconfig_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -136,8 +136,8 @@ func testScrapeConfigCreation(t *testing.T) {
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "ak",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key.pem",
@@ -156,8 +156,8 @@ func testScrapeConfigCreation(t *testing.T) {
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "ak",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key.pem",
@@ -176,8 +176,8 @@ func testScrapeConfigCreation(t *testing.T) {
 				ScalewaySDConfigs: []monitoringv1alpha1.ScalewaySDConfig{
 					{
 						AccessKey: "ak",
-						SecretKey: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
+						SecretKey: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "secret",
 							},
 							Key: "key.pem",
@@ -461,8 +461,8 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 	sc := framework.MakeBasicScrapeConfig(ns, "scrape-config")
 	sc.Spec.Scheme = ptr.To(monitoringv1.SchemeHTTPS)
 	sc.Spec.Authorization = &monitoringv1.SafeAuthorization{
-		Credentials: &v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		Credentials: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: "prometheus-sa-secret",
 			},
 			Key: "token",
@@ -472,23 +472,23 @@ func testScrapeConfigKubernetesNodeRole(t *testing.T) {
 		// since we cannot validate server name in cert
 		InsecureSkipVerify: ptr.To(true),
 		CA: monitoringv1.SecretOrConfigMap{
-			Secret: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key: "ca.crt",
 			},
 		},
 		Cert: monitoringv1.SecretOrConfigMap{
-			Secret: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: secretName,
 				},
 				Key: "cert.pem",
 			},
 		},
-		KeySecret: &v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		KeySecret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: secretName,
 			},
 			Key: "key.pem",
@@ -2427,8 +2427,8 @@ var AzureSDTestCases = []scrapeCRDTestCase{
 					TenantID:             ptr.To("22222222-2222-2222-2222-222222222222"),
 					ClientID:             ptr.To("33333333-3333-3333-3333-333333333333"),
 					SubscriptionID:       "11111111-1111-1111-1111-111111111111",
-					ClientSecret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					ClientSecret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "azure-client-secret",
 						},
 						Key: "clientSecret",
@@ -2521,8 +2521,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceDedicatedServer,
 					Endpoint:          ptr.To("https://api.ovh.com/endpoint"),
 					RefreshInterval:   ptr.To(monitoringv1.Duration("30s")),
@@ -2537,8 +2537,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceDedicatedServer,
 				},
 			},
@@ -2551,8 +2551,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 				},
 			},
@@ -2565,8 +2565,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 				},
 			},
@@ -2578,8 +2578,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 		scrapeConfigSpec: monitoringv1alpha1.ScrapeConfigSpec{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 				},
 			},
@@ -2592,8 +2592,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 				},
 			},
@@ -2606,8 +2606,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceDedicatedServer,
 				},
 			},
@@ -2620,8 +2620,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           "InvalidService",
 				},
 			},
@@ -2634,8 +2634,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 				},
 			},
 		},
@@ -2647,8 +2647,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 				},
 			},
@@ -2661,8 +2661,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 					Endpoint:          ptr.To(""),
 				},
@@ -2676,8 +2676,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 					RefreshInterval:   ptr.To(monitoringv1.Duration("")),
 				},
@@ -2691,8 +2691,8 @@ var OVHCloudSDTestCases = []scrapeCRDTestCase{
 			OVHCloudSDConfigs: []monitoringv1alpha1.OVHCloudSDConfig{
 				{
 					ApplicationKey:    "valid-app-key",
-					ApplicationSecret: v1.SecretKeySelector{Key: "valid-secret-key"},
-					ConsumerKey:       v1.SecretKeySelector{Key: "valid-consumer-key"},
+					ApplicationSecret: corev1.SecretKeySelector{Key: "valid-secret-key"},
+					ConsumerKey:       corev1.SecretKeySelector{Key: "valid-consumer-key"},
 					Service:           monitoringv1alpha1.OVHServiceVPS,
 					RefreshInterval:   ptr.To(monitoringv1.Duration("30s")),
 				},
@@ -3397,8 +3397,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3416,8 +3416,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3434,8 +3434,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 				{
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3453,8 +3453,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3472,8 +3472,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3490,8 +3490,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 				{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3509,8 +3509,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3528,8 +3528,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleBaremetal,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3547,8 +3547,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      "Invalid Role",
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3565,8 +3565,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 				{
 					ProjectID: "1",
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3584,8 +3584,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3604,8 +3604,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3624,8 +3624,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3644,8 +3644,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3664,8 +3664,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3684,8 +3684,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3704,8 +3704,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3724,8 +3724,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleBaremetal,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3744,8 +3744,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3764,8 +3764,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3784,8 +3784,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleBaremetal,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3804,8 +3804,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3824,8 +3824,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleInstance,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",
@@ -3844,8 +3844,8 @@ var ScalewaySDTestCases = []scrapeCRDTestCase{
 					ProjectID: "1",
 					Role:      monitoringv1alpha1.ScalewayRoleBaremetal,
 					AccessKey: "AccessKey",
-					SecretKey: v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					SecretKey: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "secret",
 						},
 						Key: "key.pem",

--- a/test/e2e/status_subresource_test.go
+++ b/test/e2e/status_subresource_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -89,7 +88,7 @@ func testServiceMonitorStatusSubresource(t *testing.T) {
 	// Create a first service monitor to check that the operator only updates the binding when needed.
 	sm1 := framework.MakeBasicServiceMonitor("smon1")
 	sm1.Labels["group"] = name
-	sm1, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm1, v1.CreateOptions{})
+	sm1, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
@@ -105,7 +104,7 @@ func testServiceMonitorStatusSubresource(t *testing.T) {
 	// Create a second service monitor to check that the operator updates the binding when the condition changes.
 	sm2 := framework.MakeBasicServiceMonitor("smon2")
 	sm2.Labels["group"] = name
-	sm2, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm2, v1.CreateOptions{})
+	sm2, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sm2, err = framework.WaitForServiceMonitorCondition(ctx, sm2, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -115,7 +114,7 @@ func testServiceMonitorStatusSubresource(t *testing.T) {
 	// change the status of the service monitor and the observed timetstamp
 	// should be the same as before.
 	sm1.Labels["test"] = "test"
-	sm1, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm1, v1.UpdateOptions{})
+	sm1, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second service monitor to reference an non-existing Secret.
@@ -127,7 +126,7 @@ func testServiceMonitorStatusSubresource(t *testing.T) {
 			},
 		},
 	}
-	sm2, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm2, v1.UpdateOptions{})
+	sm2, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second ServiceMonitor should change to Accepted=False.
@@ -169,7 +168,7 @@ func testGarbageCollectionOfServiceMonitorBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	sm := framework.MakeBasicServiceMonitor(name)
-	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, v1.CreateOptions{})
+	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sm, err = framework.WaitForServiceMonitorCondition(ctx, sm, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -177,7 +176,7 @@ func testGarbageCollectionOfServiceMonitorBinding(t *testing.T) {
 
 	// Update the ServiceMonitor's labels, Prometheus doesn't select the resource anymore.
 	sm.Labels = map[string]string{}
-	sm, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm, v1.UpdateOptions{})
+	sm, err = framework.MonClientV1.ServiceMonitors(ns).Update(ctx, sm, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForServiceMonitorWorkloadBindingCleanup(ctx, sm, p, monitoringv1.PrometheusName, 1*time.Minute)
@@ -214,7 +213,7 @@ func testServiceMonitorStatusWithMultipleWorkloads(t *testing.T) {
 
 	sm := framework.MakeBasicServiceMonitor(name)
 	sm.Spec.Endpoints[0].BearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, v1.CreateOptions{})
+	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// The ServiceMonitor should be accepted by the Prometheus "server1" resource.
@@ -251,7 +250,7 @@ func testRmServiceMonitorBindingDuringWorkloadDelete(t *testing.T) {
 	require.NoError(t, err, "failed to create Prometheus")
 	smon := framework.MakeBasicServiceMonitor(name)
 
-	sm, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, smon, v1.CreateOptions{})
+	sm, err := framework.MonClientV1.ServiceMonitors(ns).Create(ctx, smon, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sm, err = framework.WaitForServiceMonitorCondition(ctx, sm, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -292,7 +291,7 @@ func testPodMonitorStatusSubresource(t *testing.T) {
 	// Create a first podmonitor to check that the operator only updates the binding when needed.
 	pm1 := framework.MakeBasicPodMonitor("pmon1")
 	pm1.Labels["group"] = name
-	pm1, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm1, v1.CreateOptions{})
+	pm1, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
@@ -308,7 +307,7 @@ func testPodMonitorStatusSubresource(t *testing.T) {
 	// Create a second podmonitor to check that the operator updates the binding when the condition changes.
 	pm2 := framework.MakeBasicPodMonitor("pmon2")
 	pm2.Labels["group"] = name
-	pm2, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm2, v1.CreateOptions{})
+	pm2, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pm2, err = framework.WaitForPodMonitorCondition(ctx, pm2, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -318,7 +317,7 @@ func testPodMonitorStatusSubresource(t *testing.T) {
 	// change the status of the podmonitor and the observed timetstamp
 	// should be the same as before.
 	pm1.Labels["test"] = "test"
-	pm1, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm1, v1.UpdateOptions{})
+	pm1, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second podmonitor to reference an non-existing Secret.
@@ -330,7 +329,7 @@ func testPodMonitorStatusSubresource(t *testing.T) {
 			},
 		},
 	}
-	pm2, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm2, v1.UpdateOptions{})
+	pm2, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second PodMonitor should change to Accepted=False.
@@ -414,7 +413,7 @@ func testProbeStatusSubresource(t *testing.T) {
 	// change the status of the probe and the observed timetstamp
 	// should be the same as before.
 	probe1.Labels["test"] = "test"
-	probe1, err = framework.MonClientV1.Probes(ns).Update(ctx, probe1, v1.UpdateOptions{})
+	probe1, err = framework.MonClientV1.Probes(ns).Update(ctx, probe1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second probe to reference an non-existing Secret.
@@ -426,7 +425,7 @@ func testProbeStatusSubresource(t *testing.T) {
 			},
 		},
 	}
-	probe2, err = framework.MonClientV1.Probes(ns).Update(ctx, probe2, v1.UpdateOptions{})
+	probe2, err = framework.MonClientV1.Probes(ns).Update(ctx, probe2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second Probe should change to Accepted=False.
@@ -468,7 +467,7 @@ func testGarbageCollectionOfPodMonitorBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	pm := framework.MakeBasicPodMonitor(name)
-	pm, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm, v1.CreateOptions{})
+	pm, err = framework.MonClientV1.PodMonitors(ns).Create(ctx, pm, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pm, err = framework.WaitForPodMonitorCondition(ctx, pm, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -476,7 +475,7 @@ func testGarbageCollectionOfPodMonitorBinding(t *testing.T) {
 
 	// Update the PodMonitor's labels, Prometheus doesn't select the resource anymore.
 	pm.Labels = map[string]string{}
-	pm, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm, v1.UpdateOptions{})
+	pm, err = framework.MonClientV1.PodMonitors(ns).Update(ctx, pm, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForPodMonitorWorkloadBindingCleanup(ctx, pm, p, monitoringv1.PrometheusName, 1*time.Minute)
@@ -508,7 +507,7 @@ func testRmPodMonitorBindingDuringWorkloadDelete(t *testing.T) {
 	require.NoError(t, err, "failed to create Prometheus")
 	pmon := framework.MakeBasicPodMonitor(name)
 
-	pm, err := framework.MonClientV1.PodMonitors(ns).Create(ctx, pmon, v1.CreateOptions{})
+	pm, err := framework.MonClientV1.PodMonitors(ns).Create(ctx, pmon, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pm, err = framework.WaitForPodMonitorCondition(ctx, pm, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -554,7 +553,7 @@ func testScrapeConfigStatusSubresource(t *testing.T) {
 	// Create a first scrapeConfig to check that the operator only updates the binding when needed.
 	sc1 := framework.MakeBasicScrapeConfig(ns, "sc1")
 	sc1.Labels["group"] = name
-	sc1, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc1, v1.CreateOptions{})
+	sc1, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
@@ -570,7 +569,7 @@ func testScrapeConfigStatusSubresource(t *testing.T) {
 	// Create a second scrapeConfig to check that the operator updates the binding when the condition changes.
 	sc2 := framework.MakeBasicScrapeConfig(ns, "sc2")
 	sc2.Labels["group"] = name
-	sc2, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc2, v1.CreateOptions{})
+	sc2, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sc2, err = framework.WaitForScrapeConfigCondition(ctx, sc2, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -580,7 +579,7 @@ func testScrapeConfigStatusSubresource(t *testing.T) {
 	// change the status of the scrapeConfig and the observed timetstamp
 	// should be the same as before.
 	sc1.Labels["test"] = "test"
-	sc1, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc1, v1.UpdateOptions{})
+	sc1, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second scrapeConfig to reference an non-existing Secret.
@@ -592,7 +591,7 @@ func testScrapeConfigStatusSubresource(t *testing.T) {
 			},
 		},
 	}
-	sc2, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc2, v1.UpdateOptions{})
+	sc2, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second ScrapeConfig should change to Accepted=False.
@@ -642,7 +641,7 @@ func testGarbageCollectionOfScrapeConfigBinding(t *testing.T) {
 	sc := framework.MakeBasicScrapeConfig(ns, name)
 	sc.Labels["group"] = name
 
-	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, v1.CreateOptions{})
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sc, err = framework.WaitForScrapeConfigCondition(ctx, sc, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -650,7 +649,7 @@ func testGarbageCollectionOfScrapeConfigBinding(t *testing.T) {
 
 	// Update the ScrapeConfig's labels, Prometheus doesn't select the resource anymore.
 	sc.Labels = map[string]string{}
-	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc, v1.UpdateOptions{})
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Update(ctx, sc, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForScrapeConfigWorkloadBindingCleanup(ctx, sc, p, monitoringv1.PrometheusName, 1*time.Minute)
@@ -689,7 +688,7 @@ func testRmScrapeConfigBindingDuringWorkloadDelete(t *testing.T) {
 	sc := framework.MakeBasicScrapeConfig(ns, name)
 	sc.Labels["group"] = name
 
-	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, v1.CreateOptions{})
+	sc, err = framework.MonClientV1alpha1.ScrapeConfigs(ns).Create(ctx, sc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	sc, err = framework.WaitForScrapeConfigCondition(ctx, sc, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -783,7 +782,7 @@ func testGarbageCollectionOfProbeBinding(t *testing.T) {
 
 	// Update the Probe's labels, Prometheus doesn't select the resource anymore.
 	probe.Labels = map[string]string{}
-	probe, err = framework.MonClientV1.Probes(ns).Update(ctx, probe, v1.UpdateOptions{})
+	probe, err = framework.MonClientV1.Probes(ns).Update(ctx, probe, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForProbeWorkloadBindingCleanup(ctx, probe, p, monitoringv1.PrometheusName, 1*time.Minute)
@@ -888,7 +887,7 @@ func testPrometheusRuleStatusSubresource(t *testing.T) {
 		},
 	})
 	pr1.Labels["group"] = name
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, v1.CreateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
@@ -914,7 +913,7 @@ func testPrometheusRuleStatusSubresource(t *testing.T) {
 		},
 	})
 	pr2.Labels["group"] = name
-	pr2, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr2, v1.CreateOptions{})
+	pr2, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr2, err = framework.WaitForRuleCondition(ctx, pr2, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -924,7 +923,7 @@ func testPrometheusRuleStatusSubresource(t *testing.T) {
 	// change the status of the PrometheusRule and the observed timestamp
 	// should be the same as before.
 	pr1.Labels["test"] = "test"
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, v1.UpdateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second PrometheusRule to have an invalid rule expression.
@@ -932,7 +931,7 @@ func testPrometheusRuleStatusSubresource(t *testing.T) {
 		Record: "test:invalid",
 		Expr:   intstr.FromString("invalid_expr{"),
 	})
-	pr2, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr2, v1.UpdateOptions{})
+	pr2, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second PrometheusRule should change to Accepted=False.
@@ -991,11 +990,11 @@ func testGarbageCollectionOfPrometheusRuleBinding(t *testing.T) {
 		},
 	})
 	pr1.Labels["group"] = name
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, v1.CreateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr1.Labels = map[string]string{}
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, v1.UpdateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForRuleWorkloadBindingCleanup(ctx, pr1, p, monitoringv1.PrometheusName, 1*time.Minute)
@@ -1044,7 +1043,7 @@ func testRmPrometheusRuleBindingDuringWorkloadDelete(t *testing.T) {
 		},
 	})
 	pr.Labels["group"] = name
-	pr, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr, v1.CreateOptions{})
+	pr, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr, err = framework.WaitForRuleCondition(ctx, pr, p, monitoringv1.PrometheusName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -1081,7 +1080,7 @@ func testFinalizerForThanosRulerWhenStatusForConfigResEnabled(t *testing.T) {
 	_, err = framework.CreateThanosRulerAndWaitUntilReady(ctx, ns, tr)
 	require.NoError(t, err)
 
-	ruler, err := framework.MonClientV1.ThanosRulers(ns).Get(ctx, name, v1.GetOptions{})
+	ruler, err := framework.MonClientV1.ThanosRulers(ns).Get(ctx, name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	finalizers := ruler.GetFinalizers()
@@ -1134,7 +1133,7 @@ func testPrometheusRuleStatusSubresourceForThanosRuler(t *testing.T) {
 		},
 	})
 	pr1.Labels["group"] = name
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, v1.CreateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Record the lastTransitionTime value.
@@ -1160,7 +1159,7 @@ func testPrometheusRuleStatusSubresourceForThanosRuler(t *testing.T) {
 		},
 	})
 	pr2.Labels["group"] = name
-	pr2, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr2, v1.CreateOptions{})
+	pr2, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr2, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr2, err = framework.WaitForRuleCondition(ctx, pr2, tr, monitoringv1.ThanosRulerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
@@ -1170,7 +1169,7 @@ func testPrometheusRuleStatusSubresourceForThanosRuler(t *testing.T) {
 	// change the status of the PrometheusRule and the observed timestamp
 	// should be the same as before.
 	pr1.Labels["test"] = "test"
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, v1.UpdateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Update the second PrometheusRule to have an invalid rule expression.
@@ -1178,7 +1177,7 @@ func testPrometheusRuleStatusSubresourceForThanosRuler(t *testing.T) {
 		Record: "test:invalid",
 		Expr:   intstr.FromString("invalid_expr{"),
 	})
-	pr2, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr2, v1.UpdateOptions{})
+	pr2, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr2, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// The second PrometheusRule should change to Accepted=False.
@@ -1237,14 +1236,14 @@ func testGarbageCollectionOfPromRuleBindingForThanosRuler(t *testing.T) {
 		},
 	})
 	pr1.Labels["group"] = name
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, v1.CreateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr1, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr1, err = framework.WaitForRuleCondition(ctx, pr1, tr, monitoringv1.ThanosRulerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 1*time.Minute)
 	require.NoError(t, err)
 
 	pr1.Labels = map[string]string{}
-	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, v1.UpdateOptions{})
+	pr1, err = framework.MonClientV1.PrometheusRules(ns).Update(ctx, pr1, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.WaitForRuleWorkloadBindingCleanup(ctx, pr1, tr, monitoringv1.ThanosRulerName, 1*time.Minute)
@@ -1293,7 +1292,7 @@ func testRmPromeRuleBindingDuringWorkloadDeleteForThanosRuler(t *testing.T) {
 		},
 	})
 	pr.Labels["group"] = name
-	pr, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr, v1.CreateOptions{})
+	pr, err = framework.MonClientV1.PrometheusRules(ns).Create(ctx, pr, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	pr, err = framework.WaitForRuleCondition(ctx, pr, tr, monitoringv1.ThanosRulerName, monitoringv1.Accepted, monitoringv1.ConditionTrue, 3*time.Minute)

--- a/test/e2e/thanosruler_test.go
+++ b/test/e2e/thanosruler_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,7 +110,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheus.Name, name, corev1.ServiceTypeClusterIP)
 	if _, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), thanosNamespace, svc); err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func testThanosRulerPrometheusRuleInDifferentNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	thanosService := framework.MakeThanosRulerService(thanos.Name, "not-relevant", v1.ServiceTypeClusterIP)
+	thanosService := framework.MakeThanosRulerService(thanos.Name, "not-relevant", corev1.ServiceTypeClusterIP)
 	if finalizerFn, err := framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), thanosNamespace, thanosService); err != nil {
 		t.Fatalf("creating Thanos ruler service failed: %v", err)
 	} else {
@@ -315,7 +315,7 @@ func testTRAlertmanagerConfig(t *testing.T) {
 	alertmanager, err := framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), framework.MakeBasicAlertmanager(ns, name, 1))
 	require.NoError(t, err)
 
-	amSVC := framework.MakeAlertmanagerService(alertmanager.Name, group, v1.ServiceTypeClusterIP)
+	amSVC := framework.MakeAlertmanagerService(alertmanager.Name, group, corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, amSVC)
 	require.NoError(t, err)
 
@@ -323,12 +323,12 @@ func testTRAlertmanagerConfig(t *testing.T) {
 	prometheus, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, framework.MakeBasicPrometheus(ns, name, name, 1))
 	require.NoError(t, err)
 
-	svc := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	svc := framework.MakePrometheusService(prometheus.Name, name, corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc)
 	require.NoError(t, err)
 
 	// Create Secret with Alertmanager config,
-	trAmConfigSecret := &v1.Secret{
+	trAmConfigSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
@@ -348,8 +348,8 @@ alertmanagers:
 	// Create Thanos ruler resource and service
 	thanos := framework.MakeBasicThanosRuler(name, 1, fmt.Sprintf("http://%s:%d/", svc.Name, svc.Spec.Ports[0].Port))
 	thanos.Spec.EvaluationInterval = "1s"
-	thanos.Spec.AlertManagersConfig = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	thanos.Spec.AlertManagersConfig = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: secretName,
 		},
 		Key: configKey,
@@ -358,7 +358,7 @@ alertmanagers:
 	_, err = framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanos)
 	require.NoError(t, err)
 
-	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, framework.MakeThanosRulerService(thanos.Name, group, v1.ServiceTypeClusterIP))
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, framework.MakeThanosRulerService(thanos.Name, group, corev1.ServiceTypeClusterIP))
 	require.NoError(t, err)
 
 	// Create firing rule
@@ -402,7 +402,7 @@ func testTRQueryConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create Secret with query config,
-	trQueryConfSecret := &v1.Secret{
+	trQueryConfSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
@@ -421,8 +421,8 @@ func testTRQueryConfig(t *testing.T) {
 	// setting queryEndpoint to "" as it will be ignored because we set QueryConfig
 	thanos := framework.MakeBasicThanosRuler(name, 1, "")
 	thanos.Spec.EvaluationInterval = "1s"
-	thanos.Spec.QueryConfig = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	thanos.Spec.QueryConfig = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: secretName,
 		},
 		Key: configKey,
@@ -431,7 +431,7 @@ func testTRQueryConfig(t *testing.T) {
 	_, err = framework.CreateThanosRulerAndWaitUntilReady(context.Background(), ns, thanos)
 	require.NoError(t, err)
 
-	svc := framework.MakeThanosRulerService(thanos.Name, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakeThanosRulerService(thanos.Name, group, corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, svc)
 	require.NoError(t, err)
 
@@ -472,11 +472,11 @@ func testTRCheckStorageClass(t *testing.T) {
 		monitoringv1.ThanosRulerSpec{
 			Storage: &monitoringv1.StorageSpec{
 				VolumeClaimTemplate: monitoringv1.EmbeddedPersistentVolumeClaim{
-					Spec: v1.PersistentVolumeClaimSpec{
+					Spec: corev1.PersistentVolumeClaimSpec{
 						StorageClassName: ptr.To("unknown-storage-class"),
-						Resources: v1.VolumeResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse("200Mi"),
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("200Mi"),
 							},
 						},
 					},
@@ -516,14 +516,14 @@ func testThanosRulerServiceName(t *testing.T) {
 	ns := framework.CreateNamespace(ctx, t, testCtx)
 	name := "test-servicename"
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", name),
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
 				{
 					Name: "web",
 					Port: 9090,
@@ -580,12 +580,12 @@ func testThanosRulerStateless(t *testing.T) {
 	prometheus.Spec.RuleSelector = nil
 	require.NoError(t, err)
 
-	promSVC := framework.MakePrometheusService(prometheus.Name, name, v1.ServiceTypeClusterIP)
+	promSVC := framework.MakePrometheusService(prometheus.Name, name, corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(ctx, ns, promSVC)
 	require.NoError(t, err)
 
 	// Create the query config secret.
-	trQueryConfSecret := &v1.Secret{
+	trQueryConfSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
@@ -612,8 +612,8 @@ func testThanosRulerStateless(t *testing.T) {
 			},
 		},
 	}
-	thanos.Spec.QueryConfig = &v1.SecretKeySelector{
-		LocalObjectReference: v1.LocalObjectReference{
+	thanos.Spec.QueryConfig = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
 			Name: secretName,
 		},
 		Key: configKey,
@@ -622,7 +622,7 @@ func testThanosRulerStateless(t *testing.T) {
 	_, err = framework.CreateThanosRulerAndWaitUntilReady(ctx, ns, thanos)
 	require.NoError(t, err)
 
-	svc := framework.MakeThanosRulerService(thanos.Name, group, v1.ServiceTypeClusterIP)
+	svc := framework.MakeThanosRulerService(thanos.Name, group, corev1.ServiceTypeClusterIP)
 	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(ctx, ns, svc)
 	require.NoError(t, err)
 

--- a/test/e2e/upgradepath_test.go
+++ b/test/e2e/upgradepath_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -42,16 +42,16 @@ func testOperatorUpgrade(t *testing.T) {
 	name := "operator-upgrade"
 
 	// Create Alertmanager, Prometheus, Thanosruler services with selector labels promised by Prometheus Operator
-	alertmanagerService := v1.Service{
+	alertmanagerService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("alertmanager-%s", name),
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9093,
@@ -67,16 +67,16 @@ func testOperatorUpgrade(t *testing.T) {
 		},
 	}
 
-	prometheusService := v1.Service{
+	prometheusService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("prometheus-%s", name),
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9090,
@@ -94,16 +94,16 @@ func testOperatorUpgrade(t *testing.T) {
 		},
 	}
 
-	thanosRulerService := v1.Service{
+	thanosRulerService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("thanos-ruler-%s", name),
 			Labels: map[string]string{
 				"group": name,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9090,

--- a/test/framework/alertmanager.go
+++ b/test/framework/alertmanager.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
-	v1 "k8s.io/api/core/v1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -120,7 +120,7 @@ func (f *Framework) CreateAlertmanagerConfig(ctx context.Context, ns, name strin
 			},
 			Route: &monitoringv1alpha1.Route{
 				Receiver: "null",
-				Routes: []extv1.JSON{
+				Routes: []apiextensionsv1.JSON{
 					{
 						Raw: subRouteJSON,
 					},
@@ -132,17 +132,17 @@ func (f *Framework) CreateAlertmanagerConfig(ctx context.Context, ns, name strin
 	return f.MonClientV1alpha1.AlertmanagerConfigs(ns).Create(ctx, amConfig, metav1.CreateOptions{})
 }
 
-func (f *Framework) MakeAlertmanagerService(name, group string, serviceType v1.ServiceType) *v1.Service {
-	service := &v1.Service{
+func (f *Framework) MakeAlertmanagerService(name, group string, serviceType corev1.ServiceType) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("alertmanager-%s", name),
 			Labels: map[string]string{
 				"group": group,
 			},
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Type: serviceType,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9093,
@@ -158,13 +158,13 @@ func (f *Framework) MakeAlertmanagerService(name, group string, serviceType v1.S
 	return service
 }
 
-func (f *Framework) SecretFromYaml(filepath string) (*v1.Secret, error) {
+func (f *Framework) SecretFromYaml(filepath string) (*corev1.Secret, error) {
 	manifest, err := os.Open(filepath)
 	if err != nil {
 		return nil, err
 	}
 
-	s := v1.Secret{}
+	s := corev1.Secret{}
 	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&s)
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func (f *Framework) SecretFromYaml(filepath string) (*v1.Secret, error) {
 	return &s, nil
 }
 
-func (f *Framework) AlertmanagerConfigSecret(ns, name string) (*v1.Secret, error) {
+func (f *Framework) AlertmanagerConfigSecret(ns, name string) (*corev1.Secret, error) {
 	s, err := f.SecretFromYaml("../../test/framework/resources/alertmanager-main-secret.yaml")
 	if err != nil {
 		return nil, err

--- a/test/framework/config_map.go
+++ b/test/framework/config_map.go
@@ -20,16 +20,16 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func MakeConfigMapWithCert(ns, name, keyKey, certKey, caKey string,
-	keyBytes, certBytes, caBytes []byte) *v1.ConfigMap {
+	keyBytes, certBytes, caBytes []byte) *corev1.ConfigMap {
 
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 		Data:       map[string]string{},
 	}
@@ -49,9 +49,9 @@ func MakeConfigMapWithCert(ns, name, keyKey, certKey, caKey string,
 	return cm
 }
 
-func (f *Framework) WaitForConfigMapExist(ctx context.Context, ns, name string) (*v1.ConfigMap, error) {
+func (f *Framework) WaitForConfigMapExist(ctx context.Context, ns, name string) (*corev1.ConfigMap, error) {
 	var (
-		configMap *v1.ConfigMap
+		configMap *corev1.ConfigMap
 		getErr    error
 	)
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, f.DefaultTimeout, true, func(ctx context.Context) (bool, error) {

--- a/test/framework/crd.go
+++ b/test/framework/crd.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +33,7 @@ import (
 )
 
 // GetCRD gets a custom resource definition from the apiserver.
-func (f *Framework) GetCRD(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
+func (f *Framework) GetCRD(ctx context.Context, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crd, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to get CRD with name %v: %w", name, err)
@@ -42,7 +42,7 @@ func (f *Framework) GetCRD(ctx context.Context, name string) (*v1.CustomResource
 }
 
 // ListCRDs gets a list of custom resource definitions from the apiserver.
-func (f *Framework) ListCRDs(ctx context.Context) (*v1.CustomResourceDefinitionList, error) {
+func (f *Framework) ListCRDs(ctx context.Context) (*apiextensionsv1.CustomResourceDefinitionList, error) {
 	crds, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to list CRDs: %w", err)
@@ -51,7 +51,7 @@ func (f *Framework) ListCRDs(ctx context.Context) (*v1.CustomResourceDefinitionL
 }
 
 // CreateOrUpdateCRD creates a custom resource definition on the apiserver.
-func (f *Framework) CreateOrUpdateCRD(ctx context.Context, crd *v1.CustomResourceDefinition) error {
+func (f *Framework) CreateOrUpdateCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
 	c, err := f.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("getting CRD %s: %w", crd.Spec.Names.Kind, err)
@@ -86,7 +86,7 @@ func (f *Framework) DeleteCRD(ctx context.Context, name string) error {
 }
 
 // MakeCRD creates a CustomResourceDefinition object from yaml manifest.
-func (f *Framework) MakeCRD(source string) (*v1.CustomResourceDefinition, error) {
+func (f *Framework) MakeCRD(source string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, fmt.Errorf("get manifest from source %s: %w", source, err)
@@ -97,7 +97,7 @@ func (f *Framework) MakeCRD(source string) (*v1.CustomResourceDefinition, error)
 		return nil, fmt.Errorf("get manifest content: %w", err)
 	}
 
-	crd := v1.CustomResourceDefinition{}
+	crd := apiextensionsv1.CustomResourceDefinition{}
 	err = yaml.Unmarshal(content, &crd)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal CRD asset file %s: %w", source, err)

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/gogo/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -143,17 +143,17 @@ func New(kubeconfig, opImage, exampleDir, resourcesDir string, operatorVersion s
 	return f, nil
 }
 
-func (f *Framework) MakeEchoService(name, group string, serviceType v1.ServiceType) *v1.Service {
-	service := &v1.Service{
+func (f *Framework) MakeEchoService(name, group string, serviceType corev1.ServiceType) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("echo-%s", name),
 			Labels: map[string]string{
 				"group": group,
 			},
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Type: serviceType,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9090,
@@ -180,18 +180,18 @@ func (f *Framework) MakeEchoDeployment(group string) *appsv1.Deployment {
 					"echo": group,
 				},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"echo": group,
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "echoserver",
 							Image: "k8s.gcr.io/echoserver:1.10",
-							Ports: []v1.ContainerPort{
+							Ports: []corev1.ContainerPort{
 								{
 									Name:          "web",
 									ContainerPort: 8443,
@@ -321,70 +321,70 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.AlertmanagerName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.Alertmanagers(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.Alertmanagers(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Alertmanager CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PodMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.PodMonitors(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.PodMonitors(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PodMonitor CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ProbeName, func(opts metav1.ListOptions) (object runtime.Object, err error) {
-		return f.MonClientV1.Probes(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.Probes(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Probe CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PrometheusName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.Prometheuses(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.Prometheuses(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize Prometheus CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.PrometheusRuleName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.PrometheusRules(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.PrometheusRules(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PrometheusRule CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ServiceMonitorName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.ServiceMonitors(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.ServiceMonitors(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize ServiceMonitor CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1.ThanosRulerName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1.ThanosRulers(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1.ThanosRulers(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize ThanosRuler CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.AlertmanagerConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1alpha1.AlertmanagerConfigs(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1alpha1.AlertmanagerConfigs(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize AlertmanagerConfig v1alpha1 CRD: %w", err)
 	}
 
 	err = WaitForCRDReady(func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1beta1.AlertmanagerConfigs(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1beta1.AlertmanagerConfigs(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("wait for AlertmanagerConfig v1beta1 CRD: %w", err)
 	}
 
 	err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.PrometheusAgentName, func(opts metav1.ListOptions) (runtime.Object, error) {
-		return f.MonClientV1alpha1.PrometheusAgents(v1.NamespaceAll).List(ctx, opts)
+		return f.MonClientV1alpha1.PrometheusAgents(corev1.NamespaceAll).List(ctx, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize PrometheusAgent v1alpha1 CRD: %w", err)
@@ -392,7 +392,7 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 
 	if opts.EnableScrapeConfigs {
 		err = f.CreateOrUpdateCRDAndWaitUntilReady(ctx, monitoringv1alpha1.ScrapeConfigName, func(opts metav1.ListOptions) (runtime.Object, error) {
-			return f.MonClientV1alpha1.ScrapeConfigs(v1.NamespaceAll).List(ctx, opts)
+			return f.MonClientV1alpha1.ScrapeConfigs(corev1.NamespaceAll).List(ctx, opts)
 		})
 		if err != nil {
 			return nil, fmt.Errorf("initialize ScrapeConfig v1alpha1 CRD: %w", err)
@@ -484,12 +484,12 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 
 	// Load the certificate and key from the created secret into the operator
 	deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes,
-		v1.Volume{
+		corev1.Volume{
 			Name:         "cert",
-			VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: prometheusOperatorCertsSecretName}}})
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: prometheusOperatorCertsSecretName}}})
 
 	deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts,
-		v1.VolumeMount{Name: "cert", MountPath: operatorTLSDir, ReadOnly: true})
+		corev1.VolumeMount{Name: "cert", MountPath: operatorTLSDir, ReadOnly: true})
 
 	// The addition of rule admission webhooks requires TLS, so enable it and
 	// switch to a more common https port
@@ -518,7 +518,7 @@ func (f *Framework) CreateOrUpdatePrometheusOperatorWithOpts(
 
 	service.Namespace = opts.Namespace
 	service.Spec.ClusterIP = ""
-	service.Spec.Ports = []v1.ServicePort{{Name: "https", Port: 443, TargetPort: intstr.FromInt(8443)}}
+	service.Spec.Ports = []corev1.ServicePort{{Name: "https", Port: 443, TargetPort: intstr.FromInt(8443)}}
 
 	if _, err := f.CreateOrUpdateServiceAndWaitUntilReady(ctx, opts.Namespace, service); err != nil {
 		return finalizers, fmt.Errorf("failed to create or update prometheus operator service: %w", err)
@@ -715,7 +715,7 @@ func (f *Framework) SetupPrometheusRBACGlobal(ctx context.Context, t *testing.T,
 	testCtx.AddFinalizerFn(finalizerFn)
 }
 
-func (f *Framework) configureAlertmanagerConfigConversion(ctx context.Context, svc *v1.Service, cert []byte) (FinalizerFn, error) {
+func (f *Framework) configureAlertmanagerConfigConversion(ctx context.Context, svc *corev1.Service, cert []byte) (FinalizerFn, error) {
 	patch, err := f.MakeCRD(fmt.Sprintf("%s/alertmanager-crd-conversion/patch.json", f.exampleDir))
 	if err != nil {
 		return nil, err
@@ -790,7 +790,7 @@ func (f *Framework) CreateOrUpdateAdmissionWebhookServer(
 	ctx context.Context,
 	namespace string,
 	image string,
-) (*v1.Service, []byte, error) {
+) (*corev1.Service, []byte, error) {
 
 	certBytes, keyBytes, err := certutil.GenerateSelfSignedCertKey(
 		fmt.Sprintf("%s.%s.svc", admissionWebhookServiceName, namespace),

--- a/test/framework/helpers.go
+++ b/test/framework/helpers.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -151,7 +151,7 @@ func WaitForHTTPSuccessStatusCode(timeout time.Duration, url string) error {
 	return nil
 }
 
-func podRunsImage(p v1.Pod, image string) bool {
+func podRunsImage(p corev1.Pod, image string) bool {
 	for _, c := range p.Spec.Containers {
 		if image == c.Image {
 			return true

--- a/test/framework/ingress.go
+++ b/test/framework/ingress.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -82,7 +82,7 @@ func (f *Framework) SetupNginxIngressControllerIncDefaultBackend(ctx context.Con
 		return fmt.Errorf("reading default http backend service yaml failed: %w", err)
 	}
 
-	service := v1.Service{}
+	service := corev1.Service{}
 	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&service)
 	if err != nil {
 		return fmt.Errorf("decoding http backend service yaml failed: %w", err)
@@ -116,7 +116,7 @@ func (f *Framework) DeleteNginxIngressControllerIncDefaultBackend(ctx context.Co
 		return fmt.Errorf("reading default http backend service yaml failed: %w", err)
 	}
 
-	service := v1.Service{}
+	service := corev1.Service{}
 	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&service)
 	if err != nil {
 		return fmt.Errorf("decoding http backend service yaml failed: %w", err)

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -19,7 +19,7 @@ import (
 	"maps"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -34,7 +34,7 @@ func (f *Framework) CreateNamespace(ctx context.Context, t *testing.T, testCtx *
 		t.Fatalf("failed to generate namespace %v: %v", name, err)
 	}
 
-	_, err = f.KubeClient.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+	_, err = f.KubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: map[string]string{"app.kubernetes.io/created-by": "e2e-test"},

--- a/test/framework/node.go
+++ b/test/framework/node.go
@@ -20,16 +20,16 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Nodes returns the list of nodes in the cluster.
-func (f *Framework) Nodes(ctx context.Context) ([]v1.Node, error) {
+func (f *Framework) Nodes(ctx context.Context) ([]corev1.Node, error) {
 	var (
 		loopErr error
-		nodes   *v1.NodeList
+		nodes   *corev1.NodeList
 	)
 
 	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*1, true, func(_ context.Context) (bool, error) {

--- a/test/framework/pod.go
+++ b/test/framework/pod.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -53,7 +53,7 @@ func (f *Framework) WritePodLogs(ctx context.Context, w io.Writer, ns, pod strin
 		containers = append(containers, c.Name)
 	}
 
-	plo := v1.PodLogOptions{}
+	plo := corev1.PodLogOptions{}
 	if opts.TailLines > 0 {
 		plo.TailLines = &opts.TailLines
 	}
@@ -122,7 +122,7 @@ func (f *Framework) ExecWithOptions(ctx context.Context, options ExecOptions) (s
 		Namespace(options.Namespace).
 		SubResource("exec").
 		Param("container", options.ContainerName)
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: options.ContainerName,
 		Command:   options.Command,
 		Stdin:     options.Stdin != nil,

--- a/test/framework/probe.go
+++ b/test/framework/probe.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,18 +30,18 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
-func (f *Framework) MakeBlackBoxExporterService(ns, name string) *v1.Service {
-	return &v1.Service{
+func (f *Framework) MakeBlackBoxExporterService(ns, name string) *corev1.Service {
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				operator.ApplicationNameLabelKey: "blackbox-exporter",
 			},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Port:       9115,
 					TargetPort: intstr.FromInt(9115),
@@ -52,7 +52,7 @@ func (f *Framework) MakeBlackBoxExporterService(ns, name string) *v1.Service {
 }
 
 func (f *Framework) createBlackBoxExporterConfigMapAndWaitExists(ctx context.Context, ns, name string) error {
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
@@ -93,27 +93,27 @@ func (f *Framework) createBlackBoxExporterDeploymentAndWaitReady(ctx context.Con
 					operator.ApplicationNameLabelKey: "blackbox-exporter",
 				},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						operator.ApplicationNameLabelKey: "blackbox-exporter",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "blackbox-exporter",
 							Image: "prom/blackbox-exporter:v0.17.0",
 							Args: []string{
 								"--config.file=/config/blackbox.yml",
 							},
-							Ports: []v1.ContainerPort{
+							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 9115,
-									Protocol:      v1.ProtocolTCP,
+									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							VolumeMounts: []v1.VolumeMount{
+							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config",
 									MountPath: "/config",
@@ -121,12 +121,12 @@ func (f *Framework) createBlackBoxExporterDeploymentAndWaitReady(ctx context.Con
 							},
 						},
 					},
-					Volumes: []v1.Volume{
+					Volumes: []corev1.Volume{
 						{
 							Name: "config",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: name,
 									},
 								},

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -122,8 +122,8 @@ func (f *Framework) CreateCertificateResources(namespace, certsDir string, prwtc
 	}
 
 	var (
-		secrets    = map[string]*v1.Secret{}
-		configMaps = map[string]*v1.ConfigMap{}
+		secrets    = map[string]*corev1.Secret{}
+		configMaps = map[string]*corev1.ConfigMap{}
 	)
 
 	secrets[ScrapingTLSSecret] = MakeSecretWithCert(namespace, ScrapingTLSSecret, []string{PrivateKey, CertKey, CAKey}, [][]byte{scrapingKey, scrapingCert, serverCert})
@@ -203,9 +203,9 @@ func (f *Framework) MakeBasicPrometheus(ns, name, group string, replicas int32) 
 					},
 				},
 				ServiceAccountName: "prometheus",
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("400Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
 			},
@@ -239,8 +239,8 @@ func (prwtc PromRemoteWriteTestConfig) AddRemoteWriteWithTLSToPrometheus(p *moni
 	}
 
 	if prwtc.ClientKey.SecretName != "" && prwtc.ClientCert.ResourceName != "" {
-		p.Spec.RemoteWrite[0].TLSConfig.KeySecret = &v1.SecretKeySelector{
-			LocalObjectReference: v1.LocalObjectReference{
+		p.Spec.RemoteWrite[0].TLSConfig.KeySecret = &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
 				Name: prwtc.ClientKey.SecretName,
 			},
 			Key: PrivateKey,
@@ -248,15 +248,15 @@ func (prwtc PromRemoteWriteTestConfig) AddRemoteWriteWithTLSToPrometheus(p *moni
 		p.Spec.RemoteWrite[0].TLSConfig.Cert = monitoringv1.SecretOrConfigMap{}
 
 		if prwtc.ClientCert.ResourceType == SECRET {
-			p.Spec.RemoteWrite[0].TLSConfig.Cert.Secret = &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			p.Spec.RemoteWrite[0].TLSConfig.Cert.Secret = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: prwtc.ClientCert.ResourceName,
 				},
 				Key: CertKey,
 			}
 		} else { //certType == CONFIGMAP
-			p.Spec.RemoteWrite[0].TLSConfig.Cert.ConfigMap = &v1.ConfigMapKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			p.Spec.RemoteWrite[0].TLSConfig.Cert.ConfigMap = &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: prwtc.ClientCert.ResourceName,
 				},
 				Key: CertKey,
@@ -269,15 +269,15 @@ func (prwtc PromRemoteWriteTestConfig) AddRemoteWriteWithTLSToPrometheus(p *moni
 		p.Spec.RemoteWrite[0].TLSConfig.CA = monitoringv1.SecretOrConfigMap{}
 		switch prwtc.CA.ResourceType {
 		case SECRET:
-			p.Spec.RemoteWrite[0].TLSConfig.CA.Secret = &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			p.Spec.RemoteWrite[0].TLSConfig.CA.Secret = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: prwtc.CA.ResourceName,
 				},
 				Key: CAKey,
 			}
 		case CONFIGMAP:
-			p.Spec.RemoteWrite[0].TLSConfig.CA.ConfigMap = &v1.ConfigMapKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+			p.Spec.RemoteWrite[0].TLSConfig.CA.ConfigMap = &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: prwtc.CA.ResourceName,
 				},
 				Key: CAKey,
@@ -295,23 +295,23 @@ func (f *Framework) EnableRemoteWriteReceiverWithTLS(p *monitoringv1.Prometheus)
 		WebConfigFileFields: monitoringv1.WebConfigFileFields{
 			TLSConfig: &monitoringv1.WebTLSConfig{
 				ClientCA: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: ServerCASecret,
 						},
 						Key: CAKey,
 					},
 				},
 				Cert: monitoringv1.SecretOrConfigMap{
-					Secret: &v1.SecretKeySelector{
-						LocalObjectReference: v1.LocalObjectReference{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: ServerTLSSecret,
 						},
 						Key: CertKey,
 					},
 				},
-				KeySecret: v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: ServerTLSSecret,
 					},
 					Key: PrivateKey,
@@ -383,17 +383,17 @@ func (f *Framework) MakeBasicPodMonitor(name string) *monitoringv1.PodMonitor {
 	}
 }
 
-func (f *Framework) MakePrometheusService(name, group string, serviceType v1.ServiceType) *v1.Service {
-	service := &v1.Service{
+func (f *Framework) MakePrometheusService(name, group string, serviceType corev1.ServiceType) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("prometheus-%s", name),
 			Labels: map[string]string{
 				"group": group,
 			},
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Type: serviceType,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9090,
@@ -408,13 +408,13 @@ func (f *Framework) MakePrometheusService(name, group string, serviceType v1.Ser
 	return service
 }
 
-func (f *Framework) MakeThanosQuerierService(name string) *v1.Service {
-	service := &v1.Service{
+func (f *Framework) MakeThanosQuerierService(name string) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       10902,

--- a/test/framework/prometheusagent.go
+++ b/test/framework/prometheusagent.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -57,9 +57,9 @@ func (f *Framework) MakeBasicPrometheusAgent(ns, name, group string, replicas in
 					},
 				},
 				ServiceAccountName: "prometheus",
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("400Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
 			},
@@ -79,9 +79,9 @@ func (f *Framework) MakeBasicPrometheusAgentDaemonSet(ns, name string) *monitori
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				Version:            operator.DefaultPrometheusVersion,
 				ServiceAccountName: "prometheus",
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("400Mi"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
 				PodMonitorSelector: &metav1.LabelSelector{

--- a/test/framework/replication_controller.go
+++ b/test/framework/replication_controller.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -31,7 +31,7 @@ func (f *Framework) createReplicationControllerViaYml(ctx context.Context, names
 		return err
 	}
 
-	var rC v1.ReplicationController
+	var rC corev1.ReplicationController
 	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&rC)
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func (f *Framework) deleteReplicationControllerViaYml(ctx context.Context, names
 		return err
 	}
 
-	var rC v1.ReplicationController
+	var rC corev1.ReplicationController
 	err = yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&rC)
 	if err != nil {
 		return err
@@ -64,7 +64,7 @@ func (f *Framework) deleteReplicationControllerViaYml(ctx context.Context, names
 	return f.KubeClient.CoreV1().ReplicationControllers(namespace).Delete(ctx, rC.Name, metav1.DeleteOptions{})
 }
 
-func (f *Framework) scaleDownReplicationController(ctx context.Context, namespace string, rC v1.ReplicationController) error {
+func (f *Framework) scaleDownReplicationController(ctx context.Context, namespace string, rC corev1.ReplicationController) error {
 	*rC.Spec.Replicas = 0
 	rCAPI := f.KubeClient.CoreV1().ReplicationControllers(namespace)
 

--- a/test/framework/service.go
+++ b/test/framework/service.go
@@ -19,19 +19,19 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func MakeService(source string) (*v1.Service, error) {
+func MakeService(source string) (*corev1.Service, error) {
 	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
-	resource := v1.Service{}
+	resource := corev1.Service{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&resource); err != nil {
 		return nil, fmt.Errorf("failed to decode file %s: %w", source, err)
 	}
@@ -39,7 +39,7 @@ func MakeService(source string) (*v1.Service, error) {
 	return &resource, nil
 }
 
-func (f *Framework) CreateOrUpdateServiceAndWaitUntilReady(ctx context.Context, namespace string, service *v1.Service) (FinalizerFn, error) {
+func (f *Framework) CreateOrUpdateServiceAndWaitUntilReady(ctx context.Context, namespace string, service *corev1.Service) (FinalizerFn, error) {
 	finalizerFn := func() error { return f.DeleteServiceAndWaitUntilGone(ctx, namespace, service.Name) }
 
 	s, err := f.KubeClient.CoreV1().Services(namespace).Get(ctx, service.Name, metav1.GetOptions{})
@@ -105,7 +105,7 @@ func (f *Framework) DeleteServiceAndWaitUntilGone(ctx context.Context, namespace
 }
 
 //nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
-func (f *Framework) getEndpoints(ctx context.Context, namespace, serviceName string) (*v1.Endpoints, error) {
+func (f *Framework) getEndpoints(ctx context.Context, namespace, serviceName string) (*corev1.Endpoints, error) {
 	endpoints, err := f.KubeClient.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("requesting endpoints for service %v failed: %w", serviceName, err)

--- a/test/framework/service_account.go
+++ b/test/framework/service_account.go
@@ -17,7 +17,7 @@ package framework
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -56,13 +56,13 @@ func (f *Framework) createOrUpdateServiceAccount(ctx context.Context, namespace 
 	return finalizer, nil
 }
 
-func parseServiceAccountYaml(source string) (*v1.ServiceAccount, error) {
+func parseServiceAccountYaml(source string) (*corev1.ServiceAccount, error) {
 	manifest, err := SourceToIOReader(source)
 	if err != nil {
 		return nil, err
 	}
 
-	serviceAccount := v1.ServiceAccount{}
+	serviceAccount := corev1.ServiceAccount{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&serviceAccount); err != nil {
 		return nil, err
 	}

--- a/test/framework/storage.go
+++ b/test/framework/storage.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -39,7 +39,7 @@ func (f *Framework) WaitForBoundPVC(ctx context.Context, ns string, labelSelecto
 		}
 
 		for _, pvc := range pvcs.Items {
-			if pvc.Status.Phase != v1.ClaimBound {
+			if pvc.Status.Phase != corev1.ClaimBound {
 				pollErr = fmt.Errorf("expecting PVC %s to have Bound phase, got %q", pvc.Name, pvc.Status.Phase)
 				return false, nil
 			}

--- a/test/framework/thanosruler.go
+++ b/test/framework/thanosruler.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -144,17 +144,17 @@ func (f *Framework) WaitForThanosRulerReady(ctx context.Context, ns string, tr *
 	return nil
 }
 
-func (f *Framework) MakeThanosRulerService(name, group string, serviceType v1.ServiceType) *v1.Service {
-	service := &v1.Service{
+func (f *Framework) MakeThanosRulerService(name, group string, serviceType corev1.ServiceType) *corev1.Service {
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("thanos-ruler-%s", name),
 			Labels: map[string]string{
 				"group": group,
 			},
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Type: serviceType,
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "web",
 					Port:       9090,


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Add standardization of import as aliases

This pr is the next of https://github.com/prometheus-operator/prometheus-operator/pull/8114

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
None
```
