### PR TITLE
fix: load OpenStack SD TLS config into the asset store

### DIFF
--- a/pkg/prometheus/resource_selector.go
+++ b/pkg/prometheus/resource_selector.go
@@ -970,6 +970,10 @@ func (rs *ResourceSelector) validateOpenStackSDConfigs(ctx context.Context, sc *
 				return fmt.Errorf("[%d]: %w", i, err)
 			}
 		}
+
+		if err := rs.store.AddSafeTLSConfig(ctx, sc.GetNamespace(), config.TLSConfig); err != nil {
+			return fmt.Errorf("[%d]: %w", i, err)
+		}
 	}
 	return nil
 }

--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -3246,6 +3246,50 @@ func TestSelectScrapeConfigs(t *testing.T) {
 			promVersion: "3.2.0",
 		},
 		{
+			scenario: "OpenStack SD config with valid TLS config",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.OpenStackSDConfigs = []monitoringv1alpha1.OpenStackSDConfig{
+					{
+						Role:   monitoringv1alpha1.OpenStackRoleInstance,
+						Region: "RegionOne",
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "secret",
+									},
+									Key: "ca",
+								},
+							},
+						},
+					},
+				}
+			},
+			valid: true,
+		},
+		{
+			scenario: "OpenStack SD config with TLS config referencing a non-existent secret",
+			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
+				sc.OpenStackSDConfigs = []monitoringv1alpha1.OpenStackSDConfig{
+					{
+						Role:   monitoringv1alpha1.OpenStackRoleInstance,
+						Region: "RegionOne",
+						TLSConfig: &monitoringv1.SafeTLSConfig{
+							CA: monitoringv1.SecretOrConfigMap{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "wrong",
+									},
+									Key: "ca",
+								},
+							},
+						},
+					},
+				}
+			},
+			valid: false,
+		},
+		{
 			scenario: "DigitalOcean SD config with valid TLS Config",
 			updateSpec: func(sc *monitoringv1alpha1.ScrapeConfigSpec) {
 				sc.DigitalOceanSDConfigs = []monitoringv1alpha1.DigitalOceanSDConfig{


### PR DESCRIPTION
## Description

OpenStack is the only service discovery validator that never loads its `tlsConfig` into the asset store. `validateOpenStackSDConfigs` checks the `password` and `applicationCredentialSecret` secrets, but it does not call `rs.store.AddSafeTLSConfig` like every other validator that exposes a `tlsConfig` field does.

The config generator still emits the TLS settings for OpenStack via `addSafeTLStoYaml` in `promcfg.go`. Because the validator never loaded those secrets, the asset is never registered or mounted, so the generated `ca_file`/`cert_file`/`key_file` paths point at files that do not exist, and a typo'd secret name is accepted at admission instead of being rejected.

This adds the missing `AddSafeTLSConfig` call to the OpenStack validation loop. It is the same fix that #8644 applied to Consul SD for OAuth2.

## Type of change

- [x] `BUGFIX` (non-breaking change which fixes an issue)

## Verification

Added two cases to `TestSelectScrapeConfigs` for an OpenStack `tlsConfig`: one with a valid secret reference and one pointing at a non-existent secret. On `main` the non-existent case is accepted as valid; with the fix it is rejected. Removing the new line makes that case fail, so the test covers the bug. `go build ./pkg/prometheus/` and `go test ./pkg/prometheus/` pass.

## Changelog entry

```release-note
Load TLS credentials into the asset store for OpenStack service discovery so the generated scrape configuration includes the TLS settings.
```
