### PR TITLE
test: verify recreation of statefulsets

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -1049,6 +1049,10 @@ func testPromStorageUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(context.Background(), metav1.ListOptions{LabelSelector: p.Status.Selector})
+	require.NoError(t, err)
+	require.Len(t, sts.Items, 1)
+
 	p, err = framework.PatchPrometheusAndWaitUntilReady(
 		context.Background(),
 		p.Name,
@@ -1076,6 +1080,11 @@ func testPromStorageUpdate(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	updatedSts, err := framework.KubeClient.AppsV1().StatefulSets(ns).List(context.Background(), metav1.ListOptions{LabelSelector: p.Status.Selector})
+	require.NoError(t, err)
+	require.Len(t, updatedSts.Items, 1)
+	require.NotEqual(t, sts.Items[0].UID, updatedSts.Items[0].UID, "StatefulSet should have different UIDs because the statefulset has been recreated")
 
 	err = framework.WaitForBoundPVC(context.Background(), ns, "test=testPromStorageUpdate", 1)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This commit extends `testPromStorageUpdate` to verify that the statefulset is recreated when the storage spec is updated.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
