### PR TITLE
Allow the operator to wait for CRDs to be installed

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -39,6 +40,7 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	k8sflag "k8s.io/component-base/cli/flag"
@@ -73,15 +75,25 @@ func checkPrerequisites(
 	allowedNamespaces []string,
 	groupVersion schema.GroupVersion,
 	resource string,
+	installWaitingTime time.Duration,
 	attributes ...k8s.ResourceAttribute,
 ) (bool, error) {
-	installed, err := k8s.IsAPIGroupVersionResourceSupported(kclient.Discovery(), groupVersion, resource)
+	installed, err := checkInstalled(kclient, groupVersion, resource)
+
+	if installWaitingTime > 0 {
+		installed, err = checkInstalledWithTimeout(ctx, kclient, groupVersion, resource, installWaitingTime)
+	}
+
 	if err != nil {
-		return false, fmt.Errorf("failed to check presence of resource %q (group %q): %w", resource, groupVersion, err)
+		return false, err
 	}
 
 	if !installed {
-		logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster", resource, groupVersion))
+		if installWaitingTime > 0 {
+			logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster after %v retry", resource, groupVersion, installWaitingTime))
+		} else {
+			logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster", resource, groupVersion))
+		}
 		return false, nil
 	}
 
@@ -98,6 +110,40 @@ func checkPrerequisites(
 	}
 
 	return true, nil
+}
+
+func checkInstalledWithTimeout(
+	ctx context.Context,
+	kclient kubernetes.Interface,
+	groupVersion schema.GroupVersion,
+	resource string,
+	installWaitingTime time.Duration,
+) (bool, error) {
+	var (
+		installed bool
+		realErr   error
+	)
+
+	_ = wait.PollUntilContextTimeout(ctx, time.Second, installWaitingTime, false, func(_ context.Context) (bool, error) {
+		installed, realErr = checkInstalled(kclient, groupVersion, resource)
+
+		return installed, realErr
+	})
+
+	return installed, realErr
+}
+
+func checkInstalled(
+	kclient kubernetes.Interface,
+	groupVersion schema.GroupVersion,
+	resource string,
+) (bool, error) {
+	installed, err := k8s.IsAPIGroupVersionResourceSupported(kclient.Discovery(), groupVersion, resource)
+	if err != nil {
+		return false, fmt.Errorf("failed to check presence of resource %q (group %q): %w", resource, groupVersion, err)
+	}
+
+	return installed, err
 }
 
 const (
@@ -122,6 +168,9 @@ var (
 
 	disableUnmanagedPrometheusConfiguration bool
 
+	crdInstalledWaitingTime time.Duration
+	crdsWaitToBeInstalled   crdsList
+
 	// Parameters for the kubelet endpoints controller.
 	kubeletObject        string
 	kubeletSelector      operator.LabelSelector
@@ -133,6 +182,28 @@ var (
 
 	featureGates = k8sflag.NewMapStringBool(ptr.To(map[string]bool{}))
 )
+
+type crdsList []string
+
+func (s *crdsList) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *crdsList) Set(value string) error {
+	parts := strings.Split(value, ",")
+
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.ToLower(p)
+		if slices.Contains([]string{"storageclass", "scrapeconfig", "prometheus", "prometheusagent", "alertmanager", "thanosruler"}, p) {
+			*s = append(*s, p)
+		} else {
+			return fmt.Errorf("Unknown CRD: %q. Valid CRDs include storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler", p)
+		}
+	}
+
+	return nil
+}
 
 func parseFlags(fs *flag.FlagSet) {
 	// Web server settings.
@@ -195,6 +266,8 @@ func parseFlags(fs *flag.FlagSet) {
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
+	fs.DurationVar(&crdInstalledWaitingTime, "crd-installed-waiting-time", 0, "The waiting time for a CRD to be installed. During this time, the operator checks every second whether the CRD is installed. Need to be set together with --crds-wait-to-be-installed for the operator to know what CRDs to wait for.")
+	fs.Var(&crdsWaitToBeInstalled, "crds-wait-to-be-installed", "CRDs that the operator will wait to be installed. Valid values are storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler. Need to be set with crd-installed-waiting-time so that the operator knows how long to wait for.")
 	cfg.RegisterFeatureGatesFlags(fs, featureGates)
 
 	logging.RegisterFlags(fs, &logConfig)
@@ -354,6 +427,18 @@ func start() int {
 		logger.Info("Disabling support for unmanaged Prometheus configurations")
 		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithoutUnmanagedConfiguration())
 	}
+
+	if crdInstalledWaitingTime > 0 && crdsWaitToBeInstalled == nil {
+		logger.Error("crd-installed-waiting-time command line argument is set but crds-wait-to-be-installed is not. Need to be set together")
+		cancel()
+		return 1
+	}
+
+	var storageClassInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "storageclass") {
+		storageClassInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	// Check if we can read the storage classs
 	canReadStorageClass, err := checkPrerequisites(
 		ctx,
@@ -362,6 +447,7 @@ func start() int {
 		nil,
 		storagev1.SchemeGroupVersion,
 		storagev1.SchemeGroupVersion.WithResource("storageclasses").Resource,
+		storageClassInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    storagev1.GroupName,
 			Version:  storagev1.SchemeGroupVersion.Version,
@@ -401,6 +487,11 @@ func start() int {
 	}
 	cfg.EventRecorderFactory = operator.NewEventRecorderFactory(canEmitEvents)
 
+	var scrapeConfigInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "scrapeconfig") {
+		scrapeConfigInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	scrapeConfigSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -408,6 +499,7 @@ func start() int {
 		cfg.Namespaces.AllowList.Slice(),
 		monitoringv1alpha1.SchemeGroupVersion,
 		monitoringv1alpha1.ScrapeConfigName,
+		scrapeConfigInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
@@ -433,6 +525,11 @@ func start() int {
 		promAgentControllerOptions = append(promAgentControllerOptions, prometheusagentcontroller.WithEndpointSlice())
 	}
 
+	var prometheusInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "prometheus") {
+		prometheusInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	prometheusSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -440,6 +537,7 @@ func start() int {
 		cfg.Namespaces.PrometheusAllowList.Slice(),
 		monitoringv1.SchemeGroupVersion,
 		monitoringv1.PrometheusName,
+		prometheusInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1.Version,
@@ -488,6 +586,11 @@ func start() int {
 		}
 	}
 
+	var prometheusAgentInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "prometheusagent") {
+		prometheusAgentInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	prometheusAgentSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -495,6 +598,7 @@ func start() int {
 		cfg.Namespaces.PrometheusAllowList.Slice(),
 		monitoringv1alpha1.SchemeGroupVersion,
 		monitoringv1alpha1.PrometheusAgentName,
+		prometheusAgentInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
@@ -568,6 +672,11 @@ func start() int {
 		}
 	}
 
+	var alertmanagerInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "alertmanager") {
+		alertmanagerInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	alertmanagerSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -575,6 +684,7 @@ func start() int {
 		cfg.Namespaces.AlertmanagerAllowList.Slice(),
 		monitoringv1.SchemeGroupVersion,
 		monitoringv1.AlertmanagerName,
+		alertmanagerInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1.Version,
@@ -609,6 +719,11 @@ func start() int {
 		}
 	}
 
+	var thanosrulerInstallWaitTime time.Duration
+	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "thanosruler") {
+		thanosrulerInstallWaitTime = crdInstalledWaitingTime
+	}
+
 	thanosRulerSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -616,6 +731,7 @@ func start() int {
 		cfg.Namespaces.ThanosRulerAllowList.Slice(),
 		monitoringv1.SchemeGroupVersion,
 		monitoringv1.ThanosRulerName,
+		thanosrulerInstallWaitTime,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1.Version,

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -189,16 +189,15 @@ func (s *crdsList) String() string {
 	return strings.Join(*s, ",")
 }
 
-func (s *crdsList) Set(value string) error {
-	parts := strings.Split(value, ",")
+func (s *crdsList) Set(values string) error {
+	vals := strings.Split(values, ",")
 
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		p = strings.ToLower(p)
-		if slices.Contains([]string{"storageclass", "scrapeconfig", "prometheus", "prometheusagent", "alertmanager", "thanosruler"}, p) {
-			*s = append(*s, p)
+	for _, val := range vals {
+		normalizedVal := strings.Join(strings.Fields(strings.ToLower(val)), "")
+		if slices.Contains([]string{"storageclass", "scrapeconfig", "prometheus", "prometheusagent", "alertmanager", "thanosruler"}, normalizedVal) {
+			*s = append(*s, normalizedVal)
 		} else {
-			return fmt.Errorf("Unknown CRD: %q. Valid CRDs include storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler", p)
+			return fmt.Errorf("Unknown CRD: %q. Valid CRDs include storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler", val)
 		}
 	}
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -78,10 +78,15 @@ func checkPrerequisites(
 	installWaitingTime time.Duration,
 	attributes ...k8s.ResourceAttribute,
 ) (bool, error) {
-	installed, err := checkInstalled(kclient, groupVersion, resource)
+	var (
+		installed bool
+		err       error
+	)
 
 	if installWaitingTime > 0 {
 		installed, err = checkInstalledWithTimeout(ctx, kclient, groupVersion, resource, installWaitingTime)
+	} else {
+		installed, err = checkInstalled(kclient, groupVersion, resource)
 	}
 
 	if err != nil {
@@ -90,7 +95,7 @@ func checkPrerequisites(
 
 	if !installed {
 		if installWaitingTime > 0 {
-			logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster after %v retry", resource, groupVersion, installWaitingTime))
+			logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster after %v", resource, groupVersion, installWaitingTime))
 		} else {
 			logger.Warn(fmt.Sprintf("resource %q (group: %q) not installed in the cluster", resource, groupVersion))
 		}
@@ -168,8 +173,8 @@ var (
 
 	disableUnmanagedPrometheusConfiguration bool
 
-	crdInstalledWaitingTime time.Duration
-	crdsWaitToBeInstalled   crdsList
+	checkForCrdsOnStartupTimeout time.Duration
+	checkForCrdsOnStartup        crdsList
 
 	// Parameters for the kubelet endpoints controller.
 	kubeletObject        string
@@ -190,14 +195,12 @@ func (s *crdsList) String() string {
 }
 
 func (s *crdsList) Set(values string) error {
-	vals := strings.Split(values, ",")
-
-	for _, val := range vals {
+	for val := range strings.SplitSeq(values, ",") {
 		normalizedVal := strings.Join(strings.Fields(strings.ToLower(val)), "")
-		if slices.Contains([]string{"storageclass", "scrapeconfig", "prometheus", "prometheusagent", "alertmanager", "thanosruler"}, normalizedVal) {
+		if slices.Contains([]string{"prometheus", "prometheusagent", "alertmanager", "thanosruler"}, normalizedVal) {
 			*s = append(*s, normalizedVal)
 		} else {
-			return fmt.Errorf("Unknown CRD: %q. Valid CRDs include storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler", val)
+			return fmt.Errorf("unknown CRD: %q. Valid CRDs include storageclass, prometheus, prometheusagent, alertmanager, thanosruler", val)
 		}
 	}
 
@@ -265,9 +268,8 @@ func parseFlags(fs *flag.FlagSet) {
 
 	fs.Float64Var(&memlimitRatio, "auto-gomemlimit-ratio", defaultMemlimitRatio, "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory. The value should be greater than 0.0 and less than 1.0. Default: 0.0 (disabled).")
 	fs.BoolVar(&disableUnmanagedPrometheusConfiguration, "disable-unmanaged-prometheus-configuration", false, "Disable support for unmanaged Prometheus configuration when all resource selectors are nil. As stated in the API documentation, unmanaged Prometheus configuration is a deprecated feature which can be avoided with '.spec.additionalScrapeConfigs' or the ScrapeConfig CRD. Default: false.")
-	fs.DurationVar(&crdInstalledWaitingTime, "crd-installed-waiting-time", 0, "The waiting time for a CRD to be installed. During this time, the operator checks every second whether the CRD is installed. Need to be set together with --crds-wait-to-be-installed for the operator to know what CRDs to wait for.")
-	fs.Var(&crdsWaitToBeInstalled, "crds-wait-to-be-installed", "CRDs that the operator will wait to be installed. Valid values are storageclass, scrapeconfig, prometheus, prometheusagent, alertmanager, thanosruler. Need to be set with crd-installed-waiting-time so that the operator knows how long to wait for.")
-	cfg.RegisterFeatureGatesFlags(fs, featureGates)
+	fs.DurationVar(&checkForCrdsOnStartupTimeout, "check-for-crds-on-startup-timeout", 0, "How long the operator will wait for Custom Resource Definitions to be present on startup before exiting with error. Only relevant when --check-for-crds-on-startup is defined.")
+	fs.Var(&checkForCrdsOnStartup, "check-for-crds-on-startup", "Comma-separated list of Custom Resource Definitions that should be present in the cluster and which the operator should have access to. By default, no check is performed. Valid values are prometheuses, prometheusagents, alertmanagers, thanosrulers.")
 
 	logging.RegisterFlags(fs, &logConfig)
 	versionutil.RegisterFlags(fs)
@@ -427,15 +429,10 @@ func start() int {
 		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithoutUnmanagedConfiguration())
 	}
 
-	if crdInstalledWaitingTime > 0 && crdsWaitToBeInstalled == nil {
-		logger.Error("crd-installed-waiting-time command line argument is set but crds-wait-to-be-installed is not. Need to be set together")
+	if checkForCrdsOnStartupTimeout > 0 && checkForCrdsOnStartup == nil {
+		logger.Error("--check-for-crds-on-startup-timeout is set but --check-for-crds-on-startup is not. Need to be set together")
 		cancel()
 		return 1
-	}
-
-	var storageClassInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "storageclass") {
-		storageClassInstallWaitTime = crdInstalledWaitingTime
 	}
 
 	// Check if we can read the storage classs
@@ -446,7 +443,7 @@ func start() int {
 		nil,
 		storagev1.SchemeGroupVersion,
 		storagev1.SchemeGroupVersion.WithResource("storageclasses").Resource,
-		storageClassInstallWaitTime,
+		0,
 		k8s.ResourceAttribute{
 			Group:    storagev1.GroupName,
 			Version:  storagev1.SchemeGroupVersion.Version,
@@ -486,11 +483,6 @@ func start() int {
 	}
 	cfg.EventRecorderFactory = operator.NewEventRecorderFactory(canEmitEvents)
 
-	var scrapeConfigInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "scrapeconfig") {
-		scrapeConfigInstallWaitTime = crdInstalledWaitingTime
-	}
-
 	scrapeConfigSupported, err := checkPrerequisites(
 		ctx,
 		logger,
@@ -498,7 +490,7 @@ func start() int {
 		cfg.Namespaces.AllowList.Slice(),
 		monitoringv1alpha1.SchemeGroupVersion,
 		monitoringv1alpha1.ScrapeConfigName,
-		scrapeConfigInstallWaitTime,
+		0,
 		k8s.ResourceAttribute{
 			Group:    monitoring.GroupName,
 			Version:  monitoringv1alpha1.Version,
@@ -525,8 +517,8 @@ func start() int {
 	}
 
 	var prometheusInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "prometheus") {
-		prometheusInstallWaitTime = crdInstalledWaitingTime
+	if checkForCrdsOnStartupTimeout > 0 && slices.Contains(checkForCrdsOnStartup, "prometheus") {
+		prometheusInstallWaitTime = checkForCrdsOnStartupTimeout
 	}
 
 	prometheusSupported, err := checkPrerequisites(
@@ -586,8 +578,8 @@ func start() int {
 	}
 
 	var prometheusAgentInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "prometheusagent") {
-		prometheusAgentInstallWaitTime = crdInstalledWaitingTime
+	if checkForCrdsOnStartupTimeout > 0 && slices.Contains(checkForCrdsOnStartup, "prometheusagent") {
+		prometheusAgentInstallWaitTime = checkForCrdsOnStartupTimeout
 	}
 
 	prometheusAgentSupported, err := checkPrerequisites(
@@ -672,8 +664,8 @@ func start() int {
 	}
 
 	var alertmanagerInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "alertmanager") {
-		alertmanagerInstallWaitTime = crdInstalledWaitingTime
+	if checkForCrdsOnStartupTimeout > 0 && slices.Contains(checkForCrdsOnStartup, "alertmanager") {
+		alertmanagerInstallWaitTime = checkForCrdsOnStartupTimeout
 	}
 
 	alertmanagerSupported, err := checkPrerequisites(
@@ -719,8 +711,8 @@ func start() int {
 	}
 
 	var thanosrulerInstallWaitTime time.Duration
-	if crdInstalledWaitingTime > 0 && slices.Contains(crdsWaitToBeInstalled, "thanosruler") {
-		thanosrulerInstallWaitTime = crdInstalledWaitingTime
+	if checkForCrdsOnStartupTimeout > 0 && slices.Contains(checkForCrdsOnStartup, "thanosruler") {
+		thanosrulerInstallWaitTime = checkForCrdsOnStartupTimeout
 	}
 
 	thanosRulerSupported, err := checkPrerequisites(

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+)
+
+// polls is the number of times ServerResourcesForGroupVersion function in this file runs.
+// We use this to test whether checkInstalledWithTimeout polls several times even if ServerResourcesForGroupVersion returns false first time.
+var polls = 0
+
+type mockKubernetesClient struct {
+	kubernetes.Interface
+	discovery discovery.DiscoveryInterface
+}
+
+func newMockKubernetesClient() kubernetes.Interface {
+	return &mockKubernetesClient{
+		discovery: &mockDiscoveryClient{},
+	}
+}
+
+func (m *mockKubernetesClient) Discovery() discovery.DiscoveryInterface {
+	return m.discovery
+}
+
+type mockDiscoveryClient struct {
+	discovery.DiscoveryInterface
+}
+
+func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(_ string) (*metav1.APIResourceList, error) {
+	// Make the function runs for 10 second so that
+	// we can control how many time this is called until timeout
+	time.Sleep(10 * time.Second)
+
+	polls++
+
+	// checkInstalledWithTimeout will only return true after 3 polls.
+	if polls >= 3 {
+		return &metav1.APIResourceList{
+			APIResources: []metav1.APIResource{
+				metav1.APIResource{
+					Name: "true",
+				},
+			},
+		}, nil
+	}
+
+	return &metav1.APIResourceList{
+		APIResources: []metav1.APIResource{
+			metav1.APIResource{
+				Name: "false",
+			},
+		},
+	}, nil
+}
+
+func TestWaitForCRDInstalled(t *testing.T) {
+	ctx := context.Background()
+	client := newMockKubernetesClient()
+
+	// Because we set the timeout as 5 seconds here, and ServerResourcesForGroupVersion runs for 10 second,
+	// there will be only 1 poll, and we expectcheckInstalledWithTimeout to return false.
+	installed, err := checkInstalledWithTimeout(ctx, client, storagev1.SchemeGroupVersion, "true", 5*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, polls, 1)
+	require.False(t, installed)
+
+	// Now the timeout is 50 seconds, ServerResourcesForGroupVersion will be polled more than 1 time.
+	// Because ServerResourcesForGroupVersion has already run at least 3 times now, we expectcheckInstalledWithTimeout to return true.
+	installed, err = checkInstalledWithTimeout(ctx, client, storagev1.SchemeGroupVersion, "true", 50*time.Second)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, polls, 3)
+	require.True(t, installed)
+}
+
+func TestSetCRDToWaitFor(t *testing.T) {
+	var crds *crdsList
+
+	require.NoError(t, crds.Set("storage class"))
+	require.NoError(t, crds.Set("Scrape Config"))
+	require.NoError(t, crds.Set("PROMETHEUS"))
+	require.NoError(t, crds.Set("proMeTheusAgent"))
+	require.NoError(t, crds.Set("ALERT MANAGER"))
+	require.NoError(t, crds.Set("thaNos ruLer"))
+
+	require.Error(t, crds.Set("foo"))
+}

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -96,7 +96,7 @@ func TestWaitForCRDInstalled(t *testing.T) {
 }
 
 func TestSetCRDToWaitFor(t *testing.T) {
-	var crds *crdsList
+	crds := &crdsList{}
 
 	require.NoError(t, crds.Set("storage class"))
 	require.NoError(t, crds.Set("Scrape Config"))

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The prometheus-operator Authors
+// Copyright The prometheus-operator Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ type mockDiscoveryClient struct {
 
 func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(_ string) (*metav1.APIResourceList, error) {
 	// Make the function runs for 10 second so that
-	// we can control how many time this is called until timeout
+	// we can control how many times this is called until timeout
 	time.Sleep(10 * time.Second)
 
 	polls++
@@ -60,7 +60,7 @@ func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(_ string) (*metav1.
 	if polls >= 3 {
 		return &metav1.APIResourceList{
 			APIResources: []metav1.APIResource{
-				metav1.APIResource{
+				{
 					Name: "true",
 				},
 			},
@@ -69,7 +69,7 @@ func (m *mockDiscoveryClient) ServerResourcesForGroupVersion(_ string) (*metav1.
 
 	return &metav1.APIResourceList{
 		APIResources: []metav1.APIResource{
-			metav1.APIResource{
+			{
 				Name: "false",
 			},
 		},
@@ -81,14 +81,14 @@ func TestWaitForCRDInstalled(t *testing.T) {
 	client := newMockKubernetesClient()
 
 	// Because we set the timeout as 5 seconds here, and ServerResourcesForGroupVersion runs for 10 second,
-	// there will be only 1 poll, and we expectcheckInstalledWithTimeout to return false.
+	// there will be only 1 poll, and we expect checkInstalledWithTimeout to return false.
 	installed, err := checkInstalledWithTimeout(ctx, client, storagev1.SchemeGroupVersion, "true", 5*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, polls, 1)
 	require.False(t, installed)
 
 	// Now the timeout is 50 seconds, ServerResourcesForGroupVersion will be polled more than 1 time.
-	// Because ServerResourcesForGroupVersion has already run at least 3 times now, we expectcheckInstalledWithTimeout to return true.
+	// Because ServerResourcesForGroupVersion has already run at least 3 times now, we expect checkInstalledWithTimeout to return true.
 	installed, err = checkInstalledWithTimeout(ctx, client, storagev1.SchemeGroupVersion, "true", 50*time.Second)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, polls, 3)
@@ -98,8 +98,6 @@ func TestWaitForCRDInstalled(t *testing.T) {
 func TestSetCRDToWaitFor(t *testing.T) {
 	crds := &crdsList{}
 
-	require.NoError(t, crds.Set("storage class"))
-	require.NoError(t, crds.Set("Scrape Config"))
 	require.NoError(t, crds.Set("PROMETHEUS"))
 	require.NoError(t, crds.Set("proMeTheusAgent"))
 	require.NoError(t, crds.Set("ALERT MANAGER"))


### PR DESCRIPTION
## Description

Closes: #7459 

This PR add flags that users can use to set the waiting time for CRDs to be installed. `--crds-wait-to-be-installed` sets the CRDs to wait for. `--crd-installed-waiting-time` sets the waiting time during which the operator checks every second whether the CRDs are installed. Both flags need to be set together.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit tests for:
- Setting flag values
- The operator waits and checks for CRDs installed until timeout

## Changelog entry
Allow the operator to wait for CRDs to be installed