### PR TITLE
test: add unit test for Alertmanager

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -2624,6 +2624,59 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "skeleton_base_multiple_alertmanagerconfigs.golden",
 		},
 		{
+			name:    "skeleton base, multiple CRs with namespaceMatcher disabled",
+			kclient: fake.NewClientset(),
+			baseConfig: alertmanagerConfig{
+				Route:     &route{Receiver: "null"},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			matcherStrategy: monitoringv1.AlertmanagerConfigMatcherStrategy{
+				Type: "None",
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"ns1/amc1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc1",
+						Namespace: "ns1",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+							GroupBy:  []string{"job"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test"}},
+					},
+				},
+				"ns2/amc1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc1",
+						Namespace: "ns2",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test2",
+							GroupBy:  []string{"job"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test2"}},
+					},
+				},
+				"ns2/amc2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amc2",
+						Namespace: "ns2",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test2",
+							GroupBy:  []string{"job", "instance"},
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{Name: "test2"}},
+					},
+				},
+			},
+			golden: "skeleton_base_multiple_CRs_with_namespaceMatcher_disabled.golden",
+		},
+		{
 			name:    "skeleton base, simple CR with namespaceMatcher disabled",
 			kclient: fake.NewClientset(),
 			baseConfig: alertmanagerConfig{

--- a/pkg/alertmanager/testdata/skeleton_base_multiple_CRs_with_namespaceMatcher_disabled.golden
+++ b/pkg/alertmanager/testdata/skeleton_base_multiple_CRs_with_namespaceMatcher_disabled.golden
@@ -1,0 +1,22 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: ns1/amc1/test
+    group_by:
+    - job
+    continue: true
+  - receiver: ns2/amc1/test2
+    group_by:
+    - job
+    continue: true
+  - receiver: ns2/amc2/test2
+    group_by:
+    - job
+    - instance
+    continue: true
+receivers:
+- name: "null"
+- name: ns1/amc1/test
+- name: ns2/amc1/test2
+- name: ns2/amc2/test2
+templates: []


### PR DESCRIPTION
## Description

This commit adds a unit test for Alertmanager when `matcherStrategy` is `None` and multiple AlertmanagerConfig resources are provided.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
