### PR TITLE
pkg/listwatch: fix goroutine leak and data race in pollBasedListerWatcher

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -251,6 +252,10 @@ type pollBasedListerWatcher struct {
 	ctx context.Context
 	l   *slog.Logger
 
+	mtx        sync.Mutex
+	cancelPoll context.CancelFunc
+	pollWg     sync.WaitGroup
+
 	cache map[string]cacheEntry
 }
 
@@ -319,18 +324,47 @@ func (pblw *pollBasedListerWatcher) Watch(_ metav1.ListOptions) (watch.Interface
 	return pblw, nil
 }
 
-func (pblw *pollBasedListerWatcher) Stop() {}
+func (pblw *pollBasedListerWatcher) Stop() {
+	pblw.mtx.Lock()
+	if pblw.cancelPoll != nil {
+		pblw.cancelPoll()
+		pblw.cancelPoll = nil
+	}
+	pblw.mtx.Unlock()
+	pblw.pollWg.Wait()
+}
 
 func (pblw *pollBasedListerWatcher) ResultChan() <-chan watch.Event {
+	// Cancel any previous polling goroutine to prevent goroutine leaks
+	// when the watch is re-established after a reconnection.
+	pblw.mtx.Lock()
+	if pblw.cancelPoll != nil {
+		pblw.cancelPoll()
+	}
+	pblw.mtx.Unlock()
+	pblw.pollWg.Wait()
+
+	pollCtx, cancel := context.WithCancel(pblw.ctx)
+	pblw.mtx.Lock()
+	pblw.cancelPoll = cancel
+	pblw.mtx.Unlock()
+
+	pblw.pollWg.Add(1)
 	go func() {
+		defer pblw.pollWg.Done()
+
 		jitter, err := rand.Int(rand.Reader, big.NewInt(int64(pollInterval)))
 		if err == nil {
-			time.Sleep(time.Duration(jitter.Int64()))
+			select {
+			case <-time.After(time.Duration(jitter.Int64())):
+			case <-pollCtx.Done():
+				return
+			}
 		} else {
 			pblw.l.Info("failed to generate random jitter", "err", err)
 		}
 
-		_ = wait.PollUntilContextCancel(pblw.ctx, pollInterval, false, pblw.poll)
+		_ = wait.PollUntilContextCancel(pollCtx, pollInterval, false, pblw.poll)
 	}()
 
 	return pblw.ch
@@ -343,6 +377,10 @@ func (pblw *pollBasedListerWatcher) poll(ctx context.Context) (bool, error) {
 	)
 
 	for ns, entry := range pblw.cache {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+
 		var resourceVersion string
 		if entry.ns != nil {
 			// The resource is in the cache.
@@ -370,9 +408,13 @@ func (pblw *pollBasedListerWatcher) poll(ctx context.Context) (bool, error) {
 	for _, ns := range deleted {
 		entry := pblw.cache[ns]
 
-		pblw.ch <- watch.Event{
+		select {
+		case pblw.ch <- watch.Event{
 			Type:   watch.Deleted,
 			Object: entry.ns,
+		}:
+		case <-ctx.Done():
+			return false, ctx.Err()
 		}
 
 		pblw.cache[ns] = cacheEntry{
@@ -393,9 +435,13 @@ func (pblw *pollBasedListerWatcher) poll(ctx context.Context) (bool, error) {
 			continue
 		}
 
-		pblw.ch <- watch.Event{
+		select {
+		case pblw.ch <- watch.Event{
 			Type:   eventType,
 			Object: ns,
+		}:
+		case <-ctx.Done():
+			return false, ctx.Err()
 		}
 
 		pblw.cache[ns.Name] = cacheEntry{

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -349,10 +349,7 @@ func (pblw *pollBasedListerWatcher) ResultChan() <-chan watch.Event {
 	pblw.cancelPoll = cancel
 	pblw.mtx.Unlock()
 
-	pblw.pollWg.Add(1)
-	go func() {
-		defer pblw.pollWg.Done()
-
+	pblw.pollWg.Go(func() {
 		jitter, err := rand.Int(rand.Reader, big.NewInt(int64(pollInterval)))
 		if err == nil {
 			select {
@@ -365,7 +362,7 @@ func (pblw *pollBasedListerWatcher) ResultChan() <-chan watch.Event {
 		}
 
 		_ = wait.PollUntilContextCancel(pollCtx, pollInterval, false, pblw.poll)
-	}()
+	})
 
 	return pblw.ch
 }


### PR DESCRIPTION
#### What this PR does

Fixes three interrelated concurrency bugs in `pollBasedListerWatcher` (`pkg/listwatch/listwatch.go`):

1. **Goroutine leak**: `ResultChan()` spawns a new polling goroutine on every call, but `Stop()` is a no-op. When client-go's reflector re-establishes a watch (e.g. after a network error), it calls `Stop()` then `Watch()` then `ResultChan()`, leaking the previous goroutine. Each reconnection leaks one goroutine.

2. **Data race on cache**: Multiple leaked goroutines from (1) all call `poll()` concurrently, reading and writing the shared `cache` map without synchronization.

3. **Permanently stuck goroutine**: `poll()` sends events to the channel using blocking sends. After `Stop()`, the reflector stops reading from the channel, so the goroutine can block on a channel send permanently.

#### How it is fixed

- Track the polling goroutine with a `context.CancelFunc` and `sync.WaitGroup` so that `ResultChan()` cancels and waits for any previous goroutine before starting a new one.
- Implement `Stop()` to cancel the active goroutine and wait for it to exit, fulfilling the `watch.Interface` contract.
- Use context-aware channel sends (`select` with `ctx.Done`) in `poll()` so the goroutine can be unblocked when `Stop()` is called while the event channel buffer is full.
- Replace `time.Sleep` jitter with a context-aware `select` for prompt exit during the initial jitter delay.
- Add an early `ctx.Err()` check in the poll loop to avoid unnecessary API calls after cancellation.

All 23 existing tests pass with `-race` flag enabled.