### PR TITLE
Add version label to thanos pods

### DIFF
--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -413,15 +413,17 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		maps.Copy(podLabels, tr.Spec.PodMetadata.Labels)
 		maps.Copy(podAnnotations, tr.Spec.PodMetadata.Annotations)
 	}
-	// In cases where an existing selector label is modified, or a new one is added, new sts cannot match existing pods.
-	// We should try to avoid removing such immutable fields whenever possible since doing
-	// so forces us to enter the 'recreate cycle' and can potentially lead to downtime.
+	// In cases where an existing selector label is modified, or a new one is
+	// added, new sts cannot match existing pods.
+	// We should try to avoid removing such immutable fields whenever possible
+	// since doing so forces us to enter the 'recreate cycle' and can
+	// potentially lead to downtime.
 	// The requirement to make a change here should be carefully evaluated.
-	selectorLabels := makeSelectorLabels(tr.Name)
+	podLabels = config.Labels.Merge(podLabels)
+	maps.Copy(podLabels, makeSelectorLabels(tr.Name))
+	selectorLabels := maps.Clone(podLabels)
 
-	finalLabels := config.Labels.Merge(podLabels)
-	maps.Copy(finalLabels, selectorLabels)
-
+	podLabels[operator.ApplicationVersionLabelKey] = version.String()
 	podAnnotations[operator.DefaultContainerAnnotationKey] = "thanos-ruler"
 
 	storageVolName := volumeName(tr.Name)
@@ -495,11 +497,11 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		PodManagementPolicy: appsv1.PodManagementPolicyType(podManagementPolicy),
 		UpdateStrategy:      operator.UpdateStrategyForStatefulSet(tr.Spec.UpdateStrategy),
 		Selector: &metav1.LabelSelector{
-			MatchLabels: finalLabels,
+			MatchLabels: selectorLabels,
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      finalLabels,
+				Labels:      podLabels,
 				Annotations: podAnnotations,
 			},
 			Spec: corev1.PodSpec{

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -72,6 +72,7 @@ func TestStatefulSetLabelsAndAnnotations(t *testing.T) {
 		"app.kubernetes.io/instance":   "test",
 		"app.kubernetes.io/managed-by": "prometheus-operator",
 		"app.kubernetes.io/name":       "thanos-ruler",
+		"app.kubernetes.io/version":    strings.TrimPrefix(operator.DefaultThanosVersion, "v"),
 		// user-defined labels.
 		"operatorlabel": "operator-value",
 		"podlabel":      "test-label",


### PR DESCRIPTION
## Description

to be consistent with Alertmanager and Prometheus controllers.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
