### PR TITLE
chore: switch sharding features to beta

### DIFF
--- a/Documentation/platform/operator.md
+++ b/Documentation/platform/operator.md
@@ -70,8 +70,8 @@ Arguments:
     	Feature gates are a set of key=value pairs that describe Prometheus-Operator features.
     	Available feature gates:
     	  PrometheusAgentDaemonSet: Enables the DaemonSet mode for PrometheusAgent (enabled: false)
-    	  PrometheusShardRetentionPolicy: Enables shard retention policy for Prometheus (enabled: false)
-    	  PrometheusTopologySharding: Enables the zone aware sharding for Prometheus (enabled: false)
+    	  PrometheusShardRetentionPolicy: Enables shard retention policy for Prometheus (enabled: true)
+    	  PrometheusTopologySharding: Enables the zone aware sharding for Prometheus (enabled: true)
     	  RemoteWriteCustomResourceDefinition: Enables the RemoteWrite CRD support (enabled: false)
     	  StatusForConfigurationResources: Updates the status subresource for configuration resources (enabled: false)
   -key-file string
@@ -101,13 +101,15 @@ Arguments:
   -namespaces value
     	Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with --deny-namespaces.
   -prometheus-config-reloader string
-    	Prometheus config reloader image (default "quay.io/prometheus-operator/prometheus-config-reloader:v0.89.0")
+    	Prometheus config reloader image (default "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0")
   -prometheus-default-base-image string
     	Prometheus default base image (path without tag/version) (default "quay.io/prometheus/prometheus")
   -prometheus-instance-namespaces value
     	Namespaces where Prometheus and PrometheusAgent custom resources and corresponding Secrets, Configmaps and StatefulSets are watched/created. If set this takes precedence over --namespaces or --deny-namespaces for Prometheus custom resources.
   -prometheus-instance-selector value
     	Label selector to filter Prometheus and PrometheusAgent Custom Resources to watch.
+  -repair-policy-for-statefulsets value
+    	Policy to use when a StatefulSet rollout is stuck. Possible values: 'none' (default), 'evict' or 'delete'. (default none)
   -secret-field-selector value
     	Field selector to filter Secrets to watch
   -secret-label-selector value

--- a/Documentation/platform/sharding.md
+++ b/Documentation/platform/sharding.md
@@ -80,7 +80,7 @@ spec:
 
 ### Topology-aware sharding
 
-> **Alpha:** Topology-aware sharding requires the `PrometheusTopologySharding` feature gate to be enabled on the operator.
+> **Beta:** Topology-aware sharding requires the `PrometheusTopologySharding` feature gate to be enabled on the operator.
 
 In multi-zone clusters, the default address-based sharding distributes targets without regard for their zone, which can generate costly cross-zone traffic. Topology-aware sharding pins each Prometheus shard to a specific zone so that it only scrapes targets local to that zone.
 
@@ -111,7 +111,7 @@ With this configuration and 4 shards across 2 zones, shards 0 and 2 are schedule
 
 ### Retaining shards
 
-> **Alpha:** Shard retention requires the `PrometheusShardRetentionPolicy` feature gate to be enabled on the operator.
+> **Beta:** Shard retention requires the `PrometheusShardRetentionPolicy` feature gate to be enabled on the operator.
 
 When scaling down the number of shards, the pods from the removed shards are deleted by default along with access to their historical data. To preserve scaled-down shards so their data remains queryable until the retention duration expires, set `.spec.shardRetentionPolicy.whenScaled` to `Retain`:
 

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -9520,7 +9520,8 @@ spec:
               shardRetentionPolicy:
                 description: |-
                   shardRetentionPolicy defines the retention policy for the Prometheus shards.
-                  (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
+
+                  (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
                 properties:
                   retain:
                     description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -9520,7 +9520,8 @@ spec:
               shardRetentionPolicy:
                 description: |-
                   shardRetentionPolicy defines the retention policy for the Prometheus shards.
-                  (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
+
+                  (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
                 properties:
                   retain:
                     description: |-

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -8018,7 +8018,7 @@
                     "type": "string"
                   },
                   "shardRetentionPolicy": {
-                    "description": "shardRetentionPolicy defines the retention policy for the Prometheus shards.\n(Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.",
+                    "description": "shardRetentionPolicy defines the retention policy for the Prometheus shards.\n\n(Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).",
                     "properties": {
                       "retain": {
                         "description": "retain defines the config for retention when the retention policy is set\nto `Retain`.\n\nIf not defined, the operator will use the retention duration configured\nfor the Prometheus data. If the resource uses size-based retention, the\nshard(s) are kept forever (unless manually deleted).",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1215,7 +1215,8 @@ type PrometheusSpec struct {
 	RetentionSize ByteSize `json:"retentionSize,omitempty"`
 
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
-	// (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
+	//
+	// (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
 	//
 	// +optional
 	ShardRetentionPolicy *ShardRetentionPolicy `json:"shardRetentionPolicy,omitempty"`
@@ -1392,7 +1393,8 @@ const (
 
 	// TopologyShardingStrategyMode enables zone-aware sharding.
 	// Each shard is assigned to a specific topology zone and only scrapes targets in that zone.
-	// (Alpha) Using this mode requires the `PrometheusTopologySharding` feature gate to be enabled.
+	//
+	// (Beta) Using this mode requires the `PrometheusTopologySharding` feature gate (enabled by default).
 	TopologyShardingStrategyMode ShardingStrategyMode = "Topology"
 )
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -43,7 +43,8 @@ type PrometheusSpecApplyConfiguration struct {
 	// retentionSize defines the maximum number of bytes used by the Prometheus data.
 	RetentionSize *monitoringv1.ByteSize `json:"retentionSize,omitempty"`
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
-	// (Alpha) Using this field requires the 'PrometheusShardRetentionPolicy' feature gate to be enabled.
+	//
+	// (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
 	ShardRetentionPolicy *ShardRetentionPolicyApplyConfiguration `json:"shardRetentionPolicy,omitempty"`
 	// disableCompaction when true, the Prometheus compaction is disabled.
 	// When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -104,11 +104,11 @@ func DefaultConfig(cpu, memory string) Config {
 			},
 			PrometheusTopologyShardingFeature: FeatureGate{
 				description: "Enables the zone aware sharding for Prometheus",
-				enabled:     false,
+				enabled:     true,
 			},
 			PrometheusShardRetentionPolicyFeature: FeatureGate{
 				description: "Enables shard retention policy for Prometheus",
-				enabled:     false,
+				enabled:     true,
 			},
 			StatusForConfigurationResourcesFeature: FeatureGate{
 				description: "Updates the status subresource for configuration resources",

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -6127,7 +6127,7 @@ func testPrometheusShardingStrategyCELValidations(t *testing.T) {
 				p.Spec.ShardingStrategy = &monitoringv1.ShardingStrategy{
 					Mode: ptr.To(monitoringv1.TopologyShardingStrategyMode),
 					Topology: &monitoringv1.TopologyShardingStrategy{
-						Values: []string{"zone1", "zone2"},
+						Values: []string{"zone-a", "zone-b"},
 					},
 				}
 			},
@@ -6140,7 +6140,7 @@ func testPrometheusShardingStrategyCELValidations(t *testing.T) {
 				p.Spec.ShardingStrategy = &monitoringv1.ShardingStrategy{
 					Mode: ptr.To(monitoringv1.TopologyShardingStrategyMode),
 					Topology: &monitoringv1.TopologyShardingStrategy{
-						Values: []string{"zone1", "zone2", "zone3"},
+						Values: []string{"zone-a", "zone-b", "zone-c"},
 					},
 				}
 			},
@@ -6153,7 +6153,7 @@ func testPrometheusShardingStrategyCELValidations(t *testing.T) {
 				p.Spec.ShardingStrategy = &monitoringv1.ShardingStrategy{
 					Mode: ptr.To(monitoringv1.TopologyShardingStrategyMode),
 					Topology: &monitoringv1.TopologyShardingStrategy{
-						Values: []string{"zone1", "zone2"},
+						Values: []string{"zone-a", "zone-b"},
 					},
 				}
 			},


### PR DESCRIPTION
## Description

This commit enables the following feature gates to beta, meaning that they are now enabled by default (it's still possible to disable them if needed):
* `PrometheusTopologySharding`
* `PrometheusShardRetentionPolicy`

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
