### PR TITLE
fix(prometheus): validate web TLS secret keys during reconciliation

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -639,7 +639,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to reconcile the TLS secrets: %w", err)
 	}
 
-	if err := c.createOrUpdateWebConfigSecret(ctx, am); err != nil {
+	if err := c.createOrUpdateWebConfigSecret(ctx, am, assetStore); err != nil {
 		return fmt.Errorf("failed to synchronize the web config secret: %w", err)
 	}
 
@@ -1872,10 +1872,14 @@ func (c *Operator) newTLSAssetSecret(am *monitoringv1.Alertmanager) *corev1.Secr
 	return s
 }
 
-func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, a *monitoringv1.Alertmanager) error {
+func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, a *monitoringv1.Alertmanager, assetStore *assets.StoreBuilder) error {
 	var fields monitoringv1.WebConfigFileFields
 	if a.Spec.Web != nil {
 		fields = a.Spec.Web.WebConfigFileFields
+	}
+
+	if err := webconfig.ValidateTLSAssets(ctx, a.Namespace, assetStore, fields.TLSConfig); err != nil {
+		return fmt.Errorf("invalid web TLS configuration: %w", err)
 	}
 
 	webConfig, err := webconfig.New(

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -993,7 +993,7 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 		return closure, fmt.Errorf("failed to reconcile the TLS secrets: %w", err)
 	}
 
-	if err := c.createOrUpdateWebConfigSecret(ctx, p); err != nil {
+	if err := c.createOrUpdateWebConfigSecret(ctx, p, assetStore); err != nil {
 		return closure, fmt.Errorf("synchronizing web config secret failed: %w", err)
 	}
 
@@ -1647,10 +1647,14 @@ func (c *Operator) createOrUpdateConfigurationSecret(ctx context.Context, logger
 	return k8s.CreateOrUpdateSecret(ctx, sClient, s)
 }
 
-func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitoringv1.Prometheus) error {
+func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitoringv1.Prometheus, assetStore *assets.StoreBuilder) error {
 	var fields monitoringv1.WebConfigFileFields
 	if p.Spec.Web != nil {
 		fields = p.Spec.Web.WebConfigFileFields
+	}
+
+	if err := webconfig.ValidateTLSAssets(ctx, p.Namespace, assetStore, fields.TLSConfig); err != nil {
+		return fmt.Errorf("invalid web TLS configuration: %w", err)
 	}
 
 	webConfig, err := webconfig.New(

--- a/pkg/webconfig/validate.go
+++ b/pkg/webconfig/validate.go
@@ -1,0 +1,57 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webconfig
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+)
+
+// ValidateTLSAssets verifies that web TLS secret and configmap references exist
+// and contain the configured keys before mounting them into the workload.
+func ValidateTLSAssets(ctx context.Context, namespace string, store *assets.StoreBuilder, tls *monitoringv1.WebTLSConfig) error {
+	if tls == nil {
+		return nil
+	}
+
+	if err := tls.Validate(); err != nil {
+		return err
+	}
+
+	if tls.KeySecret != (corev1.SecretKeySelector{}) {
+		if _, err := store.GetSecretKey(ctx, namespace, tls.KeySecret); err != nil {
+			return fmt.Errorf("invalid TLS key secret: %w", err)
+		}
+	}
+
+	if tls.Cert != (monitoringv1.SecretOrConfigMap{}) {
+		if _, err := store.GetKey(ctx, namespace, tls.Cert); err != nil {
+			return fmt.Errorf("invalid TLS certificate reference: %w", err)
+		}
+	}
+
+	if tls.ClientCA != (monitoringv1.SecretOrConfigMap{}) {
+		if _, err := store.GetKey(ctx, namespace, tls.ClientCA); err != nil {
+			return fmt.Errorf("invalid TLS client CA reference: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/webconfig/validate_test.go
+++ b/pkg/webconfig/validate_test.go
@@ -1,0 +1,170 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webconfig_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+	"github.com/prometheus-operator/prometheus-operator/pkg/webconfig"
+)
+
+func TestValidateTLSAssets(t *testing.T) {
+	const namespace = "ns1"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tls-secret",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert-data"),
+			"tls.key": []byte("key-data"),
+			"ca.crt":  []byte("ca-data"),
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tls-configmap",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"tls.crt": "cert-data",
+			"ca.crt":  "ca-data",
+		},
+	}
+
+	validKeySecret := corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+		Key:                  "tls.key",
+	}
+	validCertSecret := monitoringv1.SecretOrConfigMap{
+		Secret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+			Key:                  "tls.crt",
+		},
+	}
+	validCertConfigMap := monitoringv1.SecretOrConfigMap{
+		ConfigMap: &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "tls-configmap"},
+			Key:                  "tls.crt",
+		},
+	}
+	validClientCA := monitoringv1.SecretOrConfigMap{
+		Secret: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+			Key:                  "ca.crt",
+		},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		tls     *monitoringv1.WebTLSConfig
+		wantErr bool
+	}{
+		{
+			name: "nil tls config",
+			tls:  nil,
+		},
+		{
+			name: "valid secret references",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: validKeySecret,
+				Cert:      validCertSecret,
+				ClientCA:  validClientCA,
+			},
+		},
+		{
+			name: "valid cert from configmap",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: validKeySecret,
+				Cert:      validCertConfigMap,
+			},
+		},
+		{
+			name: "missing key in secret",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+					Key:                  "missing.key",
+				},
+				Cert: validCertSecret,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing secret",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "missing-secret"},
+					Key:                  "tls.key",
+				},
+				Cert: validCertSecret,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing cert key",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: validKeySecret,
+				Cert: monitoringv1.SecretOrConfigMap{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+						Key:                  "missing.crt",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing client CA key",
+			tls: &monitoringv1.WebTLSConfig{
+				KeySecret: validKeySecret,
+				Cert:      validCertSecret,
+				ClientCA: monitoringv1.SecretOrConfigMap{
+					Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "tls-secret"},
+						Key:                  "missing-ca.crt",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing cert and key definition",
+			tls:  &monitoringv1.WebTLSConfig{},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(secret, configMap)
+			store := assets.NewStoreBuilder(client.CoreV1(), client.CoreV1())
+
+			err := webconfig.ValidateTLSAssets(context.Background(), namespace, store, tc.tls)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/webconfig/validate_test.go
+++ b/pkg/webconfig/validate_test.go
@@ -150,8 +150,8 @@ func TestValidateTLSAssets(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing cert and key definition",
-			tls:  &monitoringv1.WebTLSConfig{},
+			name:    "missing cert and key definition",
+			tls:     &monitoringv1.WebTLSConfig{},
 			wantErr: true,
 		},
 	} {


### PR DESCRIPTION
## Summary

Fixes #4940.

Validates `spec.web.tlsConfig` secret and configmap key references during reconciliation so invalid key names fail the Prometheus operator early instead of crashlooping the pod.

## Testing

- `go test ./pkg/webconfig/...`