### PR TITLE
Fix: update library name for Alertmanager Mattermost URL type

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2121,7 +2121,7 @@ func (cb *ConfigBuilder) convertGlobalMattermostConfig(ctx context.Context, out 
 		if err != nil {
 			return fmt.Errorf("failed to parse Webhook URL: %w", err)
 		}
-		out.MattermostWebhookURL = &config.URL{URL: u}
+		out.MattermostWebhookURL = &commoncfg.URL{URL: u}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This PR updates the library name to fix the compile error of Mattermost global config URL.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update the library name to fix the compile error of Mattermost global config URL
```
