### PR TITLE
Ensure that targets are distributed only to active shards when the policy is Retain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 * [FEATURE] Implement shard retention based on Prometheus data retention (it requires the `PrometheusShardRetentionPolicy` feature gate). #8478
+* [BUGFIX] Ensure that inactive shards don't scrape any targets when the sharding retention policy is `Retain`. #8513
 
 ## 0.90.1 / 2026-03-25
 

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/alecthomas/units"
@@ -69,16 +70,17 @@ func sanitizeLabelName(name string) string {
 // ConfigGenerator knows how to generate a Prometheus configuration which is
 // compatible with a given Prometheus version.
 type ConfigGenerator struct {
-	logger                     *slog.Logger
-	version                    semver.Version
-	notCompatible              bool
-	prom                       monitoringv1.PrometheusInterface
-	endpointSliceSupported     bool // True when the cluster supports EndpointSlice.
-	scrapeClasses              map[string]monitoringv1.ScrapeClass
-	defaultScrapeClassName     string
-	daemonSet                  bool
-	prometheusTopologySharding bool
-	inlineTLSConfig            bool
+	logger                      *slog.Logger
+	version                     semver.Version
+	notCompatible               bool
+	prom                        monitoringv1.PrometheusInterface
+	endpointSliceSupported      bool // True when the cluster supports EndpointSlice.
+	scrapeClasses               map[string]monitoringv1.ScrapeClass
+	defaultScrapeClassName      string
+	daemonSet                   bool
+	prometheusTopologySharding  bool
+	prometheusRetentionPolicies bool
+	inlineTLSConfig             bool
 
 	bypassVersionCheck bool
 }
@@ -100,6 +102,12 @@ func WithDaemonSet() ConfigGeneratorOption {
 func WithPrometheusTopologySharding() ConfigGeneratorOption {
 	return func(cg *ConfigGenerator) {
 		cg.prometheusTopologySharding = true
+	}
+}
+
+func WithPrometheusRetentionPolicies() ConfigGeneratorOption {
+	return func(cg *ConfigGenerator) {
+		cg.prometheusRetentionPolicies = true
 	}
 }
 
@@ -244,17 +252,18 @@ func (cg *ConfigGenerator) Version() semver.Version {
 // logger.
 func (cg *ConfigGenerator) WithKeyVals(keyvals ...any) *ConfigGenerator {
 	return &ConfigGenerator{
-		logger:                     cg.logger.With(keyvals...),
-		version:                    cg.version,
-		notCompatible:              cg.notCompatible,
-		prom:                       cg.prom,
-		endpointSliceSupported:     cg.endpointSliceSupported,
-		scrapeClasses:              cg.scrapeClasses,
-		defaultScrapeClassName:     cg.defaultScrapeClassName,
-		daemonSet:                  cg.daemonSet,
-		prometheusTopologySharding: cg.prometheusTopologySharding,
-		inlineTLSConfig:            cg.inlineTLSConfig,
-		bypassVersionCheck:         cg.bypassVersionCheck,
+		logger:                      cg.logger.With(keyvals...),
+		version:                     cg.version,
+		notCompatible:               cg.notCompatible,
+		prom:                        cg.prom,
+		endpointSliceSupported:      cg.endpointSliceSupported,
+		scrapeClasses:               cg.scrapeClasses,
+		defaultScrapeClassName:      cg.defaultScrapeClassName,
+		daemonSet:                   cg.daemonSet,
+		prometheusTopologySharding:  cg.prometheusTopologySharding,
+		prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+		inlineTLSConfig:             cg.inlineTLSConfig,
+		bypassVersionCheck:          cg.bypassVersionCheck,
 	}
 }
 
@@ -269,17 +278,18 @@ func (cg *ConfigGenerator) WithMinimumVersion(version string) *ConfigGenerator {
 
 	if cg.version.LT(semver.MustParse(version)) {
 		return &ConfigGenerator{
-			logger:                     cg.logger.With("minimum_version", version),
-			version:                    cg.version,
-			notCompatible:              true,
-			prom:                       cg.prom,
-			endpointSliceSupported:     cg.endpointSliceSupported,
-			scrapeClasses:              cg.scrapeClasses,
-			defaultScrapeClassName:     cg.defaultScrapeClassName,
-			daemonSet:                  cg.daemonSet,
-			prometheusTopologySharding: cg.prometheusTopologySharding,
-			inlineTLSConfig:            cg.inlineTLSConfig,
-			bypassVersionCheck:         cg.bypassVersionCheck,
+			logger:                      cg.logger.With("minimum_version", version),
+			version:                     cg.version,
+			notCompatible:               true,
+			prom:                        cg.prom,
+			endpointSliceSupported:      cg.endpointSliceSupported,
+			scrapeClasses:               cg.scrapeClasses,
+			defaultScrapeClassName:      cg.defaultScrapeClassName,
+			daemonSet:                   cg.daemonSet,
+			prometheusTopologySharding:  cg.prometheusTopologySharding,
+			prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+			inlineTLSConfig:             cg.inlineTLSConfig,
+			bypassVersionCheck:          cg.bypassVersionCheck,
 		}
 	}
 
@@ -297,17 +307,18 @@ func (cg *ConfigGenerator) WithMaximumVersion(version string) *ConfigGenerator {
 
 	if cg.version.GTE(semver.MustParse(version)) {
 		return &ConfigGenerator{
-			logger:                     cg.logger.With("maximum_version", version),
-			version:                    cg.version,
-			notCompatible:              true,
-			prom:                       cg.prom,
-			endpointSliceSupported:     cg.endpointSliceSupported,
-			scrapeClasses:              cg.scrapeClasses,
-			defaultScrapeClassName:     cg.defaultScrapeClassName,
-			daemonSet:                  cg.daemonSet,
-			prometheusTopologySharding: cg.prometheusTopologySharding,
-			inlineTLSConfig:            cg.inlineTLSConfig,
-			bypassVersionCheck:         cg.bypassVersionCheck,
+			logger:                      cg.logger.With("maximum_version", version),
+			version:                     cg.version,
+			notCompatible:               true,
+			prom:                        cg.prom,
+			endpointSliceSupported:      cg.endpointSliceSupported,
+			scrapeClasses:               cg.scrapeClasses,
+			defaultScrapeClassName:      cg.defaultScrapeClassName,
+			daemonSet:                   cg.daemonSet,
+			prometheusTopologySharding:  cg.prometheusTopologySharding,
+			prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+			inlineTLSConfig:             cg.inlineTLSConfig,
+			bypassVersionCheck:          cg.bypassVersionCheck,
 		}
 	}
 
@@ -1550,7 +1561,7 @@ func (cg *ConfigGenerator) generatePodMonitorConfig(
 
 	// DaemonSet mode doesn't support sharding.
 	if !cg.daemonSet {
-		relabelings = appendShardingRelabelingWithAddress(relabelings, shards)
+		relabelings = cg.appendShardingRelabelingWithAddress(relabelings, shards)
 	}
 
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
@@ -1806,7 +1817,7 @@ func (cg *ConfigGenerator) generateProbeConfig(
 		relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, m.Spec.Targets.Ingress.RelabelConfigs))...)
 	}
 
-	relabelings = appendShardingRelabelingForProbes(relabelings, shards)
+	relabelings = cg.appendShardingRelabelingForProbes(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	if m.Spec.BearerTokenSecret != nil { //nolint:staticcheck // Ignore SA1019 this field is marked as deprecated.
@@ -2096,7 +2107,7 @@ func (cg *ConfigGenerator) generateServiceMonitorConfig(
 	labeler := namespacelabeler.New(cpf.EnforcedNamespaceLabel, cpf.ExcludedFromEnforcement, false)
 	relabelings = append(relabelings, generateRelabelConfig(labeler.GetRelabelingConfigs(m.TypeMeta, m.ObjectMeta, ep.RelabelConfigs))...)
 
-	relabelings = appendShardingRelabelingWithAddress(relabelings, shards)
+	relabelings = cg.appendShardingRelabelingWithAddress(relabelings, shards)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
 	cfg = cg.AddLimitsToYAML(cfg, sampleLimitKey, m.Spec.SampleLimit, cpf.EnforcedSampleLimit)
@@ -2152,12 +2163,12 @@ func (cg *ConfigGenerator) getLimit(user *uint64, enforced *uint64) *uint64 {
 	return enforced
 }
 
-func appendShardingRelabelingWithAddress(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {
-	return appendShardingRelabelingWithLabel(relabelings, shards, "__address__")
+func (cg *ConfigGenerator) appendShardingRelabelingWithAddress(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {
+	return cg.appendShardingRelabelingWithLabel(relabelings, shards, "__address__")
 }
 
-func appendShardingRelabelingForProbes(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {
-	return appendShardingRelabelingWithLabel(relabelings, shards, "__param_target")
+func (cg *ConfigGenerator) appendShardingRelabelingForProbes(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {
+	return cg.appendShardingRelabelingWithLabel(relabelings, shards, "__param_target")
 }
 
 func (cg *ConfigGenerator) appendShardingRelabelingWithAddressIfMissing(relabelings []yaml.MapSlice, shards int32) []yaml.MapSlice {
@@ -2169,10 +2180,41 @@ func (cg *ConfigGenerator) appendShardingRelabelingWithAddressIfMissing(relabeli
 			}
 		}
 	}
-	return appendShardingRelabelingWithAddress(relabelings, shards)
+	return cg.appendShardingRelabelingWithAddress(relabelings, shards)
 }
 
-func appendShardingRelabelingWithLabel(relabelings []yaml.MapSlice, shards int32, shardLabel string) []yaml.MapSlice {
+// generateInRangeShardPattern generates a regex pattern that matches shard IDs
+// that are in the valid range [0, shards-1].
+// This is used to drop all targets on inactive shards during scale-down operations.
+func generateInRangeShardPattern(shards int32) string {
+	// Enumerate all valid shard numbers from 0 to shards-1
+	var inRangeShards []string
+	for i := range shards {
+		inRangeShards = append(inRangeShards, strconv.Itoa(int(i)))
+	}
+
+	// Join with OR operator: e.g., for shards=2: "0|1"
+	return strings.Join(inRangeShards, "|")
+}
+
+func (cg *ConfigGenerator) appendShardingRelabelingWithLabel(relabelings []yaml.MapSlice, shards int32, shardLabel string) []yaml.MapSlice {
+	if cg.prometheusRetentionPolicies {
+		relabelings = append(relabelings,
+			// Capture the current SHARD environment variable value.
+			yaml.MapSlice{
+				{Key: "target_label", Value: "__tmp_current_shard"},
+				{Key: "replacement", Value: fmt.Sprintf("$(%s)", operator.ShardEnvVar)},
+				{Key: "action", Value: "replace"},
+			},
+			// Keep only targets where the current shard is in the active range [0, shards-1].
+			// This ensures inactive shards (after scale-down with Retain policy) scrape nothing.
+			yaml.MapSlice{
+				{Key: "source_labels", Value: []string{"__tmp_current_shard"}},
+				{Key: "regex", Value: generateInRangeShardPattern(shards)},
+				{Key: "action", Value: "keep"},
+			})
+	}
+
 	return append(relabelings,
 		// Store the "shardLabel" value into the __tmp_hash label unless the
 		// latter is already set.

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -14220,3 +14220,77 @@ func TestAppendScrapeNativeHistograms(t *testing.T) {
 		})
 	}
 }
+
+func TestShardingRelabelConfigsWithRetention(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		shards           int32
+		retentionEnabled bool
+		golden           string
+	}{
+		{
+			name:             "without_retention",
+			shards:           2,
+			retentionEnabled: false,
+			golden:           "ShardingRelabelConfigs_without_retention.golden",
+		},
+		{
+			name:             "with_retention_2_shards",
+			shards:           2,
+			retentionEnabled: true,
+			golden:           "ShardingRelabelConfigs_with_retention_2_shards.golden",
+		},
+		{
+			name:             "with_retention_3_shards",
+			shards:           3,
+			retentionEnabled: true,
+			golden:           "ShardingRelabelConfigs_with_retention_3_shards.golden",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := defaultPrometheus()
+			p.Spec.Shards = ptr.To(tc.shards)
+
+			opts := []ConfigGeneratorOption{}
+			if tc.retentionEnabled {
+				opts = append(opts, WithPrometheusRetentionPolicies())
+			}
+
+			cg := mustNewConfigGenerator(t, p, opts...)
+			cfg, err := cg.GenerateServerConfiguration(
+				p,
+				map[string]*monitoringv1.ServiceMonitor{
+					"test": {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "default",
+						},
+						Spec: monitoringv1.ServiceMonitorSpec{
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"foo": "bar",
+								},
+							},
+							Endpoints: []monitoringv1.Endpoint{
+								{
+									Port:     "web",
+									Interval: "30s",
+								},
+							},
+						},
+					},
+				},
+				nil,
+				nil,
+				nil,
+				&assets.StoreBuilder{},
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			require.NoError(t, err)
+			golden.Assert(t, string(cfg), tc.golden)
+		})
+	}
+}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -952,6 +952,9 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 	if c.endpointSliceSupported {
 		opts = append(opts, prompkg.WithEndpointSliceSupport())
 	}
+	if c.retentionPoliciesEnabled {
+		opts = append(opts, prompkg.WithPrometheusRetentionPolicies())
+	}
 	cg, err := prompkg.NewConfigGenerator(logger, p, opts...)
 	if err != nil {
 		return closure, err

--- a/pkg/prometheus/testdata/ShardingRelabelConfigs_with_retention_2_shards.golden
+++ b/pkg/prometheus/testdata/ShardingRelabelConfigs_with_retention_2_shards.golden
@@ -1,0 +1,88 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - target_label: __tmp_current_shard
+    replacement: $(SHARD)
+    action: replace
+  - source_labels:
+    - __tmp_current_shard
+    regex: 0|1
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(SHARD);|.+;.+
+    action: keep

--- a/pkg/prometheus/testdata/ShardingRelabelConfigs_with_retention_3_shards.golden
+++ b/pkg/prometheus/testdata/ShardingRelabelConfigs_with_retention_3_shards.golden
@@ -1,0 +1,88 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - target_label: __tmp_current_shard
+    replacement: $(SHARD)
+    action: replace
+  - source_labels:
+    - __tmp_current_shard
+    regex: 0|1|2
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 3
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(SHARD);|.+;.+
+    action: keep

--- a/pkg/prometheus/testdata/ShardingRelabelConfigs_without_retention.golden
+++ b/pkg/prometheus/testdata/ShardingRelabelConfigs_without_retention.golden
@@ -1,0 +1,81 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(SHARD);|.+;.+
+    action: keep

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -450,6 +450,7 @@ func TestGatedFeatures(t *testing.T) {
 		"PromAgentReconcileDaemonSetResourceDelete":            testPromAgentReconcileDaemonSetResourceDelete,
 		"PrometheusAgentDaemonSetSelectPodMonitor":             testPrometheusAgentDaemonSetSelectPodMonitor,
 		"PrometheusRetentionPolicies":                          testPrometheusRetentionPolicies,
+		"PrometheusTargetDistributionOnResharding":             testPrometheusTargetDistributionOnResharding,
 		"FinalizerWhenStatusForConfigResourcesEnabled":         testFinalizerWhenStatusForConfigResourcesEnabled,
 		"ShardingStrategyCELValidations":                       testPrometheusShardingStrategyCELValidations,
 		"PrometheusAgentDaemonSetCELValidations":               testPrometheusAgentDaemonSetCELValidations,

--- a/test/e2e/prometheus_shard_retention_policy_test.go
+++ b/test/e2e/prometheus_shard_retention_policy_test.go
@@ -17,14 +17,15 @@ package e2e
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	applyconfigurationsappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	"k8s.io/utils/ptr"
 
@@ -34,9 +35,11 @@ import (
 )
 
 // testPrometheusTargetDistributionOnResharding verifies that targets are
-// correctly distributed across expected shard(s) when their number scales up
-// and down.
-// TODO: add a target (Prometheus) scraped by all shards.
+// correctly distributed across active shard(s) when their number scales up
+// and down and the Retain policy is used. It also ensures that targets setting
+// the __tmp_disable_sharding label are scraped by all active shards.
+//
+// After a scale-down, the "inactive" shards shouldn't scrape any target.
 func testPrometheusTargetDistributionOnResharding(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -98,9 +101,8 @@ func testPrometheusTargetDistributionOnResharding(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	sm := framework.MakeBasicServiceMonitor("test")
-	// Update the selector to select only the app pods.
-	sm.Spec.Selector.MatchLabels["group"] = "app"
+	// Create a service monitor for the app deployment.
+	sm := framework.MakeBasicServiceMonitor("app")
 	sm.Spec.Endpoints[0] = monitoringv1.Endpoint{
 		Interval: monitoringv1.Duration("5s"),
 		Port:     "web",
@@ -129,12 +131,35 @@ func testPrometheusTargetDistributionOnResharding(t *testing.T) {
 	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Deploy a Prometheus resource with 1 shard and ensure that it discovers 10 targets.
+	// Create 1 service monitor for the Prometheus service.
+	sm = framework.MakeBasicServiceMonitor("test")
+	sm.Spec.Endpoints[0].RelabelConfigs = []monitoringv1.RelabelConfig{
+		{
+			TargetLabel: "__tmp_disable_sharding",
+			Action:      "Replace",
+			Replacement: ptr.To("true"),
+		},
+	}
+	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Deploy a Prometheus resource with 1 shard and ensure that it discovers
+	// 10 targets for the app service and 1 target for the test service.
 	// We test only against the Retain strategy. There's no need to verify with
 	// the Delete strategy because the second shard will not exist anymore in
 	// case of scale down.
 	prom := framework.MakeBasicPrometheus(ns, "test", "test", 1)
 	prom.Spec.Shards = ptr.To(int32(1))
+	prom.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "group",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"app", "test"},
+			},
+		},
+	}
+
 	prom.Spec.ShardRetentionPolicy = &monitoringv1.ShardRetentionPolicy{
 		WhenScaled: ptr.To(monitoringv1.RetainWhenScaledRetentionType),
 	}
@@ -153,38 +178,48 @@ func testPrometheusTargetDistributionOnResharding(t *testing.T) {
 	_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom)
 	require.NoError(t, err)
 
-	err = framework.WaitForHealthyTargets(context.Background(), ns, shardServices[0].Name, 10)
+	// Expecting 10 app pods + 1 prometheus pod.
+	err = framework.WaitForHealthyTargets(context.Background(), ns, shardServices[0].Name, 11)
 	require.NoError(t, err)
 
 	// Scale up the number of shards to 2 and ensure that
-	// * Each shard discovers a positive number of targets.
-	// * The sum of targets is 10.
+	// * Each shard discovers more than 2 targets (at least 1 app pod + 2 prometheus pods).
+	// * The sum of targets is 10 app pods + 2*2 prometheus pods = 14.
 	_, err = framework.ScalePrometheusAndWaitUntilReady(ctx, "test", ns, 2)
 	require.NoError(t, err)
 
-	var total atomic.Int32
 	t.Run("2 active shards", func(t *testing.T) {
-		for _, svc := range shardServices {
-			t.Run(svc.Name, func(t *testing.T) {
-				t.Parallel()
-
-				err = framework.WaitForHealthyTargetsWithCondition(
+		var pollErr error
+		err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+			var total int
+			for _, svc := range shardServices {
+				err := framework.WaitForHealthyTargetsWithCondition(
 					context.Background(),
 					ns,
 					svc.Name,
 					func(targets []*testFramework.Target) error {
-						if len(targets) == 0 {
-							return errors.New("expected more than zero targets")
+						if len(targets) < 2 {
+							return errors.New("expected more than 2 targets")
 						}
-						_ = total.Add(int32(len(targets)))
+
+						total += len(targets)
 						return nil
 					},
 				)
-				require.NoError(t, err)
-			})
-		}
+				if err != nil {
+					pollErr = fmt.Errorf("%s: %w", svc.Name, err)
+					return false, nil
+				}
+			}
+
+			if total != 14 {
+				pollErr = fmt.Errorf("expected 14 targets, got %d", total)
+				return false, nil
+			}
+			return true, nil
+		})
+		require.NoError(t, err, fmt.Sprintf("%s: %s", err, pollErr))
 	})
-	require.Equal(t, int32(10), total.Load())
 
 	// Scale down the number of shards to 1 and ensure that all targets are
 	// reaffected to the first shard.
@@ -198,9 +233,10 @@ func testPrometheusTargetDistributionOnResharding(t *testing.T) {
 
 				var targets int
 				if i == 0 {
-					targets = 10
+					// 10 app pods + 2 prometheus pods.
+					targets = 12
 				}
-				err = framework.WaitForHealthyTargets(context.Background(), ns, svc.Name, targets)
+				err := framework.WaitForHealthyTargets(context.Background(), ns, svc.Name, targets)
 				require.NoError(t, err)
 			})
 		}

--- a/test/e2e/prometheus_shard_retention_policy_test.go
+++ b/test/e2e/prometheus_shard_retention_policy_test.go
@@ -16,11 +16,14 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applyconfigurationsappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	"k8s.io/utils/ptr"
@@ -29,6 +32,180 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
 )
+
+// testPrometheusTargetDistributionOnResharding verifies that targets are
+// correctly distributed across expected shard(s) when their number scales up
+// and down.
+// TODO: add a target (Prometheus) scraped by all shards.
+func testPrometheusTargetDistributionOnResharding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusShardRetentionPolicyFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	// Deploy an application with 10 replicas to ensure that targets will be
+	// spread across the 2 shards.
+	dep, err := testFramework.MakeDeployment("../../test/framework/resources/basic-auth-app-deployment.yaml")
+	require.NoError(t, err)
+	dep.Spec.Replicas = ptr.To(int32(10))
+
+	framework.CreateDeployment(context.Background(), ns, dep)
+	require.NoError(t, err)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app",
+			Labels: map[string]string{
+				"group": "app",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: dep.Spec.Template.ObjectMeta.Labels,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "web",
+					Port: 8080,
+				},
+			},
+		},
+	}
+	_, err = framework.KubeClient.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth",
+			Namespace: ns,
+		},
+		StringData: map[string]string{
+			"user": "user",
+			"pass": "pass",
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	sm := framework.MakeBasicServiceMonitor("test")
+	// Update the selector to select only the app pods.
+	sm.Spec.Selector.MatchLabels["group"] = "app"
+	sm.Spec.Endpoints[0] = monitoringv1.Endpoint{
+		Interval: monitoringv1.Duration("5s"),
+		Port:     "web",
+		HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
+			HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
+				HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+					BasicAuth: &monitoringv1.BasicAuth{
+						Username: corev1.SecretKeySelector{
+							Key: "user",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "auth",
+							},
+						},
+						Password: corev1.SecretKeySelector{
+							Key: "pass",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "auth",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sm, err = framework.MonClientV1.ServiceMonitors(ns).Create(ctx, sm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Deploy a Prometheus resource with 1 shard and ensure that it discovers 10 targets.
+	// We test only against the Retain strategy. There's no need to verify with
+	// the Delete strategy because the second shard will not exist anymore in
+	// case of scale down.
+	prom := framework.MakeBasicPrometheus(ns, "test", "test", 1)
+	prom.Spec.Shards = ptr.To(int32(1))
+	prom.Spec.ShardRetentionPolicy = &monitoringv1.ShardRetentionPolicy{
+		WhenScaled: ptr.To(monitoringv1.RetainWhenScaledRetentionType),
+	}
+
+	shardServices := make([]*corev1.Service, 2)
+	for i := range shardServices {
+		svc := framework.MakePrometheusService("test", "test", corev1.ServiceTypeClusterIP)
+		svc.Name += "-" + strconv.Itoa(i)
+		svc.Spec.Selector["operator.prometheus.io/shard"] = strconv.Itoa(i)
+
+		svc, err = framework.KubeClient.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
+		require.NoError(t, err)
+		shardServices[i] = svc
+	}
+
+	_, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, prom)
+	require.NoError(t, err)
+
+	err = framework.WaitForHealthyTargets(context.Background(), ns, shardServices[0].Name, 10)
+	require.NoError(t, err)
+
+	// Scale up the number of shards to 2 and ensure that
+	// * Each shard discovers a positive number of targets.
+	// * The sum of targets is 10.
+	_, err = framework.ScalePrometheusAndWaitUntilReady(ctx, "test", ns, 2)
+	require.NoError(t, err)
+
+	var total atomic.Int32
+	t.Run("2 active shards", func(t *testing.T) {
+		for _, svc := range shardServices {
+			t.Run(svc.Name, func(t *testing.T) {
+				t.Parallel()
+
+				err = framework.WaitForHealthyTargetsWithCondition(
+					context.Background(),
+					ns,
+					svc.Name,
+					func(targets []*testFramework.Target) error {
+						if len(targets) == 0 {
+							return errors.New("expected more than zero targets")
+						}
+						_ = total.Add(int32(len(targets)))
+						return nil
+					},
+				)
+				require.NoError(t, err)
+			})
+		}
+	})
+	require.Equal(t, int32(10), total.Load())
+
+	// Scale down the number of shards to 1 and ensure that all targets are
+	// reaffected to the first shard.
+	_, err = framework.ScalePrometheusAndWaitUntilReady(ctx, "test", ns, 1)
+	require.NoError(t, err)
+
+	t.Run("1 active shard", func(t *testing.T) {
+		for i, svc := range shardServices {
+			t.Run(svc.Name, func(t *testing.T) {
+				t.Parallel()
+
+				var targets int
+				if i == 0 {
+					targets = 10
+				}
+				err = framework.WaitForHealthyTargets(context.Background(), ns, svc.Name, targets)
+				require.NoError(t, err)
+			})
+		}
+	})
+}
 
 // testPrometheusRetentionPolicies tests the shard retention policies for Prometheus.
 // ShardRetentionPolicy requires the ShardRetention feature gate to be enabled,

--- a/test/e2e/prometheus_shard_retention_policy_test.go
+++ b/test/e2e/prometheus_shard_retention_policy_test.go
@@ -1,0 +1,150 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyconfigurationsappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	"k8s.io/utils/ptr"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	testFramework "github.com/prometheus-operator/prometheus-operator/test/framework"
+)
+
+// testPrometheusRetentionPolicies tests the shard retention policies for Prometheus.
+// ShardRetentionPolicy requires the ShardRetention feature gate to be enabled,
+// therefore, it runs in the feature-gated test suite.
+func testPrometheusRetentionPolicies(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(ctx, t, testCtx)
+	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
+		ctx, testFramework.PrometheusOperatorOpts{
+			Namespace:           ns,
+			AllowedNamespaces:   []string{ns},
+			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusShardRetentionPolicyFeature},
+		},
+	)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		whenScaledDown *monitoringv1.WhenScaledRetentionType
+	}{
+		{
+			name:           "delete policy",
+			whenScaledDown: ptr.To(monitoringv1.DeleteWhenScaledRetentionType),
+		},
+		{
+			name:           "retain policy",
+			whenScaledDown: ptr.To(monitoringv1.RetainWhenScaledRetentionType),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "shard-retention-" + strconv.Itoa(i)
+			p := framework.MakeBasicPrometheus(ns, name, name, 1)
+			p.Spec.ShardRetentionPolicy = &monitoringv1.ShardRetentionPolicy{
+				WhenScaled: tc.whenScaledDown,
+			}
+			p.Spec.Shards = ptr.To(int32(2))
+			_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
+			require.NoError(t, err)
+
+			t.Log("scaling down the number of shards to 1")
+			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 1)
+			require.NoError(t, err)
+			require.Equal(t, int32(1), p.Status.Shards)
+
+			sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: p.Status.Selector})
+			require.NoError(t, err)
+
+			expectedRemaining := 2
+			if *tc.whenScaledDown == monitoringv1.DeleteWhenScaledRetentionType {
+				expectedRemaining = 1
+			}
+			require.Len(t, sts.Items, expectedRemaining)
+
+			if expectedRemaining == 1 {
+				return
+			}
+
+			var shard1 string
+			for _, sts := range sts.Items {
+				deadlineAnnotation, found := sts.Annotations["operator.prometheus.io/deletion-deadline"]
+				switch shard := sts.Labels["operator.prometheus.io/shard"]; shard {
+				case "0":
+					require.False(t, found)
+				case "1":
+					require.True(t, found)
+					require.NotEmpty(t, deadlineAnnotation)
+					shard1 = sts.Name
+				default:
+					t.Fatalf("unexpected shard label: %s", shard)
+				}
+			}
+
+			t.Log("scaling up the number of shards to 2")
+			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 2)
+			require.NoError(t, err)
+			require.Equal(t, int32(2), p.Status.Shards)
+
+			sts, err = framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: p.Status.Selector})
+			require.NoError(t, err)
+			require.Len(t, sts.Items, 2)
+
+			for _, sts := range sts.Items {
+				_, found := sts.Annotations["operator.prometheus.io/deletion-deadline"]
+				switch shard := sts.Labels["operator.prometheus.io/shard"]; shard {
+				case "0":
+				case "1":
+					require.False(t, found)
+				default:
+					t.Fatalf("unexpected shard label: %s", shard)
+				}
+			}
+
+			t.Log("scaling down the number of shards to 1 again")
+			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 1)
+			require.NoError(t, err)
+			require.Equal(t, int32(1), p.Status.Shards)
+
+			// Update the deadline annotation to trigger a deletion of the statefulset.
+			_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Apply(
+				ctx,
+				applyconfigurationsappsv1.StatefulSet(shard1, ns).WithAnnotations(map[string]string{
+					"operator.prometheus.io/deletion-deadline": time.Now().UTC().Format(time.RFC3339),
+				}),
+				metav1.ApplyOptions{FieldManager: "e2e-test", Force: true},
+			)
+			require.NoError(t, err)
+
+			err = framework.WaitForPodsReady(ctx, ns, 2*time.Minute, 1, metav1.ListOptions{LabelSelector: p.Status.Selector})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -5461,7 +5461,7 @@ func testPrometheusServiceName(t *testing.T) {
 }
 
 // testPrometheusReconciliationOnSecretChanges ensures that the operator
-// reconciles the configureation whenever a secret referenced by a service
+// reconciles the configuration whenever a secret referenced by a service
 // monitor gets added/deleted in another namespace than the workload.
 func testPrometheusReconciliationOnSecretChanges(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	applyconfigurationsappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/utils/ptr"
 
@@ -5459,125 +5458,6 @@ func testPrometheusServiceName(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, svcList.Items, 1)
 	require.Equal(t, svcList.Items[0].Name, svc.Name)
-}
-
-// testPrometheusRetentionPolicies tests the shard retention policies for Prometheus.
-// ShardRetentionPolicy requires the ShardRetention feature gate to be enabled,
-// therefore, it runs in the feature-gated test suite.
-func testPrometheusRetentionPolicies(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	testCtx := framework.NewTestCtx(t)
-	defer testCtx.Cleanup(t)
-
-	ns := framework.CreateNamespace(ctx, t, testCtx)
-	framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
-	_, err := framework.CreateOrUpdatePrometheusOperatorWithOpts(
-		ctx, testFramework.PrometheusOperatorOpts{
-			Namespace:           ns,
-			AllowedNamespaces:   []string{ns},
-			EnabledFeatureGates: []operator.FeatureGateName{operator.PrometheusShardRetentionPolicyFeature},
-		},
-	)
-	require.NoError(t, err)
-
-	testCases := []struct {
-		name           string
-		whenScaledDown *monitoringv1.WhenScaledRetentionType
-	}{
-		{
-			name:           "delete policy",
-			whenScaledDown: ptr.To(monitoringv1.DeleteWhenScaledRetentionType),
-		},
-		{
-			name:           "retain policy",
-			whenScaledDown: ptr.To(monitoringv1.RetainWhenScaledRetentionType),
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			name := "shard-retention-" + strconv.Itoa(i)
-			p := framework.MakeBasicPrometheus(ns, name, name, 1)
-			p.Spec.ShardRetentionPolicy = &monitoringv1.ShardRetentionPolicy{
-				WhenScaled: tc.whenScaledDown,
-			}
-			p.Spec.Shards = ptr.To(int32(2))
-			_, err := framework.CreatePrometheusAndWaitUntilReady(ctx, ns, p)
-			require.NoError(t, err)
-
-			t.Log("scaling down the number of shards to 1")
-			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 1)
-			require.NoError(t, err)
-			require.Equal(t, int32(1), p.Status.Shards)
-
-			sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: p.Status.Selector})
-			require.NoError(t, err)
-
-			expectedRemaining := 2
-			if *tc.whenScaledDown == monitoringv1.DeleteWhenScaledRetentionType {
-				expectedRemaining = 1
-			}
-			require.Len(t, sts.Items, expectedRemaining)
-
-			if expectedRemaining == 1 {
-				return
-			}
-
-			var shard1 string
-			for _, sts := range sts.Items {
-				deadlineAnnotation, found := sts.Annotations["operator.prometheus.io/deletion-deadline"]
-				switch shard := sts.Labels["operator.prometheus.io/shard"]; shard {
-				case "0":
-					require.False(t, found)
-				case "1":
-					require.True(t, found)
-					require.NotEmpty(t, deadlineAnnotation)
-					shard1 = sts.Name
-				default:
-					t.Fatalf("unexpected shard label: %s", shard)
-				}
-			}
-
-			t.Log("scaling up the number of shards to 2")
-			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 2)
-			require.NoError(t, err)
-			require.Equal(t, int32(2), p.Status.Shards)
-
-			sts, err = framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: p.Status.Selector})
-			require.NoError(t, err)
-			require.Len(t, sts.Items, 2)
-
-			for _, sts := range sts.Items {
-				_, found := sts.Annotations["operator.prometheus.io/deletion-deadline"]
-				switch shard := sts.Labels["operator.prometheus.io/shard"]; shard {
-				case "0":
-				case "1":
-					require.False(t, found)
-				default:
-					t.Fatalf("unexpected shard label: %s", shard)
-				}
-			}
-
-			t.Log("scaling down the number of shards to 1 again")
-			p, err = framework.ScalePrometheusAndWaitUntilReady(ctx, name, ns, 1)
-			require.NoError(t, err)
-			require.Equal(t, int32(1), p.Status.Shards)
-
-			// Update the deadline annotation to trigger a deletion of the statefulset.
-			_, err = framework.KubeClient.AppsV1().StatefulSets(ns).Apply(
-				ctx,
-				applyconfigurationsappsv1.StatefulSet(shard1, ns).WithAnnotations(map[string]string{
-					"operator.prometheus.io/deletion-deadline": time.Now().UTC().Format(time.RFC3339),
-				}),
-				metav1.ApplyOptions{FieldManager: "e2e-test", Force: true},
-			)
-			require.NoError(t, err)
-
-			err = framework.WaitForPodsReady(ctx, ns, 2*time.Minute, 1, metav1.ListOptions{LabelSelector: p.Status.Selector})
-			require.NoError(t, err)
-		})
-	}
 }
 
 // testPrometheusReconciliationOnSecretChanges ensures that the operator

--- a/test/framework/prometheus.go
+++ b/test/framework/prometheus.go
@@ -456,6 +456,7 @@ func (f *Framework) UpdatePrometheusReplicasAndWaitUntilReady(ctx context.Contex
 	)
 }
 
+// ScalePrometheusAndWaitUntilReady scales the number of shards.
 func (f *Framework) ScalePrometheusAndWaitUntilReady(ctx context.Context, name, ns string, shards int32) (*monitoringv1.Prometheus, error) {
 	promClient := f.MonClientV1.Prometheuses(ns)
 	scale, err := promClient.GetScale(ctx, name, metav1.GetOptions{})
@@ -468,6 +469,7 @@ func (f *Framework) ScalePrometheusAndWaitUntilReady(ctx context.Context, name, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to scale Prometheus %s/%s: %w", ns, name, err)
 	}
+
 	p, err := promClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Prometheus %s/%s: %w", ns, name, err)
@@ -633,21 +635,35 @@ func (f *Framework) WaitForActiveTargets(ctx context.Context, ns, svcName string
 // WaitForHealthyTargets waits for a number of targets to be configured and
 // healthy.
 func (f *Framework) WaitForHealthyTargets(ctx context.Context, ns, svcName string, amount int) error {
+	return f.WaitForHealthyTargetsWithCondition(
+		ctx,
+		ns,
+		svcName,
+		func(targets []*Target) error {
+			if len(targets) != amount {
+				return fmt.Errorf("expected %d, found %d healthy targets", amount, len(targets))
+			}
+
+			return nil
+		},
+	)
+}
+
+// WaitForHealthyTargetsWithCondition queries healthy targets from the
+// Prometheus API endpoint and waits for the condition function to return no
+// error.
+func (f *Framework) WaitForHealthyTargetsWithCondition(ctx context.Context, ns, svcName string, cond func([]*Target) error) error {
 	var loopErr error
 
-	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*1, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*1, true, func(_ context.Context) (bool, error) {
 		var targets []*Target
-		targets, loopErr = f.GetHealthyTargets(ctx, ns, svcName)
+		targets, loopErr = f.GetHealthyTargets(context.Background(), ns, svcName)
 		if loopErr != nil {
 			return false, nil
 		}
 
-		if len(targets) == amount {
-			return true, nil
-		}
-
-		loopErr = fmt.Errorf("expected %d, found %d healthy targets", amount, len(targets))
-		return false, nil
+		loopErr = cond(targets)
+		return loopErr == nil, nil
 	})
 	if err != nil {
 		return fmt.Errorf("%s: waiting for healthy targets failed: %v: %v", svcName, err, loopErr)


### PR DESCRIPTION
## Description

This PR ensures that when a Prometheus shard becomes inactive after the resource has been scaled down and the Retain policy is used,  all targets are redistributed to the active shards (including targets which should be scraped by all shards). It also adds a corresponding e2e test.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
