### PR TITLE
Fix: validate ProxyConfig in OAuth2 validation

### DIFF
--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -729,6 +729,10 @@ func (o *OAuth2) Validate() error {
 		return fmt.Errorf("invalid OAuth2 tlsConfig: %w", err)
 	}
 
+	if err := o.ProxyConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid OAuth2 proxyConfig: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/apis/monitoring/v1/types_test.go
+++ b/pkg/apis/monitoring/v1/types_test.go
@@ -505,6 +505,55 @@ func TestValidateOAuth2(t *testing.T) {
 			},
 			err: false,
 		},
+		{
+			name: "valid ProxyConfig with proxyUrl",
+			config: &OAuth2{
+				ClientID:     SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
+				ClientSecret: v1.SecretKeySelector{},
+				TokenURL:     "http://tokenurl.org",
+				ProxyConfig: ProxyConfig{
+					ProxyURL: new("http://proxy.example.com:8080"),
+				},
+			},
+			err: false,
+		},
+		{
+			name: "valid ProxyConfig with proxyFromEnvironment",
+			config: &OAuth2{
+				ClientID:     SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
+				ClientSecret: v1.SecretKeySelector{},
+				TokenURL:     "http://tokenurl.org",
+				ProxyConfig: ProxyConfig{
+					ProxyFromEnvironment: new(true),
+				},
+			},
+			err: false,
+		},
+		{
+			name: "invalid ProxyConfig with proxyFromEnvironment and proxyUrl",
+			config: &OAuth2{
+				ClientID:     SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
+				ClientSecret: v1.SecretKeySelector{},
+				TokenURL:     "http://tokenurl.org",
+				ProxyConfig: ProxyConfig{
+					ProxyFromEnvironment: new(true),
+					ProxyURL:             new("http://proxy.example.com:8080"),
+				},
+			},
+			err: true,
+		},
+		{
+			name: "invalid ProxyConfig with noProxy but no proxyUrl",
+			config: &OAuth2{
+				ClientID:     SecretOrConfigMap{Secret: &v1.SecretKeySelector{}},
+				ClientSecret: v1.SecretKeySelector{},
+				TokenURL:     "http://tokenurl.org",
+				ProxyConfig: ProxyConfig{
+					NoProxy: new("localhost"),
+				},
+			},
+			err: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.config.Validate()


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

ref: https://github.com/prometheus-operator/prometheus-operator/pull/8565

 `OAuth2` embeds `ProxyConfig` inline, but `OAuth2.Validate()` never calls `ProxyConfig.Validate()`. This means invalid proxy configurations (e.g. `proxyFromEnvironment` set together with `proxyUrl`, or `noProxy` without `proxyUrl`) pass validation silently and only surface as runtime errors when Prometheus tries to use them.                                                                                                                             
                                                                                                                                                          
  This PR wires the existing `ProxyConfig.Validate()` into `OAuth2.Validate()` so that misconfigurations are caught early at the API validation layer. 

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Validate ProxyConfig fields when validating OAuth2 configuration in monitoring CRDs
```
