### PR TITLE
refactor(crd): change RemoteReadConfig url type from `string` to `URL`

### DIFF
--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7051,7 +7051,11 @@ spec:
                           type: string
                       type: object
                     url:
-                      description: url defines the URL of the endpoint to query from.
+                      description: |-
+                        url defines the URL of the endpoint to query from.
+
+                        It must use the HTTP or HTTPS scheme.
+                      pattern: ^(http|https)://.+$
                       type: string
                   required:
                   - url

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7051,7 +7051,11 @@ spec:
                           type: string
                       type: object
                     url:
-                      description: url defines the URL of the endpoint to query from.
+                      description: |-
+                        url defines the URL of the endpoint to query from.
+
+                        It must use the HTTP or HTTPS scheme.
+                      pattern: ^(http|https)://.+$
                       type: string
                   required:
                   - url

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -5966,7 +5966,8 @@
                           "type": "object"
                         },
                         "url": {
-                          "description": "url defines the URL of the endpoint to query from.",
+                          "description": "url defines the URL of the endpoint to query from.\n\nIt must use the HTTP or HTTPS scheme.",
+                          "pattern": "^(http|https)://.+$",
                           "type": "string"
                         }
                       },

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -2069,8 +2069,10 @@ type AzureWorkloadIdentity struct {
 // +k8s:openapi-gen=true
 type RemoteReadSpec struct {
 	// url defines the URL of the endpoint to query from.
+	//
+	// It must use the HTTP or HTTPS scheme.
 	// +required
-	URL string `json:"url"`
+	URL URL `json:"url"`
 
 	// name of the remote read queue, it must be unique if specified. The
 	// name is used in metrics and logging in order to differentiate read

--- a/pkg/client/applyconfiguration/monitoring/v1/remotereadspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/remotereadspec.go
@@ -28,7 +28,9 @@ import (
 // from a remote endpoint.
 type RemoteReadSpecApplyConfiguration struct {
 	// url defines the URL of the endpoint to query from.
-	URL *string `json:"url,omitempty"`
+	//
+	// It must use the HTTP or HTTPS scheme.
+	URL *monitoringv1.URL `json:"url,omitempty"`
 	// name of the remote read queue, it must be unique if specified. The
 	// name is used in metrics and logging in order to differentiate read
 	// configurations.
@@ -94,7 +96,7 @@ func RemoteReadSpec() *RemoteReadSpecApplyConfiguration {
 // WithURL sets the URL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the URL field is set to the value of the last call.
-func (b *RemoteReadSpecApplyConfiguration) WithURL(value string) *RemoteReadSpecApplyConfiguration {
+func (b *RemoteReadSpecApplyConfiguration) WithURL(value monitoringv1.URL) *RemoteReadSpecApplyConfiguration {
 	b.URL = &value
 	return b
 }


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Change the url field in the RemoteReadConfig struct from `string` to `URL` type

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
change RemoteReadConfig url type from `string` to `URL`
```
