### PR TITLE
docs: add a kubernetes_sd example to the ScrapeConfig guide

### DIFF
--- a/Documentation/developer/scrapeconfig.md
+++ b/Documentation/developer/scrapeconfig.md
@@ -86,6 +86,28 @@ For the full list of supported fields and service discoveries, check the [API do
 If you have an interest in another service discovery mechanism or you see something missing in the implementation, please
 [open an issue](https://github.com/prometheus-operator/prometheus-operator/issues).
 
+## `kubernetes_sd`
+
+`kubernetes_sd` discovers scrape targets from the Kubernetes API. The `role` field selects what kind of object to discover; valid values are `Node`, `Pod`, `Service`, `Endpoints`, `EndpointSlice` and `Ingress`. Note that the value is capitalized.
+
+When Prometheus runs inside the cluster, which is the usual case with prometheus-operator, the API server address and credentials are discovered automatically, so a minimal configuration only needs a `role`. For example, to discover the cluster nodes:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kubernetes-sd
+  namespace: my-namespace
+  labels:
+    prometheus: system-monitoring-prometheus
+    app.kubernetes.io/name: scrape-config-example
+spec:
+  kubernetesSDConfigs:
+    - role: Node
+```
+
+`role` is the only required field. Use `namespaces.names` to restrict discovery to specific namespaces and `selectors` to filter the discovered objects. As with a Prometheus `kubernetes_sd_config`, discovered targets normally need `relabelings` to derive the scrape address and target labels from the discovery metadata. See the [API documentation](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.KubernetesSDConfig) for the full list of fields.
+
 ## `static_config`
 
 For example, to scrape the target located at `http://prometheus.demo.do.prometheus.io:9090`, use the following:


### PR DESCRIPTION
## Description

Adds a `kubernetes_sd` example section to the ScrapeConfig developer guide (`Documentation/developer/scrapeconfig.md`).

The guide lists **Kubernetes Service Discovery first** among the Tier-1 fully-supported mechanisms and already has worked examples for `static_config`, `file_sd` and `http_sd`, but it had no `kubernetes_sd` example. As the issue and several follow-up comments show, users get tripped up by the field shape and by the capitalized `role` enum (`Node`, not `node`).

The new section adds:
- a minimal node-discovery `ScrapeConfig`,
- a note that `role` is required and capitalized, with the valid values,
- a note that in-cluster Prometheus discovers the API server and credentials automatically,
- pointers to `namespaces`, `selectors` and `relabelings`, and a link to the API reference.

Field names and the `role` enum were verified against `pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go`.

`make docs` / `make check-docs` (mdox) pass.

Closes #6517
