### PR TITLE
operator: add missing return after meta.Accessor error in FindOwner

### DIFF
--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -396,6 +396,7 @@ func (rr *ResourceReconciler) FindOwner(obj metav1.Object) metav1.Object {
 		o, err := meta.Accessor(owner)
 		if err != nil {
 			rr.logger.Error("failed to get owner meta", "err", err, "gvk", owner.GetObjectKind().GroupVersionKind().String(), "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", rr.resourceKind)
+			return nil
 		}
 
 		return o


### PR DESCRIPTION
When `meta.Accessor(owner)` fails in `FindOwner`, the error is logged but execution falls through to `return o`, where `o` is nil or invalid. Every other error path in `FindOwner` returns `nil` explicitly (lines 388-392). This adds the missing `return nil` for consistency and safety.

## Failure scenario

If `meta.Accessor` ever returns a non-nil but invalid accessor on error, callers would use corrupted data instead of getting the nil they expect. Currently `o` happens to be nil on error, but relying on that is fragile.

## Bug origin

Introduced in #6938 (2024-09-17) when the owner lookup was simplified into a single `FindOwner` method.