### PR TITLE
feat: add promql-options CLI arguments to admission webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## UNRELEASED
 
 * [FEATURE] Implement shard retention based on Prometheus data retention (it requires the `PrometheusShardRetentionPolicy` feature gate). #8478
-* [ENHANCEMENT] Add `cipherSuites` support for Thanos Sidecars and Rulers. #8524
-* [ENHANCEMENT] Add `curves` support for Thanos Sidecars and Rulers. #xxxx
-* [BUGFIX] Ensure that inactive shards don't scrape any targets when the sharding retention policy is `Retain`. #8513
 * [FEATURE] Configure node selector when sharding mode is `Topology` for `Prometheus` and `PrometheusAgent` custom resources (it requires the `PrometheusTopologySharding` feature gate). #8486
 * [FEATURE] Configure external label with topology information when sharding mode is `Topology` for `Prometheus` and `PrometheusAgent` custom resources (it requires the `PrometheusTopologySharding` feature gate). #8519
+* [FEATURE] Add `--promql-options` CLI argument to the admission-webhook binary. #8531
+* [ENHANCEMENT] Add `cipherSuites` support for Thanos Sidecars and Rulers. #8524
+* [ENHANCEMENT] Add `curves` support for Thanos Sidecars and Rulers. #8542
+* [BUGFIX] Ensure that inactive shards don't scrape any targets when the sharding retention policy is `Retain`. #8513
 
 ## 0.90.1 / 2026-03-25
 

--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -21,10 +21,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus-operator/prometheus-operator/internal/goruntime"
@@ -45,6 +47,7 @@ func main() {
 		logConfig            logging.Config
 		memlimitRatio        float64
 		nameValidationScheme string
+		promqlOptionsStr     string
 	)
 
 	server.RegisterFlags(flagset, &serverConfig)
@@ -53,6 +56,7 @@ func main() {
 
 	flagset.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultGOMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	flagset.StringVar(&nameValidationScheme, "name-validation-scheme", defaultValidationScheme, "The name validation scheme to use ('legacy' or 'utf8').")
+	flagset.StringVar(&promqlOptionsStr, "promql-options", "", "Comma-separated list of PromQL parser options to enable. Valid values: experimental-functions, duration-expression-parsing, extended-range-selectors, binop-fill-modifiers.")
 
 	_ = flagset.Parse(os.Args[1:])
 
@@ -80,12 +84,31 @@ func main() {
 		os.Exit(1)
 	}
 
+	var parserOptions parser.Options
+	for opt := range strings.SplitSeq(promqlOptionsStr, ",") {
+		switch strings.TrimSpace(opt) {
+		case "":
+			// skip empty string (flag not set)
+		case "experimental-functions":
+			parserOptions.EnableExperimentalFunctions = true
+		case "duration-expression-parsing":
+			parserOptions.ExperimentalDurationExpr = true
+		case "extended-range-selectors":
+			parserOptions.EnableExtendedRangeSelectors = true
+		case "binop-fill-modifiers":
+			parserOptions.EnableBinopFillModifiers = true
+		default:
+			logger.Error("invalid -promql-options value", "value", opt, "supported", []string{"experimental-functions", "duration-expression-parsing", "extended-range-selectors", "binop-fill-modifiers"})
+			os.Exit(1)
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	wg, ctx := errgroup.WithContext(ctx)
 
 	mux := http.NewServeMux()
-	admit := admission.New(logger.With("component", "admissionwebhook"), validationScheme)
+	admit := admission.New(logger.With("component", "admissionwebhook"), validationScheme, parserOptions)
 	admit.Register(mux)
 
 	r := metrics.NewRegistry("prometheus_operator_admission_webhook")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
+	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -730,7 +731,7 @@ func start() int {
 
 	// Setup the web server.
 	mux := http.NewServeMux()
-	admit := admission.New(logger.With("component", "admissionwebhook"), model.LegacyValidation)
+	admit := admission.New(logger.With("component", "admissionwebhook"), model.LegacyValidation, parser.Options{})
 	admit.Register(mux)
 
 	r.MustRegister(cfg.Gates)

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,9 +79,10 @@ type Admission struct {
 	logger           *slog.Logger
 	wh               http.Handler
 	validationScheme model.ValidationScheme
+	parserOptions    parser.Options
 }
 
-func New(logger *slog.Logger, validationScheme model.ValidationScheme) *Admission {
+func New(logger *slog.Logger, validationScheme model.ValidationScheme, parserOptions parser.Options) *Admission {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(monitoringv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1beta1.AddToScheme(scheme))
@@ -89,6 +91,7 @@ func New(logger *slog.Logger, validationScheme model.ValidationScheme) *Admissio
 		logger:           logger,
 		wh:               conversion.NewWebhookHandler(scheme, conversion.NewRegistry()),
 		validationScheme: validationScheme,
+		parserOptions:    parserOptions,
 	}
 }
 
@@ -239,7 +242,7 @@ func (a *Admission) validatePrometheusRules(ar v1.AdmissionReview) *v1.Admission
 		return toAdmissionResponseFailure(errUnmarshalRules, prometheusRuleResource, []error{err})
 	}
 
-	errors := promoperator.ValidateRule(promRule.Spec, a.validationScheme)
+	errors := promoperator.ValidateRule(promRule.Spec, a.validationScheme, a.parserOptions)
 	if len(errors) != 0 {
 		const m = "Invalid rule"
 		a.logger.Debug(m, "content", promRule.Spec)

--- a/pkg/admission/admission_test.go
+++ b/pkg/admission/admission_test.go
@@ -27,6 +27,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 	v1 "k8s.io/api/admission/v1"
@@ -326,6 +327,7 @@ func apiWithValidationScheme(validationScheme model.ValidationScheme) *Admission
 	return New(
 		slog.New(slog.DiscardHandler),
 		validationScheme,
+		parser.Options{},
 	)
 }
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -137,7 +137,7 @@ func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitori
 		validationScheme = ValidationSchemeForPrometheus(prs.version)
 	}
 
-	errs := ValidateRule(promRuleSpec, validationScheme)
+	errs := ValidateRule(promRuleSpec, validationScheme, parser.Options{})
 	if len(errs) != 0 {
 		const m = "invalid rule"
 		logger.Debug(m, "content", content)
@@ -199,7 +199,7 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 }
 
 // ValidateRule takes PrometheusRuleSpec and validates it using the upstream prometheus rule validator.
-func ValidateRule(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme model.ValidationScheme) []error {
+func ValidateRule(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme model.ValidationScheme, parserOptions parser.Options) []error {
 	for i := range promRuleSpec.Groups {
 		// The upstream Prometheus rule validator doesn't support the
 		// partial_response_strategy field.
@@ -229,7 +229,7 @@ func ValidateRule(promRuleSpec monitoringv1.PrometheusRuleSpec, validationScheme
 		return []error{fmt.Errorf("the length of rendered Prometheus Rule is %d bytes which is above the maximum limit of %d bytes", promRuleSize, MaxConfigMapDataSize)}
 	}
 
-	_, errs := rulefmt.Parse(content, false, validationScheme, parser.NewParser(parser.Options{}))
+	_, errs := rulefmt.Parse(content, false, validationScheme, parser.NewParser(parserOptions))
 	return errs
 }
 

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,6 +65,10 @@ func TestMakeRulesConfigMaps(t *testing.T) {
 
 	// UTF-8 validation.
 	t.Run("UTF8Validation", TestUTF8Validation)
+
+	// Experimental functions.
+	t.Run("shouldRejectRuleWithExperimentalFunction", shouldRejectRuleWithExperimentalFunction)
+	t.Run("shouldAcceptRuleWithExperimentalFunction", shouldAcceptRuleWithExperimentalFunction)
 }
 
 func newRuleSelectorForConfigGeneration(ruleFormat RuleConfigurationFormat, version semver.Version) PrometheusRuleSelector {
@@ -523,10 +528,10 @@ func shouldErrorOnTooLargePrometheusRule(t *testing.T) {
 		},
 	}
 
-	err := ValidateRule(ruleSpec, model.UTF8Validation)
+	err := ValidateRule(ruleSpec, model.UTF8Validation, parser.Options{})
 	require.NotEmpty(t, err, "expected ValidateRule to return error of size limit with UTF8Validation")
 
-	err = ValidateRule(ruleSpec, model.LegacyValidation)
+	err = ValidateRule(ruleSpec, model.LegacyValidation, parser.Options{})
 	require.NotEmpty(t, err, "expected ValidateRule to return error of size limit with LegacyValidation")
 }
 
@@ -687,6 +692,33 @@ func createUTF8Rule() *monitoringv1.PrometheusRule {
 			},
 		}},
 	}
+}
+
+// mad_over_time is an experimental PromQL function gated by EnableExperimentalFunctions.
+func ruleSpecWithExperimentalFunction() monitoringv1.PrometheusRuleSpec {
+	return monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{
+			{
+				Name: "group",
+				Rules: []monitoringv1.Rule{
+					{
+						Record: "record",
+						Expr:   intstr.FromString("mad_over_time(some_metric[5m])"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func shouldRejectRuleWithExperimentalFunction(t *testing.T) {
+	errs := ValidateRule(ruleSpecWithExperimentalFunction(), model.LegacyValidation, parser.Options{})
+	require.NotEmpty(t, errs, "expected ValidateRule to return an error when experimental functions are disabled")
+}
+
+func shouldAcceptRuleWithExperimentalFunction(t *testing.T) {
+	errs := ValidateRule(ruleSpecWithExperimentalFunction(), model.LegacyValidation, parser.Options{EnableExperimentalFunctions: true})
+	require.Empty(t, errs, "expected ValidateRule to succeed when experimental functions are enabled")
 }
 
 func TestPrometheusRuleSync(t *testing.T) {


### PR DESCRIPTION
## Description

Written with the help of Claude Code.

Related #7099

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
