### PR TITLE
alertmanager: return error on invalid SMTP smarthost format

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1299,7 +1299,12 @@ func (cb *ConfigBuilder) convertEmailConfig(ctx context.Context, in monitoringv1
 	}
 
 	if ptr.Deref(in.Smarthost, "") != "" {
-		out.Smarthost.Host, out.Smarthost.Port, _ = net.SplitHostPort(*in.Smarthost)
+		host, port, err := net.SplitHostPort(*in.Smarthost)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SMTP smarthost %q: %w", *in.Smarthost, err)
+		}
+		out.Smarthost.Host = host
+		out.Smarthost.Port = port
 	}
 
 	if in.AuthPassword != nil {


### PR DESCRIPTION
The `net.SplitHostPort` error in the email receiver config conversion is silently discarded with `_`. On failure, `Host` and `Port` are set to empty strings, producing an SMTP configuration that fails silently at email send time.

## Failure scenario

If the smarthost value reaches the conversion layer without passing through validation (e.g., a new API version or an alternative code path that skips the v1alpha1/v1beta1 validators), a malformed smarthost like `no-port-here` silently produces empty Host and Port fields. The resulting Alertmanager config connects to an empty host, and email notifications fail with no indication of what went wrong.

## Context

Validation in `pkg/alertmanager/validation/` checks `SplitHostPort` and rejects invalid values. However, the conversion layer in `amcfg.go` should independently handle errors as a defense-in-depth measure. The `_` assignment predates the validation code added in #8270.