### PR TITLE
fix: load Consul SD OAuth2 credentials into asset store

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -797,6 +797,10 @@ func (rs *ResourceSelector) validateConsulSDConfigs(ctx context.Context, sc *mon
 			return fmt.Errorf("[%d]: %w", i, err)
 		}
 
+		if err := rs.store.AddOAuth2(ctx, sc.GetNamespace(), config.OAuth2); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
+		}
+
 		if err := rs.store.AddSafeTLSConfig(ctx, sc.GetNamespace(), config.TLSConfig); err != nil {
 			return fmt.Errorf("[%d]: %w", i, err)
 		}

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -2461,6 +2461,62 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			promVersion: "3.11.1",
 		},
 		{
+			scenario: "Consul SD config with valid OAuth2",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{
+					{
+						Server: "example.com",
+						OAuth2: &monitoringv1.OAuth2{
+							ClientID: monitoringv1.SecretOrConfigMap{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "configmap",
+									},
+									Key: "key1",
+								},
+							},
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret",
+								},
+								Key: "key1",
+							},
+							TokenURL: "http://example.com/token",
+						},
+					},
+				}
+			},
+			valid: true,
+		},
+		{
+			scenario: "Consul SD config with OAuth2 referencing a non-existent secret",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{
+					{
+						Server: "example.com",
+						OAuth2: &monitoringv1.OAuth2{
+							ClientID: monitoringv1.SecretOrConfigMap{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "configmap",
+									},
+									Key: "key1",
+								},
+							},
+							ClientSecret: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "wrong",
+								},
+								Key: "key1",
+							},
+							TokenURL: "http://example.com/token",
+						},
+					},
+				}
+			},
+			valid: false,
+		},
+		{
 			scenario: "Consul SD proxy config with invalid secret key",
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.ConsulSDConfigs = []monitoringv1alpha1.ConsulSDConfig{


### PR DESCRIPTION
## Description

So the Consul service discovery had a problem when you used OAuth2 to talk to the Consul API. The config looked fine, the operator accepted it without complaining, but the OAuth2 part just quietly disappeared from the generated Prometheus config.

I traced it down and the issue is in validateConsulSDConfigs. Every other SD type loads its OAuth2 secret into the asset store during validation, but Consul was missing that one call. It loaded basic auth, authorization, TLS and the token ref, just not OAuth2. So when the config got generated later, the store lookup for the client id/secret failed, and addOAuth2ToYaml just logged an error and returned the config without the oauth2 block. Nothing crashed, nothing got rejected.

The bad part is how silent it is. Prometheus ends up hitting the Consul API with no auth, Consul says 401 or 403, and all the targets behind that config basically vanish. You don't really notice until you go looking for metrics that aren't there. Same kind of bug was already fixed for Ionos earlier, Consul just got left out.

The fix is small, I just added the rs.store.AddOAuth2(...) call in the Consul validation loop like the rest of them have. Now the secret actually gets loaded so the oauth2 block renders properly, and if someone points at a secret that doesn't exist it gets rejected loudly instead of silently dropping the auth.

I also added a couple of test cases in TestSelectScrapeConfigs, one for a valid OAuth2 ref and one pointing at a missing secret. I checked it actually catches the bug too, when I pulled the fix out the missing secret case failed because the broken config was still treated as valid.


## Type of change

- [x] `BUGFIX` (non-breaking change which fixes an issue)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
 Load OAuth2 credentials into the asset store for Consul service discovery so the generated scrape configuration includes the OAuth2 settings.
```
