### PR TITLE
operator: fix dropped gzip Close errors in GzipConfig and GunzipConfig

### DIFF
--- a/pkg/operator/gzip_config.go
+++ b/pkg/operator/gzip_config.go
@@ -27,11 +27,10 @@ func GzipConfig(w io.Writer, conf []byte) error {
 	}
 
 	buf := gzip.NewWriter(w)
-	defer buf.Close()
 	if _, err := buf.Write(conf); err != nil {
 		return err
 	}
-	return nil
+	return buf.Close()
 }
 
 func GunzipConfig(b []byte) (string, error) {
@@ -41,8 +40,10 @@ func GunzipConfig(b []byte) (string, error) {
 		return "", err
 	}
 	uncompressed := new(strings.Builder)
-	_, err = io.Copy(uncompressed, reader)
-	if err != nil {
+	if _, err = io.Copy(uncompressed, reader); err != nil {
+		return "", err
+	}
+	if err := reader.Close(); err != nil {
 		return "", err
 	}
 	return uncompressed.String(), nil


### PR DESCRIPTION
## What

Fix error handling in both gzip helper functions in `pkg/operator/gzip_config.go`.

Fixes #8572

## Why

**GzipConfig**: `gzip.Writer.Close()` flushes buffered data and writes the mandatory gzip footer (CRC32 checksum + uncompressed size). Using `defer buf.Close()` silently discards this error. If Close fails, the function returns nil (success) but the output is corrupted (missing footer).

Both Prometheus and Alertmanager config compression paths rely on this:
- `pkg/prometheus/common.go:136`
- `pkg/alertmanager/operator.go:992`

**GunzipConfig**: `gzip.Reader.Close()` is never called. The Go standard library documentation states: "In order to verify the integrity of the data, the caller must call Close when finished reading."

## How

- `GzipConfig`: Return `buf.Close()` directly instead of deferring it.
- `GunzipConfig`: Add `reader.Close()` after `io.Copy` and propagate its error.

## Verification

- `go build ./pkg/operator/... ./pkg/prometheus/... ./pkg/alertmanager/...` passes
- `go test ./pkg/operator/...` passes
- `go vet ./pkg/operator/...` clean