### PR TITLE
feat(ci): Add `nodurations` and `noreferences` linters to golangci-kal config

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -23,21 +23,23 @@ linters:
             # Whenever a new linter is added, it should not break the backward
             # compatibility of existing APIs (at least for v1 APIs).
             enable:
-              - "nobools"
               - "commentstart"
               - "conflictingmarkers"
               - "duplicatemarkers"
+              - "forbiddenmarkers"
+              - "nobools"
+              - "nodurations"
               - "nofloats"
-              - "optionalorrequired"
-              - "statussubresource"
-              - "uniquemarkers"
-              - "jsontags"
-              - "statusoptional"
+              - "nomaps"
               - "nophase"
               - "nonullable"
+              - "noreferences"
               - "notimestamp"
-              - "forbiddenmarkers"
-              - "nomaps"
+              - "optionalorrequired"
+              - "jsontags"
+              - "statusoptional"
+              - "statussubresource"
+              - "uniquemarkers"
             disable:
               - "*"
           lintersConfig:


### PR DESCRIPTION
## Description

- Add `nodurations` and `noreferences` linters to the golangci-kal linter configuration                                                                                                                                             
- Reorder the linter list alphabetically for better maintainability and consistency  

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add `nodurations` and `noreferences` linters to golangci-kal config
```
