### PR TITLE
Fix: Add logic to check empty string for Alertmanager Mattermost top-level fields

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -3227,9 +3227,11 @@ func (mc *mattermostConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 			"image_urL":   &mc.ImageURL,
 		}
 		for fieldName, valuePtr := range fieldNameMapping {
-			msg := fmt.Sprintf("'%s'"+commonErrorMsg, fieldName)
-			logger.Warn(msg, "current_version", amVersion.String())
-			*valuePtr = ""
+			if *valuePtr != "" {
+				msg := fmt.Sprintf("'%s'"+commonErrorMsg, fieldName)
+				logger.Warn(msg, "current_version", amVersion.String())
+				*valuePtr = ""
+			}
 		}
 
 		if len(mc.Fields) > 0 {


### PR DESCRIPTION
## Description

Continue from #8508, missing the logic to check empty string before logging the error message.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add logic to check empty string before logging the error message for Alertmanager Mattermost top-level attachment fields
```
