### PR TITLE
Fix Issue8641: Fix incorrect retention configuration generation for Prometheus v3 < v3.11.0

### DIFF
--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1129,7 +1129,7 @@ func (cg *ConfigGenerator) appendStorageSettingsConfig(
 		}
 	}
 
-	if cg.WithMinimumVersion("3.11.0").IsCompatible() {
+	if cg.Version().GTE(semver.MustParse("3.11.0")) {
 		var retentionSlice yaml.MapSlice
 		retentionTime := string(RetentionTimeOrDefault(retention, retentionSize))
 		if retentionTime != "" {

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -6151,6 +6151,13 @@ func TestRetentionConfigFile(t *testing.T) {
 			retentionSize: "512MB",
 			golden:        "RetentionConfigFile_v3.10.0.golden",
 		},
+		{
+			name:          "retention is not in the configuration file for Prometheus v3.5.4",
+			version:       "v3.5.4",
+			retention:     "2d",
+			retentionSize: "512MB",
+			golden:        "RetentionConfigFile_v3.10.0.golden",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := defaultPrometheus()


### PR DESCRIPTION
## Description

The Prometheus Operator was incorrectly assuming that all Prometheus v3 versions support the new `storage.tsdb.retention` YAML field introduced in v3.11.0.

Because the operator's default Prometheus version is now set to `v3.11.3`, the internal compatibility check `cg.WithMinimumVersion("3.11.0").IsCompatible() `  would return `true` for any Prometheus v3 instance where a specific version was not explicitly provided (or if a version like `v3.5.4` was used but the major version check took precedence). This resulted in Prometheus v3.5.x instances crashing with the error: `field retention not found in type config.plain.`

This PR changes the logic to use an explicit SemVer comparison, ensuring the new YAML structure is only generated for Prometheus versions that actually support it (>= v3.11.0).

https://prometheus.io/docs/introduction/release-cycle/

Closes: #8641 

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
I have added a new test case to `pkg/prometheus/promcfg_test.go` within `TestRetentionConfigFile` that specifically targets Prometheus `v3.5.4`. The test verifies that for this version, the `retention` field is correctly omitted from the generated configuration, matching the behavior of versions < v3.11.0.

Test command and log:

```
go test -v ./pkg/prometheus -run TestRetentionConfigFile

=== RUN   TestRetentionConfigFile
=== RUN   TestRetentionConfigFile/retention_is_not_in_the_configuration_file_for_Prometheus_v3.5.4
--- PASS: TestRetentionConfigFile (0.04s)
    --- PASS: TestRetentionConfigFile/retention_is_not_in_the_configuration_file_for_Prometheus_v3.5.4 (0.00s)
PASS
```

## Changelog entry

```release-note
Fix incorrect generation of storage.tsdb.retention YAML field for Prometheus v3 versions older than v3.11.0.
```
