### PR TITLE
Fix: update Alertmanager secret config logic to validate Telegram bot token

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3031,6 +3031,10 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 		tc.BotTokenFile = ""
 	}
 
+	if tc.BotToken == "" && tc.BotTokenFile == "" && lessThanV0_31 {
+		return fmt.Errorf("missing mandatory field botToken or botTokenFile")
+	}
+
 	if tc.MessageThreadID != 0 && lessThanV0_26 {
 		msg := "'message_thread_id' supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
 		logger.Warn(msg, "current_version", amVersion.String())

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3025,10 +3025,6 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 		tc.BotTokenFile = ""
 	}
 
-	if tc.BotToken == "" && tc.BotTokenFile == "" {
-		return fmt.Errorf("missing mandatory field botToken or botTokenFile")
-	}
-
 	if tc.BotToken != "" && tc.BotTokenFile != "" {
 		msg := "'bot_token' and 'bot_token_file' are mutually exclusive for telegram receiver config - 'bot_token' has taken precedence"
 		logger.Warn(msg)

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -7802,6 +7802,9 @@ func TestSanitizeTelegramConfig(t *testing.T) {
 	logger := newNopLogger(t)
 	versionTelegramExampleAllowed := semver.Version{Major: 0, Minor: 26}
 
+	versionWithGlobalTelegramBotToken := semver.Version{Major: 0, Minor: 31}
+	versionWithoutGlobalTelegramBotToken := semver.Version{Major: 0, Minor: 30}
+
 	for _, tc := range []struct {
 		name           string
 		againstVersion semver.Version
@@ -7844,6 +7847,40 @@ func TestSanitizeTelegramConfig(t *testing.T) {
 				},
 			},
 			golden: "telegram_valid_url_passes.golden",
+		},
+		{
+			name:           "telegram no bot token specified",
+			againstVersion: versionWithoutGlobalTelegramBotToken,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						TelegramConfigs: []*telegramConfig{
+							{
+								APIUrl: "http://example.com",
+								ChatID: 12345,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:           "telegram no bot token specified with global bot token version",
+			againstVersion: versionWithGlobalTelegramBotToken,
+			in: &alertmanagerConfig{
+				Receivers: []*receiver{
+					{
+						TelegramConfigs: []*telegramConfig{
+							{
+								APIUrl: "http://example.com",
+								ChatID: 12345,
+							},
+						},
+					},
+				},
+			},
+			golden: "telegram_no_bot_token_specified_with_global_bot_token_version.golden",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/alertmanager/testdata/telegram_no_bot_token_specified_with_global_bot_token_version.golden
+++ b/pkg/alertmanager/testdata/telegram_no_bot_token_specified_with_global_bot_token_version.golden
@@ -1,0 +1,6 @@
+receivers:
+- name: ""
+  telegram_configs:
+  - api_url: http://example.com
+    chat_id: 12345
+templates: []


### PR DESCRIPTION
## Description

This PR updates the logic to check bot_token and bot_token_file exists in the Alertmanager secret config.

Reason: Alertmanager >= 0.31.0 introduces the global configuration of telegram_bot_token and telegram_bot_token_file. Hence, the bot token is not required to be added in the receiver.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Update Telegram bot token validation logic in Alertmanager secret config.
```
