### PR TITLE
feat: Add ephemeral storage configuration for config-reloader

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -162,6 +162,8 @@ func parseFlags(fs *flag.FlagSet) {
 	fs.Var(&cfg.ReloaderConfig.CPULimits, "config-reloader-cpu-limit", "Config Reloader CPU limits. Value \"0\" disables it and causes no limit to be configured.")
 	fs.Var(&cfg.ReloaderConfig.MemoryRequests, "config-reloader-memory-request", "Config Reloader memory requests. Value \"0\" disables it and causes no request to be configured.")
 	fs.Var(&cfg.ReloaderConfig.MemoryLimits, "config-reloader-memory-limit", "Config Reloader memory limits. Value \"0\" disables it and causes no limit to be configured.")
+	fs.Var(&cfg.ReloaderConfig.EphemeralStorageRequests, "config-reloader-ephemeral-storage-request", "Config Reloader ephemeral-storage requests. Value \"0\" disables it and causes no request to be configured.")
+	fs.Var(&cfg.ReloaderConfig.EphemeralStorageLimits, "config-reloader-ephemeral-storage-limit", "Config Reloader ephemeral-storage limits. Value \"0\" disables it and causes no limit to be configured.")
 	fs.BoolVar(&cfg.ReloaderConfig.EnableProbes, "enable-config-reloader-probes", false, "Enable liveness, readiness, and startup probes for the config-reloader container. Default: false")
 
 	fs.StringVar(&cfg.AlertmanagerDefaultBaseImage, "alertmanager-default-base-image", operator.DefaultAlertmanagerBaseImage, "Alertmanager default base image (path without tag/version)")

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -138,12 +138,14 @@ func (c *Config) RegisterFeatureGatesFlags(fs *flag.FlagSet, flags *k8sflag.MapS
 type ContainerConfig struct {
 	// The struct tag are needed for github.com/mitchellh/hashstructure to take
 	// the field values into account when generating the statefulset hash.
-	CPURequests    Quantity `hash:"string"`
-	CPULimits      Quantity `hash:"string"`
-	MemoryRequests Quantity `hash:"string"`
-	MemoryLimits   Quantity `hash:"string"`
-	Image          string
-	EnableProbes   bool
+	CPURequests              Quantity `hash:"string"`
+	CPULimits                Quantity `hash:"string"`
+	MemoryRequests           Quantity `hash:"string"`
+	MemoryLimits             Quantity `hash:"string"`
+	EphemeralStorageRequests Quantity `hash:"string"`
+	EphemeralStorageLimits   Quantity `hash:"string"`
+	Image                    string
+	EnableProbes             bool
 }
 
 func (cc ContainerConfig) ResourceRequirements() corev1.ResourceRequirements {
@@ -163,6 +165,12 @@ func (cc ContainerConfig) ResourceRequirements() corev1.ResourceRequirements {
 	}
 	if cc.MemoryLimits.String() != "0" {
 		resources.Limits[corev1.ResourceMemory] = cc.MemoryLimits.q
+	}
+	if cc.EphemeralStorageRequests.String() != "0" {
+		resources.Requests[corev1.ResourceEphemeralStorage] = cc.EphemeralStorageRequests.q
+	}
+	if cc.EphemeralStorageLimits.String() != "0" {
+		resources.Limits[corev1.ResourceEphemeralStorage] = cc.EphemeralStorageLimits.q
 	}
 
 	return resources


### PR DESCRIPTION
## Description

This change introduces the ability to configure ephemeral storage requests and limits for the Prometheus config-reloader container.

The `ContainerConfig` struct in `pkg/operator/config.go` has been updated with `EphemeralStorageRequests` and `EphemeralStorageLimits` fields. The `ResourceRequirements()` method now includes logic to apply these ephemeral storage settings.

Corresponding command-line flags (`--config-reloader-ephemeral-storage-request` and `--config-reloader-ephemeral-storage-limit`) have been added in `cmd/operator/main.go` to expose these configuration options to the operator.

This feature allows for more granular resource management and resource quota enforcement for the config-reloader sidecar.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Ran `make test-unit`, `make check`, and `make generate`. Unit tests passed. `make generate` produced no changes.
`make check` was run and reported unrelated errors in internal/log/log.go

## Changelog entry

```release-note
Add support for configuring ephemeral storage requests and limits for the config-reloader container.
```