### PR TITLE
Fix(docs): fix misspelling in rules_test.go comment  

### DIFF
--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -369,7 +369,7 @@ func testPrometheusRuleWithParserOptions(t *testing.T) {
 	defer testCtx.Cleanup(t)
 	ns := framework.CreateNamespace(context.Background(), t, testCtx)
 
-	// Skip the admission webhook because the test exercices PromQL features
+	// Skip the admission webhook because the test exercises PromQL features
 	// which aren't enabled by default.
 	ruleNamespaceSelector := map[string]string{"excludeFromWebhook": "true"}
 	err := framework.AddLabelsToNamespace(context.Background(), ns, ruleNamespaceSelector)


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

Fix misspelling of "exercises" in a comment within `testPrometheusRuleWithParserOptions`    

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
None
```
