### PR TITLE
alertmanager: honor optional MSTeams webhook secrets

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -731,25 +731,27 @@ func (cb *ConfigBuilder) convertReceiver(ctx context.Context, in *monitoringv1al
 
 	var msTeamsConfigs []*msTeamsConfig
 	if l := len(in.MSTeamsConfigs); l > 0 {
-		msTeamsConfigs = make([]*msTeamsConfig, l)
 		for i := range in.MSTeamsConfigs {
 			receiver, err := cb.convertMSTeamsConfig(ctx, in.MSTeamsConfigs[i], crKey)
 			if err != nil {
 				return nil, fmt.Errorf("MSTeamsConfig[%d]: %w", i, err)
 			}
-			msTeamsConfigs[i] = receiver
+			if receiver != nil {
+				msTeamsConfigs = append(msTeamsConfigs, receiver)
+			}
 		}
 	}
 
 	var msTeamsV2Configs []*msTeamsV2Config
 	if l := len(in.MSTeamsV2Configs); l > 0 {
-		msTeamsV2Configs = make([]*msTeamsV2Config, l)
 		for i := range in.MSTeamsV2Configs {
 			receiver, err := cb.convertMSTeamsV2Config(ctx, in.MSTeamsV2Configs[i], crKey)
 			if err != nil {
 				return nil, fmt.Errorf("MSTeamsConfigV2[%d]: %w", i, err)
 			}
-			msTeamsV2Configs[i] = receiver
+			if receiver != nil {
+				msTeamsV2Configs = append(msTeamsV2Configs, receiver)
+			}
 		}
 	}
 
@@ -1575,6 +1577,9 @@ func (cb *ConfigBuilder) convertMSTeamsConfig(
 	if err != nil {
 		return nil, err
 	}
+	if webHookURL == "" && ptr.Deref(in.WebhookURL.Optional, false) {
+		return nil, nil
+	}
 
 	out.WebhookURL = webHookURL
 
@@ -1606,6 +1611,9 @@ func (cb *ConfigBuilder) convertMSTeamsV2Config(
 		webHookURL, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.WebhookURL)
 		if err != nil {
 			return nil, err
+		}
+		if webHookURL == "" && ptr.Deref(in.WebhookURL.Optional, false) {
+			return nil, nil
 		}
 
 		out.WebhookURL = webHookURL

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -3867,6 +3867,47 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "CR_with_MSTeamsV2_Receiver_Partial_Conf.golden",
 		},
 		{
+			name:      "CR with MSTeamsV2 Receiver with optional missing webhook secret",
+			amVersion: &version28,
+			kclient:   fake.NewClientset(),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+						},
+						Receivers: []monitoringv1alpha1.Receiver{
+							{
+								Name: "test",
+								MSTeamsV2Configs: []monitoringv1alpha1.MSTeamsV2Config{
+									{
+										WebhookURL: &corev1.SecretKeySelector{
+											Key:      "url",
+											Optional: ptr.To(true),
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "missing-ms-teams-secret",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "CR_with_MSTeamsV2_Receiver_Optional_Missing_Secret.golden",
+		},
+		{
 			name:      "CR with EmailConfig with Required Fields specified at Receiver level",
 			amVersion: &version26,
 			kclient:   fake.NewClientset(),

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -3724,6 +3724,47 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "CR_with_MSTeams_Receiver_Partial_Conf.golden",
 		},
 		{
+			name:      "CR with MSTeams Receiver with optional missing webhook secret",
+			amVersion: &version26,
+			kclient:   fake.NewClientset(),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+						},
+						Receivers: []monitoringv1alpha1.Receiver{
+							{
+								Name: "test",
+								MSTeamsConfigs: []monitoringv1alpha1.MSTeamsConfig{
+									{
+										WebhookURL: corev1.SecretKeySelector{
+											Key:      "url",
+											Optional: ptr.To(true),
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "missing-ms-teams-secret",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			golden: "CR_with_MSTeams_Receiver_Optional_Missing_Secret.golden",
+		},
+		{
 			name:      "CR with MSTeamsV2 Receiver",
 			amVersion: &version28,
 			kclient: fake.NewClientset(

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1392,6 +1392,32 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "msteamsv2-with-optional-missing-webhook-url-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						MSTeamsV2Configs: []monitoringv1alpha1.MSTeamsV2Config{
+							{
+								WebhookURL: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "not-existing-secret"},
+									Key:                  "url",
+									Optional:             ptr.To(true),
+								},
+							},
+						},
+					}},
+				},
+			},
+			ok: true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "email-config-with-implicit-tls",
 					Namespace: "ns1",
 				},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1316,6 +1316,32 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "msteams-with-optional-missing-webhook-url-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						MSTeamsConfigs: []monitoringv1alpha1.MSTeamsConfig{
+							{
+								WebhookURL: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "not-existing-secret"},
+									Key:                  "url",
+									Optional:             ptr.To(true),
+								},
+							},
+						},
+					}},
+				},
+			},
+			ok: true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "msteams-with-missing-webhook-url-key",
 					Namespace: "ns1",
 				},

--- a/pkg/alertmanager/testdata/CR_with_MSTeamsV2_Receiver_Optional_Missing_Secret.golden
+++ b/pkg/alertmanager/testdata/CR_with_MSTeamsV2_Receiver_Optional_Missing_Secret.golden
@@ -1,0 +1,11 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+templates: []

--- a/pkg/alertmanager/testdata/CR_with_MSTeams_Receiver_Optional_Missing_Secret.golden
+++ b/pkg/alertmanager/testdata/CR_with_MSTeams_Receiver_Optional_Missing_Secret.golden
@@ -1,0 +1,11 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+templates: []

--- a/pkg/assets/store.go
+++ b/pkg/assets/store.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -317,6 +319,8 @@ func (s *StoreBuilder) GetSecretKey(ctx context.Context, namespace string, sel c
 		return "", errors.New("namespace cannot be empty")
 	}
 
+	optional := ptr.Deref(sel.Optional, false)
+
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sel.Name,
@@ -332,6 +336,9 @@ func (s *StoreBuilder) GetSecretKey(ctx context.Context, namespace string, sel c
 	if !exists {
 		secret, err := s.sClient.Secrets(namespace).Get(ctx, sel.Name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) && optional {
+				return "", nil
+			}
 			return "", fmt.Errorf("unable to get secret %q: %w", sel.Name, err)
 		}
 		if err = s.objStore.Add(secret); err != nil {
@@ -342,6 +349,9 @@ func (s *StoreBuilder) GetSecretKey(ctx context.Context, namespace string, sel c
 
 	secret := obj.(*corev1.Secret)
 	if _, found := secret.Data[sel.Key]; !found {
+		if optional {
+			return "", nil
+		}
 		return "", fmt.Errorf("key %q in secret %q not found", sel.Key, sel.Name)
 	}
 
@@ -387,17 +397,25 @@ func (cos *cacheOnlyStore) GetConfigMapKey(sel corev1.ConfigMapKeySelector) (str
 }
 
 func (cos *cacheOnlyStore) GetSecretKey(sel corev1.SecretKeySelector) ([]byte, error) {
+	optional := ptr.Deref(sel.Optional, false)
+
 	obj, exists, err := cos.c.Get(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sel.Name, Namespace: cos.ns}})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret %s/%s: %w", cos.ns, sel.Name, err)
 	}
 
 	if !exists {
+		if optional {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("secret %s/%s not found", cos.ns, sel.Name)
 	}
 
 	s := obj.(*corev1.Secret)
 	if _, found := s.Data[sel.Key]; !found {
+		if optional {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("key %q in secret %s/%s not found", sel.Key, cos.ns, sel.Name)
 	}
 

--- a/pkg/assets/store_test.go
+++ b/pkg/assets/store_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
@@ -78,14 +79,17 @@ func TestGetSecretKey(t *testing.T) {
 	)
 
 	for _, tc := range []struct {
+		name         string
 		ns           string
 		selectedName string
 		selectedKey  string
+		optional     *bool
 
 		err      bool
 		expected string
 	}{
 		{
+			name:         "existing secret key",
 			ns:           "ns1",
 			selectedName: "secret",
 			selectedKey:  "key1",
@@ -94,6 +98,7 @@ func TestGetSecretKey(t *testing.T) {
 		},
 		// Wrong namespace.
 		{
+			name:         "missing namespace",
 			ns:           "ns2",
 			selectedName: "secret",
 			selectedKey:  "key1",
@@ -102,6 +107,7 @@ func TestGetSecretKey(t *testing.T) {
 		},
 		// Wrong name.
 		{
+			name:         "missing secret",
 			ns:           "ns1",
 			selectedName: "secreet",
 			selectedKey:  "key1",
@@ -110,21 +116,37 @@ func TestGetSecretKey(t *testing.T) {
 		},
 		// Wrong key.
 		{
+			name:         "missing key",
 			ns:           "ns1",
 			selectedName: "secret",
 			selectedKey:  "key2",
 
 			err: true,
 		},
+		{
+			name:         "optional missing secret",
+			ns:           "ns1",
+			selectedName: "secreet",
+			selectedKey:  "key1",
+			optional:     ptr.To(true),
+		},
+		{
+			name:         "optional missing key",
+			ns:           "ns1",
+			selectedName: "secret",
+			selectedKey:  "key2",
+			optional:     ptr.To(true),
+		},
 	} {
-		t.Run("", func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			store := NewStoreBuilder(c.CoreV1(), c.CoreV1())
 
 			sel := corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: tc.selectedName,
 				},
-				Key: tc.selectedKey,
+				Key:      tc.selectedKey,
+				Optional: tc.optional,
 			}
 
 			s, err := store.GetSecretKey(context.Background(), tc.ns, sel)
@@ -137,6 +159,10 @@ func TestGetSecretKey(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expected, s, "expecting %q, got %q", tc.expected, s)
+
+			b, err := store.ForNamespace(tc.ns).GetSecretKey(sel)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, string(b))
 		})
 	}
 }


### PR DESCRIPTION
## Description

Honor `SecretKeySelector.optional` for Microsoft Teams webhook secrets in
`AlertmanagerConfig` processing.

This change makes optional missing webhook secrets and keys non-fatal in the
shared secret loader and skips the affected MSTeams receiver entry when
rendering Alertmanager configuration. That keeps the rest of the
AlertmanagerConfig valid instead of failing reconciliation.

Closes: #7264

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Added regression tests for optional missing secret and key lookups in the
  shared assets store.
- Added AlertmanagerConfig validation coverage for optional missing MSTeams
  webhook secrets.
- Added config generation coverage to ensure the MSTeams receiver is omitted
  when its optional webhook secret is missing.
- Ran:
  `go test ./pkg/assets ./pkg/alertmanager -run 'TestGetSecretKey|TestCheckAlertmanagerConfig|TestGenerateConfig|TestInitializeFromAlertmanagerConfig'`

## Changelog entry

```release-note
Honor optional MSTeams webhook secrets in AlertmanagerConfig processing instead of failing reconciliation when the secret or key is missing.
```
