### PR TITLE
feat: allows Probes to configure HTTP settings

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1662,6 +1662,8 @@ func (cg *ConfigGenerator) generateProbeConfig(
 
 	cfg = cg.addProxyConfigtoYaml(cfg, s, m.Spec.ProberSpec.ProxyConfig)
 
+	cfg = cg.addHTTPConfigToYAML(cfg, s, &m.Spec.HTTPConfig, scrapeClass)
+
 	// As stated in the CRD documentation, if both StaticConfig and Ingress are
 	// defined, the former takes precedence which is why the first case statement
 	// checks for m.Spec.Targets.StaticConfig.
@@ -1806,8 +1808,6 @@ func (cg *ConfigGenerator) generateProbeConfig(
 
 	relabelings = appendShardingRelabelingForProbes(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
-
-	cfg = cg.addTLStoYaml(cfg, s, mergeSafeTLSConfigWithScrapeClass(m.Spec.TLSConfig, scrapeClass))
 
 	if m.Spec.BearerTokenSecret != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
 		b, err := s.GetSecretKey(*m.Spec.BearerTokenSecret) //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -866,6 +866,33 @@ func TestProbeIngressSDConfigGenerationWithLabelEnforce(t *testing.T) {
 	golden.Assert(t, string(cfg), "ProbeIngressSDConfigGenerationWithLabelEnforce.golden")
 }
 
+func TestProbeWithHttp2Disabled(t *testing.T) {
+	p := defaultPrometheus()
+	p.Spec.EnforcedNamespaceLabel = "namespace"
+
+	probe := defaultProbe()
+	enableHTTP2 := false
+	probe.Spec.HTTPConfig.EnableHTTP2 = &enableHTTP2
+
+	cg := mustNewConfigGenerator(t, p)
+	cfg, err := cg.GenerateServerConfiguration(
+		p,
+		nil,
+		nil,
+		map[string]*monitoringv1.Probe{
+			"probe1": probe,
+		},
+		nil,
+		&assets.StoreBuilder{},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	golden.Assert(t, string(cfg), "ProbeWithHttp2Disabled.golden")
+}
+
 func TestK8SSDConfigGeneration(t *testing.T) {
 	sm := &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/prometheus/testdata/ProbeWithHttp2Disabled.golden
+++ b/pkg/prometheus/testdata/ProbeWithHttp2Disabled.golden
@@ -1,0 +1,58 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: probe/default/defaultProbe
+  honor_timestamps: true
+  metrics_path: /probe
+  scheme: http
+  params:
+    module:
+    - http_2xx
+  enable_http2: false
+  static_configs:
+  - targets:
+    - prometheus.io
+    - promcon.io
+    labels:
+      namespace: custom
+      static: label
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - source_labels:
+    - __address__
+    target_label: __param_target
+  - source_labels:
+    - __param_target
+    target_label: instance
+  - target_label: __address__
+    replacement: blackbox.exporter.io
+  - target_label: namespace
+    replacement: default
+  - source_labels:
+    - __param_target
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 1
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(SHARD);|.+;.+
+    action: keep
+  metric_relabel_configs:
+  - regex: noisy_labels.*
+    action: labeldrop
+  - target_label: namespace
+    replacement: default

--- a/pkg/prometheus/testdata/monitorObjectWithDefaultScrapeClassAndTLSConfig.golden
+++ b/pkg/prometheus/testdata/monitorObjectWithDefaultScrapeClassAndTLSConfig.golden
@@ -149,6 +149,10 @@ scrape_configs:
   params:
     module:
     - http_2xx
+  tls_config:
+    ca_file: /etc/prometheus/secrets/default/ca.crt
+    cert_file: /etc/prometheus/secrets/default/tls.crt
+    key_file: /etc/prometheus/secrets/default/tls.key
   static_configs:
   - targets:
     - prometheus.io
@@ -185,10 +189,6 @@ scrape_configs:
     - __tmp_disable_sharding
     regex: $(SHARD);|.+;.+
     action: keep
-  tls_config:
-    ca_file: /etc/prometheus/secrets/default/ca.crt
-    cert_file: /etc/prometheus/secrets/default/tls.crt
-    key_file: /etc/prometheus/secrets/default/tls.key
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop

--- a/pkg/prometheus/testdata/monitorObjectWithNonDefaultScrapeClassAndTLSConfig.golden
+++ b/pkg/prometheus/testdata/monitorObjectWithNonDefaultScrapeClassAndTLSConfig.golden
@@ -149,6 +149,10 @@ scrape_configs:
   params:
     module:
     - http_2xx
+  tls_config:
+    ca_file: /etc/prometheus/secrets/ca.crt
+    cert_file: /etc/prometheus/secrets/tls.crt
+    key_file: /etc/prometheus/secrets/tls.key
   static_configs:
   - targets:
     - prometheus.io
@@ -185,10 +189,6 @@ scrape_configs:
     - __tmp_disable_sharding
     regex: $(SHARD);|.+;.+
     action: keep
-  tls_config:
-    ca_file: /etc/prometheus/secrets/ca.crt
-    cert_file: /etc/prometheus/secrets/tls.crt
-    key_file: /etc/prometheus/secrets/tls.key
   metric_relabel_configs:
   - regex: noisy_labels.*
     action: labeldrop


### PR DESCRIPTION
## Description

In https://github.com/prometheus-operator/prometheus-operator/pull/8112, the code was changed to unify the HTTP configuration, but the configuration was never applied to probes. For instance, changing the HTTP configuration to use HTTP 1.1 instead of HTTP 2.0 was not correctly applied.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

The new test shows the configuration with one of the HTTP config flag set, and correctly generated by the Operator.

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Make the HTTP configuration available to Probes
```
