### PR TITLE
fix: improve structured logging patterns

### DIFF
--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -155,7 +155,7 @@ func (a *Admission) serveAdmission(w http.ResponseWriter, r *http.Request, admit
 
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		a.logger.Warn(fmt.Sprintf("invalid Content-Type %s, want `application/json`", contentType))
+		a.logger.Warn("invalid Content-Type, want `application/json`", "contentType", contentType)
 		http.Error(w, "invalid Content-Type, want `application/json`", http.StatusUnsupportedMediaType)
 		return
 	}

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -439,7 +439,7 @@ func (c *Operator) enqueueForNamespace(nsName string) {
 		return
 	}
 	if !exists {
-		c.logger.Error(fmt.Sprintf("get namespace to enqueue Alertmanager instances failed: namespace %q does not exist", nsName))
+		c.logger.Error("get namespace to enqueue Alertmanager instances failed: namespace does not exist", "namespace", nsName)
 		return
 	}
 	ns := nsObject.(*corev1.Namespace)

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -527,7 +527,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		for _, v := range amCfg.Templates {
 			if v.ConfigMap != nil {
 				if keys.Has(v.ConfigMap.Key) {
-					logger.Debug(fmt.Sprintf("skipping %q due to duplicate key %q", v.ConfigMap.Key, v.ConfigMap.Name))
+					logger.Debug("skipping due to duplicate key", "key", v.ConfigMap.Key, "configmap", v.ConfigMap.Name)
 					continue
 				}
 				sources = append(sources, corev1.VolumeProjection{
@@ -545,7 +545,7 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 			}
 			if v.Secret != nil {
 				if keys.Has(v.Secret.Key) {
-					logger.Debug(fmt.Sprintf("skipping %q due to duplicate key %q", v.Secret.Key, v.Secret.Name))
+					logger.Debug("skipping due to duplicate key", "key", v.Secret.Key, "secret", v.Secret.Name)
 					continue
 				}
 				sources = append(sources, corev1.VolumeProjection{

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -40,7 +40,7 @@ func LoadSecretRef(ctx context.Context, logger *slog.Logger, client typedcorev1.
 	secret, err := client.Get(ctx, sks.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) && optional {
-			logger.Debug(fmt.Sprintf("secret %v could not be found", sks.Name))
+			logger.Debug("secret could not be found", "secret", sks.Name)
 			return nil, nil
 		}
 
@@ -50,7 +50,7 @@ func LoadSecretRef(ctx context.Context, logger *slog.Logger, client typedcorev1.
 	b, found := secret.Data[sks.Key]
 	if !found {
 		if optional {
-			logger.Debug(fmt.Sprintf("secret %v could not be found", sks.Name))
+			logger.Debug("secret could not be found", "secret", sks.Name)
 			return nil, nil
 		}
 

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -431,7 +431,7 @@ func (rr *ResourceReconciler) OnAdd(obj any, _ bool) {
 		return
 	}
 
-	rr.logger.Debug(fmt.Sprintf("%s added", rr.resourceKind), "key", key)
+	rr.logger.Debug("resource added", "resourceKind", rr.resourceKind, "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, AddEvent).Inc()
 
 	rr.reconcileQ.Add(key)
@@ -477,7 +477,7 @@ func (rr *ResourceReconciler) OnUpdate(old, cur any) {
 		return
 	}
 
-	rr.logger.Debug(fmt.Sprintf("%s updated", rr.resourceKind), "key", key)
+	rr.logger.Debug("resource updated", "resourceKind", rr.resourceKind, "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, UpdateEvent).Inc()
 
 	rr.reconcileQ.Add(key)
@@ -508,7 +508,7 @@ func (rr *ResourceReconciler) OnDelete(obj any) {
 		return
 	}
 
-	rr.logger.Debug(fmt.Sprintf("%s deleted", rr.resourceKind), "key", key)
+	rr.logger.Debug("resource deleted", "resourceKind", rr.resourceKind, "key", key)
 	rr.metrics.TriggerByCounter(rr.resourceKind, DeleteEvent).Inc()
 
 	rr.reconcileQ.Add(key)

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -171,12 +171,12 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 	for i := range promRuleSpec.Groups {
 		if promRuleSpec.Groups[i].Limit != nil && prs.version.LT(minVersionLimits) {
 			promRuleSpec.Groups[i].Limit = nil
-			logger.Warn(fmt.Sprintf("ignoring `limit` not supported by %s", component), "minimum_version", minVersionLimits)
+			logger.Warn("ignoring `limit` not supported by component", "component", component, "minimum_version", minVersionLimits)
 		}
 
 		if promRuleSpec.Groups[i].QueryOffset != nil && prs.version.LT(minVersionQueryOffset) {
 			promRuleSpec.Groups[i].QueryOffset = nil
-			logger.Warn(fmt.Sprintf("ignoring `query_offset` not supported by %s", component), "minimum_version", minVersionQueryOffset)
+			logger.Warn("ignoring `query_offset` not supported by component", "component", component, "minimum_version", minVersionQueryOffset)
 		}
 
 		if prs.ruleFormat == PrometheusFormat {
@@ -186,13 +186,13 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 
 		if len(promRuleSpec.Groups[i].Labels) > 0 && prs.version.LT(minVersionRuleGroupLabels) {
 			promRuleSpec.Groups[i].Labels = nil
-			logger.Warn(fmt.Sprintf("ignoring group labels since not supported by %s", component), "minimum_version", minVersionRuleGroupLabels)
+			logger.Warn("ignoring group labels since not supported by component", "component", component, "minimum_version", minVersionRuleGroupLabels)
 		}
 
 		for j := range promRuleSpec.Groups[i].Rules {
 			if promRuleSpec.Groups[i].Rules[j].KeepFiringFor != nil && prs.version.LT(minVersionKeepFiringFor) {
 				promRuleSpec.Groups[i].Rules[j].KeepFiringFor = nil
-				logger.Warn(fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
+				logger.Warn("ignoring 'keep_firing_for' not supported by component", "component", component, "minimum_version", minVersionKeepFiringFor)
 			}
 		}
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -4792,7 +4792,7 @@ func (cg *ConfigGenerator) generateScrapeConfig(
 			case monitoringv1alpha1.OVHServiceDedicatedServer:
 				configs[i] = append(configs[i], yaml.MapItem{Key: "service", Value: "dedicated_server"})
 			default:
-				cg.logger.Warn(fmt.Sprintf("ignoring service not supported by Prometheus: %s", string(config.Service)))
+				cg.logger.Warn("ignoring service not supported by Prometheus", "service", config.Service)
 			}
 
 			if config.Endpoint != nil {


### PR DESCRIPTION
## Summary
Replace unstructured `logger.*(fmt.Sprintf(...))` calls with proper structured logging using key-value pairs.

## Changes
- pkg/k8s/secrets.go: 2 fixes
- pkg/admission/admission.go: 1 fix
- pkg/operator/rules.go: 4 fixes
- pkg/operator/resource_reconciler.go: 3 fixes
- pkg/alertmanager/statefulset.go: 2 fixes
- pkg/prometheus/promcfg.go: 4 fixes
- pkg/alertmanager/operator.go: 1 fix

## Example
```go
// Before
logger.Debug(fmt.Sprintf("skipping %q due to duplicate key %q", v.ConfigMap.Key, v.ConfigMap.Name))

// After
logger.Debug("skipping due to duplicate key", "key", v.ConfigMap.Key, "configmap", v.ConfigMap.Name)
```
