### PR TITLE
pkg/prometheus: validate Probe static target labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* [BUGFIX] Validate target labels in `Probe` static configuration to prevent invalid Prometheus scrape configs. #7901
+
 ## 0.91.0 / 2026-05-05
 
 * [CHANGE] Enforce mutual exclusion of `basicAuth`, `authorization` and `oauth2` in `ScrapeConfig` CRD. #8480

--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/url"
 	"slices"
@@ -470,6 +471,9 @@ func (rs *ResourceSelector) checkProbe(ctx context.Context, probe *monitoringv1.
 	}
 
 	if probe.Spec.Targets.StaticConfig != nil {
+		if err := rs.validateStaticConfigLabels(probe.Spec.Targets.StaticConfig.Labels); err != nil {
+			return fmt.Errorf("targets.staticConfig.labels: %w", err)
+		}
 		if err := rs.ValidateRelabelConfigs(probe.Spec.Targets.StaticConfig.RelabelConfigs); err != nil {
 			return fmt.Errorf("targets.staticConfig.relabelConfigs: %w", err)
 		}
@@ -489,6 +493,17 @@ func (rs *ResourceSelector) checkProbe(ctx context.Context, probe *monitoringv1.
 		return fmt.Errorf("%q url specified in proberSpec is invalid, it should be of the format `hostname` or `hostname:port`: %w", probe.Spec.ProberSpec.URL, err)
 	}
 
+	return nil
+}
+
+func (rs *ResourceSelector) validateStaticConfigLabels(labels map[string]string) error {
+	keys := slices.Collect(maps.Keys(labels))
+	slices.Sort(keys)
+	for _, labelName := range keys {
+		if !isValidLabelName(labelName, rs.version) {
+			return fmt.Errorf("invalid label %q", labelName)
+		}
+	}
 	return nil
 }
 
@@ -1317,10 +1332,8 @@ func (rs *ResourceSelector) validateScalewaySDConfigs(ctx context.Context, sc *m
 
 func (rs *ResourceSelector) validateStaticConfig(sc *monitoringv1alpha1.ScrapeConfig) error {
 	for i, config := range sc.Spec.StaticConfigs {
-		for labelName := range config.Labels {
-			if !isValidLabelName(labelName, rs.version) {
-				return fmt.Errorf("[%d]: invalid label in map %s", i, labelName)
-			}
+		if err := rs.validateStaticConfigLabels(config.Labels); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
 		}
 	}
 

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -318,6 +318,29 @@ func TestSelectProbes(t *testing.T) {
 			valid: true,
 		},
 		{
+			scenario: "valid static target labels",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig.Labels = map[string]string{"owner": "team-a"}
+			},
+			valid: true,
+		},
+		{
+			scenario: "invalid static target label with prom2",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig.Labels = map[string]string{"cluster-id": "xxx"}
+			},
+			promVersion: "2.55.0",
+			valid:       false,
+		},
+		{
+			scenario:    "static target label with prom3",
+			promVersion: "3.0.0",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.Targets.StaticConfig.Labels = map[string]string{"cluster-id": "xxx"}
+			},
+			valid: true,
+		},
+		{
 			scenario: "utf-8 static relabeling config with prom2",
 			updateSpec: func(ps *monitoringv1.ProbeSpec) {
 				ps.Targets.StaticConfig.RelabelConfigs = []monitoringv1.RelabelConfig{


### PR DESCRIPTION
## Summary

- Validate `Probe.spec.targets.staticConfig.labels` when selecting Probe resources for a Prometheus instance.
- Use the same version-aware label name rules as `ScrapeConfig` static configs, so invalid labels (e.g. `cluster-id` on Prometheus < 3.0) are rejected at reconciliation time instead of causing Prometheus to crash on config load.

Fixes #7901

## Test plan

- [x] `go test ./pkg/prometheus/... -run TestSelectProbes`
- [x] Added cases for valid labels, invalid legacy labels on Prometheus 2.x, and UTF-8 labels on Prometheus 3.x

cc @simonpasquier @slashpai