### PR TITLE
admission: add missing return after http.Error on marshal failure

### DIFF
--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -180,13 +180,14 @@ func (a *Admission) serveAdmission(w http.ResponseWriter, r *http.Request, admit
 	responseAdmissionReview.Kind = requestedAdmissionReview.Kind
 
 	respBytes, err := json.Marshal(responseAdmissionReview)
-
-	a.logger.Debug("sending response", "content", string(respBytes))
-
 	if err != nil {
 		a.logger.Error("Cannot serialize response", "err", err)
 		http.Error(w, fmt.Sprintf("could not serialize response: %v", err), http.StatusInternalServerError)
+		return
 	}
+
+	a.logger.Debug("sending response", "content", string(respBytes))
+
 	if _, err := w.Write(respBytes); err != nil {
 		a.logger.Error("Cannot write response", "err", err)
 		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
## What this PR does

In `pkg/admission/admission.go`, function `serveAdmission`: when `json.Marshal(responseAdmissionReview)` fails, `http.Error` is called but execution falls through to `w.Write(respBytes)` with nil bytes on an already-committed response. This triggers Go's "http: superfluous response.WriteHeader call" warning and writes corrupted output.

The two earlier error handlers (empty body, wrong content-type) both correctly `return`. This was the only path missing it.

**Fix:**
- Added `return` after the `http.Error` call on the marshal error path
- Moved the debug log after the error check so it only runs when `respBytes` is valid

## AI Disclosure

Developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. All code reviewed and verified by the human author.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>