### PR TITLE
test: fix retention policy flakiness

### DIFF
--- a/test/e2e/prometheus_shard_retention_policy_test.go
+++ b/test/e2e/prometheus_shard_retention_policy_test.go
@@ -300,9 +300,10 @@ func testPrometheusRetentionPolicies(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, int32(1), p.Status.Shards)
 
-			sts, err = framework.KubeClient.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: p.Status.Selector})
-			require.NoError(t, err)
-			require.Len(t, sts.Items, 1)
+			// The retention reconciler runs once per minute and the
+			// API server still needs to process the StatefulSet deletion
+			// so poll until only the active shard remains.
+			require.NoError(t, framework.WaitForStatefulSetReplicas(ctx, ns, metav1.ListOptions{LabelSelector: p.Status.Selector}, 1))
 		})
 	}
 }

--- a/test/framework/statefulset.go
+++ b/test/framework/statefulset.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // RemoveAllLabelsFromStatefulSet removes all labels from a StatefulSet using JSON Patch.
@@ -49,5 +51,27 @@ func (f *Framework) RemoveAllLabelsFromStatefulSet(ctx context.Context, name, na
 		return fmt.Errorf("expected all labels to be removed from StatefulSet, but got %d labels: %v", len(updatedSts.Labels), updatedSts.Labels)
 	}
 
+	return nil
+}
+
+// WaitForStatefulSetReplicas polls until the number of StatefulSets in the
+// given namespace matching listOpts equals expected.
+func (f *Framework) WaitForStatefulSetReplicas(ctx context.Context, ns string, listOpts metav1.ListOptions, expected int) error {
+	var loopErr error
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		sts, listErr := f.KubeClient.AppsV1().StatefulSets(ns).List(ctx, listOpts)
+		if listErr != nil {
+			loopErr = fmt.Errorf("failed to list StatefulSets in namespace %s: %w", ns, listErr)
+			return false, nil
+		}
+		if len(sts.Items) != expected {
+			loopErr = fmt.Errorf("expected %d StatefulSets in namespace %s, got %d", expected, ns, len(sts.Items))
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("%v: %w", loopErr, err)
+	}
 	return nil
 }


### PR DESCRIPTION
## Description

This commit addresses the flakiness in the retention policy test. After scaling down to 1 shard the inactive shard statefulset doesn't disappear immeditaley. The previous `require.Len` assertion ran the instant `ScalePrometheusAndWaitUntilReady` returned causing race condition

Addresses #8543

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #8543

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
