### PR TITLE
operator: use read lock for read-only ReconciliationTracker methods

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -113,8 +113,8 @@ func (rt *ReconciliationTracker) init() {
 // HasRefTo returns true if the object identified by key has a direct or
 // indirect reference to obj (secret or configmap).
 func (rt *ReconciliationTracker) HasRefTo(key string, obj runtime.Object) bool {
-	rt.mtx.Lock()
-	defer rt.mtx.Unlock()
+	rt.mtx.RLock()
+	defer rt.mtx.RUnlock()
 
 	refTracker, found := rt.refTracker[key]
 	if !found {
@@ -169,8 +169,8 @@ func (rt *ReconciliationTracker) SetReasonAndMessage(key string, reason, message
 // GetStatus returns the last reconciliation status for the given object.
 // The second value indicates whether the object is known or not.
 func (rt *ReconciliationTracker) getStatus(k string) (ReconciliationStatus, bool) {
-	rt.mtx.Lock()
-	defer rt.mtx.Unlock()
+	rt.mtx.RLock()
+	defer rt.mtx.RUnlock()
 
 	s, found := rt.statusByObject[k]
 	if !found {


### PR DESCRIPTION
## Description

`HasRefTo` and `getStatus` only read from the `refTracker` and `statusByObject` maps but acquire an exclusive write lock (`Lock`), unnecessarily serializing with all other operations on the `ReconciliationTracker`.

`HasRefTo` is called from `HasReferenceFunc` (the informer event filter) for every Secret/ConfigMap event, iterating over all workloads. The exclusive lock serializes these calls with `SetStatus`, `ResetStatus`, `UpdateReferenceTracker`, `ForgetObject`, and Prometheus metrics collection via `Collect`. Under high event volume with many workloads, this creates cascading delays in informer event delivery.

Use `RLock` instead to allow concurrent reads, consistent with `Collect` which already uses `RLock` on the same mutex.

`HasRefTo` introduced in #7615, `getStatus` lock introduced in #4580.

## Type of change

- [ ] `BUGFIX` (non-breaking change which fixes an issue)

## Verification

All existing tests pass. The change is mechanical: read-only methods now use the read lock instead of the write lock.

```release-note
Fix unnecessary lock contention in ReconciliationTracker by using read locks for read-only operations.
```