### PR TITLE
docs: add user guide for ServiceMonitor attachMetadata.node

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -445,6 +445,18 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>resources</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core">
@@ -2203,7 +2215,8 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2220,7 +2233,8 @@ Kubernetes meta/v1.LabelSelector
 <p>scrapeConfigNamespaceSelector defines the namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
 namespace only.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -2345,6 +2359,22 @@ configuration (either in the monitoring resources or via scrape class).</p>
 <p>You can also disable sharding on a specific target by setting the
 <code>__tmp_disable_sharding</code> label with relabeling configuration. When
 the label value isn&rsquo;t empty, all Prometheus shards will scrape the target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shardingStrategy</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategy">
+ShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.</p>
+<p>When not defined, the operator defaults to the &lsquo;Address&rsquo; mode which distributes
+targets based on a hash of the target address.</p>
 </td>
 </tr>
 <tr>
@@ -2662,6 +2692,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines on which Nodes the Pods are scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -4818,6 +4860,18 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>resources</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core">
@@ -5515,17 +5569,16 @@ string
 <td>
 <code>grpcServerTlsConfig</code><br/>
 <em>
-<a href="#monitoring.coreos.com/v1.TLSConfig">
-TLSConfig
+<a href="#monitoring.coreos.com/v1.GRPCServerTLSConfig">
+GRPCServerTLSConfig
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>grpcServerTlsConfig defines the gRPC server from which Thanos Querier reads
-recorded rule data.
-Note: Currently only the CAFile, CertFile, and KeyFile fields are supported.
-Maps to the &lsquo;&ndash;grpc-server-tls-*&rsquo; CLI args.</p>
+recorded rule data.</p>
+<p>Note: Currently only the <code>minVersion</code>, <code>caFile</code>, <code>certFile</code>, <code>keyFile</code>, <code>cipherSuites</code> and <code>curves</code> fields are supported.</p>
 </td>
 </tr>
 <tr>
@@ -6571,6 +6624,20 @@ GlobalWeChatConfig
 <p>wechat defines the default WeChat Config</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>mattermost</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.GlobalMattermostConfig">
+GlobalMattermostConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>mattermost defines the default Mattermost Config</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.AlertmanagerLimitsSpec">AlertmanagerLimitsSpec
@@ -6979,6 +7046,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines which Nodes the Pods are scheduled on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -7868,6 +7947,9 @@ bool
 targets.</p>
 <p>The Prometheus service account must have the <code>list</code> and <code>watch</code>
 permissions on the <code>Nodes</code> objects.</p>
+<p>Node metadata labels are not automatically added to scraped metrics. They are
+exposed as <code>__meta_kubernetes_node_*</code> labels and can be copied to timeseries
+with relabeling configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -8437,7 +8519,8 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -8454,7 +8537,8 @@ Kubernetes meta/v1.LabelSelector
 <p>scrapeConfigNamespaceSelector defines the namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
 namespace only.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -8579,6 +8663,22 @@ configuration (either in the monitoring resources or via scrape class).</p>
 <p>You can also disable sharding on a specific target by setting the
 <code>__tmp_disable_sharding</code> label with relabeling configuration. When
 the label value isn&rsquo;t empty, all Prometheus shards will scrape the target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shardingStrategy</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategy">
+ShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.</p>
+<p>When not defined, the operator defaults to the &lsquo;Address&rsquo; mode which distributes
+targets based on a hash of the target address.</p>
 </td>
 </tr>
 <tr>
@@ -8896,6 +8996,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines on which Nodes the Pods are scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -10648,7 +10760,7 @@ Kubernetes core/v1.VolumeResourceRequirements
 <td>
 <em>(Optional)</em>
 <p>resources represents the minimum resources the volume should have.
-If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+Users are allowed to specify resource requirements
 that are lower than previous value but must still be higher than capacity recorded in the
 status field of the claim.
 More info: <a href="https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources">https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources</a></p>
@@ -11213,6 +11325,192 @@ than zero disables the storage.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1.GRPCServerTLSConfig">GRPCServerTLSConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.ThanosRulerSpec">ThanosRulerSpec</a>, <a href="#monitoring.coreos.com/v1.ThanosSpec">ThanosSpec</a>)
+</p>
+<div>
+<p>GRPCServerTLSConfig defines TLS configuration for a gRPC server.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ca</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.SecretOrConfigMap">
+SecretOrConfigMap
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ca defines the Certificate authority used when verifying server certificates.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cert</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.SecretOrConfigMap">
+SecretOrConfigMap
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>cert defines the Client certificate to present when doing client-authentication.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>keySecret</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keySecret defines the Secret containing the client key file for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>serverName is used to verify the hostname for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>insecureSkipVerify</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>insecureSkipVerify defines how to disable target certificate validation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minVersion</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.TLSVersion">
+TLSVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>minVersion defines the minimum acceptable TLS version.</p>
+<p>It requires Prometheus &gt;= v2.35.0 or Thanos &gt;= v0.28.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxVersion</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.TLSVersion">
+TLSVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>maxVersion defines the maximum acceptable TLS version.</p>
+<p>It requires Prometheus &gt;= v2.41.0 or Thanos &gt;= v0.31.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>caFile defines the path to the CA cert in the Prometheus container to use for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>certFile defines the path to the client cert file in the Prometheus container for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>keyFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>keyFile defines the path to the client key file in the Prometheus container for the targets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cipherSuites</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>cipherSuites defines the list of supported cipher suites for TLS
+versions up to TLS 1.2.</p>
+<p>If not defined, the Go default cipher suites are used.
+Available cipher suites are documented in the Go documentation:
+<a href="https://golang.org/pkg/crypto/tls/#pkg-constants">https://golang.org/pkg/crypto/tls/#pkg-constants</a></p>
+<p>It requires Thanos &gt;= v0.42.0. Note that the operator doesn&rsquo;t verify if
+the Thanos version supports the provided values.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>curves</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>curves defines the list of preferred elliptic curves for
+TLS handshakes.</p>
+<p>If not defined, the Go default curves are used.
+Available curves are documented in the Go documentation:
+<a href="https://golang.org/pkg/crypto/tls/#CurveID">https://golang.org/pkg/crypto/tls/#CurveID</a></p>
+<p>It requires Thanos &gt;= v0.42.0. Note that the operator doesn&rsquo;t verify if
+the Thanos version supports the provided values.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="monitoring.coreos.com/v1.GlobalJiraConfig">GlobalJiraConfig
 </h3>
 <p>
@@ -11242,6 +11540,39 @@ URL
 <em>(Optional)</em>
 <p>apiURL defines the default Jira API URL.</p>
 <p>It requires Alertmanager &gt;= v0.28.0.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="monitoring.coreos.com/v1.GlobalMattermostConfig">GlobalMattermostConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.AlertmanagerGlobalConfig">AlertmanagerGlobalConfig</a>)
+</p>
+<div>
+<p>GlobalMattermostConfig configures global Mattermost parameters.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>webhookURL</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>webhookURL defines the default Mattermost Webhook URL.</p>
+<p>It requires Alertmanager &gt;= v0.32.0.</p>
 </td>
 </tr>
 </tbody>
@@ -12801,7 +13132,9 @@ client&rsquo;s secret.</p>
 <td>
 <code>tokenUrl</code><br/>
 <em>
-string
+<a href="#monitoring.coreos.com/v1.URL">
+URL
+</a>
 </em>
 </td>
 <td>
@@ -13016,6 +13349,38 @@ bool
 <p>promoteScopeMetadata controls whether to promote OpenTelemetry scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
 As per the OpenTelemetry specification, the aforementioned scope metadata should be identifying, i.e. made into metric labels.
 It requires Prometheus &gt;= v3.6.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labelNameUnderscoreSanitization</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>labelNameUnderscoreSanitization controls whether to enable prepending of &lsquo;key<em>&rsquo; to labels starting with &lsquo;</em>&rsquo;.
+Reserved labels starting with &lsquo;__&rsquo; are not modified.
+This is only relevant when translation_strategy uses underscore escaping (e.g., &ldquo;UnderscoreEscapingWithSuffixes&rdquo; or &ldquo;UnderscoreEscapingWithoutSuffixes&rdquo;).</p>
+<p>Notice: This one has no impact if <code>nameEscapingScheme</code> is <code>AllowUTF8</code>.</p>
+<p>It requires Prometheus &gt;= v3.8.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labelNamePreserveMultipleUnderscores</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>labelNamePreserveMultipleUnderscores enables preserving of multiple consecutive underscores in label names when translation_strategy uses
+underscore escaping.
+When true (default), multiple consecutive underscores are preserved during label name sanitization.</p>
+<p>Notice: This one has no impact if <code>nameEscapingScheme</code> is <code>AllowUTF8</code>.</p>
+<p>It requires Prometheus &gt;= v3.8.0.</p>
 </td>
 </tr>
 </tbody>
@@ -14976,7 +15341,8 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -14993,7 +15359,8 @@ Kubernetes meta/v1.LabelSelector
 <p>scrapeConfigNamespaceSelector defines the namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
 namespace only.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -15118,6 +15485,22 @@ configuration (either in the monitoring resources or via scrape class).</p>
 <p>You can also disable sharding on a specific target by setting the
 <code>__tmp_disable_sharding</code> label with relabeling configuration. When
 the label value isn&rsquo;t empty, all Prometheus shards will scrape the target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shardingStrategy</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategy">
+ShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.</p>
+<p>When not defined, the operator defaults to the &lsquo;Address&rsquo; mode which distributes
+targets based on a hash of the target address.</p>
 </td>
 </tr>
 <tr>
@@ -15435,6 +15818,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines on which Nodes the Pods are scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -17811,11 +18206,14 @@ to a remote endpoint.</p>
 <td>
 <code>url</code><br/>
 <em>
-string
+<a href="#monitoring.coreos.com/v1.URL">
+URL
+</a>
 </em>
 </td>
 <td>
 <p>url defines the URL of the endpoint to send samples to.</p>
+<p>It must use the HTTP or HTTPS scheme.</p>
 </td>
 </tr>
 <tr>
@@ -18204,7 +18602,8 @@ Duration
 </em>
 </td>
 <td>
-<p>retentionPeriod defines the retentionPeriod for shard retention policy.</p>
+<p>retentionPeriod defines how long the scaled-down shard(s) need to be
+kept before being deleted.</p>
 </td>
 </tr>
 </tbody>
@@ -19451,8 +19850,11 @@ RetainConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>retain defines the config for retention when the retention policy is set to <code>Retain</code>.
-This field is ineffective as of now.</p>
+<p>retain defines the config for retention when the retention policy is set
+to <code>Retain</code>.</p>
+<p>If not defined, the operator will use the retention duration configured
+for the Prometheus data. If the resource uses size-based retention, the
+shard(s) are kept forever (unless manually deleted).</p>
 </td>
 </tr>
 </tbody>
@@ -19530,6 +19932,85 @@ int32
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="monitoring.coreos.com/v1.ShardingStrategy">ShardingStrategy
+</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+</p>
+<div>
+<p>ShardingStrategy defines the sharding strategy for Prometheus.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>mode</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategyMode">
+ShardingStrategyMode
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>mode defines the sharding mode. Can be &lsquo;Address&rsquo; or &lsquo;Topology&rsquo;.</p>
+<p>&lsquo;Address&rsquo; is the default mode and distributes targets across shards
+based on a hash of the target address.</p>
+<p>&lsquo;Topology&rsquo; enables zone-aware sharding where each shard is assigned to a
+specific topology zone and only scrapes targets in that zone.
+(Alpha) Using the &lsquo;Topology&rsquo; mode requires the <code>PrometheusTopologySharding</code>
+feature gate to be enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topology</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.TopologyShardingStrategy">
+TopologyShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>topology defines the configuration for topology-aware sharding.
+This field is only valid when mode is set to &lsquo;Topology&rsquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="monitoring.coreos.com/v1.ShardingStrategyMode">ShardingStrategyMode
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.ShardingStrategy">ShardingStrategy</a>)
+</p>
+<div>
+<p>ShardingStrategyMode defines the sharding mode for Prometheus.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Address&#34;</p></td>
+<td><p>AddressShardingStrategyMode is the default sharding mode.
+Targets are distributed across shards based on a hash of the target address.</p>
+</td>
+</tr><tr><td><p>&#34;Topology&#34;</p></td>
+<td><p>TopologyShardingStrategyMode enables zone-aware sharding.
+Each shard is assigned to a specific topology zone and only scrapes targets in that zone.
+(Alpha) Using this mode requires the <code>PrometheusTopologySharding</code> feature gate to be enabled.</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.Sigv4">Sigv4
 </h3>
@@ -19612,6 +20093,19 @@ string
 <td>
 <em>(Optional)</em>
 <p>roleArn defines the named AWS profile used to authenticate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>externalId</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+It requires Prometheus &gt;= v3.11.0 or Alertmanager &gt;= v0.33.0. Currently not supported by Thanos.</p>
 </td>
 </tr>
 <tr>
@@ -19797,7 +20291,7 @@ is to use a label selector alongside manually created PersistentVolumes.</p>
 <h3 id="monitoring.coreos.com/v1.TLSConfig">TLSConfig
 </h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.APIServerConfig">APIServerConfig</a>, <a href="#monitoring.coreos.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>, <a href="#monitoring.coreos.com/v1.HTTPConfigWithTLSFiles">HTTPConfigWithTLSFiles</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1.ScrapeClass">ScrapeClass</a>, <a href="#monitoring.coreos.com/v1.ThanosRulerSpec">ThanosRulerSpec</a>, <a href="#monitoring.coreos.com/v1.ThanosSpec">ThanosSpec</a>, <a href="#monitoring.coreos.com/v1.TracingConfig">TracingConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.APIServerConfig">APIServerConfig</a>, <a href="#monitoring.coreos.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>, <a href="#monitoring.coreos.com/v1.GRPCServerTLSConfig">GRPCServerTLSConfig</a>, <a href="#monitoring.coreos.com/v1.HTTPConfigWithTLSFiles">HTTPConfigWithTLSFiles</a>, <a href="#monitoring.coreos.com/v1.RemoteReadSpec">RemoteReadSpec</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>, <a href="#monitoring.coreos.com/v1.ScrapeClass">ScrapeClass</a>, <a href="#monitoring.coreos.com/v1.TracingConfig">TracingConfig</a>)
 </p>
 <div>
 <p>TLSConfig defines full TLS configuration.</p>
@@ -20057,6 +20551,29 @@ in a breaking way.</p>
 <p>It requires Prometheus &gt;= v2.39.0 or PrometheusAgent &gt;= v2.54.0.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>staleSeriesCompactionThreshold</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity">
+k8s.io/apimachinery/pkg/api/resource.Quantity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>staleSeriesCompactionThreshold configures the trigger point for compacting
+stale series from memory into persistent blocks and removing those stale
+series from memory.</p>
+<p>The threshold is a number between 0.0 and 1.0. It represents the ratio of
+stale series in memory to the total series in memory. The stale series
+compaction is triggered when this ratio crosses the configured threshold.
+It may not trigger the stale series compaction if the usual head compaction
+is about to happen soon.</p>
+<p>If set to 0, stale series compaction is disabled.</p>
+<p>It requires Prometheus &gt;= v3.10.0.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1.ThanosRulerSpec">ThanosRulerSpec
@@ -20186,6 +20703,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines which Nodes the Pods are scheduled on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -20887,17 +21416,16 @@ string
 <td>
 <code>grpcServerTlsConfig</code><br/>
 <em>
-<a href="#monitoring.coreos.com/v1.TLSConfig">
-TLSConfig
+<a href="#monitoring.coreos.com/v1.GRPCServerTLSConfig">
+GRPCServerTLSConfig
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>grpcServerTlsConfig defines the gRPC server from which Thanos Querier reads
-recorded rule data.
-Note: Currently only the CAFile, CertFile, and KeyFile fields are supported.
-Maps to the &lsquo;&ndash;grpc-server-tls-*&rsquo; CLI args.</p>
+recorded rule data.</p>
+<p>Note: Currently only the <code>minVersion</code>, <code>caFile</code>, <code>certFile</code>, <code>keyFile</code>, <code>cipherSuites</code> and <code>curves</code> fields are supported.</p>
 </td>
 </tr>
 <tr>
@@ -21433,15 +21961,15 @@ in a breaking way.</p>
 <td>
 <code>grpcServerTlsConfig</code><br/>
 <em>
-<a href="#monitoring.coreos.com/v1.TLSConfig">
-TLSConfig
+<a href="#monitoring.coreos.com/v1.GRPCServerTLSConfig">
+GRPCServerTLSConfig
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
 <p>grpcServerTlsConfig defines the TLS parameters for the gRPC server providing the StoreAPI.</p>
-<p>Note: Currently only the <code>caFile</code>, <code>certFile</code>, and <code>keyFile</code> fields are supported.</p>
+<p>Note: Currently only the <code>minVersion</code>, <code>caFile</code>, <code>certFile</code>, <code>keyFile</code>, <code>cipherSuites</code> and <code>curves</code> fields are supported.</p>
 </td>
 </tr>
 <tr>
@@ -21579,6 +22107,53 @@ if they are invalid or not supported the given Thanos version.
 In case of an argument conflict (e.g. an argument which is already set by the
 operator itself) or when providing an invalid argument, the reconciliation will
 fail and an error will be logged.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="monitoring.coreos.com/v1.TopologyShardingStrategy">TopologyShardingStrategy
+</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.ShardingStrategy">ShardingStrategy</a>)
+</p>
+<div>
+<p>TopologyShardingStrategy defines the configuration for topology-aware sharding.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>externalLabelName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>externalLabelName defines the name of the Prometheus external label used
+to communicate the topology zone assigned to the Prometheus instance.
+If not defined, it defaults to &ldquo;zone&rdquo;.
+If set to the empty string, no external label is added to the Prometheus configuration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>values defines the list of topology values (e.g. zone names) to be used
+for sharding. The configured number of shards must be greater than or
+equal to the number of values.</p>
 </td>
 </tr>
 </tbody>
@@ -21946,7 +22521,7 @@ Supported values are:
 <h3 id="monitoring.coreos.com/v1.URL">URL
 (<code>string</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.AlertmanagerGlobalConfig">AlertmanagerGlobalConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalJiraConfig">GlobalJiraConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalRocketChatConfig">GlobalRocketChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalTelegramConfig">GlobalTelegramConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalVictorOpsConfig">GlobalVictorOpsConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWeChatConfig">GlobalWeChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWebexConfig">GlobalWebexConfig</a>)
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1.AlertmanagerGlobalConfig">AlertmanagerGlobalConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalJiraConfig">GlobalJiraConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalRocketChatConfig">GlobalRocketChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalTelegramConfig">GlobalTelegramConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalVictorOpsConfig">GlobalVictorOpsConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWeChatConfig">GlobalWeChatConfig</a>, <a href="#monitoring.coreos.com/v1.GlobalWebexConfig">GlobalWebexConfig</a>, <a href="#monitoring.coreos.com/v1.OAuth2">OAuth2</a>, <a href="#monitoring.coreos.com/v1.RemoteWriteSpec">RemoteWriteSpec</a>)
 </p>
 <div>
 <p>URL represents a valid URL</p>
@@ -22798,7 +23373,8 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -22815,7 +23391,8 @@ Kubernetes meta/v1.LabelSelector
 <p>scrapeConfigNamespaceSelector defines the namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
 namespace only.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -22940,6 +23517,22 @@ configuration (either in the monitoring resources or via scrape class).</p>
 <p>You can also disable sharding on a specific target by setting the
 <code>__tmp_disable_sharding</code> label with relabeling configuration. When
 the label value isn&rsquo;t empty, all Prometheus shards will scrape the target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shardingStrategy</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategy">
+ShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.</p>
+<p>When not defined, the operator defaults to the &lsquo;Address&rsquo; mode which distributes
+targets based on a hash of the target address.</p>
 </td>
 </tr>
 <tr>
@@ -23257,6 +23850,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines on which Nodes the Pods are scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -25408,6 +26013,8 @@ Only valid for Pod, Endpoint and Endpointslice roles.</p>
 <td></td>
 </tr><tr><td><p>&#34;SDK&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;WorkloadIdentity&#34;</p></td>
+<td></td>
 </tr></tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1alpha1.AzureSDConfig">AzureSDConfig
@@ -25682,7 +26289,7 @@ SafeTLSConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>tlsConfig defies the TLS configuration applying to the target HTTP endpoint.</p>
+<p>tlsConfig defines the TLS configuration applying to the target HTTP endpoint.</p>
 </td>
 </tr>
 </tbody>
@@ -25854,8 +26461,22 @@ string
 <td>
 <em>(Optional)</em>
 <p>filter defines the filter expression used to filter the catalog results.
-See <a href="https://www.consul.io/api-docs/catalog#list-services">https://www.consul.io/api-docs/catalog#list-services</a>
+See <a href="https://developer.hashicorp.com/consul/api-docs/catalog#filtering">https://developer.hashicorp.com/consul/api-docs/catalog#filtering</a>
 It requires Prometheus &gt;= 3.0.0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>healthFilter</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>healthFilter defines the filter expression used to filter the health results.
+See <a href="https://developer.hashicorp.com/consul/api-docs/health#filtering">https://developer.hashicorp.com/consul/api-docs/health#filtering</a>
+It requires Prometheus &gt;= 3.11.2.</p>
 </td>
 </tr>
 <tr>
@@ -27354,6 +27975,22 @@ This includes settings for certificates, CA validation, and TLS protocol options
 </tr>
 <tr>
 <td>
+<code>forceImplicitTLS</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
+true: force use of implicit TLS (direct TLS connection on any port)
+false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
+nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+It requires Alertmanager &gt;= v0.31.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>threading</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1alpha1.EmailThreadingConfig">
@@ -27363,7 +28000,8 @@ EmailThreadingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>threading defines the threading configuration for email receiver.</p>
+<p>threading defines the threading configuration for email receiver.
+It requires Alertmanager &gt;= v0.30.0.</p>
 </td>
 </tr>
 </tbody>
@@ -27385,34 +28023,16 @@ EmailThreadingConfig
 <tbody>
 <tr>
 <td>
-<code>enabled</code><br/>
-<code>forceImplicitTLS</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>enabled defines whether to enable threading, which makes alert notifications in the same
-alert group show up in the same email thread.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>threadByDate</code><br/>
 <em>
-string
+<a href="#monitoring.coreos.com/v1alpha1.ThreadByDateType">
+ThreadByDateType
+</a>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>threadByDate defines what granularity of current date to thread by. Accepted values: daily, none.
-(none means group by alert group key, no date).</p>
-<p>forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
-true: force use of implicit TLS (direct TLS connection on any port)
-false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
-nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
-It requires Alertmanager &gt;= v0.31.0.</p>
+<p>threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None.
+(None means group by alert group key, no date).</p>
 </td>
 </tr>
 </tbody>
@@ -29208,8 +29828,7 @@ bool
 </p>
 <div>
 <p>LightSailSDConfig configurations allow retrieving scrape targets from AWS Lightsail instances.
-See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#lightsail_sd_config">https://prometheus.io/docs/prometheus/latest/configuration/configuration/#lightsail_sd_config</a>
-TODO: Need to document that we will not be supporting the <code>_file</code> fields.</p>
+See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#lightsail_sd_config">https://prometheus.io/docs/prometheus/latest/configuration/configuration/#lightsail_sd_config</a></p>
 </div>
 <table>
 <thead>
@@ -31596,7 +32215,8 @@ gzipped Prometheus configuration under the <code>prometheus.yaml.gz</code> key.
 This behavior is <em>deprecated</em> and will be removed in the next major version
 of the custom resource definition. It is recommended to use
 <code>spec.additionalScrapeConfigs</code> instead.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -31613,7 +32233,8 @@ Kubernetes meta/v1.LabelSelector
 <p>scrapeConfigNamespaceSelector defines the namespaces to match for ScrapeConfig discovery. An empty label selector
 matches all namespaces. A null label selector matches the current
 namespace only.</p>
-<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level.</p>
+<p>Note that the ScrapeConfig custom resource definition is currently at Alpha level
+and will be graduated to Beta in a future release.</p>
 </td>
 </tr>
 <tr>
@@ -31738,6 +32359,22 @@ configuration (either in the monitoring resources or via scrape class).</p>
 <p>You can also disable sharding on a specific target by setting the
 <code>__tmp_disable_sharding</code> label with relabeling configuration. When
 the label value isn&rsquo;t empty, all Prometheus shards will scrape the target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shardingStrategy</code><br/>
+<em>
+<a href="#monitoring.coreos.com/v1.ShardingStrategy">
+ShardingStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.</p>
+<p>When not defined, the operator defaults to the &lsquo;Address&rsquo; mode which distributes
+targets based on a hash of the target address.</p>
 </td>
 </tr>
 <tr>
@@ -32055,6 +32692,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>nodeSelector defines on which Nodes the Pods are scheduled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedulerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.</p>
 </td>
 </tr>
 <tr>
@@ -34578,8 +35227,9 @@ HTTPConfig
 </p>
 <div>
 <p>ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services.
-See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config">https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config</a>
-TODO: Need to document that we will not be supporting the <code>_file</code> fields.</p>
+See <a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config">https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config</a></p>
+<p>Note: The <code>_file</code> variants of credential fields (e.g. <code>secret_key_file</code>)
+from the Prometheus configuration are not supported. Use Kubernetes secrets via <code>secretKey</code> instead.</p>
 </div>
 <table>
 <thead>
@@ -36462,6 +37112,26 @@ HTTPConfig
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.coreos.com/v1alpha1.ThreadByDateType">ThreadByDateType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1alpha1.EmailThreadingConfig">EmailThreadingConfig</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Daily&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td></td>
+</tr></tbody>
+</table>
 <h3 id="monitoring.coreos.com/v1alpha1.Time">Time
 (<code>string</code> alias)</h3>
 <p>
@@ -37767,6 +38437,22 @@ This includes settings for certificates, CA validation, and TLS protocol options
 </tr>
 <tr>
 <td>
+<code>forceImplicitTLS</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
+true: force use of implicit TLS (direct TLS connection on any port)
+false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
+nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+It requires Alertmanager &gt;= v0.31.0.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>threading</code><br/>
 <em>
 <a href="#monitoring.coreos.com/v1beta1.EmailThreadingConfig">
@@ -37776,7 +38462,8 @@ EmailThreadingConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>threading defines the threading configuration for email receiver.</p>
+<p>threading defines the threading configuration for email receiver.
+It requires Alertmanager &gt;= v0.30.0.</p>
 </td>
 </tr>
 </tbody>
@@ -37798,34 +38485,16 @@ EmailThreadingConfig
 <tbody>
 <tr>
 <td>
-<code>enabled</code><br/>
-<code>forceImplicitTLS</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>enabled defines whether to enable threading, which makes alert notifications in the same
-alert group show up in the same email thread.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>threadByDate</code><br/>
 <em>
-string
+<a href="#monitoring.coreos.com/v1beta1.ThreadByDateType">
+ThreadByDateType
+</a>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>threadByDate defines what granularity of current date to thread by. Accepted values: daily, none.
-(none means group by alert group key, no date).</p>
-<p>forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
-true: force use of implicit TLS (direct TLS connection on any port)
-false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
-nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
-It requires Alertmanager &gt;= v0.31.0.</p>
+<p>threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None.
+(None means group by alert group key, no date).</p>
 </td>
 </tr>
 </tbody>
@@ -41077,6 +41746,26 @@ HTTPConfig
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="monitoring.coreos.com/v1beta1.ThreadByDateType">ThreadByDateType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#monitoring.coreos.com/v1beta1.EmailThreadingConfig">EmailThreadingConfig</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Daily&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td></td>
+</tr></tbody>
 </table>
 <h3 id="monitoring.coreos.com/v1beta1.Time">Time
 (<code>string</code> alias)</h3>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -67,6 +67,10 @@ spec:
 
                       The Prometheus service account must have the `list` and `watch`
                       permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6757,6 +6757,10 @@ spec:
 
                             The Prometheus service account must have the `list` and `watch`
                             permissions on the `Nodes` objects.
+
+                            Node metadata labels are not automatically added to scraped metrics. They are
+                            exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                            with relabeling configuration.
                           type: boolean
                       type: object
                     authorization:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8505,6 +8505,10 @@ spec:
 
                             The Prometheus service account must have the `list` and `watch`
                             permissions on the `Nodes` objects.
+
+                            Node metadata labels are not automatically added to scraped metrics. They are
+                            exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                            with relabeling configuration.
                           type: boolean
                       type: object
                     authorization:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -68,6 +68,10 @@ spec:
 
                       The Prometheus service account must have the `list` and `watch`
                       permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -67,6 +67,10 @@ spec:
 
                       The Prometheus service account must have the `list` and `watch`
                       permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6757,6 +6757,10 @@ spec:
 
                             The Prometheus service account must have the `list` and `watch`
                             permissions on the `Nodes` objects.
+
+                            Node metadata labels are not automatically added to scraped metrics. They are
+                            exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                            with relabeling configuration.
                           type: boolean
                       type: object
                     authorization:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8505,6 +8505,10 @@ spec:
 
                             The Prometheus service account must have the `list` and `watch`
                             permissions on the `Nodes` objects.
+
+                            Node metadata labels are not automatically added to scraped metrics. They are
+                            exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                            with relabeling configuration.
                           type: boolean
                       type: object
                     authorization:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -68,6 +68,10 @@ spec:
 
                       The Prometheus service account must have the `list` and `watch`
                       permissions on the `Nodes` objects.
+
+                      Node metadata labels are not automatically added to scraped metrics. They are
+                      exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+                      with relabeling configuration.
                     type: boolean
                 type: object
               bodySizeLimit:

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -48,7 +48,7 @@
                     "description": "attachMetadata defines additional metadata which is added to the\ndiscovered targets.\n\nIt requires Prometheus >= v2.35.0.",
                     "properties": {
                       "node": {
-                        "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.",
+                        "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.\n\nNode metadata labels are not automatically added to scraped metrics. They are\nexposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries\nwith relabeling configuration.",
                         "type": "boolean"
                       }
                     },

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5708,7 +5708,7 @@
                           "description": "attachMetadata defines additional metadata to the discovered targets.\nWhen the scrape object defines its own configuration, it takes\nprecedence over the scrape class configuration.",
                           "properties": {
                             "node": {
-                              "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.",
+                              "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.\n\nNode metadata labels are not automatically added to scraped metrics. They are\nexposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries\nwith relabeling configuration.",
                               "type": "boolean"
                             }
                           },

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7237,7 +7237,7 @@
                           "description": "attachMetadata defines additional metadata to the discovered targets.\nWhen the scrape object defines its own configuration, it takes\nprecedence over the scrape class configuration.",
                           "properties": {
                             "node": {
-                              "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.",
+                              "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.\n\nNode metadata labels are not automatically added to scraped metrics. They are\nexposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries\nwith relabeling configuration.",
                               "type": "boolean"
                             }
                           },

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -48,7 +48,7 @@
                     "description": "attachMetadata defines additional metadata which is added to the\ndiscovered targets.\n\nIt requires Prometheus >= v2.37.0.",
                     "properties": {
                       "node": {
-                        "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.",
+                        "description": "node when set to true, Prometheus attaches node metadata to the discovered\ntargets.\n\nThe Prometheus service account must have the `list` and `watch`\npermissions on the `Nodes` objects.\n\nNode metadata labels are not automatically added to scraped metrics. They are\nexposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries\nwith relabeling configuration.",
                         "type": "boolean"
                       }
                     },

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -653,6 +653,10 @@ type AttachMetadata struct {
 	// The Prometheus service account must have the `list` and `watch`
 	// permissions on the `Nodes` objects.
 	//
+	// Node metadata labels are not automatically added to scraped metrics. They are
+	// exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+	// with relabeling configuration.
+	//
 	// +optional
 	Node *bool `json:"node,omitempty"` // nolint:kubeapilinter
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/attachmetadata.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/attachmetadata.go
@@ -24,6 +24,10 @@ type AttachMetadataApplyConfiguration struct {
 	//
 	// The Prometheus service account must have the `list` and `watch`
 	// permissions on the `Nodes` objects.
+	//
+	// Node metadata labels are not automatically added to scraped metrics. They are
+	// exposed as `__meta_kubernetes_node_*` labels and can be copied to timeseries
+	// with relabeling configuration.
 	Node *bool `json:"node,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Adds a user guide explaining how `spec.attachMetadata.node` works in Prometheus Operator, including prerequisites, verification steps, and the relabeling required to copy node discovery labels onto metrics.

## Motivation

Users often enable `attachMetadata.node` expecting node labels to appear on scraped metrics automatically (see #7166). The operator correctly generates `attach_metadata.node: true`, but Prometheus exposes node labels as `__meta_kubernetes_node_label_*` discovery labels until relabeling is configured.

## Test plan

- [x] Documentation renders as Markdown
- [ ] Reviewed against Prometheus `kubernetes_sd_config` behavior and operator-generated config

Fixes #7166