### PR TITLE
refactor(crd): change OAuth2 TokenURL type from string to URL

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -761,6 +761,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -1834,6 +1835,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -2601,6 +2603,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -3439,6 +3442,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -4287,6 +4291,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -5147,6 +5152,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -6075,6 +6081,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -7068,6 +7075,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -7875,6 +7883,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -8762,6 +8771,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -9570,6 +9580,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -10320,6 +10331,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -11050,6 +11062,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -11862,6 +11875,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -12990,6 +13004,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -14039,6 +14054,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -14798,6 +14814,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -15620,6 +15637,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -16454,6 +16472,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -17292,6 +17311,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -18194,6 +18214,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -19172,6 +19193,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -19971,6 +19993,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -20843,6 +20866,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -21636,6 +21660,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -22380,6 +22405,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -23102,6 +23128,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -23892,6 +23919,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -760,7 +760,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -1834,7 +1833,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -2602,7 +2600,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -3441,7 +3438,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -4290,7 +4286,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -5151,7 +5146,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -6080,7 +6074,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -7074,7 +7067,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -7882,7 +7874,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -8770,7 +8761,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -9579,7 +9569,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -10330,7 +10319,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -11061,7 +11049,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -11874,7 +11861,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -13003,7 +12989,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -14053,7 +14038,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -14813,7 +14797,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -15636,7 +15619,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -16471,7 +16453,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -17310,7 +17291,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -18213,7 +18193,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -19192,7 +19171,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -19992,7 +19970,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -20865,7 +20842,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -21659,7 +21635,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -22404,7 +22379,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -23127,7 +23101,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -23918,7 +23891,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1629,6 +1629,7 @@ spec:
                                 description: tokenUrl defines the URL to fetch the
                                   token from.
                                 minLength: 1
+                                pattern: ^(http|https)://.+$
                                 type: string
                             required:
                             - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -1628,7 +1628,6 @@ spec:
                               tokenUrl:
                                 description: tokenUrl defines the URL to fetch the
                                   token from.
-                                minLength: 1
                                 pattern: ^(http|https)://.+$
                                 type: string
                             required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -768,7 +768,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -769,6 +769,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -681,6 +681,7 @@ spec:
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
                     minLength: 1
+                    pattern: ^(http|https)://.+$
                     type: string
                 required:
                 - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -680,7 +680,6 @@ spec:
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
-                    minLength: 1
                     pattern: ^(http|https)://.+$
                     type: string
                 required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6108,6 +6108,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6107,7 +6107,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6803,7 +6803,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -7707,7 +7706,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -6804,6 +6804,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -7707,6 +7708,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -574,6 +574,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -1376,6 +1377,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -2067,6 +2069,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -2836,6 +2839,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -3550,6 +3554,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -4597,6 +4602,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -5381,6 +5387,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -6080,6 +6087,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -6703,6 +6711,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -7440,6 +7449,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -8165,6 +8175,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -8888,6 +8899,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -9540,6 +9552,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -10374,6 +10387,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -10942,6 +10956,7 @@ spec:
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
                     minLength: 1
+                    pattern: ^(http|https)://.+$
                     type: string
                 required:
                 - clientId
@@ -11872,6 +11887,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -573,7 +573,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -1376,7 +1375,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -2068,7 +2066,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -2838,7 +2835,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -3553,7 +3549,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -4601,7 +4596,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -5386,7 +5380,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -6086,7 +6079,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -6710,7 +6702,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -7448,7 +7439,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -8174,7 +8164,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -8898,7 +8887,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -9551,7 +9539,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -10386,7 +10373,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -10955,7 +10941,6 @@ spec:
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
-                    minLength: 1
                     pattern: ^(http|https)://.+$
                     type: string
                 required:
@@ -11886,7 +11871,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -690,6 +690,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -689,7 +689,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5468,6 +5468,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5467,7 +5467,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -761,6 +761,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -1834,6 +1835,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -2601,6 +2603,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -3439,6 +3442,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -4287,6 +4291,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -5147,6 +5152,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -6075,6 +6081,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -7068,6 +7075,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -7875,6 +7883,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -8762,6 +8771,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -9570,6 +9580,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -10320,6 +10331,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -11050,6 +11062,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId
@@ -11862,6 +11875,7 @@ spec:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
                                     minLength: 1
+                                    pattern: ^(http|https)://.+$
                                     type: string
                                 required:
                                 - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -760,7 +760,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -1834,7 +1833,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -2602,7 +2600,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -3441,7 +3438,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -4290,7 +4286,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -5151,7 +5146,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -6080,7 +6074,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -7074,7 +7067,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -7882,7 +7874,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -8770,7 +8761,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -9579,7 +9569,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -10330,7 +10319,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -11061,7 +11049,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:
@@ -11874,7 +11861,6 @@ spec:
                                   tokenUrl:
                                     description: tokenUrl defines the URL to fetch
                                       the token from.
-                                    minLength: 1
                                     pattern: ^(http|https)://.+$
                                     type: string
                                 required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1629,6 +1629,7 @@ spec:
                                 description: tokenUrl defines the URL to fetch the
                                   token from.
                                 minLength: 1
+                                pattern: ^(http|https)://.+$
                                 type: string
                             required:
                             - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -1628,7 +1628,6 @@ spec:
                               tokenUrl:
                                 description: tokenUrl defines the URL to fetch the
                                   token from.
-                                minLength: 1
                                 pattern: ^(http|https)://.+$
                                 type: string
                             required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -768,7 +768,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -769,6 +769,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -681,6 +681,7 @@ spec:
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
                     minLength: 1
+                    pattern: ^(http|https)://.+$
                     type: string
                 required:
                 - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -680,7 +680,6 @@ spec:
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
-                    minLength: 1
                     pattern: ^(http|https)://.+$
                     type: string
                 required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6108,6 +6108,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6107,7 +6107,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6803,7 +6803,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -7707,7 +7706,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -6804,6 +6804,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -7707,6 +7708,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -574,6 +574,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -1376,6 +1377,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -2067,6 +2069,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -2836,6 +2839,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -3550,6 +3554,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -4597,6 +4602,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -5381,6 +5387,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -6080,6 +6087,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -6703,6 +6711,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -7440,6 +7449,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -8165,6 +8175,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -8888,6 +8899,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -9540,6 +9552,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -10374,6 +10387,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId
@@ -10942,6 +10956,7 @@ spec:
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
                     minLength: 1
+                    pattern: ^(http|https)://.+$
                     type: string
                 required:
                 - clientId
@@ -11872,6 +11887,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -573,7 +573,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -1376,7 +1375,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -2068,7 +2066,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -2838,7 +2835,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -3553,7 +3549,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -4601,7 +4596,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -5386,7 +5380,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -6086,7 +6079,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -6710,7 +6702,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -7448,7 +7439,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -8174,7 +8164,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -8898,7 +8887,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -9551,7 +9539,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -10386,7 +10373,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:
@@ -10955,7 +10941,6 @@ spec:
                     type: object
                   tokenUrl:
                     description: tokenUrl defines the URL to fetch the token from.
-                    minLength: 1
                     pattern: ^(http|https)://.+$
                     type: string
                 required:
@@ -11886,7 +11871,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -690,6 +690,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -689,7 +689,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5468,6 +5468,7 @@ spec:
                           description: tokenUrl defines the URL to fetch the token
                             from.
                           minLength: 1
+                          pattern: ^(http|https)://.+$
                           type: string
                       required:
                       - clientId

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5467,7 +5467,6 @@ spec:
                         tokenUrl:
                           description: tokenUrl defines the URL to fetch the token
                             from.
-                          minLength: 1
                           pattern: ^(http|https)://.+$
                           type: string
                       required:

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -705,7 +705,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -1688,7 +1687,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -2383,7 +2381,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -3145,7 +3142,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -3925,7 +3921,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -4707,7 +4702,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -5535,7 +5529,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -6429,7 +6422,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -7166,7 +7158,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -7968,7 +7959,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -8703,7 +8693,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -9388,7 +9377,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -10057,7 +10045,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
@@ -10790,7 +10777,6 @@
                                       },
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
-                                        "minLength": 1,
                                         "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -706,6 +706,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -1688,6 +1689,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -2382,6 +2384,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -3143,6 +3146,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -3922,6 +3926,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -4703,6 +4708,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -5530,6 +5536,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -6423,6 +6430,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -7159,6 +7167,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -7960,6 +7969,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -8694,6 +8704,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -9378,6 +9389,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -10046,6 +10058,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },
@@ -10778,6 +10791,7 @@
                                       "tokenUrl": {
                                         "description": "tokenUrl defines the URL to fetch the token from.",
                                         "minLength": 1,
+                                        "pattern": "^(http|https)://.+$",
                                         "type": "string"
                                       }
                                     },

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -564,6 +564,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -1534,6 +1535,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -2224,6 +2226,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -2977,6 +2980,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -3747,6 +3751,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -4518,6 +4523,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -5331,6 +5337,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -6217,6 +6224,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -6949,6 +6957,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -7743,6 +7752,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -8470,6 +8480,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -9150,6 +9161,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -9814,6 +9826,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },
@@ -10536,6 +10549,7 @@
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
                                     minLength: 1,
+                                    pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
                                 },

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -563,7 +563,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -1534,7 +1533,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -2225,7 +2223,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -2979,7 +2976,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -3750,7 +3746,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -4522,7 +4517,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -5336,7 +5330,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -6223,7 +6216,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -6956,7 +6948,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -7751,7 +7742,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -8479,7 +8469,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -9160,7 +9149,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -9825,7 +9813,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },
@@ -10548,7 +10535,6 @@
                                   },
                                   tokenUrl: {
                                     description: 'tokenUrl defines the URL to fetch the token from.',
-                                    minLength: 1,
                                     pattern: '^(http|https)://.+$',
                                     type: 'string',
                                   },

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1405,6 +1405,7 @@
                                   "tokenUrl": {
                                     "description": "tokenUrl defines the URL to fetch the token from.",
                                     "minLength": 1,
+                                    "pattern": "^(http|https)://.+$",
                                     "type": "string"
                                   }
                                 },

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -1404,7 +1404,6 @@
                                   },
                                   "tokenUrl": {
                                     "description": "tokenUrl defines the URL to fetch the token from.",
-                                    "minLength": 1,
                                     "pattern": "^(http|https)://.+$",
                                     "type": "string"
                                   }

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -643,6 +643,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -642,7 +642,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -593,7 +593,6 @@
                       },
                       "tokenUrl": {
                         "description": "tokenUrl defines the URL to fetch the token from.",
-                        "minLength": 1,
                         "pattern": "^(http|https)://.+$",
                         "type": "string"
                       }

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -594,6 +594,7 @@
                       "tokenUrl": {
                         "description": "tokenUrl defines the URL to fetch the token from.",
                         "minLength": 1,
+                        "pattern": "^(http|https)://.+$",
                         "type": "string"
                       }
                     },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5139,6 +5139,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5138,7 +5138,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5725,7 +5725,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -6538,7 +6537,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5726,6 +5726,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -6538,6 +6539,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -522,6 +522,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -1259,6 +1260,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -1906,6 +1908,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -2629,6 +2632,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -3300,6 +3304,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -4275,6 +4280,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -4997,6 +5003,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -5648,6 +5655,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -6232,6 +6240,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -6909,6 +6918,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -7591,6 +7601,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -8265,6 +8276,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -8876,6 +8888,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -9639,6 +9652,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },
@@ -10178,6 +10192,7 @@
                       "tokenUrl": {
                         "description": "tokenUrl defines the URL to fetch the token from.",
                         "minLength": 1,
+                        "pattern": "^(http|https)://.+$",
                         "type": "string"
                       }
                     },
@@ -11038,6 +11053,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -521,7 +521,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -1259,7 +1258,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -1907,7 +1905,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -2631,7 +2628,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -3303,7 +3299,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -4279,7 +4274,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -5002,7 +4996,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -5654,7 +5647,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -6239,7 +6231,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -6917,7 +6908,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -7600,7 +7590,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -8275,7 +8264,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -8887,7 +8875,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -9651,7 +9638,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
@@ -10191,7 +10177,6 @@
                       },
                       "tokenUrl": {
                         "description": "tokenUrl defines the URL to fetch the token from.",
-                        "minLength": 1,
                         "pattern": "^(http|https)://.+$",
                         "type": "string"
                       }
@@ -11052,7 +11037,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -577,6 +577,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -576,7 +576,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4718,7 +4718,6 @@
                             },
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
-                              "minLength": 1,
                               "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4719,6 +4719,7 @@
                             "tokenUrl": {
                               "description": "tokenUrl defines the URL to fetch the token from.",
                               "minLength": 1,
+                              "pattern": "^(http|https)://.+$",
                               "type": "string"
                             }
                           },

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1901,7 +1901,7 @@ func (cb *ConfigBuilder) convertHTTPConfig(ctx context.Context, in *monitoringv1
 			ClientID:       clientID,
 			ClientSecret:   clientSecret,
 			Scopes:         in.OAuth2.Scopes,
-			TokenURL:       in.OAuth2.TokenURL,
+			TokenURL:       string(in.OAuth2.TokenURL),
 			EndpointParams: in.OAuth2.EndpointParams,
 			proxyConfig:    proxyConfig,
 		}

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -673,7 +673,6 @@ type OAuth2 struct {
 
 	// tokenUrl defines the URL to fetch the token from.
 	//
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	TokenURL URL `json:"tokenUrl"`
 

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -675,7 +675,7 @@ type OAuth2 struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
-	TokenURL string `json:"tokenUrl"`
+	TokenURL URL `json:"tokenUrl"`
 
 	// scopes defines the OAuth2 scopes used for the token request.
 	//
@@ -707,7 +707,7 @@ func (o *OAuth2) Validate() error {
 		return nil
 	}
 
-	if o.TokenURL == "" {
+	if string(o.TokenURL) == "" {
 		return errors.New("OAuth2 tokenURL must be specified")
 	}
 

--- a/pkg/client/applyconfiguration/monitoring/v1/oauth2.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/oauth2.go
@@ -17,6 +17,7 @@
 package v1
 
 import (
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -32,7 +33,7 @@ type OAuth2ApplyConfiguration struct {
 	// client's secret.
 	ClientSecret *corev1.SecretKeySelector `json:"clientSecret,omitempty"`
 	// tokenUrl defines the URL to fetch the token from.
-	TokenURL *string `json:"tokenUrl,omitempty"`
+	TokenURL *monitoringv1.URL `json:"tokenUrl,omitempty"`
 	// scopes defines the OAuth2 scopes used for the token request.
 	Scopes []string `json:"scopes,omitempty"`
 	// endpointParams configures the HTTP parameters to append to the token
@@ -71,7 +72,7 @@ func (b *OAuth2ApplyConfiguration) WithClientSecret(value corev1.SecretKeySelect
 // WithTokenURL sets the TokenURL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TokenURL field is set to the value of the last call.
-func (b *OAuth2ApplyConfiguration) WithTokenURL(value string) *OAuth2ApplyConfiguration {
+func (b *OAuth2ApplyConfiguration) WithTokenURL(value monitoringv1.URL) *OAuth2ApplyConfiguration {
 	b.TokenURL = &value
 	return b
 }


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

Change the `TokenURL` field in the `OAuth2` struct from `string` to `URL` type, enabling built-in URL validation across all CRDs that reference OAuth2 configuration

ref:  https://github.com/prometheus-operator/prometheus-operator/pull/8565#discussion_r3267125224

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
change OAuth2 TokenURL type from string to URL
```
