### PR TITLE
Fix: update type of Mattermost Webhook URL

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2284,7 +2284,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 		gc.SMTPForceImplicitTLS = nil
 	}
 
-	if gc.MattermostWebhookURL != "" && amVersion.LT(semver.MustParse("0.32.0")) {
+	if gc.MattermostWebhookURL != nil && amVersion.LT(semver.MustParse("0.32.0")) {
 		msg := "'mattermost_webhook_url' supported in Alertmanager >= 0.32.0 only - dropping field from provided config"
 		logger.Warn(msg, "current_version", amVersion.String())
 		gc.MattermostWebhookURL = ""
@@ -2296,7 +2296,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 		gc.MattermostWebhookURLFile = ""
 	}
 
-	if gc.MattermostWebhookURL != "" && gc.MattermostWebhookURLFile != "" {
+	if gc.MattermostWebhookURL != nil && gc.MattermostWebhookURLFile != "" {
 		msg := "'mattermost_webhook_url' and 'mattermost_webhook_url_file' are mutually exclusive - 'mattermost_webhook_url' has taken precedence"
 		logger.Warn(msg)
 		gc.MattermostWebhookURLFile = ""

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2287,7 +2287,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 	if gc.MattermostWebhookURL != nil && amVersion.LT(semver.MustParse("0.32.0")) {
 		msg := "'mattermost_webhook_url' supported in Alertmanager >= 0.32.0 only - dropping field from provided config"
 		logger.Warn(msg, "current_version", amVersion.String())
-		gc.MattermostWebhookURL = ""
+		gc.MattermostWebhookURL = nil
 	}
 
 	if gc.MattermostWebhookURLFile != "" && amVersion.LT(semver.MustParse("0.32.0")) {

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -4333,7 +4333,7 @@ func TestSanitizeConfig(t *testing.T) {
 				Global: &globalConfig{
 					MattermostWebhookURL: &config.URL{
 						URL: &url.URL{
-							Host: "https://mattermost.example.com",
+							Host: "www.test.com",
 						}},
 				},
 			},
@@ -4346,7 +4346,7 @@ func TestSanitizeConfig(t *testing.T) {
 				Global: &globalConfig{
 					MattermostWebhookURL: &config.URL{
 						URL: &url.URL{
-							Host: "https://mattermost.example.com",
+							Host: "www.test.com",
 						}},
 				},
 			},
@@ -4379,7 +4379,7 @@ func TestSanitizeConfig(t *testing.T) {
 				Global: &globalConfig{
 					MattermostWebhookURL: &config.URL{
 						URL: &url.URL{
-							Host: "https://mattermost.example.com",
+							Host: "www.test.com",
 						}},
 					MattermostWebhookURLFile: "/mattermost/webhook/url",
 				},

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -4331,7 +4331,10 @@ func TestSanitizeConfig(t *testing.T) {
 			againstVersion: versionGlobalMattermostWebhookURLAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
-					MattermostWebhookURL: "https://mattermost.example.com",
+					MattermostWebhookURL: &config.URL{
+						URL: &url.URL{
+							Host: "https://mattermost.example.com",
+						}},
 				},
 			},
 			golden: "test_mattermost_webhook_url_supported_version.golden",
@@ -4341,7 +4344,10 @@ func TestSanitizeConfig(t *testing.T) {
 			againstVersion: versionGlobalMattermostWebhookURLNotAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
-					MattermostWebhookURL: "https://mattermost.example.com",
+					MattermostWebhookURL: &config.URL{
+						URL: &url.URL{
+							Host: "https://mattermost.example.com",
+						}},
 				},
 			},
 			golden: "test_mattermost_webhook_url_unsupported_version.golden",
@@ -4371,7 +4377,10 @@ func TestSanitizeConfig(t *testing.T) {
 			againstVersion: versionGlobalMattermostWebhookURLAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
-					MattermostWebhookURL:     "https://mattermost.example.com",
+					MattermostWebhookURL: &config.URL{
+						URL: &url.URL{
+							Host: "https://mattermost.example.com",
+						}},
 					MattermostWebhookURLFile: "/mattermost/webhook/url",
 				},
 			},
@@ -5142,7 +5151,10 @@ func TestSanitizeConfig(t *testing.T) {
 			againstVersion: versionMattermostEmptyWebhookURLAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
-					MattermostWebhookURL: "www.test.com",
+					MattermostWebhookURL: &config.URL{
+						URL: &url.URL{
+							Host: "www.test.com",
+						}},
 				},
 				Receivers: []*receiver{
 					{
@@ -5161,7 +5173,10 @@ func TestSanitizeConfig(t *testing.T) {
 			againstVersion: versionMattermostEmptyWebhookURLNotAllowed,
 			in: &alertmanagerConfig{
 				Global: &globalConfig{
-					MattermostWebhookURL: "www.test.com",
+					MattermostWebhookURL: &config.URL{
+						URL: &url.URL{
+							Host: "www.test.com",
+						}},
 				},
 				Receivers: []*receiver{
 					{

--- a/pkg/alertmanager/testdata/test_mattermost_empty_webhook_url_supported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_empty_webhook_url_supported_version.golden
@@ -1,5 +1,5 @@
 global:
-  mattermost_webhook_url: www.test.com
+  mattermost_webhook_url: //www.test.com
 receivers:
 - name: ""
   mattermost_configs:

--- a/pkg/alertmanager/testdata/test_mattermost_webhook_url_supported_version.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_webhook_url_supported_version.golden
@@ -1,3 +1,3 @@
 global:
-  mattermost_webhook_url: https://mattermost.example.com
+  mattermost_webhook_url: //www.test.com
 templates: []

--- a/pkg/alertmanager/testdata/test_mattermost_webhook_url_takes_precedence_over_mattermost_webhook_url_file_in_global_config.golden
+++ b/pkg/alertmanager/testdata/test_mattermost_webhook_url_takes_precedence_over_mattermost_webhook_url_file_in_global_config.golden
@@ -1,3 +1,3 @@
 global:
-  mattermost_webhook_url: https://mattermost.example.com
+  mattermost_webhook_url: //www.test.com
 templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -83,7 +83,7 @@ type globalConfig struct {
 	SlackAppTokenFile        string          `yaml:"slack_app_token_file,omitempty"`
 	SlackAppURL              *config.URL     `yaml:"slack_app_url,omitempty"`
 	WeChatAPISecretFile      string          `yaml:"wechat_api_secret_file,omitempty"`
-	MattermostWebhookURL     string          `yaml:"mattermost_webhook_url,omitempty"`
+	MattermostWebhookURL     *config.URL     `yaml:"mattermost_webhook_url,omitempty"`
 	MattermostWebhookURLFile string          `yaml:"mattermost_webhook_url_file,omitempty"`
 }
 


### PR DESCRIPTION
## Description

This PR fixes the type of Mattermost Webhook URL in the global config. The type is changed from string to *config.URL.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing
## Changelog entry

```release-note
Update the type of Mattermost Webhook URL in global config
```
