### PR TITLE
prometheus: use pod topology labels for zone sharding on K8s >= 1.35

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -432,6 +432,16 @@ func start() int {
 		promAgentControllerOptions = append(promAgentControllerOptions, prometheusagentcontroller.WithEndpointSlice())
 	}
 
+	// PodTopologyLabelsAdmission (KEP-4742) is enabled by default in K8s >= 1.35.
+	// It injects topology.kubernetes.io/zone as a pod label, removing the need
+	// for attach_metadata.node=true in topology sharding configurations.
+	podTopologyLabelsSupported := cfg.KubernetesVersion.GTE(semver.MustParse("1.35.0"))
+	logger.Info("Kubernetes API capabilities", "pod_topology_labels", podTopologyLabelsSupported)
+	if podTopologyLabelsSupported {
+		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithPodTopologyLabels())
+		promAgentControllerOptions = append(promAgentControllerOptions, prometheusagentcontroller.WithPodTopologyLabels())
+	}
+
 	prometheusSupported, err := checkPrerequisites(
 		ctx,
 		logger,

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -99,6 +99,7 @@ type Operator struct {
 	daemonSetFeatureGateEnabled  bool
 	configResourcesStatusEnabled bool
 	topologyShardingEnabled      bool
+	podTopologyLabelsSupported   bool
 
 	finalizerSyncer *operator.FinalizerSyncer
 }
@@ -132,6 +133,14 @@ func WithStorageClassValidation() ControllerOption {
 func WithConfigResourceStatus() ControllerOption {
 	return func(o *Operator) {
 		o.configResourcesStatusEnabled = true
+	}
+}
+
+// WithPodTopologyLabels tells that the cluster runs K8s >= 1.35 where
+// PodTopologyLabelsAdmission automatically injects topology labels onto pods.
+func WithPodTopologyLabels() ControllerOption {
+	return func(o *Operator) {
+		o.podTopologyLabelsSupported = true
 	}
 }
 
@@ -676,6 +685,9 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 	if c.topologyShardingEnabled {
 		opts = append(opts, prompkg.WithPrometheusTopologySharding())
+	}
+	if c.podTopologyLabelsSupported {
+		opts = append(opts, prompkg.WithPodTopologyLabelsSupport())
 	}
 
 	cg, err := prompkg.NewConfigGenerator(logger, p, opts...)

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -2288,11 +2288,22 @@ func (cg *ConfigGenerator) appendShardingRelabelingWithLabel(relabelings []yaml.
 		modulus = cg.shardsPerZone(shards)
 		shardEnvVar = operator.InzoneShardEnvVar
 
+		// Step 1: populate __tmp_topology from endpointslice zone (no-op for pod role).
+		relabelings = append(relabelings,
+			yaml.MapSlice{
+				{Key: "source_labels", Value: []string{endpointSliceZoneMetaLabel, topologyTmpLabel}},
+				{Key: "target_label", Value: topologyTmpLabel},
+				{Key: "regex", Value: "(.+);"},
+				{Key: "replacement", Value: "$1"},
+				{Key: "action", Value: "replace"},
+			},
+		)
+
+		// Step 2: if __tmp_topology is still empty, use the pod topology label
+		// (K8s >= 1.35, PodTopologyLabelsAdmission) or the node label (older clusters,
+		// requires attach_metadata: {node: true}) as fallback.
 		if cg.podTopologyLabelsSupported {
-			// K8s >= 1.35: PodTopologyLabelsAdmission injects topology.kubernetes.io/zone
-			// as a pod label, so attach_metadata.node is not needed.
 			relabelings = append(relabelings,
-				// Populate __tmp_topology from the pod topology label (no-op for pod role targets without the label).
 				yaml.MapSlice{
 					{Key: "source_labels", Value: []string{podZoneMetaLabel, podZonePresentMetaLabel, topologyTmpLabel}},
 					{Key: "target_label", Value: topologyTmpLabel},
@@ -2300,24 +2311,9 @@ func (cg *ConfigGenerator) appendShardingRelabelingWithLabel(relabelings []yaml.
 					{Key: "replacement", Value: "$1"},
 					{Key: "action", Value: "replace"},
 				},
-				// Keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
-				yaml.MapSlice{
-					{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
-					{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
-					{Key: "action", Value: "keep"},
-				},
 			)
 		} else {
 			relabelings = append(relabelings,
-				// Populate __tmp_topology from endpointslice zone label (no-op for pod role).
-				yaml.MapSlice{
-					{Key: "source_labels", Value: []string{endpointSliceZoneMetaLabel, topologyTmpLabel}},
-					{Key: "target_label", Value: topologyTmpLabel},
-					{Key: "regex", Value: "(.+);"},
-					{Key: "replacement", Value: "$1"},
-					{Key: "action", Value: "replace"},
-				},
-				// Fallback to node topology label (requires attach_metadata: {node: true}).
 				yaml.MapSlice{
 					{Key: "source_labels", Value: []string{nodeZoneMetaLabel, nodeZonePresentMetaLabel, topologyTmpLabel}},
 					{Key: "target_label", Value: topologyTmpLabel},
@@ -2325,14 +2321,17 @@ func (cg *ConfigGenerator) appendShardingRelabelingWithLabel(relabelings []yaml.
 					{Key: "replacement", Value: "$1"},
 					{Key: "action", Value: "replace"},
 				},
-				// Keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
-				yaml.MapSlice{
-					{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
-					{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
-					{Key: "action", Value: "keep"},
-				},
 			)
 		}
+
+		// Step 3: keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
+		relabelings = append(relabelings,
+			yaml.MapSlice{
+				{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
+				{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
+				{Key: "action", Value: "keep"},
+			},
+		)
 	}
 
 	return append(relabelings,

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -65,6 +65,10 @@ const (
 	nodeZoneMetaLabel          = "__meta_kubernetes_node_label_topology_kubernetes_io_zone"
 	nodeZonePresentMetaLabel   = "__meta_kubernetes_node_labelpresent_topology_kubernetes_io_zone"
 	endpointSliceZoneMetaLabel = "__meta_kubernetes_endpointslice_endpoint_zone"
+	// podZoneMetaLabel and podZonePresentMetaLabel are the SD meta labels for the
+	// topology.kubernetes.io/zone pod label injected by PodTopologyLabelsAdmission (K8s >= 1.35).
+	podZoneMetaLabel        = "__meta_kubernetes_pod_label_topology_kubernetes_io_zone"
+	podZonePresentMetaLabel = "__meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone"
 )
 
 var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
@@ -86,6 +90,7 @@ type ConfigGenerator struct {
 	daemonSet                   bool
 	prometheusTopologySharding  bool
 	prometheusRetentionPolicies bool
+	podTopologyLabelsSupported  bool // True when K8s >= 1.35 (PodTopologyLabelsAdmission).
 	inlineTLSConfig             bool
 
 	bypassVersionCheck bool
@@ -114,6 +119,17 @@ func WithPrometheusTopologySharding() ConfigGeneratorOption {
 func WithPrometheusRetentionPolicies() ConfigGeneratorOption {
 	return func(cg *ConfigGenerator) {
 		cg.prometheusRetentionPolicies = true
+	}
+}
+
+// WithPodTopologyLabelsSupport tells the config generator that K8s >= 1.35 is
+// available, meaning the PodTopologyLabelsAdmission feature gate automatically
+// injects topology.kubernetes.io/zone as a pod label. When enabled, the operator
+// no longer forces attach_metadata.node=true for topology sharding and instead
+// uses the pod label SD meta label for zone detection.
+func WithPodTopologyLabelsSupport() ConfigGeneratorOption {
+	return func(cg *ConfigGenerator) {
+		cg.podTopologyLabelsSupported = true
 	}
 }
 
@@ -270,6 +286,7 @@ func (cg *ConfigGenerator) WithKeyVals(keyvals ...any) *ConfigGenerator {
 		daemonSet:                   cg.daemonSet,
 		prometheusTopologySharding:  cg.prometheusTopologySharding,
 		prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+		podTopologyLabelsSupported:  cg.podTopologyLabelsSupported,
 		inlineTLSConfig:             cg.inlineTLSConfig,
 		bypassVersionCheck:          cg.bypassVersionCheck,
 	}
@@ -296,6 +313,7 @@ func (cg *ConfigGenerator) WithMinimumVersion(version string) *ConfigGenerator {
 			daemonSet:                   cg.daemonSet,
 			prometheusTopologySharding:  cg.prometheusTopologySharding,
 			prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+			podTopologyLabelsSupported:  cg.podTopologyLabelsSupported,
 			inlineTLSConfig:             cg.inlineTLSConfig,
 			bypassVersionCheck:          cg.bypassVersionCheck,
 		}
@@ -325,6 +343,7 @@ func (cg *ConfigGenerator) WithMaximumVersion(version string) *ConfigGenerator {
 			daemonSet:                   cg.daemonSet,
 			prometheusTopologySharding:  cg.prometheusTopologySharding,
 			prometheusRetentionPolicies: cg.prometheusRetentionPolicies,
+			podTopologyLabelsSupported:  cg.podTopologyLabelsSupported,
 			inlineTLSConfig:             cg.inlineTLSConfig,
 			bypassVersionCheck:          cg.bypassVersionCheck,
 		}
@@ -2268,30 +2287,52 @@ func (cg *ConfigGenerator) appendShardingRelabelingWithLabel(relabelings []yaml.
 	if cg.isTopologyShardingActive() {
 		modulus = cg.shardsPerZone(shards)
 		shardEnvVar = operator.InzoneShardEnvVar
-		relabelings = append(relabelings,
-			// Populate __tmp_topology from endpointslice zone label (no-op for pod role).
-			yaml.MapSlice{
-				{Key: "source_labels", Value: []string{endpointSliceZoneMetaLabel, topologyTmpLabel}},
-				{Key: "target_label", Value: topologyTmpLabel},
-				{Key: "regex", Value: "(.+);"},
-				{Key: "replacement", Value: "$1"},
-				{Key: "action", Value: "replace"},
-			},
-			// Fallback to node topology label (requires attach_metadata: {node: true}).
-			yaml.MapSlice{
-				{Key: "source_labels", Value: []string{nodeZoneMetaLabel, nodeZonePresentMetaLabel, topologyTmpLabel}},
-				{Key: "target_label", Value: topologyTmpLabel},
-				{Key: "regex", Value: "(.+);true;"},
-				{Key: "replacement", Value: "$1"},
-				{Key: "action", Value: "replace"},
-			},
-			// Keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
-			yaml.MapSlice{
-				{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
-				{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
-				{Key: "action", Value: "keep"},
-			},
-		)
+
+		if cg.podTopologyLabelsSupported {
+			// K8s >= 1.35: PodTopologyLabelsAdmission injects topology.kubernetes.io/zone
+			// as a pod label, so attach_metadata.node is not needed.
+			relabelings = append(relabelings,
+				// Populate __tmp_topology from the pod topology label (no-op for pod role targets without the label).
+				yaml.MapSlice{
+					{Key: "source_labels", Value: []string{podZoneMetaLabel, podZonePresentMetaLabel, topologyTmpLabel}},
+					{Key: "target_label", Value: topologyTmpLabel},
+					{Key: "regex", Value: "(.+);true;"},
+					{Key: "replacement", Value: "$1"},
+					{Key: "action", Value: "replace"},
+				},
+				// Keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
+				yaml.MapSlice{
+					{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
+					{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
+					{Key: "action", Value: "keep"},
+				},
+			)
+		} else {
+			relabelings = append(relabelings,
+				// Populate __tmp_topology from endpointslice zone label (no-op for pod role).
+				yaml.MapSlice{
+					{Key: "source_labels", Value: []string{endpointSliceZoneMetaLabel, topologyTmpLabel}},
+					{Key: "target_label", Value: topologyTmpLabel},
+					{Key: "regex", Value: "(.+);"},
+					{Key: "replacement", Value: "$1"},
+					{Key: "action", Value: "replace"},
+				},
+				// Fallback to node topology label (requires attach_metadata: {node: true}).
+				yaml.MapSlice{
+					{Key: "source_labels", Value: []string{nodeZoneMetaLabel, nodeZonePresentMetaLabel, topologyTmpLabel}},
+					{Key: "target_label", Value: topologyTmpLabel},
+					{Key: "regex", Value: "(.+);true;"},
+					{Key: "replacement", Value: "$1"},
+					{Key: "action", Value: "replace"},
+				},
+				// Keep only targets in the assigned zone, unless __tmp_disable_sharding is set.
+				yaml.MapSlice{
+					{Key: "source_labels", Value: []string{topologyTmpLabel, hashLabelNameForDisablingSharding}},
+					{Key: "regex", Value: fmt.Sprintf("$(%s);|.+;.+", operator.TopologyZoneEnvVar)},
+					{Key: "action", Value: "keep"},
+				},
+			)
+		}
 	}
 
 	return append(relabelings,
@@ -5369,11 +5410,15 @@ func (cg *ConfigGenerator) InzoneShardForShard(shardIndex int32) int32 {
 }
 
 // mergeAttachMetadataForTopology forces attach_metadata.node=true when topology
-// sharding is active. Node metadata is required to determine the target's zone via
-// the __meta_kubernetes_node_label_topology_kubernetes_io_zone label.
+// sharding is active, unless K8s >= 1.35 (podTopologyLabelsSupported). In the
+// latter case, PodTopologyLabelsAdmission injects the zone label onto pods so
+// node metadata is no longer required.
 // Returns amc unchanged when topology sharding is not active or node is already true.
 func (cg *ConfigGenerator) mergeAttachMetadataForTopology(amc *attachMetadataConfig, minimumVersion string) *attachMetadataConfig {
 	if !cg.isTopologyShardingActive() {
+		return amc
+	}
+	if cg.podTopologyLabelsSupported {
 		return amc
 	}
 	if amc != nil && amc.node() {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -90,7 +90,7 @@ type ConfigGenerator struct {
 	daemonSet                   bool
 	prometheusTopologySharding  bool
 	prometheusRetentionPolicies bool
-	podTopologyLabelsSupported  bool // True when K8s >= 1.35 (PodTopologyLabelsAdmission).
+	podTopologyLabelsSupported  bool
 	inlineTLSConfig             bool
 
 	bypassVersionCheck bool
@@ -122,11 +122,9 @@ func WithPrometheusRetentionPolicies() ConfigGeneratorOption {
 	}
 }
 
-// WithPodTopologyLabelsSupport tells the config generator that K8s >= 1.35 is
-// available, meaning the PodTopologyLabelsAdmission feature gate automatically
-// injects topology.kubernetes.io/zone as a pod label. When enabled, the operator
+// WithPodTopologyLabelsSupport tells the config generator that the topology.kubernetes.io/zone label is injected as a pod label. In that case, the operator
 // no longer forces attach_metadata.node=true for topology sharding and instead
-// uses the pod label SD meta label for zone detection.
+// uses the pod label for zone detection.
 func WithPodTopologyLabelsSupport() ConfigGeneratorOption {
 	return func(cg *ConfigGenerator) {
 		cg.podTopologyLabelsSupported = true
@@ -5408,11 +5406,11 @@ func (cg *ConfigGenerator) InzoneShardForShard(shardIndex int32) int32 {
 	return shardIndex / numZones
 }
 
-// mergeAttachMetadataForTopology forces attach_metadata.node=true when topology
-// sharding is active, unless K8s >= 1.35 (podTopologyLabelsSupported). In the
-// latter case, PodTopologyLabelsAdmission injects the zone label onto pods so
-// node metadata is no longer required.
-// Returns amc unchanged when topology sharding is not active or node is already true.
+// mergeAttachMetadataForTopology returns amc unchanged when topology sharding is
+// not active, when podTopologyLabelsSupported is true (zone label is injected
+// directly onto pods), or when node metadata is already requested.
+// Otherwise it forces attach_metadata.node=true so that zone detection via node
+// labels is available.
 func (cg *ConfigGenerator) mergeAttachMetadataForTopology(amc *attachMetadataConfig, minimumVersion string) *attachMetadataConfig {
 	if !cg.isTopologyShardingActive() {
 		return amc

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -14573,14 +14573,13 @@ func TestTopologyShardingRelabeling(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name                   string
-		shards                 int32
-		zones                  []string
-		serviceMonitor         map[string]*monitoringv1.ServiceMonitor
-		podMonitor             map[string]*monitoringv1.PodMonitor
-		attachMetadata         *monitoringv1.AttachMetadata
-		podTopologyLabels      bool
-		golden                 string
+		name              string
+		shards            int32
+		zones             []string
+		serviceMonitor    map[string]*monitoringv1.ServiceMonitor
+		podMonitor        map[string]*monitoringv1.PodMonitor
+		podTopologyLabels bool
+		golden            string
 	}{
 		{
 			name:           "service_monitor_4shards_2zones",

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -14653,12 +14653,12 @@ func TestTopologyShardingRelabeling(t *testing.T) {
 			golden:            "TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden",
 		},
 		{
-			name:  "pod_topology_labels_attach_metadata_false_is_respected",
+			name:   "pod_topology_labels_attach_metadata_false_is_respected",
 			shards: 4,
 			zones:  []string{"zone-a", "zone-b"},
 			serviceMonitor: func() map[string]*monitoringv1.ServiceMonitor {
 				sm := basicServiceMonitor()
-				sm["test"].Spec.AttachMetadata = &monitoringv1.AttachMetadata{Node: ptr.To(false)}
+				sm["test"].Spec.AttachMetadata = &monitoringv1.AttachMetadata{Node: new(bool)}
 				return sm
 			}(),
 			podTopologyLabels: true,

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -14573,13 +14573,14 @@ func TestTopologyShardingRelabeling(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name           string
-		shards         int32
-		zones          []string
-		serviceMonitor map[string]*monitoringv1.ServiceMonitor
-		podMonitor     map[string]*monitoringv1.PodMonitor
-		attachMetadata *monitoringv1.AttachMetadata
-		golden         string
+		name                   string
+		shards                 int32
+		zones                  []string
+		serviceMonitor         map[string]*monitoringv1.ServiceMonitor
+		podMonitor             map[string]*monitoringv1.PodMonitor
+		attachMetadata         *monitoringv1.AttachMetadata
+		podTopologyLabels      bool
+		golden                 string
 	}{
 		{
 			name:           "service_monitor_4shards_2zones",
@@ -14627,6 +14628,43 @@ func TestTopologyShardingRelabeling(t *testing.T) {
 			}(),
 			golden: "TopologySharding_ServiceMonitor_force_attach_metadata_false.golden",
 		},
+		// Pod topology labels (K8s >= 1.35) — no attach_metadata.node required.
+		{
+			name:              "pod_topology_labels_service_monitor_4shards_2zones",
+			shards:            4,
+			zones:             []string{"zone-a", "zone-b"},
+			serviceMonitor:    basicServiceMonitor(),
+			podTopologyLabels: true,
+			golden:            "TopologySharding_PodTopologyLabels_ServiceMonitor_4shards_2zones.golden",
+		},
+		{
+			name:              "pod_topology_labels_pod_monitor_4shards_2zones",
+			shards:            4,
+			zones:             []string{"zone-a", "zone-b"},
+			podMonitor:        basicPodMonitor(),
+			podTopologyLabels: true,
+			golden:            "TopologySharding_PodTopologyLabels_PodMonitor_4shards_2zones.golden",
+		},
+		{
+			name:              "pod_topology_labels_service_monitor_6shards_3zones",
+			shards:            6,
+			zones:             []string{"zone-a", "zone-b", "zone-c"},
+			serviceMonitor:    basicServiceMonitor(),
+			podTopologyLabels: true,
+			golden:            "TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden",
+		},
+		{
+			name:  "pod_topology_labels_attach_metadata_false_is_respected",
+			shards: 4,
+			zones:  []string{"zone-a", "zone-b"},
+			serviceMonitor: func() map[string]*monitoringv1.ServiceMonitor {
+				sm := basicServiceMonitor()
+				sm["test"].Spec.AttachMetadata = &monitoringv1.AttachMetadata{Node: ptr.To(false)}
+				return sm
+			}(),
+			podTopologyLabels: true,
+			golden:            "TopologySharding_PodTopologyLabels_ServiceMonitor_attach_metadata_false.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := defaultPrometheus()
@@ -14636,7 +14674,12 @@ func TestTopologyShardingRelabeling(t *testing.T) {
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: tc.zones},
 			}
 
-			cg := mustNewConfigGenerator(t, p, WithPrometheusTopologySharding())
+			opts := []ConfigGeneratorOption{WithPrometheusTopologySharding()}
+			if tc.podTopologyLabels {
+				opts = append(opts, WithPodTopologyLabelsSupport())
+			}
+
+			cg := mustNewConfigGenerator(t, p, opts...)
 			cfg, err := cg.GenerateServerConfiguration(
 				p,
 				tc.serviceMonitor,

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -109,6 +109,7 @@ type Operator struct {
 	retentionPoliciesEnabled      bool
 	configResourcesStatusEnabled  bool
 	topologyShardingEnabled       bool
+	podTopologyLabelsSupported    bool
 
 	newEventRecorder operator.NewEventRecorderFunc
 	finalizerSyncer  *operator.FinalizerSyncer
@@ -169,6 +170,16 @@ func WithoutUnmanagedConfiguration() ControllerOption {
 func WithConfigResourceStatus() ControllerOption {
 	return func(o *Operator) {
 		o.configResourcesStatusEnabled = true
+	}
+}
+
+// WithPodTopologyLabels tells that the cluster runs K8s >= 1.35 where
+// PodTopologyLabelsAdmission automatically injects topology labels onto pods.
+// When set, the operator uses pod label SD meta labels for zone detection in
+// topology sharding instead of forcing attach_metadata.node=true.
+func WithPodTopologyLabels() ControllerOption {
+	return func(o *Operator) {
+		o.podTopologyLabelsSupported = true
 	}
 }
 
@@ -957,6 +968,9 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 	}
 	if c.topologyShardingEnabled {
 		opts = append(opts, prompkg.WithPrometheusTopologySharding())
+	}
+	if c.podTopologyLabelsSupported {
+		opts = append(opts, prompkg.WithPodTopologyLabelsSupport())
 	}
 	cg, err := prompkg.NewConfigGenerator(logger, p, opts...)
 	if err != nil {

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_PodMonitor_4shards_2zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_PodMonitor_4shards_2zones.golden
@@ -45,6 +45,13 @@ scrape_configs:
   - target_label: endpoint
     replacement: web
   - source_labels:
+    - __meta_kubernetes_endpointslice_endpoint_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
     - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
     - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
     - __tmp_topology

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_PodMonitor_4shards_2zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_PodMonitor_4shards_2zones.golden
@@ -1,0 +1,76 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+    zone: $(TOPOLOGY_ZONE)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: podMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_label_foo
+    - __meta_kubernetes_pod_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - target_label: job
+    replacement: default/test
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
+    - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);true;
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_topology
+    - __tmp_disable_sharding
+    regex: $(TOPOLOGY_ZONE);|.+;.+
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(INZONE_SHARD);|.+;.+
+    action: keep

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_4shards_2zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_4shards_2zones.golden
@@ -1,0 +1,95 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+    zone: $(TOPOLOGY_ZONE)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
+    - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);true;
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_topology
+    - __tmp_disable_sharding
+    regex: $(TOPOLOGY_ZONE);|.+;.+
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(INZONE_SHARD);|.+;.+
+    action: keep

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_4shards_2zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_4shards_2zones.golden
@@ -64,6 +64,13 @@ scrape_configs:
   - target_label: endpoint
     replacement: web
   - source_labels:
+    - __meta_kubernetes_endpointslice_endpoint_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
     - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
     - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
     - __tmp_topology

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden
@@ -1,0 +1,95 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+    zone: $(TOPOLOGY_ZONE)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
+    - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);true;
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_topology
+    - __tmp_disable_sharding
+    regex: $(TOPOLOGY_ZONE);|.+;.+
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(INZONE_SHARD);|.+;.+
+    action: keep

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_6shards_3zones.golden
@@ -64,6 +64,13 @@ scrape_configs:
   - target_label: endpoint
     replacement: web
   - source_labels:
+    - __meta_kubernetes_endpointslice_endpoint_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
     - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
     - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
     - __tmp_topology

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_attach_metadata_false.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_attach_metadata_false.golden
@@ -66,6 +66,13 @@ scrape_configs:
   - target_label: endpoint
     replacement: web
   - source_labels:
+    - __meta_kubernetes_endpointslice_endpoint_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
     - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
     - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
     - __tmp_topology

--- a/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_attach_metadata_false.golden
+++ b/pkg/prometheus/testdata/TopologySharding_PodTopologyLabels_ServiceMonitor_attach_metadata_false.golden
@@ -1,0 +1,97 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+    zone: $(TOPOLOGY_ZONE)
+  evaluation_interval: 30s
+scrape_configs:
+- job_name: serviceMonitor/default/test/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - default
+    attach_metadata:
+      node: false
+  scrape_interval: 30s
+  relabel_configs:
+  - source_labels:
+    - job
+    target_label: __tmp_prometheus_job_name
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_service_label_foo
+    - __meta_kubernetes_service_labelpresent_foo
+    regex: (bar);true
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_endpoint_port_name
+    regex: web
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Node;(.*)
+    replacement: ${1}
+    target_label: node
+  - source_labels:
+    - __meta_kubernetes_endpoint_address_target_kind
+    - __meta_kubernetes_endpoint_address_target_name
+    separator: ;
+    regex: Pod;(.*)
+    replacement: ${1}
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: service
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - source_labels:
+    - __meta_kubernetes_service_name
+    target_label: job
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: web
+  - source_labels:
+    - __meta_kubernetes_pod_label_topology_kubernetes_io_zone
+    - __meta_kubernetes_pod_labelpresent_topology_kubernetes_io_zone
+    - __tmp_topology
+    target_label: __tmp_topology
+    regex: (.+);true;
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_topology
+    - __tmp_disable_sharding
+    regex: $(TOPOLOGY_ZONE);|.+;.+
+    action: keep
+  - source_labels:
+    - __address__
+    - __tmp_hash
+    target_label: __tmp_hash
+    regex: (.+);
+    replacement: $1
+    action: replace
+  - source_labels:
+    - __tmp_hash
+    target_label: __tmp_hash
+    modulus: 2
+    action: hashmod
+  - source_labels:
+    - __tmp_hash
+    - __tmp_disable_sharding
+    regex: $(INZONE_SHARD);|.+;.+
+    action: keep


### PR DESCRIPTION
## Description

Right now when topology sharding is active, the operator forces `attach_metadata: {node: true}` on every kubernetes SD config so Prometheus can pick up the node's `topology.kubernetes.io/zone` label and figure out which targets belong to which zone.

The problem is that `attach_metadata.node` requires Prometheus to have read access to Node objects, and it adds extra API calls for every scrape config. Ideally you wouldn't need any of that just to do zone-based sharding.

Since Kubernetes 1.35, there's a feature called `PodTopologyLabelsAdmission` (KEP-4742) that automatically injects topology
labels like `topology.kubernetes.io/zone` directly onto pod metadata. This means the zone info is already on the pod as a regular label, available via `__meta_kubernetes_pod_label_topology_kubernetes_io_zone` in the SD config, no node attachment needed.

This PR makes the operator detect when it's running on K8s >= 1.35 and switch to using the pod label approach instead.
  Specifically:

  - When K8s >= 1.35 is detected, `mergeAttachMetadataForTopology` no longer forces `attach_metadata.node=true`.
  - The relabel rules for zone detection use `__meta_kubernetes_pod_label_topology_kubernetes_io_zone` and its `_present` label
  instead of the node label fallback.
  - The switch is automatic based on the cluster version, no new API fields needed (this was preferred over an explicit
  opt-in toggle).

  Existing behavior on older clusters is completely unchanged since the fallback path (endpointslice zone + node label) is still
  there.

  Closes #8460

## Type of change

- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)

## Verification
All 9 test cases pass, including the 4 new ones that verify the pod topology labels path generates relabel configs using
  __meta_kubernetes_pod_label_topology_kubernetes_io_zone without any attach_metadata: node: true.

<img width="1393" height="560" alt="Screenshot 2026-05-10 204031" src="https://github.com/user-attachments/assets/10e742e9-1535-4bb6-a363-557e1350565f" />

## Changelog entry

```release-note
 Use pod topology labels (K8s >= 1.35) for zone-aware sharding instead of attaching node metadata, removing the need for
  `attach_metadata.node=true` in topology sharding configurations.
```
