### PR TITLE
chore(api): enable notimestamp KAL linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -35,6 +35,7 @@ linters:
               - "statusoptional"
               - "nophase"
               - "nonullable"
+              - "notimestamp"
               - "forbiddenmarkers"
               - "nomaps"
             disable:


### PR DESCRIPTION
## Summary

Enables the `notimestamp` rule in `.golangci-kal.yml` for monitoring API types.

## Notes

- Existing fields such as `honorTimestamps` and `trackTimestampsStaleness` already carry `// nolint:kubeapilinter` for v1 API compatibility.
- `make check-api` and `make check` pass with 0 KAL issues after enabling the linter.
- This prevents new API fields from using `Timestamp` in names without an explicit exception.

## Test plan

- [x] `make check-api`
- [x] `make check`

Fixes #8127