### PR TITLE
pkg/alertmanager: validate routes against global mute time intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Add `healthFilter` field for ConsulSD in `ScrapeConfig` CRD. #8529
 * [BUGFIX] Ensure that inactive shards don't scrape any targets when the sharding retention policy is `Retain`. #8513
 * [BUGFIX] Fix Telegram bot token validation in Alertmanager configuration Secret. #8465
+* [BUGFIX] Consider mute and active time intervals from the global AlertmanagerConfig when validating selected AlertmanagerConfig resources. #8006
 
 ## 0.90.1 / 2026-03-25
 

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -279,7 +279,7 @@ func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 		Name:      amConfig.Name,
 	}
 
-	if err := checkAlertmanagerConfigResource(ctx, amConfig, cb.amVersion, cb.store); err != nil {
+	if err := checkAlertmanagerConfigResource(ctx, amConfig, cb.amVersion, cb.store, nil); err != nil {
 		return err
 	}
 

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -1035,6 +1035,22 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 		return nil, err
 	}
 
+	var globalAmConfig *monitoringv1alpha1.AlertmanagerConfig
+	if am.Spec.AlertmanagerConfiguration != nil {
+		globalAmConfig, err = c.mclient.MonitoringV1alpha1().AlertmanagerConfigs(am.Namespace).Get(ctx, am.Spec.AlertmanagerConfiguration.Name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get global AlertmanagerConfig: %w", err)
+			}
+			c.logger.Warn(
+				"global AlertmanagerConfig not found",
+				"alertmanagerconfig", am.Spec.AlertmanagerConfiguration.Name,
+				"namespace", am.Namespace,
+				"alertmanager", am.Name,
+			)
+		}
+	}
+
 	for _, ns := range namespaces {
 		err := c.alrtCfgInfs.ListAllByNamespace(ns, amConfigSelector, func(obj any) {
 			k, ok := c.accessor.MetaNamespaceKey(obj)
@@ -1060,7 +1076,7 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 
 	eventRecorder := c.newEventRecorder(am)
 	for namespaceAndName, amc := range amConfigs {
-		if err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store); err != nil {
+		if err := checkAlertmanagerConfigResource(ctx, amc, amVersion, store, globalAmConfig); err != nil {
 			rejected++
 			c.logger.Warn(
 				"skipping alertmanagerconfig",
@@ -1092,9 +1108,9 @@ func (c *Operator) selectAlertmanagerConfigs(ctx context.Context, am *monitoring
 
 // checkAlertmanagerConfigResource verifies that an AlertmanagerConfig object is valid
 // for the given Alertmanager version and has no missing references to other objects.
-func checkAlertmanagerConfigResource(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, amVersion semver.Version, store *assets.StoreBuilder) error {
+func checkAlertmanagerConfigResource(ctx context.Context, amc *monitoringv1alpha1.AlertmanagerConfig, amVersion semver.Version, store *assets.StoreBuilder, globalAmConfig *monitoringv1alpha1.AlertmanagerConfig) error {
 	// Perform semantic validation irrespective of the Alertmanager version.
-	if err := validationv1alpha1.ValidateAlertmanagerConfig(amc); err != nil {
+	if err := validationv1alpha1.ValidateAlertmanagerConfigWithGlobal(amc, globalAmConfig); err != nil {
 		return err
 	}
 

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1541,7 +1541,7 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 			if tc.version != nil {
 				amVersion = *tc.version
 			}
-			err := checkAlertmanagerConfigResource(context.Background(), tc.amConfig, amVersion, store)
+			err := checkAlertmanagerConfigResource(context.Background(), tc.amConfig, amVersion, store, nil)
 			if tc.ok {
 				require.NoError(t, err)
 				return

--- a/pkg/alertmanager/validation/v1alpha1/validation.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation.go
@@ -31,17 +31,53 @@ import (
 // In particular, it verifies things that can't be modelized with the OpenAPI
 // specification such as routes should refer to an existing receiver.
 func ValidateAlertmanagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) error {
+	return ValidateAlertmanagerConfigWithGlobal(amc, nil)
+}
+
+// ValidateAlertmanagerConfigWithGlobal checks that the given AlertmanagerConfig
+// is valid. When global is non-nil, mute and active time intervals defined in
+// the global AlertmanagerConfig are considered when validating route references.
+func ValidateAlertmanagerConfigWithGlobal(amc *monitoringv1alpha1.AlertmanagerConfig, global *monitoringv1alpha1.AlertmanagerConfig) error {
 	receivers, err := validateReceivers(amc.Spec.Receivers)
 	if err != nil {
 		return err
 	}
 
-	muteTimeIntervals, err := validateMuteTimeIntervals(amc.Spec.MuteTimeIntervals)
+	muteTimeIntervals, err := mergeMuteTimeIntervalNames(amc.Spec.MuteTimeIntervals, globalMuteTimeIntervals(global))
 	if err != nil {
 		return err
 	}
 
 	return validateRoute(amc.Spec.Route, receivers, muteTimeIntervals, true)
+}
+
+func globalMuteTimeIntervals(global *monitoringv1alpha1.AlertmanagerConfig) []monitoringv1alpha1.MuteTimeInterval {
+	if global == nil {
+		return nil
+	}
+	return global.Spec.MuteTimeIntervals
+}
+
+func mergeMuteTimeIntervalNames(local, global []monitoringv1alpha1.MuteTimeInterval) (map[string]struct{}, error) {
+	muteTimeIntervalNames, err := validateMuteTimeIntervals(local)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(global) == 0 {
+		return muteTimeIntervalNames, nil
+	}
+
+	globalNames, err := validateMuteTimeIntervals(global)
+	if err != nil {
+		return nil, err
+	}
+
+	for name := range globalNames {
+		muteTimeIntervalNames[name] = struct{}{}
+	}
+
+	return muteTimeIntervalNames, nil
 }
 
 func validateReceivers(receivers []monitoringv1alpha1.Receiver) (map[string]struct{}, error) {

--- a/pkg/alertmanager/validation/v1alpha1/validation_test.go
+++ b/pkg/alertmanager/validation/v1alpha1/validation_test.go
@@ -1,0 +1,91 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+)
+
+func TestValidateAlertmanagerConfigWithGlobal(t *testing.T) {
+	t.Parallel()
+
+	global := &monitoringv1alpha1.AlertmanagerConfig{
+		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+			MuteTimeIntervals: []monitoringv1alpha1.MuteTimeInterval{
+				{
+					Name: "public_holidays",
+					TimeIntervals: []monitoringv1alpha1.TimeInterval{
+						{
+							Months: []monitoringv1alpha1.MonthRange{"January"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		in        *monitoringv1alpha1.AlertmanagerConfig
+		global    *monitoringv1alpha1.AlertmanagerConfig
+		expectErr bool
+	}{
+		{
+			name: "route references mute time interval from global config",
+			in: &monitoringv1alpha1.AlertmanagerConfig{
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{Name: "default"},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver:          "default",
+						MuteTimeIntervals: []string{"public_holidays"},
+					},
+				},
+			},
+			global: global,
+		},
+		{
+			name: "route references mute time interval missing from local and global config",
+			in: &monitoringv1alpha1.AlertmanagerConfig{
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{Name: "default"},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver:          "default",
+						MuteTimeIntervals: []string{"public_holidays"},
+					},
+				},
+			},
+			global:    nil,
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateAlertmanagerConfigWithGlobal(tc.in, tc.global)
+			if tc.expectErr && err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When selecting `AlertmanagerConfig` resources, the operator loads the global `AlertmanagerConfig` referenced by `Alertmanager.spec.alertmanagerConfiguration` and merges its mute/active time interval names into route validation.
- Routes in namespace-scoped configs can reference mute or active time intervals defined only in the global config without being rejected with `mute time interval x not found`.
- Global interval definitions are used for validation only; they are not merged into the stored per-namespace config.

Fixes #8006

## Test plan

- [x] `go test ./pkg/alertmanager/validation/v1alpha1/... ./pkg/alertmanager/...`
- [x] Added `TestValidateAlertmanagerConfigWithGlobal` covering valid reference with global config and rejection without global config