### PR TITLE
docs: fix duplicated word in troubleshooting guide

### DIFF
--- a/Documentation/platform/troubleshooting.md
+++ b/Documentation/platform/troubleshooting.md
@@ -286,12 +286,12 @@ If the `--controller-id` flag is not set, the operator will try to reconcile all
 
 The following table illustrates the behavior based on whether the `--controller-id` flag is set and whether the `operator.prometheus.io/controller-id` annotation is present on the resources:
 
-| Operator started with with the `--controller-id` flag | Resource with the `operator.prometheus.io/controller-id` annotation | Behavior                                                                            |
-|-------------------------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| Yes                                                   | Yes                                                                 | The operator reconciles the resource only if the annotation value matches the flag. |
-| Yes                                                   | No                                                                  | The operator does not reconcile the resource                                        |
-| No                                                    | Yes                                                                 | The operator does not reconcile the resource.                                       |
-| No                                                    | No                                                                  | The operator reconciles the resource.                                               |
+| Operator started with the `--controller-id` flag | Resource with the `operator.prometheus.io/controller-id` annotation | Behavior                                                                            |
+|--------------------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| Yes                                              | Yes                                                                 | The operator reconciles the resource only if the annotation value matches the flag. |
+| Yes                                              | No                                                                  | The operator does not reconcile the resource                                        |
+| No                                               | Yes                                                                 | The operator does not reconcile the resource.                                       |
+| No                                               | No                                                                  | The operator reconciles the resource.                                               |
 
 ### Configuring Prometheus/PrometheusAgent for Mimir and Grafana Cloud
 


### PR DESCRIPTION
## Description

Small typo fix in the troubleshooting guide. The `--controller-id` behavior
table header reads "Operator started with with the `--controller-id` flag" —
"with" is repeated. The surrounding paragraphs already use "started with the
`--controller-id` flag", so this just drops the duplicated word to match.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- The duplicated "with with" appears once in `Documentation/platform/troubleshooting.md` (the table header on the `--controller-id` section).
- The corrected phrasing matches the surrounding prose in the same section.

## Changelog entry

```release-note

```
