### PR TITLE
operator: return error for malformed key=value flag input

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -237,8 +237,11 @@ func (m *Map) Set(value string) error {
 	}
 
 	for pair := range strings.SplitSeq(value, ",") {
-		pair := strings.Split(pair, "=")
-		(*m)[pair[0]] = pair[1]
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			return fmt.Errorf("invalid key=value pair: %q", pair)
+		}
+		(*m)[k] = v
 	}
 
 	return nil

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -34,6 +34,30 @@ func TestMap(t *testing.T) {
 	require.Equal(t, "foo=bar,foo2=bar2", m.String())
 
 	require.Equal(t, map[string]string{"foo": "bar", "foo2": "bar2", "foo3": "bar3"}, m.Merge(map[string]string{"foo": "xxx", "foo3": "bar3"}))
+
+	require.NoError(t, m.Set("k=v=with=equals"))
+	require.Equal(t, "v=with=equals", m["k"])
+}
+
+func TestMapSetInvalid(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "missing value",
+			value: "key",
+		},
+		{
+			name:  "one valid one invalid",
+			value: "good=value,bad",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var m Map
+			require.Error(t, m.Set(tc.value))
+		})
+	}
 }
 
 func TestFieldSelector(t *testing.T) {


### PR DESCRIPTION
## Description

`Map.Set()` panics with an index-out-of-range error when a `--annotations` or `--labels` flag value does not contain `=` (e.g. `--annotations "key"`). The `strings.Split(pair, "=")` call returns a single-element slice, and the unconditional `pair[1]` access panics, crashing the operator at startup.

Replace `strings.Split` with `strings.Cut` to validate the format and return a clear error message instead of panicking. `strings.Cut` also correctly preserves values containing `=` (e.g. `key=val=ue` maps to `val=ue`), which the previous code silently truncated.

Introduced in #5683.

## Type of change

- [x] `BUGFIX` (non-breaking change which fixes an issue)

## Verification

Added `TestMapSetInvalid` covering missing `=` and partially invalid input. Also added a test case for values containing `=` to verify correct handling. All existing tests continue to pass.

```release-note
Fix a panic in the operator when --annotations or --labels flag values are malformed (missing "=").
```