### PR TITLE
fix: avoid "namespace not found" errors

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -68,12 +68,13 @@ const (
 // Whenever the value of one of these parameters is changed, it triggers an
 // update of the managed statefulsets.
 type Config struct {
-	LocalHost                    string
-	ClusterDomain                string
-	ReloaderConfig               operator.ContainerConfig
-	AlertmanagerDefaultBaseImage string
-	Annotations                  operator.Map
-	Labels                       operator.Map
+	LocalHost                      string
+	ClusterDomain                  string
+	ReloaderConfig                 operator.ContainerConfig
+	AlertmanagerDefaultBaseImage   string
+	Annotations                    operator.Map
+	Labels                         operator.Map
+	WatchObjectRefsInAllNamespaces bool
 }
 
 // Operator manages the lifecycle of the Alertmanager statefulsets and their
@@ -170,12 +171,13 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		repairPolicy: c.RepairPolicy,
 
 		config: Config{
-			LocalHost:                    c.LocalHost,
-			ClusterDomain:                c.ClusterDomain,
-			ReloaderConfig:               c.ReloaderConfig,
-			AlertmanagerDefaultBaseImage: c.AlertmanagerDefaultBaseImage,
-			Annotations:                  c.Annotations,
-			Labels:                       c.Labels,
+			LocalHost:                      c.LocalHost,
+			ClusterDomain:                  c.ClusterDomain,
+			ReloaderConfig:                 c.ReloaderConfig,
+			AlertmanagerDefaultBaseImage:   c.AlertmanagerDefaultBaseImage,
+			Annotations:                    c.Annotations,
+			Labels:                         c.Labels,
+			WatchObjectRefsInAllNamespaces: c.WatchObjectRefsInAllNamespaces,
 		},
 	}
 	for _, opt := range options {
@@ -240,7 +242,7 @@ func (c *Operator) bootstrap(ctx context.Context, config operator.Config) error 
 	}
 
 	allowList := config.Namespaces.AlertmanagerConfigAllowList
-	if config.WatchObjectRefsInAllNamespaces {
+	if c.config.WatchObjectRefsInAllNamespaces {
 		allowList = operator.MergeAllowLists(
 			config.Namespaces.AlertmanagerAllowList,
 			config.Namespaces.AlertmanagerConfigAllowList,
@@ -384,7 +386,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1alpha1.AlertmanagerConfigKind,
-		c.enqueueForNamespace,
+		c.enqueueForNamespaceFunc(c.nsAlrtCfgInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -397,12 +399,19 @@ func (c *Operator) addHandlers() {
 		c.alrtInfs,
 		c.reconciliations,
 	)
+	var gbk operator.GetByKeyer = c.nsAlrtCfgInf.GetStore()
+	if c.config.WatchObjectRefsInAllNamespaces && c.nsAlrtInf != c.nsAlrtCfgInf {
+		gbk = operator.NewMultiGetByKeyer(
+			c.nsAlrtInf.GetStore(),
+			c.nsAlrtCfgInf.GetStore(),
+		)
+	}
 	c.secrInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		operator.SecretGVK().Kind,
-		c.enqueueForNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -412,7 +421,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		operator.ConfigMapGVK().Kind,
-		c.enqueueForNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -427,10 +436,16 @@ func (c *Operator) addHandlers() {
 	})
 }
 
+func (c *Operator) enqueueForNamespaceFunc(gbk operator.GetByKeyer) func(string) {
+	return func(ns string) {
+		c.enqueueForNamespace(gbk, ns)
+	}
+}
+
 // enqueueForNamespace enqueues all Alertmanager object keys that belong to the
 // given namespace or select objects in the given namespace.
-func (c *Operator) enqueueForNamespace(nsName string) {
-	nsObject, exists, err := c.nsAlrtCfgInf.GetStore().GetByKey(nsName)
+func (c *Operator) enqueueForNamespace(gbk operator.GetByKeyer, nsName string) {
+	nsObject, exists, err := gbk.GetByKey(nsName)
 	if err != nil {
 		c.logger.Error(
 			"get namespace to enqueue Alertmanager instances failed",

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -611,3 +611,29 @@ func SelectNamespacesFromCache(obj metav1.Object, sel *metav1.LabelSelector, nsI
 
 	return ns, nil
 }
+
+// GetByKeyer is an interface which exposes only the GetByKey() method of the
+// cache.Store interface.
+type GetByKeyer interface {
+	GetByKey(string) (any, bool, error)
+}
+
+// NewMultiGetByKeyer returns an interface which queries multiple GetByKeyer in
+// sequence and returns the first found object.
+func NewMultiGetByKeyer(gbk ...GetByKeyer) GetByKeyer {
+	return multiGetByKeyer(gbk)
+}
+
+type multiGetByKeyer []GetByKeyer
+
+// GetByKey implements the GetByKeyer interface.
+func (m multiGetByKeyer) GetByKey(key string) (any, bool, error) {
+	for _, gbk := range m {
+		o, found, err := gbk.GetByKey(key)
+		if err != nil || found {
+			return o, found, err
+		}
+	}
+
+	return nil, false, nil
+}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -172,12 +172,13 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		mclient:  mclient,
 		logger:   logger,
 		config: prompkg.Config{
-			LocalHost:                  c.LocalHost,
-			ReloaderConfig:             c.ReloaderConfig,
-			PrometheusDefaultBaseImage: c.PrometheusDefaultBaseImage,
-			ThanosDefaultBaseImage:     c.ThanosDefaultBaseImage,
-			Annotations:                c.Annotations,
-			Labels:                     c.Labels,
+			LocalHost:                      c.LocalHost,
+			ReloaderConfig:                 c.ReloaderConfig,
+			PrometheusDefaultBaseImage:     c.PrometheusDefaultBaseImage,
+			ThanosDefaultBaseImage:         c.ThanosDefaultBaseImage,
+			Annotations:                    c.Annotations,
+			Labels:                         c.Labels,
+			WatchObjectRefsInAllNamespaces: c.WatchObjectRefsInAllNamespaces,
 		},
 		metrics:                      operator.NewMetrics(r),
 		reconciliations:              &operator.ReconciliationTracker{},
@@ -535,7 +536,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.ServiceMonitorsKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -549,7 +550,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.PodMonitorsKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -563,7 +564,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.ProbesKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -578,7 +579,7 @@ func (c *Operator) addHandlers() {
 			c.accessor,
 			c.metrics,
 			monitoringv1alpha1.ScrapeConfigsKind,
-			c.enqueueForMonitorNamespace,
+			c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 			operator.WithFilter(
 				operator.AnyFilter(
 					operator.GenerationChanged,
@@ -592,12 +593,19 @@ func (c *Operator) addHandlers() {
 		c.promInfs,
 		c.reconciliations,
 	)
+	var gbk operator.GetByKeyer = c.nsPromInf.GetStore()
+	if c.config.WatchObjectRefsInAllNamespaces && c.nsPromInf != c.nsMonInf {
+		gbk = operator.NewMultiGetByKeyer(
+			c.nsPromInf.GetStore(),
+			c.nsMonInf.GetStore(),
+		)
+	}
 	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		operator.ConfigMapGVK().Kind,
-		c.enqueueForPrometheusNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -607,7 +615,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		operator.SecretGVK().Kind,
-		c.enqueueForPrometheusNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -1100,18 +1108,16 @@ func (c *Operator) createOrUpdateWebConfigSecret(ctx context.Context, p *monitor
 	return nil
 }
 
-func (c *Operator) enqueueForPrometheusNamespace(nsName string) {
-	c.enqueueForNamespace(c.nsPromInf.GetStore(), nsName)
-}
-
-func (c *Operator) enqueueForMonitorNamespace(nsName string) {
-	c.enqueueForNamespace(c.nsMonInf.GetStore(), nsName)
+func (c *Operator) enqueueForNamespaceFunc(gbk operator.GetByKeyer) func(string) {
+	return func(ns string) {
+		c.enqueueForNamespace(gbk, ns)
+	}
 }
 
 // enqueueForNamespace enqueues all Prometheus object keys that belong to the
 // given namespace or select objects in the given namespace.
-func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
-	nsObject, found, err := store.GetByKey(nsName)
+func (c *Operator) enqueueForNamespace(gbk operator.GetByKeyer, nsName string) {
+	nsObject, found, err := gbk.GetByKey(nsName)
 	if err != nil {
 		c.logger.Error(
 			"get namespace to enqueue Prometheus instances failed",

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -41,12 +41,13 @@ import (
 // Whenever the value of one of these parameters is changed, it triggers an
 // update of the managed statefulsets.
 type Config struct {
-	LocalHost                  string
-	ReloaderConfig             operator.ContainerConfig
-	PrometheusDefaultBaseImage string
-	ThanosDefaultBaseImage     string
-	Annotations                operator.Map
-	Labels                     operator.Map
+	LocalHost                      string
+	ReloaderConfig                 operator.ContainerConfig
+	PrometheusDefaultBaseImage     string
+	ThanosDefaultBaseImage         string
+	Annotations                    operator.Map
+	Labels                         operator.Map
+	WatchObjectRefsInAllNamespaces bool
 }
 
 // StatefulSetGetter returns a statefulset object identified by

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -219,12 +219,13 @@ func New(ctx context.Context, restConfig *rest.Config, c operator.Config, logger
 		accessor: operator.NewAccessor(logger),
 
 		config: prompkg.Config{
-			LocalHost:                  c.LocalHost,
-			ReloaderConfig:             c.ReloaderConfig,
-			PrometheusDefaultBaseImage: c.PrometheusDefaultBaseImage,
-			ThanosDefaultBaseImage:     c.ThanosDefaultBaseImage,
-			Annotations:                c.Annotations,
-			Labels:                     c.Labels,
+			LocalHost:                      c.LocalHost,
+			ReloaderConfig:                 c.ReloaderConfig,
+			PrometheusDefaultBaseImage:     c.PrometheusDefaultBaseImage,
+			ThanosDefaultBaseImage:         c.ThanosDefaultBaseImage,
+			Annotations:                    c.Annotations,
+			Labels:                         c.Labels,
+			WatchObjectRefsInAllNamespaces: c.WatchObjectRefsInAllNamespaces,
 		},
 		metrics:         operator.NewMetrics(r),
 		reconciliations: &operator.ReconciliationTracker{},
@@ -506,7 +507,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.ServiceMonitorsKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -520,7 +521,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.PodMonitorsKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -534,7 +535,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.ProbesKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -549,7 +550,7 @@ func (c *Operator) addHandlers() {
 			c.accessor,
 			c.metrics,
 			monitoringv1alpha1.ScrapeConfigsKind,
-			c.enqueueForMonitorNamespace,
+			c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 			operator.WithFilter(
 				operator.AnyFilter(
 					operator.GenerationChanged,
@@ -564,7 +565,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		monitoringv1.PrometheusRuleKind,
-		c.enqueueForMonitorNamespace,
+		c.enqueueForNamespaceFunc(c.nsMonInf.GetStore()),
 		operator.WithFilter(
 			operator.AnyFilter(
 				operator.GenerationChanged,
@@ -577,12 +578,19 @@ func (c *Operator) addHandlers() {
 		c.promInfs,
 		c.reconciliations,
 	)
+	var gbk operator.GetByKeyer = c.nsPromInf.GetStore()
+	if c.config.WatchObjectRefsInAllNamespaces && c.nsPromInf != c.nsMonInf {
+		gbk = operator.NewMultiGetByKeyer(
+			c.nsPromInf.GetStore(),
+			c.nsMonInf.GetStore(),
+		)
+	}
 	c.cmapInfs.AddEventHandler(operator.NewEventHandler(
 		c.logger,
 		c.accessor,
 		c.metrics,
 		operator.ConfigMapGVK().Kind,
-		c.enqueueForPrometheusNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -592,7 +600,7 @@ func (c *Operator) addHandlers() {
 		c.accessor,
 		c.metrics,
 		operator.SecretGVK().Kind,
-		c.enqueueForPrometheusNamespace,
+		c.enqueueForNamespaceFunc(gbk),
 		operator.WithFilter(operator.ResourceVersionChanged),
 		operator.WithFilter(hasRefFunc),
 	))
@@ -699,18 +707,16 @@ func (c *Operator) RefreshStatusFor(o metav1.Object) {
 	c.rr.EnqueueForStatus(o)
 }
 
-func (c *Operator) enqueueForPrometheusNamespace(nsName string) {
-	c.enqueueForNamespace(c.nsPromInf.GetStore(), nsName)
-}
-
-func (c *Operator) enqueueForMonitorNamespace(nsName string) {
-	c.enqueueForNamespace(c.nsMonInf.GetStore(), nsName)
+func (c *Operator) enqueueForNamespaceFunc(gbk operator.GetByKeyer) func(string) {
+	return func(ns string) {
+		c.enqueueForNamespace(gbk, ns)
+	}
 }
 
 // enqueueForNamespace enqueues all Prometheus object keys that belong to the
 // given namespace or select objects in the given namespace.
-func (c *Operator) enqueueForNamespace(store cache.Store, nsName string) {
-	nsObject, found, err := store.GetByKey(nsName)
+func (c *Operator) enqueueForNamespace(gbk operator.GetByKeyer, nsName string) {
+	nsObject, found, err := gbk.GetByKey(nsName)
 	if err != nil {
 		c.logger.Error(
 			"get namespace to enqueue Prometheus instances failed",


### PR DESCRIPTION
## Description

This commit ensures that the Prometheus and Alertmanager controllers look up namespaces in the relevant caches when they watch workload and configuration resources in different namespace sets.

Tested locally.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
