### PR TITLE
chore(ci): group GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Add `groups` configuration to Dependabot to batch GitHub Actions dependency updates into a single PR, reducing PR noise.
                                                                                                                                                                    
Example:                                                                                                                                                     
  Before this change, Dependabot would open one PR per GitHub Actions update:                                                                                       
  - `ci: bump actions/checkout from v3 to v4`                                                                                                                       
  - `ci: bump actions/setup-go from v5.0.0 to v5.1.0`                                                                                                               
  - `ci: bump actions/cache from v3 to v4`                                                                                                                          
                                                                                                                                                                    
  After this change, all GitHub Actions updates are grouped into one PR:                                                                                            
  - `ci: bump github-actions dependencies`                                                                                                                          
    - actions/checkout v3 → v4                                                                                                                                      
    - actions/setup-go v5.0.0 → v5.1.0                                                                                                                              
    - actions/cache v3 → v4   

ref: https://github.com/prometheus-operator/prometheus-operator/pull/8559#discussion_r3217375559

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
None
```
