### PR TITLE
docs: fix broken link to BasicAuth API reference

### DIFF
--- a/Documentation/user-guides/basic-auth.md
+++ b/Documentation/user-guides/basic-auth.md
@@ -5,7 +5,7 @@
 
 ## Basic auth for targets
 
-To authenticate a `ServiceMonitor`s over a metrics endpoint use [`basicAuth`](../api.md#monitoring.coreos.com/v1.BasicAuth)
+To authenticate a `ServiceMonitor`s over a metrics endpoint use [`basicAuth`](../api-reference/api.md#monitoring.coreos.com/v1.BasicAuth)
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
## Description

While reading the basic auth user guide I clicked the `basicAuth` link to the
API reference and hit a 404. The guide links to `../api.md`, but the generated
API reference lives at `Documentation/api-reference/api.md`. Other docs that
reference the API already use the `api-reference/api.md` path (for example
`Documentation/additional-scrape-config.md`), so this single link was just left
pointing at the old location.

This corrects the relative path so the link resolves again — no other change.

For what it's worth, the reason it slipped past the link checker is that
`.mdox.validate.yaml` ignores the `api.md#...BasicAuth` anchor, so mdox never
validated the file portion of that path.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- `Documentation/api.md` does not exist; `Documentation/api-reference/api.md` does.
- From `Documentation/user-guides/`, `../api-reference/api.md` resolves to the API reference file.
- The `#monitoring.coreos.com/v1.BasicAuth` anchor is present in `Documentation/api-reference/api.md`.

## Changelog entry

```release-note

```
