### PR TITLE
docs: add AGENTS.md and release-prep agent skill

### DIFF
--- a/.agents/skills/release-prep/SKILL.md
+++ b/.agents/skills/release-prep/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: release-prep
+description: >-
+  Prepare a Prometheus Operator release PR. Use when bumping versions,
+  updating dependencies, updating CHANGELOG, or when the user mentions
+  release preparation or cutting a release.
+---
+
+# Prometheus Operator Release Preparation
+
+The project follows a **6-week release cycle**. See [RELEASE.md](../../../RELEASE.md)
+for the full schedule, shepherd assignments and post-PR steps (tagging,
+publishing, etc.).
+
+> **Scope:** This skill covers minor releases only. Patch releases follow
+> a different process and are not covered here — refer to RELEASE.md.
+
+## Important
+
+- **NEVER commit, push or create PRs without explicit human approval.**
+- **NEVER push directly to `main`, `release-*`, or any protected branch.**
+  Always work on a feature branch and open a PR.
+- **STOP at every review gate below and wait for the user to confirm
+  before proceeding.**
+- Each phase depends on the previous one being merged. Do not start
+  the next phase until the user confirms the prior PR has been merged.
+
+## Commit and PR title conventions
+
+PR titles should describe what was updated:
+
+- Dependency bump: `chore: bump go dependencies before vX.Y.Z`
+- Operand update: `chore: update default Alertmanager version to vA.B.C`
+- Release cut: `chore: cut vX.Y.Z`
+
+## Setup
+
+Before starting, fetch the latest from upstream and create a working branch:
+
+Run `git remote -v` to identify the remote pointing to
+`prometheus-operator/prometheus-operator`. It is typically `upstream`
+(fork workflow) or `origin` (direct clone). Use that remote name in the
+commands below:
+
+```bash
+git fetch <remote>
+git checkout -b deps-vX.Y.Z <remote>/main
+```
+
+---
+
+## Phase 1: Dependency bump PR
+
+Update Go dependencies across all three modules:
+
+```bash
+make update-go-deps
+make tidy
+```
+
+This modifies `go.mod` and `go.sum` in the root, `pkg/apis/monitoring/`
+and `pkg/client/` directories.
+
+### Review gate 1
+
+**STOP.** Show the user the changed files and wait for approval before
+committing. Commit message and PR title:
+`chore: bump go dependencies before vX.Y.Z`. Sign off with `git commit -s`.
+
+Once the user approves, ask:
+> Would you like me to create the PR using `gh pr create`, or will you
+> create it manually?
+
+If using `gh`, first verify it is authenticated by running
+`gh auth status > /dev/null 2>&1` and checking the exit code. If it
+fails, ask the user to run `gh auth login` before proceeding. Push the
+branch, then show the full `gh pr create` command and wait for approval
+before executing it.
+
+**Wait for the PR to be reviewed and merged before proceeding to Phase 2.**
+
+---
+
+## Phase 2: Release cut PR
+
+**Prerequisite:** Phase 1 PR must be merged. Fetch latest and create a
+new branch (use the same remote identified during Setup):
+
+```bash
+git fetch <remote>
+git checkout -b cut-vX.Y.Z <remote>/main
+```
+
+1. **Update operand versions** — bump default Prometheus, Alertmanager and
+   Thanos versions in `pkg/operator/defaults.go` if newer versions exist.
+
+### Review gate 2
+
+**STOP.** Show the user the version changes and confirm they are correct
+before continuing.
+
+1. **Bump VERSION** — edit the `VERSION` file in the repo root.
+
+1. **Regenerate files** — this updates CRDs, bundle, jsonnet, docs and
+   example manifests (expect ~50 files to change):
+
+   ```bash
+   make clean generate
+   ```
+
+1. **Bump submodule versions in go.mod**:
+
+   ```bash
+   go mod edit -require "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring@v$(< VERSION)" pkg/client/go.mod
+   go mod edit -require "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring@v$(< VERSION)"
+   go mod edit -require "github.com/prometheus-operator/prometheus-operator/pkg/client@v$(< VERSION)"
+   ```
+
+1. **Regenerate and verify** — ensure everything is consistent after
+   the version bumps:
+
+   ```bash
+   make --always-make format generate && git diff --exit-code
+   ```
+
+1. **Update CHANGELOG.md** — add a new version header and entries in this
+   order: `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. Only
+   include user-facing changes. Each entry must include the PR number:
+
+   ```text
+   ## vX.Y.Z / YYYY-MM-DD
+
+   * [CHANGE] Description of the change. #1234
+   * [FEATURE] Description of the feature. #1235
+   * [ENHANCEMENT] Description of the enhancement. #1236
+   * [BUGFIX] Description of the fix. #1237
+   ```
+
+   Use the GitHub compare view to identify changes since the last release:
+   `https://github.com/prometheus-operator/prometheus-operator/compare/vPREVIOUS...main`
+
+### Review gate 3
+
+**STOP.** Show the user the full diff (especially CHANGELOG.md and VERSION)
+and wait for approval before committing. Commit message and PR title:
+`chore: cut vX.Y.Z`. Sign off with `git commit -s`.
+
+Once the user approves, ask:
+> Would you like me to create the PR using `gh pr create`, or will you
+> create it manually?
+
+If using `gh`, first verify it is authenticated by running
+`gh auth status > /dev/null 2>&1` and checking the exit code. If it
+fails, ask the user to run `gh auth login` before proceeding. Push the
+branch, then show the full `gh pr create` command and wait for approval
+before executing it.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,302 @@
+# Agents Guide for Prometheus Operator
+
+This document captures patterns and preferences observed from maintainer reviews
+of recently merged pull requests. Use it to align your contributions with what
+maintainers expect.
+
+---
+
+## Project Overview
+
+Prometheus Operator uses Kubernetes Custom Resource Definitions (CRDs) to
+declaratively manage Prometheus, Alertmanager, Thanos Ruler and associated
+monitoring infrastructure. It automates tasks such as deploying and scaling
+monitoring workloads, generating scrape and alerting configurations, and
+managing the lifecycle of the underlying StatefulSets and Secrets.
+
+The project exposes CRDs across three API versions (`v1`, `v1alpha1`,
+`v1beta1`) and ships three binaries:
+
+- **`operator`** — the main controller that reconciles monitoring CRDs.
+- **`prometheus-config-reloader`** — a sidecar that watches for configuration
+  changes and triggers Prometheus/Alertmanager reloads.
+- **`admission-webhook`** — validates and defaults monitoring CRDs on admission.
+
+The operator manages the following CRDs (under the `monitoring.coreos.com` API group):
+
+| CRD                  | API Version | Description                                        |
+|----------------------|-------------|----------------------------------------------------|
+| `Prometheus`         | `v1`        | Manages Prometheus server StatefulSets.            |
+| `PrometheusAgent`    | `v1alpha1`  | Manages Prometheus in agent mode.                  |
+| `Alertmanager`       | `v1`        | Manages Alertmanager clusters.                     |
+| `ThanosRuler`        | `v1`        | Manages Thanos Ruler instances.                    |
+| `ServiceMonitor`     | `v1`        | Defines how services should be scraped.            |
+| `PodMonitor`         | `v1`        | Defines how pods should be scraped.                |
+| `Probe`              | `v1`        | Defines blackbox probing targets.                  |
+| `ScrapeConfig`       | `v1alpha1`  | Defines custom scrape configurations.              |
+| `PrometheusRule`     | `v1`        | Defines Prometheus alerting and recording rules.   |
+| `AlertmanagerConfig` | `v1alpha1`  | Defines Alertmanager routing and receiver configs. |
+
+Many files in this repository (CRDs, client-go libraries, bundle manifests, docs)
+are auto-generated — never edit files matching `zz_generated.*\.go` or generated
+manifests by hand. Always run `make generate` and commit the generated changes
+before submitting a pull request.
+
+---
+
+## Commit Message Format
+
+Messages must follow `<subsystem>: <what changed>`, with an optional body
+explaining why. The subject line should be no longer than 70 characters.
+Wrap the body at 80 characters.
+
+```text
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+Examples from merged commits:
+
+```text
+feat: migrate retention options to config file
+fix: drop targets for inactive shards
+operator: fix dropped gzip Close errors in GzipConfig and GunzipConfig
+alertmanager: return error on invalid SMTP smarthost format
+pkg/prometheus: validate Probe static target labels
+docs: clarify ServiceMonitor port vs targetPort
+chore: update default Alertmanager version to v0.33.0
+chore(api): enable notimestamp KAL linter
+ci: retrigger E2E after flaky ThanosRulerStateless timeout
+test: add unit test for Alertmanager
+refactor(crd): refactoring resource.Quantity validate
+*: modernize Go code
+```
+
+Common subsystem prefixes: `prometheus`, `alertmanager`, `thanos`, `scrapeconfig`,
+`operator`, `admission`, `reloader`, `pkg/<name>`, `docs`, `chore`, `feat`, `fix`,
+`test`, `refactor`, `build(deps)`, `ci`. Use `*` when the change spans many packages.
+
+---
+
+## Commits
+
+- Each commit must compile and pass tests independently.
+- Keep commits small and focused. Do not bundle unrelated changes in one commit.
+  If a refactor is necessary, do it in a separate commit.
+- Sign off every commit with `git commit -s` to satisfy the DCO requirement.
+- Commits must be verified (GPG or SSH signed). Configure commit signing with
+  `git config commit.gpgsign true`. See the
+  [GitHub docs on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+  for setup instructions.
+
+---
+
+## Releases
+
+The project follows a 6-week release cycle. Release commits use the `chore:` prefix:
+
+```text
+chore: bump go dependencies before v0.92.0
+chore: cut v0.92.0
+```
+
+A release shepherd is assigned for each release and is responsible for the
+entire release series including patch releases. See [RELEASE.md](RELEASE.md)
+for the full schedule and process.
+
+---
+
+## CHANGELOG
+
+The CHANGELOG uses the following prefixes. When adding an entry, include the
+PR number at the end.
+
+```text
+[CHANGE]      breaking or behavioural change
+[FEATURE]     new capability
+[ENHANCEMENT] improvement to existing behaviour
+[BUGFIX]      bug fix
+```
+
+Combined prefixes like `[CHANGE/BUGFIX]` are acceptable when a fix also changes
+behaviour. Example:
+
+```text
+* [BUGFIX] Fix goroutine leak and data race in `pollBasedListerWatcher`. #8593
+```
+
+---
+
+## Code Style
+
+- Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments)
+  and the formatting/style section of
+  [Go: Best Practices for Production Environments](https://peter.bourgon.org/go-in-production/#formatting-and-style).
+- All Go source files must carry the Apache 2.0 license header. Run
+  `make fix-license` to add missing headers.
+- Import ordering is enforced by `gci` via golangci-lint with three sections:
+  standard library, third-party, then project-local
+  (`github.com/prometheus-operator/prometheus-operator`).
+- The `importas` linter enforces canonical import aliases for Kubernetes and
+  project packages. Key aliases:
+  - `corev1` for `k8s.io/api/core/v1`
+  - `metav1` for `k8s.io/apimachinery/pkg/apis/meta/v1`
+  - `apierrors` for `k8s.io/apimachinery/pkg/api/errors`
+  - `monitoringv1` for the project's `pkg/apis/monitoring/v1`
+  - `monitoringv1alpha1` / `monitoringv1beta1` for alpha and beta APIs
+- Use `fmt.Errorf` or standard `errors` for error handling. The `github.com/pkg/errors`
+  package is forbidden by `depguard`.
+- Use the `slices` package instead of `sort`.
+- Run `make check` (which runs both `make check-golang` and `make check-api`)
+  before submitting. The project uses `golangci-lint` with linters including
+  `depguard`, `godot`, `importas`, `misspell`, `revive`, `testifylint`,
+  `unconvert`, `modernize` and others.
+- The `godot` linter requires comments to end with a period.
+- Use `//nolint:linter1[,linter2,...]` sparingly; prefer fixing the code.
+
+---
+
+## CRD / API Design
+
+When designing or extending Custom Resource Definitions:
+
+- Follow the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
+  and [API changes guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md).
+- API stability policy:
+  - **Alpha** (`v1alpha1`, `v1alpha2`): breaking changes may be allowed.
+  - **Beta** (`v1beta1`, `v1beta2`): backward-incompatible changes may be allowed
+    but forward compatibility must be preserved.
+  - **Stable** (`v1`): backward and forward compatibility must be preserved.
+- The `golangci-kube-api-linter` (KAL) enforces Kubernetes API conventions on
+  CRD types in `pkg/apis/monitoring/`. Run `make check-api` to validate.
+  See `.golangci-kal.yml` for the full list of enabled rules.
+
+---
+
+## Tests
+
+- Bug fixes require a test that reproduces the bug.
+- New behaviour or API changes require unit and/or e2e tests.
+- Golden files are used extensively for testing generated Prometheus configs.
+  Update them with `make test-unit-update-golden` when modifying config generation.
+- Golden files in `pkg/prometheus/testdata/` are validated with `promtool check config`.
+
+### Running Tests
+
+```bash
+# Unit tests (short mode).
+make test-unit
+
+# All tests including long-running.
+make test-long
+
+# End-to-end tests (requires a KinD cluster).
+make test-e2e
+
+# Targeted e2e tests.
+make test-e2e-prometheus
+make test-e2e-alertmanager
+make test-e2e-thanos-ruler
+make test-e2e-feature-gates
+```
+
+Run specific tests:
+
+```bash
+go test -run ^TestPodLabelsAnnotations$ ./pkg/prometheus/server
+TEST_RUN_ARGS="-run TestPrometheusRuleCRDValidation/valid-rule-names" make test-e2e-prometheus
+```
+
+---
+
+## Pull Requests
+
+Every PR description must include:
+
+- A concise description of the change and its motivation.
+- A **type of change** checkbox (`CHANGE`, `FEATURE`, `BUGFIX`, `ENHANCEMENT`
+  or `NONE`).
+- A `release-note` fenced code block with a one-line user-facing summary.
+  If there is no user-facing change, leave the block empty.
+
+```text
+```release-note
+Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
+```
+
+```
+
+- Use GitHub closing keywords so linked issues close automatically on merge
+  (e.g. `Fixes #8243`).
+- Do not include unrelated changes — make a separate PR instead.
+- If a PR is large, split it into preparatory and follow-up PRs and reference
+  them with "Part of #NNNN" or "Depends on #NNNN".
+
+---
+
+## Documentation Changes
+
+- When changing behaviour, update any relevant text in the `Documentation/`
+  directory.
+- API reference docs are auto-generated from CRD types — update the type
+  comments, not the generated markdown.
+- Use `make docs` to format and validate markdown files and links.
+- Use `make check-docs` to verify formatting without modifying files.
+- Proposals for new features go in `Documentation/proposals/` using the
+  template at `Documentation/proposals/template.md`.
+
+---
+
+## CI Pipeline
+
+PRs are validated by the following CI checks:
+
+- **checks** — runs `make --always-make format generate && git diff --exit-code`,
+  linting (`make check-golang`, `make check-api`), `make check-metrics`,
+  `make tidy`, documentation formatting, and operator build.
+- **unit** — runs `make test-unit` and `make test-long`.
+- **e2e** — runs end-to-end tests on a KinD cluster.
+- **spell-check** — checks for spelling mistakes.
+- **actionlint** — lints GitHub Actions workflow files.
+
+Before submitting, ensure:
+
+```bash
+make --always-make format generate && git diff --exit-code  # regenerate and verify no uncommitted changes
+make check             # run golangci-lint and kube-api-linter
+make test-unit         # run unit tests
+```
+
+---
+
+## AI Use Policy
+
+The project allows AI tools for contributions but requires:
+
+- Review the change yourself before submitting.
+- Ensure you can explain the why, what and how without AI assistance.
+- When AI contributed significant parts, disclose it in the PR description or
+  commit message.
+- Avoid verbose AI-generated descriptions — keep PRs concise and focused.
+- Do not submit changes unrelated to the PR's purpose.
+
+---
+
+## Local Development
+
+1. Start a Kubernetes cluster (KinD recommended):
+
+   ```bash
+   kind create cluster
+   ```
+
+2. Run the operator locally:
+
+   ```bash
+   ./scripts/run-external.sh -c
+   ```
+
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,12 @@ Every PR description must include:
 - A `release-note` fenced code block with a one-line user-facing summary.
   If there is no user-facing change, leave the block empty.
 
-````text
+```text
 ```release-note
 Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
 ```
-````
+
+```
 
 - Use GitHub closing keywords so linked issues close automatically on merge
   (e.g. `Fixes #8243`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,165 @@
+# Agents Guide for Prometheus Operator
+
+This document captures patterns and preferences observed from maintainer reviews
+of recently merged pull requests. Use it to align your contributions with what
+maintainers expect.
+
+---
+
+## Project Overview
+
+Prometheus Operator uses Kubernetes CRDs to declaratively manage Prometheus,
+Alertmanager, Thanos Ruler and related monitoring infrastructure. See the
+[introduction](https://prometheus-operator.dev/docs/getting-started/introduction/)
+and [design](https://prometheus-operator.dev/docs/getting-started/design/)
+docs for architecture details.
+
+The project ships three binaries: `operator`, `prometheus-config-reloader`
+and `admission-webhook`. CRDs are defined under the `monitoring.coreos.com`
+API group across `v1`, `v1alpha1` and `v1beta1` versions.
+
+Many files (CRDs, client-go libraries, bundle manifests, docs) are
+auto-generated — never edit `zz_generated.*` files or generated manifests
+by hand. Always run `make generate` and commit the generated changes before
+submitting a pull request.
+
+---
+
+## Commit Message Format
+
+Messages must follow `<subsystem>: <what changed>`, with an optional body
+explaining why. The subject line should be no longer than 70 characters.
+Wrap the body at 80 characters.
+
+```text
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+Examples from merged commits:
+
+```text
+feat: migrate retention options to config file
+fix: drop targets for inactive shards
+operator: fix dropped gzip Close errors in GzipConfig and GunzipConfig
+alertmanager: return error on invalid SMTP smarthost format
+pkg/prometheus: validate Probe static target labels
+docs: clarify ServiceMonitor port vs targetPort
+chore: update default Alertmanager version to v0.33.0
+chore(api): enable notimestamp KAL linter
+ci: retrigger E2E after flaky ThanosRulerStateless timeout
+test: add unit test for Alertmanager
+refactor(crd): refactoring resource.Quantity validate
+```
+
+Common subsystem prefixes: `prometheus`, `alertmanager`, `thanos`, `scrapeconfig`,
+`operator`, `admission`, `reloader`, `pkg/<name>`, `docs`, `chore`, `feat`, `fix`,
+`test`, `refactor`, `build(deps)`, `ci`. Use `*` when the change spans many packages.
+
+---
+
+## Commits
+
+- Each commit must compile and pass tests independently.
+- Keep commits small and focused. Do not bundle unrelated changes in one commit.
+  If a refactor is necessary, do it in a separate PR when possible.
+- Sign off every commit with `git commit -s` to satisfy the DCO requirement.
+- Verified (GPG signed) commits are appreciated.
+
+---
+
+## CHANGELOG
+
+The CHANGELOG uses the following prefixes in this order. When adding an entry,
+include the PR number at the end.
+
+```text
+[CHANGE]      breaking or behavioural change
+[FEATURE]     new capability
+[ENHANCEMENT] improvement to existing behaviour
+[BUGFIX]      bug fix
+```
+
+Combined prefixes like `[CHANGE/BUGFIX]` are acceptable when a fix also changes
+behaviour. Example:
+
+```text
+* [BUGFIX] Fix goroutine leak and data race in `pollBasedListerWatcher`. #8593
+```
+
+---
+
+## Code Style
+
+- All Go source files must carry the Apache 2.0 license header. Run
+  `make fix-license` to add missing headers.
+- Run `make check` before submitting. This runs `golangci-lint` and the
+  kube-api-linter — all coding conventions (import ordering, import aliases,
+  forbidden packages, comment style, etc.) are enforced by the linter
+  configuration in `.golangci.yml`. Fix violations rather than suppressing
+  them with `//nolint`.
+
+---
+
+## CRD / API Design
+
+See the [API changes](https://prometheus-operator.dev/docs/community/contributing/#changes-to-the-apis)
+section in the contributing guide for conventions and stability guarantees.
+Run `make check-api` to validate CRD types against Kubernetes API conventions
+(configuration is in `.golangci-kal.yml`).
+
+---
+
+## Tests
+
+- Bug fixes require a test that reproduces the bug.
+- New behaviour or API changes require unit and/or e2e tests.
+- Golden files are used for testing generated configs — update them with
+  `make test-unit-update-golden` when modifying config generation.
+- Run `make test-unit` for unit tests. See [TESTING.md](TESTING.md) for the
+  full testing guide including e2e tests.
+
+---
+
+## Pull Requests
+
+Every PR description must include:
+
+- A concise description of the change and its motivation.
+- A **type of change** checkbox (`CHANGE`, `FEATURE`, `BUGFIX`, `ENHANCEMENT`
+  or `NONE`).
+- A `release-note` fenced code block with a one-line user-facing summary.
+  If there is no user-facing change, leave the block empty.
+
+````text
+```release-note
+Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
+```
+````
+
+- Use GitHub closing keywords so linked issues close automatically on merge
+  (e.g. `Fixes #8243`).
+- Do not include unrelated changes — make a separate PR instead.
+- If a PR is large, split it into preparatory and follow-up PRs and reference
+  them with "Part of #NNNN" or "Depends on #NNNN".
+
+---
+
+## Pre-submission Checklist
+
+```bash
+make --always-make format generate && git diff --exit-code  # regenerate and verify no uncommitted changes
+make check             # run golangci-lint and kube-api-linter
+make test-unit         # run unit tests
+```
+
+---
+
+## AI Use Policy
+
+See the [AI use policy](CONTRIBUTING.md#ai-use-policy) in the contributing guide.
+
+---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,6 +59,19 @@ The release shepherd is responsible for the entire release series of a major or 
 
 See the next section for details on cutting an individual release.
 
+## AI-assisted release PR preparation
+
+An AI agent skill is available at `.agents/skills/release-prep/SKILL.md` to
+guide an AI agent (e.g. Cursor, Claude) through the release preparation steps
+(dependency bumps, version bumps, code generation and CHANGELOG updates). The
+skill includes review gates to ensure human approval at each step.
+
+To use it, invoke the skill with:
+
+```text
+/release-prep prepare the release for vX.Y.Z
+```
+
 ## How to cut a new release
 
 > This guide is strongly based on the [Prometheus release instructions](https://github.com/prometheus/prometheus/blob/main/RELEASE.md).


### PR DESCRIPTION

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Add AI agent guidelines and a release preparation skill to help AI agents
(Cursor, Claude, etc.) contribute in line with project conventions.

Also adds:
- `CLAUDE.md` symlink → `AGENTS.md` (so Claude agents pick up the guidelines)
- `.cursor/skills` symlink → `.agents/skills` (so Cursor discovers skills)
- `.claude/skills` symlink → `.agents/skills` (so Claude discovers skills)

Assisted By: Claude Opus 4.6

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
