### PR TITLE
feat: validate PrometheusRule based on PromQL enabled features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [FEATURE] Configure node selector when sharding mode is `Topology` for `Prometheus` and `PrometheusAgent` custom resources (it requires the `PrometheusTopologySharding` feature gate). #8486
 * [FEATURE] Configure external label with topology information when sharding mode is `Topology` for `Prometheus` and `PrometheusAgent` custom resources (it requires the `PrometheusTopologySharding` feature gate). #8519
 * [FEATURE] Add `--promql-options` CLI argument to the admission-webhook binary. #8531
+* [FEATURE] Validate `PrometheusRule` resources selected by `Prometheus` resources based on the PromQL enabled features. #8545
 * [ENHANCEMENT] Add `cipherSuites` support for Thanos Sidecars and Rulers. #8524
 * [ENHANCEMENT] Add `curves` support for Thanos Sidecars and Rulers. #8542
 * [BUGFIX] Ensure that inactive shards don't scrape any targets when the sharding retention policy is `Retain`. #8513

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -64,11 +64,12 @@ var MaxConfigMapDataSize = int(float64(corev1.MaxSecretSize) * 0.5)
 // PrometheusRuleSelector selects PrometheusRule resources and translates them
 // to Prometheus/Thanos configuration format.
 type PrometheusRuleSelector struct {
-	ruleFormat   RuleConfigurationFormat
-	version      semver.Version
-	ruleSelector labels.Selector
-	nsLabeler    *namespacelabeler.Labeler
-	ruleInformer *informers.ForResource
+	ruleFormat    RuleConfigurationFormat
+	version       semver.Version
+	ruleSelector  labels.Selector
+	nsLabeler     *namespacelabeler.Labeler
+	ruleInformer  *informers.ForResource
+	parserOptions parser.Options
 
 	eventRecorder *EventRecorder
 
@@ -97,7 +98,7 @@ func (prs *PrometheusRuleSelection) RejectedLen() int {
 }
 
 // NewPrometheusRuleSelector returns a PrometheusRuleSelector pointer.
-func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder *EventRecorder, logger *slog.Logger) (*PrometheusRuleSelector, error) {
+func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version string, labelSelector *metav1.LabelSelector, nsLabeler *namespacelabeler.Labeler, ruleInformer *informers.ForResource, eventRecorder *EventRecorder, logger *slog.Logger, parserOptions parser.Options) (*PrometheusRuleSelector, error) {
 	componentVersion, err := semver.ParseTolerant(version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version: %w", err)
@@ -114,6 +115,7 @@ func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version strin
 		ruleSelector:  ruleSelector,
 		nsLabeler:     nsLabeler,
 		ruleInformer:  ruleInformer,
+		parserOptions: parserOptions,
 		eventRecorder: eventRecorder,
 		logger:        logger,
 	}, nil
@@ -137,7 +139,7 @@ func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitori
 		validationScheme = ValidationSchemeForPrometheus(prs.version)
 	}
 
-	errs := ValidateRule(promRuleSpec, validationScheme, parser.Options{})
+	errs := ValidateRule(promRuleSpec, validationScheme, prs.parserOptions)
 	if len(errs) != 0 {
 		const m = "invalid rule"
 		logger.Debug(m, "content", content)

--- a/pkg/prometheus/server/rules.go
+++ b/pkg/prometheus/server/rules.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
@@ -50,9 +51,23 @@ func (c *Operator) selectPrometheusRules(p *monitoringv1.Prometheus, logger *slo
 	}
 
 	var (
-		nsLabeler   = namespacelabeler.New(p.Spec.EnforcedNamespaceLabel, excludedFromEnforcement, true)
-		promVersion = operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
+		nsLabeler     = namespacelabeler.New(p.Spec.EnforcedNamespaceLabel, excludedFromEnforcement, true)
+		promVersion   = operator.StringValOrDefault(p.GetCommonPrometheusFields().Version, operator.DefaultPrometheusVersion)
+		parserOptions parser.Options
 	)
+
+	for _, f := range p.GetCommonPrometheusFields().EnableFeatures {
+		switch f {
+		case "promql-experimental-functions":
+			parserOptions.EnableExperimentalFunctions = true
+		case "promql-duration-expr":
+			parserOptions.ExperimentalDurationExpr = true
+		case "promql-extended-range-selectors":
+			parserOptions.EnableExtendedRangeSelectors = true
+		case "promql-binop-fill-modifiers":
+			parserOptions.EnableBinopFillModifiers = true
+		}
+	}
 
 	// Select and filter PrometheusRule resources.
 	promRuleSelector, err := operator.NewPrometheusRuleSelector(
@@ -63,6 +78,7 @@ func (c *Operator) selectPrometheusRules(p *monitoringv1.Prometheus, logger *slo
 		c.ruleInfs,
 		c.newEventRecorder(p),
 		logger,
+		parserOptions,
 	)
 	if err != nil {
 		return rules, fmt.Errorf("initializing PrometheusRules failed: %w", err)

--- a/pkg/thanos/rules.go
+++ b/pkg/thanos/rules.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 
@@ -64,6 +65,7 @@ func (o *Operator) selectPrometheusRules(t *monitoringv1.ThanosRuler, logger *sl
 		o.ruleInfs,
 		o.newEventRecorder(t),
 		logger,
+		parser.Options{},
 	)
 	if err != nil {
 		return rules, fmt.Errorf("initializing PrometheusRules failed: %w", err)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -275,6 +275,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromAdditionalScrapeConfig":                testPromAdditionalScrapeConfig,
 		"PromAdditionalAlertManagerConfig":          testPromAdditionalAlertManagerConfig,
 		"PromReloadRules":                           testPromReloadRules,
+		"PromRuleWithParserOptions":                 testPrometheusRuleWithParserOptions,
 		"PromMultiplePrometheusRulesSameNS":         testPromMultiplePrometheusRulesSameNS,
 		"PromMultiplePrometheusRulesDifferentNS":    testPromMultiplePrometheusRulesDifferentNS,
 		"PromRulesExceedingConfigMapLimit":          testPromRulesExceedingConfigMapLimit,

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -360,4 +361,91 @@ func TestPrometheusRuleApply(t *testing.T) {
 			assert.Equal(t, tc.expected, res.Spec.Groups)
 		})
 	}
+}
+
+func testPrometheusRuleWithParserOptions(t *testing.T) {
+	t.Parallel()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+
+	// Skip the admission webhook because the test exercices PromQL features
+	// which aren't enabled by default.
+	ruleNamespaceSelector := map[string]string{"excludeFromWebhook": "true"}
+	err := framework.AddLabelsToNamespace(context.Background(), ns, ruleNamespaceSelector)
+	require.NoError(t, err)
+
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	// Create a PrometheusRule with one group per parser option and an always-firing alert.
+	// The rules exercise syntax that would be rejected without the corresponding feature flag.
+	rule := framework.MakeBasicRule(ns, "parser-options-rule", []monitoringv1.RuleGroup{
+		{
+			Name: "always-firing",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "AlwaysFiring",
+					Expr:  intstr.FromString("vector(1) > 0"),
+				},
+			},
+		},
+		{
+			Name: "experimental-functions",
+			Rules: []monitoringv1.Rule{
+				{
+					Record: "test:limitk",
+					Expr:   intstr.FromString("limitk(5, up)"),
+				},
+			},
+		},
+		{
+			Name: "duration-expr",
+			Rules: []monitoringv1.Rule{
+				{
+					Record: "test:duration_expr",
+					Expr:   intstr.FromString("rate(up[2*1m])"),
+				},
+			},
+		},
+		{
+			Name: "extended-range-selectors",
+			Rules: []monitoringv1.Rule{
+				{
+					Record: "test:smoothed",
+					Expr:   intstr.FromString("rate(up[1m] smoothed)"),
+				},
+			},
+		},
+		{
+			Name: "binop-fill-modifiers",
+			Rules: []monitoringv1.Rule{
+				{
+					Record: "test:fill",
+					Expr:   intstr.FromString("up + fill(0) up"),
+				},
+			},
+		},
+	})
+	_, err = framework.CreateRule(context.Background(), ns, rule)
+	require.NoError(t, err)
+
+	// Deploy Prometheus with all promql-* features enabled so that the rules above are accepted.
+	p := framework.MakeBasicPrometheus(ns, "test", "test", 1)
+	p.Spec.EvaluationInterval = "1s"
+	p.Spec.EnableFeatures = []monitoringv1.EnableFeature{
+		"promql-experimental-functions",
+		"promql-duration-expr",
+		"promql-extended-range-selectors",
+		"promql-binop-fill-modifiers",
+	}
+	p, err = framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p)
+	require.NoError(t, err)
+
+	pSVC := framework.MakePrometheusService(p.Name, p.Name, corev1.ServiceTypeClusterIP)
+	_, err = framework.CreateOrUpdateServiceAndWaitUntilReady(context.Background(), ns, pSVC)
+	require.NoError(t, err)
+
+	// Firing alert confirms the PrometheusRule was accepted and evaluated.
+	err = framework.WaitForPrometheusFiringAlert(context.Background(), p.Namespace, pSVC.Name, "AlwaysFiring")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

This commit modifies the Prometheus controller to validate PromQL expressions in the `PrometheusRule` resources based on the PromQL features enabled for the Prometheus resource. It allows to deploy rules experimental PromQL functions for instance.

Closes #7099

Written with the help of Claude Code.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
