### PR TITLE
feat: support VictoriaMetrics MetricsQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,8 +376,7 @@ check-docs: $(MDOX_BINARY) ## Check documentation formatting and links.
 ###########
 
 .PHONY: test
-test: ## Run all tests (unit, long, and e2e).
-	test-unit test-long test-e2e
+test: test-unit test-long test-e2e ## Run all tests (unit, long, and e2e).
 
 .PHONY: test-unit
 test-unit: test-prometheus-goldenfiles ## Run unit tests (short mode).

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -31,12 +31,14 @@ import (
 	logging "github.com/prometheus-operator/prometheus-operator/internal/log"
 	"github.com/prometheus-operator/prometheus-operator/internal/metrics"
 	"github.com/prometheus-operator/prometheus-operator/pkg/admission"
+	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus-operator/prometheus-operator/pkg/server"
 	"github.com/prometheus-operator/prometheus-operator/pkg/versionutil"
 )
 
 const defaultGOMemlimitRatio = 0.0
 const defaultValidationScheme = "legacy"
+const defaultRuleQueryLanguage = "promql"
 
 func main() {
 	var (
@@ -45,6 +47,7 @@ func main() {
 		logConfig            logging.Config
 		memlimitRatio        float64
 		nameValidationScheme string
+		ruleQueryLanguage    string
 	)
 
 	server.RegisterFlags(flagset, &serverConfig)
@@ -53,6 +56,7 @@ func main() {
 
 	flagset.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultGOMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	flagset.StringVar(&nameValidationScheme, "name-validation-scheme", defaultValidationScheme, "The name validation scheme to use ('legacy' or 'utf8').")
+	flagset.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage, "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
 
 	_ = flagset.Parse(os.Args[1:])
 
@@ -81,12 +85,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Parse and validate the rule query language
+	var exprLanguage promoperator.ExpressionLanguage
+	switch ruleQueryLanguage {
+	case "promql":
+		exprLanguage = promoperator.PromQLLanguage
+	case "metricsql":
+		exprLanguage = promoperator.MetricsQLLanguage
+	default:
+		logger.Error("invalid rule query language", "language", ruleQueryLanguage, "supported", []string{"promql", "metricsql"})
+		os.Exit(1)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	wg, ctx := errgroup.WithContext(ctx)
 
 	mux := http.NewServeMux()
-	admit := admission.New(logger.With("component", "admissionwebhook"), validationScheme)
+	admit := admission.New(logger.With("component", "admissionwebhook"), validationScheme, exprLanguage)
 	admit.Register(mux)
 
 	r := metrics.NewRegistry("prometheus_operator_admission_webhook")

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -38,7 +38,7 @@ import (
 
 const defaultGOMemlimitRatio = 0.0
 const defaultValidationScheme = "legacy"
-const defaultRuleQueryLanguage = "promql"
+const defaultRuleQueryLanguage = promoperator.PromQLLanguage
 
 func main() {
 	var (
@@ -56,7 +56,7 @@ func main() {
 
 	flagset.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultGOMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	flagset.StringVar(&nameValidationScheme, "name-validation-scheme", defaultValidationScheme, "The name validation scheme to use ('legacy' or 'utf8').")
-	flagset.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage, "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
+	flagset.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage.String(), "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
 
 	_ = flagset.Parse(os.Args[1:])
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -105,7 +105,7 @@ const (
 
 	defaultMemlimitRatio = 0.0
 
-	defaultRuleQueryLanguage = "promql"
+	defaultRuleQueryLanguage = operator.PromQLLanguage
 )
 
 var (
@@ -198,7 +198,7 @@ func parseFlags(fs *flag.FlagSet) {
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
-	fs.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage, "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
+	fs.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage.String(), "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -104,6 +104,8 @@ const (
 	defaultReloaderMemory = "50Mi"
 
 	defaultMemlimitRatio = 0.0
+
+	defaultRuleQueryLanguage = "promql"
 )
 
 var (
@@ -131,6 +133,8 @@ var (
 	kubeletHTTPMetrics   bool
 
 	featureGates = k8sflag.NewMapStringBool(ptr.To(map[string]bool{}))
+
+	ruleQueryLanguage string
 )
 
 func parseFlags(fs *flag.FlagSet) {
@@ -194,6 +198,7 @@ func parseFlags(fs *flag.FlagSet) {
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
+	fs.StringVar(&ruleQueryLanguage, "rule-query-language", defaultRuleQueryLanguage, "The query language to use for rule expression validation ('promql' or 'metricsql'). Use 'metricsql' for VictoriaMetrics targets.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -731,7 +736,14 @@ func start() int {
 
 	// Setup the web server.
 	mux := http.NewServeMux()
-	admit := admission.New(logger.With("component", "admissionwebhook"), model.LegacyValidation)
+	var exprLanguage operator.ExpressionLanguage
+	switch ruleQueryLanguage {
+	case "metricsql":
+		exprLanguage = operator.MetricsQLLanguage
+	default:
+		exprLanguage = operator.PromQLLanguage
+	}
+	admit := admission.New(logger.With("component", "admissionwebhook"), model.LegacyValidation, exprLanguage)
 	admit.Register(mux)
 
 	r.MustRegister(cfg.Gates)

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,10 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require github.com/VictoriaMetrics/metricsql v0.85.0
+
 require (
+	github.com/VictoriaMetrics/metrics v1.35.3 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
@@ -88,6 +91,8 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/sigv4 v0.4.1 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43Dw
 github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/VictoriaMetrics/metrics v1.35.3 h1:DrQBBAjTb24WFlGAV9dAQsPDmDRyqL63kZ1Yfc+SRkM=
+github.com/VictoriaMetrics/metrics v1.35.3/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
+github.com/VictoriaMetrics/metricsql v0.85.0 h1:xI+EfqsOgY0T2yd7p8hcYQ52LOtf+1i8fQQzQ+RGtZM=
+github.com/VictoriaMetrics/metricsql v0.85.0/go.mod h1:d4EisFO6ONP/HIGDYTAtwrejJBBeKGQYiRl095bS4QQ=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -340,6 +344,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/thanos-io/thanos v0.41.0 h1:GDPGynjHBa8ORAX7DfluBFjHbMeY1BzjLTGdviFvo7Q=
 github.com/thanos-io/thanos v0.41.0/go.mod h1:ppdHafpAT8WAbcwgLiNU4jNtNe17Ct3xX9dXq+h6g2k=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
+github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -75,20 +75,22 @@ var (
 // 1. PrometheusRules (validation, mutation) - ensuring created resources can be loaded by Prometheus
 // 2. monitoringv1alpha1.AlertmanagerConfig (validation) - ensuring.
 type Admission struct {
-	logger           *slog.Logger
-	wh               http.Handler
-	validationScheme model.ValidationScheme
+	logger            *slog.Logger
+	wh                http.Handler
+	validationScheme  model.ValidationScheme
+	ruleQueryLanguage promoperator.ExpressionLanguage
 }
 
-func New(logger *slog.Logger, validationScheme model.ValidationScheme) *Admission {
+func New(logger *slog.Logger, validationScheme model.ValidationScheme, ruleQueryLanguage promoperator.ExpressionLanguage) *Admission {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(monitoringv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1beta1.AddToScheme(scheme))
 
 	return &Admission{
-		logger:           logger,
-		wh:               conversion.NewWebhookHandler(scheme, conversion.NewRegistry()),
-		validationScheme: validationScheme,
+		logger:            logger,
+		wh:                conversion.NewWebhookHandler(scheme, conversion.NewRegistry()),
+		validationScheme:  validationScheme,
+		ruleQueryLanguage: ruleQueryLanguage,
 	}
 }
 
@@ -239,7 +241,7 @@ func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.Admission
 		return toAdmissionResponseFailure(errUnmarshalRules, prometheusRuleResource, []error{err})
 	}
 
-	errors := promoperator.ValidateRule(promRule.Spec, a.validationScheme)
+	errors := promoperator.ValidateRuleWithExpressionLanguage(promRule.Spec, a.validationScheme, a.ruleQueryLanguage)
 	if len(errors) != 0 {
 		const m = "Invalid rule"
 		a.logger.Debug(m, "content", promRule.Spec)

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
+	promoperator "github.com/prometheus-operator/prometheus-operator/pkg/operator"
 )
 
 func TestMutateRule(t *testing.T) {
@@ -326,6 +327,7 @@ func apiWithValidationScheme(validationScheme model.ValidationScheme) *Admission
 	return New(
 		slog.New(slog.DiscardHandler),
 		validationScheme,
+		promoperator.PromQLLanguage,
 	)
 }
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -63,6 +63,16 @@ const (
 	MetricsQLLanguage
 )
 
+// String returns the string representation of the ExpressionLanguage.
+func (e ExpressionLanguage) String() string {
+	switch e {
+	case MetricsQLLanguage:
+		return "metricsql"
+	default:
+		return "promql"
+	}
+}
+
 const (
 	selectingPrometheusRuleResourcesAction = "SelectingPrometheusRuleResources"
 )

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 
+	metricsql "github.com/VictoriaMetrics/metricsql"
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -48,6 +49,18 @@ const (
 	PrometheusFormat RuleConfigurationFormat = iota
 	// ThanosFormat indicates that the rule configuration should comply with the Thanos format.
 	ThanosFormat
+)
+
+// ExpressionLanguage defines the query language used to validate rule expressions.
+type ExpressionLanguage int
+
+const (
+	// PromQLLanguage uses the Prometheus PromQL parser for expression validation.
+	// This is the default and is compatible with Prometheus and Thanos targets.
+	PromQLLanguage ExpressionLanguage = iota
+	// MetricsQLLanguage uses the VictoriaMetrics MetricsQL parser for expression validation.
+	// MetricsQL is a superset of PromQL and is required for VictoriaMetrics targets.
+	MetricsQLLanguage
 )
 
 const (
@@ -199,6 +212,14 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 
 // ValidateRule takes PrometheusRuleSpec and validates it using the upstream prometheus rule validator.
 func ValidateRule(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme model.ValidationScheme) []error {
+	return ValidateRuleWithExpressionLanguage(promRuleSpec, validationScheme, PromQLLanguage)
+}
+
+// ValidateRuleWithExpressionLanguage validates a PrometheusRuleSpec using the given expression language.
+// Use PromQLLanguage (the default) for Prometheus and Thanos targets.
+// Use MetricsQLLanguage for VictoriaMetrics targets, which accepts a superset of PromQL including
+// functions such as share_eq_over_time, median_over_time, and other MetricsQL extensions.
+func ValidateRuleWithExpressionLanguage(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme model.ValidationScheme, exprLang ExpressionLanguage) []error {
 	for i := range promRuleSpec.Groups {
 		// The upstream Prometheus rule validator doesn't support the
 		// partial_response_strategy field.
@@ -228,7 +249,103 @@ func ValidateRule(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme
 		return []error{fmt.Errorf("the length of rendered Prometheus Rule is %d bytes which is above the maximum limit of %d bytes", promRuleSize, MaxConfigMapDataSize)}
 	}
 
+	if exprLang == MetricsQLLanguage {
+		return validateGroupsWithMetricsQL(promRuleSpec.Groups, validationScheme)
+	}
+
 	_, errs := rulefmt.Parse(content, false, validationScheme)
+	return errs
+}
+
+// validateGroupsWithMetricsQL validates rule groups using the MetricsQL expression parser.
+// It replicates the structural checks of rulefmt.Validate but uses metricsql.Parse for expressions.
+func validateGroupsWithMetricsQL(groups []monitoringv1.RuleGroup, validationScheme model.ValidationScheme) []error {
+	var errs []error
+	seen := make(map[string]struct{})
+	for _, g := range groups {
+		if g.Name == "" {
+			errs = append(errs, errors.New("group name must not be empty"))
+		}
+		if _, ok := seen[g.Name]; ok {
+			errs = append(errs, fmt.Errorf("groupname: %q is repeated in the same file", g.Name))
+		}
+		seen[g.Name] = struct{}{}
+
+		for k, v := range g.Labels {
+			if !validationScheme.IsValidLabelName(k) || k == model.MetricNameLabel {
+				errs = append(errs, fmt.Errorf("invalid label name: %s", k))
+			}
+			if !model.LabelValue(v).IsValid() {
+				errs = append(errs, fmt.Errorf("invalid label value: %s", v))
+			}
+		}
+
+		for i, r := range g.Rules {
+			errs = append(errs, validateMetricsQLRule(g.Name, i+1, r, validationScheme)...)
+		}
+	}
+	return errs
+}
+
+// validateMetricsQLRule validates a single rule using the MetricsQL expression parser.
+func validateMetricsQLRule(groupName string, ruleIndex int, r monitoringv1.Rule, validationScheme model.ValidationScheme) []error {
+	var errs []error
+	ruleName := r.Alert
+	if ruleName == "" {
+		ruleName = r.Record
+	}
+
+	wrap := func(err error) error {
+		return fmt.Errorf("group %q, rule %d, %q: %w", groupName, ruleIndex, ruleName, err)
+	}
+
+	if r.Record != "" && r.Alert != "" {
+		errs = append(errs, wrap(errors.New("only one of 'record' and 'alert' must be set")))
+	}
+	if r.Record == "" && r.Alert == "" {
+		errs = append(errs, wrap(errors.New("one of 'record' or 'alert' must be set")))
+	}
+
+	expr := r.Expr.String()
+	if expr == "" {
+		errs = append(errs, wrap(errors.New("field 'expr' must be set in rule")))
+	} else if _, err := metricsql.Parse(expr); err != nil {
+		errs = append(errs, wrap(fmt.Errorf("could not parse expression: %w", err)))
+	}
+
+	if r.Record != "" {
+		if len(r.Annotations) > 0 {
+			errs = append(errs, wrap(errors.New("invalid field 'annotations' in recording rule")))
+		}
+		if r.For != nil && *r.For != "" {
+			errs = append(errs, wrap(errors.New("invalid field 'for' in recording rule")))
+		}
+		if r.KeepFiringFor != nil {
+			errs = append(errs, wrap(errors.New("invalid field 'keep_firing_for' in recording rule")))
+		}
+		if !validationScheme.IsValidMetricName(r.Record) {
+			errs = append(errs, wrap(fmt.Errorf("invalid recording rule name: %s", r.Record)))
+		}
+		if strings.Contains(r.Record, "{") || strings.Contains(r.Record, "}") {
+			errs = append(errs, wrap(fmt.Errorf("braces present in the recording rule name; should it be in expr?: %s", r.Record)))
+		}
+	}
+
+	for k, v := range r.Labels {
+		if !validationScheme.IsValidLabelName(k) || k == model.MetricNameLabel {
+			errs = append(errs, wrap(fmt.Errorf("invalid label name: %s", k)))
+		}
+		if !model.LabelValue(v).IsValid() {
+			errs = append(errs, wrap(fmt.Errorf("invalid label value: %s", v)))
+		}
+	}
+
+	for k := range r.Annotations {
+		if !validationScheme.IsValidLabelName(k) {
+			errs = append(errs, wrap(fmt.Errorf("invalid annotation name: %s", k)))
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -530,6 +530,142 @@ func shouldErrorOnTooLargePrometheusRule(t *testing.T) {
 	require.NotEmpty(t, err, "expected ValidateRule to return error of size limit with LegacyValidation")
 }
 
+func TestValidateRuleWithExpressionLanguage(t *testing.T) {
+	// share_eq_over_time is a MetricsQL-specific function that PromQL rejects.
+	metricsQLExpr := intstr.FromString(`share_eq_over_time(up[5m], 1)`)
+	// vector() is valid in both PromQL and MetricsQL (MetricsQL is a superset).
+	promQLExpr := intstr.FromString(`vector(1)`)
+
+	makeRecordingSpec := func(expr intstr.IntOrString) monitoringv1.PrometheusRuleSpec {
+		return monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{{
+				Name: "group",
+				Rules: []monitoringv1.Rule{{
+					Record: "slo:sli_error:ratio_rate5m",
+					Expr:   expr,
+				}},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		spec             monitoringv1.PrometheusRuleSpec
+		validationScheme model.ValidationScheme
+		exprLang         ExpressionLanguage
+		wantErrs         bool
+	}{
+		// PromQL expression × PromQL parser
+		{
+			name:             "promql_expr/promql_lang/legacy",
+			spec:             makeRecordingSpec(promQLExpr),
+			validationScheme: model.LegacyValidation,
+			exprLang:         PromQLLanguage,
+			wantErrs:         false,
+		},
+		{
+			name:             "promql_expr/promql_lang/utf8",
+			spec:             makeRecordingSpec(promQLExpr),
+			validationScheme: model.UTF8Validation,
+			exprLang:         PromQLLanguage,
+			wantErrs:         false,
+		},
+		// PromQL expression × MetricsQL parser (MetricsQL is a superset — must pass)
+		{
+			name:             "promql_expr/metricsql_lang/legacy",
+			spec:             makeRecordingSpec(promQLExpr),
+			validationScheme: model.LegacyValidation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         false,
+		},
+		{
+			name:             "promql_expr/metricsql_lang/utf8",
+			spec:             makeRecordingSpec(promQLExpr),
+			validationScheme: model.UTF8Validation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         false,
+		},
+		// MetricsQL expression × PromQL parser (must be rejected)
+		{
+			name:             "metricsql_expr/promql_lang/legacy",
+			spec:             makeRecordingSpec(metricsQLExpr),
+			validationScheme: model.LegacyValidation,
+			exprLang:         PromQLLanguage,
+			wantErrs:         true,
+		},
+		{
+			name:             "metricsql_expr/promql_lang/utf8",
+			spec:             makeRecordingSpec(metricsQLExpr),
+			validationScheme: model.UTF8Validation,
+			exprLang:         PromQLLanguage,
+			wantErrs:         true,
+		},
+		// MetricsQL expression × MetricsQL parser (must pass)
+		{
+			name:             "metricsql_expr/metricsql_lang/legacy",
+			spec:             makeRecordingSpec(metricsQLExpr),
+			validationScheme: model.LegacyValidation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         false,
+		},
+		{
+			name:             "metricsql_expr/metricsql_lang/utf8",
+			spec:             makeRecordingSpec(metricsQLExpr),
+			validationScheme: model.UTF8Validation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         false,
+		},
+		// Structural errors are caught regardless of expression language or validation scheme.
+		{
+			name: "missing_record_and_alert/promql_lang/legacy",
+			spec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{{
+					Name:  "group",
+					Rules: []monitoringv1.Rule{{Expr: promQLExpr}},
+				}},
+			},
+			validationScheme: model.LegacyValidation,
+			exprLang:         PromQLLanguage,
+			wantErrs:         true,
+		},
+		{
+			name: "missing_record_and_alert/metricsql_lang/legacy",
+			spec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{{
+					Name:  "group",
+					Rules: []monitoringv1.Rule{{Expr: metricsQLExpr}},
+				}},
+			},
+			validationScheme: model.LegacyValidation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         true,
+		},
+		{
+			name: "missing_record_and_alert/metricsql_lang/utf8",
+			spec: monitoringv1.PrometheusRuleSpec{
+				Groups: []monitoringv1.RuleGroup{{
+					Name:  "group",
+					Rules: []monitoringv1.Rule{{Expr: metricsQLExpr}},
+				}},
+			},
+			validationScheme: model.UTF8Validation,
+			exprLang:         MetricsQLLanguage,
+			wantErrs:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidateRuleWithExpressionLanguage(tc.spec, tc.validationScheme, tc.exprLang)
+			if tc.wantErrs {
+				require.NotEmpty(t, errs)
+			} else {
+				require.Empty(t, errs, "unexpected errors: %v", errs)
+			}
+		})
+	}
+}
+
 func shouldDropGroupLabelsForUnsupportedThanosVersion(t *testing.T) {
 	labels := map[string]string{
 		"key": "value",


### PR DESCRIPTION
The admission webhook presently rejects VictoriaMetric's dialect of PromQL:
MetricsQL. Make it a configurable option to accept in the cluster, where
PrometheusRule is being used and converted into VictoriaMetrics resources.

Without this patch, you cannot use PrometheusRule resources that contain
MetricsQL expressions unless the admission webhook is disabled, which is not
desirable.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>
