### PR TITLE
fix: add missing fields to azuresdconfig

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -3741,6 +3741,11 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 	if len(sc.Spec.AzureSDConfigs) > 0 {
 		configs := make([][]yaml.MapItem, len(sc.Spec.AzureSDConfigs))
 		for i, config := range sc.Spec.AzureSDConfigs {
+			configs[i] = cg.addBasicAuthToYaml(configs[i], s, config.BasicAuth)
+			configs[i] = cg.addSafeAuthorizationToYaml(configs[i], s, config.Authorization)
+			configs[i] = cg.addOAuth2ToYaml(configs[i], s, config.OAuth2)
+			configs[i] = cg.addProxyConfigtoYaml(configs[i], s, config.ProxyConfig)
+
 			if config.Environment != nil {
 				configs[i] = []yaml.MapItem{
 					{

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_basic_auth_and_TLS.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_basic_auth_and_TLS.golden
@@ -7,7 +7,10 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - authentication_method: SDK
+  - basic_auth:
+      username: value
+      password: value
+    authentication_method: SDK
     subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_http_config.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_http_config.golden
@@ -7,7 +7,16 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - authentication_method: SDK
+  - authorization:
+      type: Bearer
+      credentials: 00000000-0000-0000-0000-000000000000
+    proxy_url: http://no-proxy.com
+    no_proxy: 0.0.0.0
+    proxy_from_environment: false
+    proxy_connect_header:
+      header:
+      - value
+    authentication_method: SDK
     subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:

--- a/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_with_oauth2.golden
+++ b/pkg/prometheus/testdata/ScrapeConfigSpecConfig_AzureSDConfigValid_with_oauth2.golden
@@ -7,7 +7,17 @@ global:
 scrape_configs:
 - job_name: scrapeConfig/default/testscrapeconfig1
   azure_sd_configs:
-  - authentication_method: SDK
+  - oauth2:
+      client_id: client-id
+      client_secret: client-secret
+      token_url: http://test.url
+      scopes:
+      - scope 1
+      - scope 2
+      endpoint_params:
+        param1: value1
+        param2: value2
+    authentication_method: SDK
     subscription_id: 11AAAA11-A11A-111A-A111-1111A1111A11
   relabel_configs:
   - source_labels:


### PR DESCRIPTION
## Description

Add basicAuth, authorization, oauth2 and proxyConfig to azuresdconfig

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
