### PR TITLE
chore: change uint fields to int

### DIFF
--- a/pkg/apis/monitoring/v1/podmonitor_types.go
+++ b/pkg/apis/monitoring/v1/podmonitor_types.go
@@ -119,14 +119,14 @@ type PodMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 
 	// targetLimit defines a limit on the number of scraped targets that will
 	// be accepted.
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
@@ -151,21 +151,21 @@ type PodMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 
 	NativeHistogramConfig `json:",inline"`
 
@@ -176,7 +176,7 @@ type PodMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 
 	// attachMetadata defines additional metadata which is added to the
 	// discovered targets.

--- a/pkg/apis/monitoring/v1/probe_types.go
+++ b/pkg/apis/monitoring/v1/probe_types.go
@@ -107,11 +107,11 @@ type ProbeSpec struct {
 	// sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
 	//
@@ -133,19 +133,19 @@ type ProbeSpec struct {
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 
 	// +optional
 	NativeHistogramConfig `json:",inline"`
@@ -157,7 +157,7 @@ type ProbeSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 
 	// scrapeClass defines the scrape class to apply.
 	// +optional

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -683,7 +683,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedSampleLimit *uint64 `json:"enforcedSampleLimit,omitempty"`
+	EnforcedSampleLimit *int64 `json:"enforcedSampleLimit,omitempty"`
 	// enforcedTargetLimit when defined specifies a global limit on the number
 	// of scraped targets. The value overrides any `spec.targetLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.targetLimit` is
@@ -701,7 +701,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedTargetLimit *uint64 `json:"enforcedTargetLimit,omitempty"`
+	EnforcedTargetLimit *int64 `json:"enforcedTargetLimit,omitempty"`
 	// enforcedLabelLimit when defined specifies a global limit on the number
 	// of labels per sample. The value overrides any `spec.labelLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelLimit` is
@@ -718,7 +718,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedLabelLimit *uint64 `json:"enforcedLabelLimit,omitempty"`
+	EnforcedLabelLimit *int64 `json:"enforcedLabelLimit,omitempty"`
 	// enforcedLabelNameLengthLimit when defined specifies a global limit on the length
 	// of labels name per sample. The value overrides any `spec.labelNameLengthLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelNameLengthLimit` is
@@ -735,7 +735,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedLabelNameLengthLimit *uint64 `json:"enforcedLabelNameLengthLimit,omitempty"`
+	EnforcedLabelNameLengthLimit *int64 `json:"enforcedLabelNameLengthLimit,omitempty"`
 	// enforcedLabelValueLengthLimit when not null defines a global limit on the length
 	// of labels value per sample. The value overrides any `spec.labelValueLengthLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelValueLengthLimit` is
@@ -752,7 +752,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedLabelValueLengthLimit *uint64 `json:"enforcedLabelValueLengthLimit,omitempty"`
+	EnforcedLabelValueLengthLimit *int64 `json:"enforcedLabelValueLengthLimit,omitempty"`
 	// enforcedKeepDroppedTargets when defined specifies a global limit on the number of targets
 	// dropped by relabeling that will be kept in memory. The value overrides
 	// any `spec.keepDroppedTargets` set by
@@ -770,7 +770,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	EnforcedKeepDroppedTargets *uint64 `json:"enforcedKeepDroppedTargets,omitempty"`
+	EnforcedKeepDroppedTargets *int64 `json:"enforcedKeepDroppedTargets,omitempty"`
 	// enforcedBodySizeLimit when defined specifies a global limit on the size
 	// of uncompressed response body that will be accepted by Prometheus.
 	// Targets responding with a body larger than this many bytes will cause
@@ -915,7 +915,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
@@ -924,7 +924,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
@@ -933,7 +933,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
@@ -942,7 +942,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
@@ -951,7 +951,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 	// keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
 	// that will be kept in memory. 0 means no limit.
 	//
@@ -962,7 +962,7 @@ type CommonPrometheusFields struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 
 	// reloadStrategy defines the strategy used to reload the Prometheus configuration.
 	// If not specified, the configuration is reloaded using the /-/reload HTTP endpoint.
@@ -2209,7 +2209,7 @@ type RelabelConfig struct {
 	// Only applicable when the action is `HashMod`.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	Modulus uint64 `json:"modulus,omitempty"`
+	Modulus int64 `json:"modulus,omitempty"`
 
 	// replacement value against which a Replace action is performed if the
 	// regular expression matches.

--- a/pkg/apis/monitoring/v1/servicemonitor_types.go
+++ b/pkg/apis/monitoring/v1/servicemonitor_types.go
@@ -124,7 +124,7 @@ type ServiceMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
@@ -148,7 +148,7 @@ type ServiceMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	//
@@ -156,21 +156,21 @@ type ServiceMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 
 	// +optional
 	NativeHistogramConfig `json:",inline"`
@@ -182,7 +182,7 @@ type ServiceMonitorSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 
 	// attachMetadata defines additional metadata which is added to the
 	// discovered targets.

--- a/pkg/apis/monitoring/v1/types.go
+++ b/pkg/apis/monitoring/v1/types.go
@@ -854,7 +854,7 @@ type NativeHistogramConfig struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	NativeHistogramBucketLimit *uint64 `json:"nativeHistogramBucketLimit,omitempty"`
+	NativeHistogramBucketLimit *int64 `json:"nativeHistogramBucketLimit,omitempty"`
 
 	// nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
 	// buckets will be merged to increase the factor sufficiently.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -1066,32 +1066,32 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 	out.ArbitraryFSAccessThroughSMs = in.ArbitraryFSAccessThroughSMs
 	if in.EnforcedSampleLimit != nil {
 		in, out := &in.EnforcedSampleLimit, &out.EnforcedSampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcedTargetLimit != nil {
 		in, out := &in.EnforcedTargetLimit, &out.EnforcedTargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcedLabelLimit != nil {
 		in, out := &in.EnforcedLabelLimit, &out.EnforcedLabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcedLabelNameLengthLimit != nil {
 		in, out := &in.EnforcedLabelNameLengthLimit, &out.EnforcedLabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcedLabelValueLengthLimit != nil {
 		in, out := &in.EnforcedLabelValueLengthLimit, &out.EnforcedLabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcedKeepDroppedTargets != nil {
 		in, out := &in.EnforcedKeepDroppedTargets, &out.EnforcedKeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NameValidationScheme != nil {
@@ -1163,32 +1163,32 @@ func (in *CommonPrometheusFields) DeepCopyInto(out *CommonPrometheusFields) {
 	}
 	if in.SampleLimit != nil {
 		in, out := &in.SampleLimit, &out.SampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetLimit != nil {
 		in, out := &in.TargetLimit, &out.TargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelLimit != nil {
 		in, out := &in.LabelLimit, &out.LabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelNameLengthLimit != nil {
 		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelValueLengthLimit != nil {
 		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.KeepDroppedTargets != nil {
 		in, out := &in.KeepDroppedTargets, &out.KeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ReloadStrategy != nil {
@@ -1975,7 +1975,7 @@ func (in *NativeHistogramConfig) DeepCopyInto(out *NativeHistogramConfig) {
 	}
 	if in.NativeHistogramBucketLimit != nil {
 		in, out := &in.NativeHistogramBucketLimit, &out.NativeHistogramBucketLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NativeHistogramMinBucketFactor != nil {
@@ -2310,12 +2310,12 @@ func (in *PodMonitorSpec) DeepCopyInto(out *PodMonitorSpec) {
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
 	if in.SampleLimit != nil {
 		in, out := &in.SampleLimit, &out.SampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetLimit != nil {
 		in, out := &in.TargetLimit, &out.TargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ScrapeProtocols != nil {
@@ -2330,23 +2330,23 @@ func (in *PodMonitorSpec) DeepCopyInto(out *PodMonitorSpec) {
 	}
 	if in.LabelLimit != nil {
 		in, out := &in.LabelLimit, &out.LabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelNameLengthLimit != nil {
 		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelValueLengthLimit != nil {
 		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	in.NativeHistogramConfig.DeepCopyInto(&out.NativeHistogramConfig)
 	if in.KeepDroppedTargets != nil {
 		in, out := &in.KeepDroppedTargets, &out.KeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.AttachMetadata != nil {
@@ -2458,12 +2458,12 @@ func (in *ProbeSpec) DeepCopyInto(out *ProbeSpec) {
 	}
 	if in.SampleLimit != nil {
 		in, out := &in.SampleLimit, &out.SampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetLimit != nil {
 		in, out := &in.TargetLimit, &out.TargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ScrapeProtocols != nil {
@@ -2478,23 +2478,23 @@ func (in *ProbeSpec) DeepCopyInto(out *ProbeSpec) {
 	}
 	if in.LabelLimit != nil {
 		in, out := &in.LabelLimit, &out.LabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelNameLengthLimit != nil {
 		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelValueLengthLimit != nil {
 		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	in.NativeHistogramConfig.DeepCopyInto(&out.NativeHistogramConfig)
 	if in.KeepDroppedTargets != nil {
 		in, out := &in.KeepDroppedTargets, &out.KeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ScrapeClassName != nil {
@@ -3587,7 +3587,7 @@ func (in *ServiceMonitorSpec) DeepCopyInto(out *ServiceMonitorSpec) {
 	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
 	if in.SampleLimit != nil {
 		in, out := &in.SampleLimit, &out.SampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ScrapeProtocols != nil {
@@ -3602,28 +3602,28 @@ func (in *ServiceMonitorSpec) DeepCopyInto(out *ServiceMonitorSpec) {
 	}
 	if in.TargetLimit != nil {
 		in, out := &in.TargetLimit, &out.TargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelLimit != nil {
 		in, out := &in.LabelLimit, &out.LabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelNameLengthLimit != nil {
 		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelValueLengthLimit != nil {
 		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	in.NativeHistogramConfig.DeepCopyInto(&out.NativeHistogramConfig)
 	if in.KeepDroppedTargets != nil {
 		in, out := &in.KeepDroppedTargets, &out.KeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.AttachMetadata != nil {

--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -326,26 +326,26 @@ type ScrapeConfigSpec struct {
 	// sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 	// bodySizeLimit defines a per-scrape limit on the size of the uncompressed
 	// response body that will be accepted by Prometheus. Targets responding with
 	// a body larger than this many bytes will cause the scrape to fail.
@@ -363,7 +363,7 @@ type ScrapeConfigSpec struct {
 	//
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// metricRelabelings defines the metricRelabelings to apply to samples before ingestion.
 	// +kubebuilder:validation:MinItems=1
 	// +optional

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -3132,27 +3132,27 @@ func (in *ScrapeConfigSpec) DeepCopyInto(out *ScrapeConfigSpec) {
 	}
 	if in.SampleLimit != nil {
 		in, out := &in.SampleLimit, &out.SampleLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetLimit != nil {
 		in, out := &in.TargetLimit, &out.TargetLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelLimit != nil {
 		in, out := &in.LabelLimit, &out.LabelLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelNameLengthLimit != nil {
 		in, out := &in.LabelNameLengthLimit, &out.LabelNameLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelValueLengthLimit != nil {
 		in, out := &in.LabelValueLengthLimit, &out.LabelValueLengthLimit
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BodySizeLimit != nil {
@@ -3163,7 +3163,7 @@ func (in *ScrapeConfigSpec) DeepCopyInto(out *ScrapeConfigSpec) {
 	in.NativeHistogramConfig.DeepCopyInto(&out.NativeHistogramConfig)
 	if in.KeepDroppedTargets != nil {
 		in, out := &in.KeepDroppedTargets, &out.KeepDroppedTargets
-		*out = new(uint64)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MetricRelabelConfigs != nil {

--- a/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/commonprometheusfields.go
@@ -442,7 +442,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedSampleLimit` is greater than the `sampleLimit`, the `sampleLimit` will be set to `enforcedSampleLimit`.
 	// * Scrape objects with a sampleLimit value less than or equal to enforcedSampleLimit keep their specific value.
 	// * Scrape objects with a sampleLimit value greater than enforcedSampleLimit are set to enforcedSampleLimit.
-	EnforcedSampleLimit *uint64 `json:"enforcedSampleLimit,omitempty"`
+	EnforcedSampleLimit *int64 `json:"enforcedSampleLimit,omitempty"`
 	// enforcedTargetLimit when defined specifies a global limit on the number
 	// of scraped targets. The value overrides any `spec.targetLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.targetLimit` is
@@ -456,7 +456,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedTargetLimit` is greater than the `targetLimit`, the `targetLimit` will be set to `enforcedTargetLimit`.
 	// * Scrape objects with a targetLimit value less than or equal to enforcedTargetLimit keep their specific value.
 	// * Scrape objects with a targetLimit value greater than enforcedTargetLimit are set to enforcedTargetLimit.
-	EnforcedTargetLimit *uint64 `json:"enforcedTargetLimit,omitempty"`
+	EnforcedTargetLimit *int64 `json:"enforcedTargetLimit,omitempty"`
 	// enforcedLabelLimit when defined specifies a global limit on the number
 	// of labels per sample. The value overrides any `spec.labelLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelLimit` is
@@ -469,7 +469,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedLabelLimit` is greater than the `labelLimit`, the `labelLimit` will be set to `enforcedLabelLimit`.
 	// * Scrape objects with a labelLimit value less than or equal to enforcedLabelLimit keep their specific value.
 	// * Scrape objects with a labelLimit value greater than enforcedLabelLimit are set to enforcedLabelLimit.
-	EnforcedLabelLimit *uint64 `json:"enforcedLabelLimit,omitempty"`
+	EnforcedLabelLimit *int64 `json:"enforcedLabelLimit,omitempty"`
 	// enforcedLabelNameLengthLimit when defined specifies a global limit on the length
 	// of labels name per sample. The value overrides any `spec.labelNameLengthLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelNameLengthLimit` is
@@ -482,7 +482,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedLabelNameLengthLimit` is greater than the `labelNameLengthLimit`, the `labelNameLengthLimit` will be set to `enforcedLabelNameLengthLimit`.
 	// * Scrape objects with a labelNameLengthLimit value less than or equal to enforcedLabelNameLengthLimit keep their specific value.
 	// * Scrape objects with a labelNameLengthLimit value greater than enforcedLabelNameLengthLimit are set to enforcedLabelNameLengthLimit.
-	EnforcedLabelNameLengthLimit *uint64 `json:"enforcedLabelNameLengthLimit,omitempty"`
+	EnforcedLabelNameLengthLimit *int64 `json:"enforcedLabelNameLengthLimit,omitempty"`
 	// enforcedLabelValueLengthLimit when not null defines a global limit on the length
 	// of labels value per sample. The value overrides any `spec.labelValueLengthLimit` set by
 	// ServiceMonitor, PodMonitor, Probe objects unless `spec.labelValueLengthLimit` is
@@ -495,7 +495,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedLabelValueLengthLimit` is greater than the `labelValueLengthLimit`, the `labelValueLengthLimit` will be set to `enforcedLabelValueLengthLimit`.
 	// * Scrape objects with a labelValueLengthLimit value less than or equal to enforcedLabelValueLengthLimit keep their specific value.
 	// * Scrape objects with a labelValueLengthLimit value greater than enforcedLabelValueLengthLimit are set to enforcedLabelValueLengthLimit.
-	EnforcedLabelValueLengthLimit *uint64 `json:"enforcedLabelValueLengthLimit,omitempty"`
+	EnforcedLabelValueLengthLimit *int64 `json:"enforcedLabelValueLengthLimit,omitempty"`
 	// enforcedKeepDroppedTargets when defined specifies a global limit on the number of targets
 	// dropped by relabeling that will be kept in memory. The value overrides
 	// any `spec.keepDroppedTargets` set by
@@ -509,7 +509,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	// If Prometheus version is >= 2.45.0 and the `enforcedKeepDroppedTargets` is greater than the `keepDroppedTargets`, the `keepDroppedTargets` will be set to `enforcedKeepDroppedTargets`.
 	// * Scrape objects with a keepDroppedTargets value less than or equal to enforcedKeepDroppedTargets keep their specific value.
 	// * Scrape objects with a keepDroppedTargets value greater than enforcedKeepDroppedTargets are set to enforcedKeepDroppedTargets.
-	EnforcedKeepDroppedTargets *uint64 `json:"enforcedKeepDroppedTargets,omitempty"`
+	EnforcedKeepDroppedTargets *int64 `json:"enforcedKeepDroppedTargets,omitempty"`
 	// enforcedBodySizeLimit when defined specifies a global limit on the size
 	// of uncompressed response body that will be accepted by Prometheus.
 	// Targets responding with a body larger than this many bytes will cause
@@ -605,31 +605,31 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedSampleLimit.
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedTargetLimit.
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelLimit.
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelNameLengthLimit.
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.45.0 and newer.
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedLabelValueLengthLimit.
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 	// keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
 	// that will be kept in memory. 0 means no limit.
 	//
@@ -637,7 +637,7 @@ type CommonPrometheusFieldsApplyConfiguration struct {
 	//
 	// Note that the global limit only applies to scrape objects that don't specify an explicit limit value.
 	// If you want to enforce a maximum limit for all scrape objects, refer to enforcedKeepDroppedTargets.
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// reloadStrategy defines the strategy used to reload the Prometheus configuration.
 	// If not specified, the configuration is reloaded using the /-/reload HTTP endpoint.
 	ReloadStrategy *monitoringv1.ReloadStrategyType `json:"reloadStrategy,omitempty"`
@@ -1273,7 +1273,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedNamespaceLabel(va
 // WithEnforcedSampleLimit sets the EnforcedSampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedSampleLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedSampleLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedSampleLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedSampleLimit = &value
 	return b
 }
@@ -1281,7 +1281,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedSampleLimit(value
 // WithEnforcedTargetLimit sets the EnforcedTargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedTargetLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedTargetLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedTargetLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedTargetLimit = &value
 	return b
 }
@@ -1289,7 +1289,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedTargetLimit(value
 // WithEnforcedLabelLimit sets the EnforcedLabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedLabelLimit = &value
 	return b
 }
@@ -1297,7 +1297,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelLimit(value 
 // WithEnforcedLabelNameLengthLimit sets the EnforcedLabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelNameLengthLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelNameLengthLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelNameLengthLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedLabelNameLengthLimit = &value
 	return b
 }
@@ -1305,7 +1305,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelNameLengthLi
 // WithEnforcedLabelValueLengthLimit sets the EnforcedLabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelValueLengthLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelValueLengthLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelValueLengthLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedLabelValueLengthLimit = &value
 	return b
 }
@@ -1313,7 +1313,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedLabelValueLengthL
 // WithEnforcedKeepDroppedTargets sets the EnforcedKeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedKeepDroppedTargets field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedKeepDroppedTargets(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithEnforcedKeepDroppedTargets(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.EnforcedKeepDroppedTargets = &value
 	return b
 }
@@ -1458,7 +1458,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithBodySizeLimit(value monit
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithSampleLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithSampleLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.SampleLimit = &value
 	return b
 }
@@ -1466,7 +1466,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithSampleLimit(value uint64)
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithTargetLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithTargetLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.TargetLimit = &value
 	return b
 }
@@ -1474,7 +1474,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithTargetLimit(value uint64)
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.LabelLimit = &value
 	return b
 }
@@ -1482,7 +1482,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelLimit(value uint64) 
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelNameLengthLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelNameLengthLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.LabelNameLengthLimit = &value
 	return b
 }
@@ -1490,7 +1490,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelNameLengthLimit(valu
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelValueLengthLimit(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelValueLengthLimit(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.LabelValueLengthLimit = &value
 	return b
 }
@@ -1498,7 +1498,7 @@ func (b *CommonPrometheusFieldsApplyConfiguration) WithLabelValueLengthLimit(val
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *CommonPrometheusFieldsApplyConfiguration) WithKeepDroppedTargets(value uint64) *CommonPrometheusFieldsApplyConfiguration {
+func (b *CommonPrometheusFieldsApplyConfiguration) WithKeepDroppedTargets(value int64) *CommonPrometheusFieldsApplyConfiguration {
 	b.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/nativehistogramconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/nativehistogramconfig.go
@@ -36,7 +36,7 @@ type NativeHistogramConfigApplyConfiguration struct {
 	// nativeHistogramBucketLimit defines ff there are more than this many buckets in a native histogram,
 	// buckets will be merged to stay within the limit.
 	// It requires Prometheus >= v2.45.0.
-	NativeHistogramBucketLimit *uint64 `json:"nativeHistogramBucketLimit,omitempty"`
+	NativeHistogramBucketLimit *int64 `json:"nativeHistogramBucketLimit,omitempty"`
 	// nativeHistogramMinBucketFactor defines if the growth factor of one bucket to the next is smaller than this,
 	// buckets will be merged to increase the factor sufficiently.
 	// It requires Prometheus >= v2.50.0.
@@ -71,7 +71,7 @@ func (b *NativeHistogramConfigApplyConfiguration) WithScrapeClassicHistograms(va
 // WithNativeHistogramBucketLimit sets the NativeHistogramBucketLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the NativeHistogramBucketLimit field is set to the value of the last call.
-func (b *NativeHistogramConfigApplyConfiguration) WithNativeHistogramBucketLimit(value uint64) *NativeHistogramConfigApplyConfiguration {
+func (b *NativeHistogramConfigApplyConfiguration) WithNativeHistogramBucketLimit(value int64) *NativeHistogramConfigApplyConfiguration {
 	b.NativeHistogramBucketLimit = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/podmonitorspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/podmonitorspec.go
@@ -57,10 +57,10 @@ type PodMonitorSpecApplyConfiguration struct {
 	NamespaceSelector *NamespaceSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
 	// sampleLimit defines a per-scrape limit on the number of scraped samples
 	// that will be accepted.
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will
 	// be accepted.
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
 	//
@@ -75,21 +75,21 @@ type PodMonitorSpecApplyConfiguration struct {
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelValueLengthLimit                   *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit                   *int64 `json:"labelValueLengthLimit,omitempty"`
 	NativeHistogramConfigApplyConfiguration `json:",inline"`
 	// keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
 	// that will be kept in memory. 0 means no limit.
 	//
 	// It requires Prometheus >= v2.47.0.
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// attachMetadata defines additional metadata which is added to the
 	// discovered targets.
 	//
@@ -168,7 +168,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithNamespaceSelector(value *Namespac
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithSampleLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithSampleLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.SampleLimit = &value
 	return b
 }
@@ -176,7 +176,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithSampleLimit(value uint64) *PodMon
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithTargetLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithTargetLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.TargetLimit = &value
 	return b
 }
@@ -202,7 +202,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithFallbackScrapeProtocol(value moni
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithLabelLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithLabelLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.LabelLimit = &value
 	return b
 }
@@ -210,7 +210,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithLabelLimit(value uint64) *PodMoni
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.LabelNameLengthLimit = &value
 	return b
 }
@@ -218,7 +218,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.LabelValueLengthLimit = &value
 	return b
 }
@@ -242,7 +242,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithScrapeClassicHistograms(value boo
 // WithNativeHistogramBucketLimit sets the NativeHistogramBucketLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the NativeHistogramBucketLimit field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithNativeHistogramBucketLimit(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithNativeHistogramBucketLimit(value int64) *PodMonitorSpecApplyConfiguration {
 	b.NativeHistogramConfigApplyConfiguration.NativeHistogramBucketLimit = &value
 	return b
 }
@@ -266,7 +266,7 @@ func (b *PodMonitorSpecApplyConfiguration) WithConvertClassicHistogramsToNHCB(va
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *PodMonitorSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *PodMonitorSpecApplyConfiguration {
+func (b *PodMonitorSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *PodMonitorSpecApplyConfiguration {
 	b.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/probespec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/probespec.go
@@ -50,9 +50,9 @@ type ProbeSpecApplyConfiguration struct {
 	// authorization section for this endpoint
 	Authorization *SafeAuthorizationApplyConfiguration `json:"authorization,omitempty"`
 	// sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
 	//
@@ -66,19 +66,19 @@ type ProbeSpecApplyConfiguration struct {
 	FallbackScrapeProtocol *monitoringv1.ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelValueLengthLimit                   *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit                   *int64 `json:"labelValueLengthLimit,omitempty"`
 	NativeHistogramConfigApplyConfiguration `json:",inline"`
 	// keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
 	// that will be kept in memory. 0 means no limit.
 	//
 	// It requires Prometheus >= v2.47.0.
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// scrapeClass defines the scrape class to apply.
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
 	// params defines the list of HTTP query parameters for the scrape.
@@ -166,7 +166,7 @@ func (b *ProbeSpecApplyConfiguration) WithAuthorization(value *SafeAuthorization
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithSampleLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithSampleLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.SampleLimit = &value
 	return b
 }
@@ -174,7 +174,7 @@ func (b *ProbeSpecApplyConfiguration) WithSampleLimit(value uint64) *ProbeSpecAp
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithTargetLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithTargetLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.TargetLimit = &value
 	return b
 }
@@ -200,7 +200,7 @@ func (b *ProbeSpecApplyConfiguration) WithFallbackScrapeProtocol(value monitorin
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithLabelLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithLabelLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.LabelLimit = &value
 	return b
 }
@@ -208,7 +208,7 @@ func (b *ProbeSpecApplyConfiguration) WithLabelLimit(value uint64) *ProbeSpecApp
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.LabelNameLengthLimit = &value
 	return b
 }
@@ -216,7 +216,7 @@ func (b *ProbeSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *Pr
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.LabelValueLengthLimit = &value
 	return b
 }
@@ -240,7 +240,7 @@ func (b *ProbeSpecApplyConfiguration) WithScrapeClassicHistograms(value bool) *P
 // WithNativeHistogramBucketLimit sets the NativeHistogramBucketLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the NativeHistogramBucketLimit field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithNativeHistogramBucketLimit(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithNativeHistogramBucketLimit(value int64) *ProbeSpecApplyConfiguration {
 	b.NativeHistogramConfigApplyConfiguration.NativeHistogramBucketLimit = &value
 	return b
 }
@@ -264,7 +264,7 @@ func (b *ProbeSpecApplyConfiguration) WithConvertClassicHistogramsToNHCB(value b
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *ProbeSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *ProbeSpecApplyConfiguration {
+func (b *ProbeSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *ProbeSpecApplyConfiguration {
 	b.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -722,7 +722,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedNamespaceLabel(value stri
 // WithEnforcedSampleLimit sets the EnforcedSampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedSampleLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedSampleLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedSampleLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedSampleLimit = &value
 	return b
 }
@@ -730,7 +730,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedSampleLimit(value uint64)
 // WithEnforcedTargetLimit sets the EnforcedTargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedTargetLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedTargetLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedTargetLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedTargetLimit = &value
 	return b
 }
@@ -738,7 +738,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedTargetLimit(value uint64)
 // WithEnforcedLabelLimit sets the EnforcedLabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelLimit = &value
 	return b
 }
@@ -746,7 +746,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelLimit(value uint64) 
 // WithEnforcedLabelNameLengthLimit sets the EnforcedLabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelNameLengthLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelNameLengthLimit = &value
 	return b
 }
@@ -754,7 +754,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit(valu
 // WithEnforcedLabelValueLengthLimit sets the EnforcedLabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelValueLengthLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelValueLengthLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelValueLengthLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelValueLengthLimit = &value
 	return b
 }
@@ -762,7 +762,7 @@ func (b *PrometheusSpecApplyConfiguration) WithEnforcedLabelValueLengthLimit(val
 // WithEnforcedKeepDroppedTargets sets the EnforcedKeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedKeepDroppedTargets field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithEnforcedKeepDroppedTargets(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithEnforcedKeepDroppedTargets(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedKeepDroppedTargets = &value
 	return b
 }
@@ -907,7 +907,7 @@ func (b *PrometheusSpecApplyConfiguration) WithBodySizeLimit(value monitoringv1.
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithSampleLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithSampleLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.SampleLimit = &value
 	return b
 }
@@ -915,7 +915,7 @@ func (b *PrometheusSpecApplyConfiguration) WithSampleLimit(value uint64) *Promet
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithTargetLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithTargetLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.TargetLimit = &value
 	return b
 }
@@ -923,7 +923,7 @@ func (b *PrometheusSpecApplyConfiguration) WithTargetLimit(value uint64) *Promet
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithLabelLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithLabelLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelLimit = &value
 	return b
 }
@@ -931,7 +931,7 @@ func (b *PrometheusSpecApplyConfiguration) WithLabelLimit(value uint64) *Prometh
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelNameLengthLimit = &value
 	return b
 }
@@ -939,7 +939,7 @@ func (b *PrometheusSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelValueLengthLimit = &value
 	return b
 }
@@ -947,7 +947,7 @@ func (b *PrometheusSpecApplyConfiguration) WithLabelValueLengthLimit(value uint6
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *PrometheusSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *PrometheusSpecApplyConfiguration {
+func (b *PrometheusSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *PrometheusSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/relabelconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/relabelconfig.go
@@ -46,7 +46,7 @@ type RelabelConfigApplyConfiguration struct {
 	// modulus to take of the hash of the source label values.
 	//
 	// Only applicable when the action is `HashMod`.
-	Modulus *uint64 `json:"modulus,omitempty"`
+	Modulus *int64 `json:"modulus,omitempty"`
 	// replacement value against which a Replace action is performed if the
 	// regular expression matches.
 	//
@@ -104,7 +104,7 @@ func (b *RelabelConfigApplyConfiguration) WithRegex(value string) *RelabelConfig
 // WithModulus sets the Modulus field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Modulus field is set to the value of the last call.
-func (b *RelabelConfigApplyConfiguration) WithModulus(value uint64) *RelabelConfigApplyConfiguration {
+func (b *RelabelConfigApplyConfiguration) WithModulus(value int64) *RelabelConfigApplyConfiguration {
 	b.Modulus = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/servicemonitorspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/servicemonitorspec.go
@@ -62,7 +62,7 @@ type ServiceMonitorSpecApplyConfiguration struct {
 	NamespaceSelector *NamespaceSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
 	// sampleLimit defines a per-scrape limit on the number of scraped samples
 	// that will be accepted.
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// scrapeProtocols defines the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
 	//
@@ -76,25 +76,25 @@ type ServiceMonitorSpecApplyConfiguration struct {
 	FallbackScrapeProtocol *monitoringv1.ScrapeProtocol `json:"fallbackScrapeProtocol,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will
 	// be accepted.
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	//
 	// It requires Prometheus >= v2.27.0.
-	LabelValueLengthLimit                   *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit                   *int64 `json:"labelValueLengthLimit,omitempty"`
 	NativeHistogramConfigApplyConfiguration `json:",inline"`
 	// keepDroppedTargets defines the per-scrape limit on the number of targets dropped by relabeling
 	// that will be kept in memory. 0 means no limit.
 	//
 	// It requires Prometheus >= v2.47.0.
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// attachMetadata defines additional metadata which is added to the
 	// discovered targets.
 	//
@@ -189,7 +189,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithNamespaceSelector(value *Name
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithSampleLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithSampleLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.SampleLimit = &value
 	return b
 }
@@ -215,7 +215,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithFallbackScrapeProtocol(value 
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithTargetLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithTargetLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.TargetLimit = &value
 	return b
 }
@@ -223,7 +223,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithTargetLimit(value uint64) *Se
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithLabelLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithLabelLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.LabelLimit = &value
 	return b
 }
@@ -231,7 +231,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithLabelLimit(value uint64) *Ser
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.LabelNameLengthLimit = &value
 	return b
 }
@@ -239,7 +239,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithLabelNameLengthLimit(value ui
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.LabelValueLengthLimit = &value
 	return b
 }
@@ -263,7 +263,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithScrapeClassicHistograms(value
 // WithNativeHistogramBucketLimit sets the NativeHistogramBucketLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the NativeHistogramBucketLimit field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithNativeHistogramBucketLimit(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithNativeHistogramBucketLimit(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.NativeHistogramConfigApplyConfiguration.NativeHistogramBucketLimit = &value
 	return b
 }
@@ -287,7 +287,7 @@ func (b *ServiceMonitorSpecApplyConfiguration) WithConvertClassicHistogramsToNHC
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *ServiceMonitorSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *ServiceMonitorSpecApplyConfiguration {
+func (b *ServiceMonitorSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *ServiceMonitorSpecApplyConfiguration {
 	b.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/prometheusagentspec.go
@@ -627,7 +627,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedNamespaceLabel(value
 // WithEnforcedSampleLimit sets the EnforcedSampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedSampleLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedSampleLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedSampleLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedSampleLimit = &value
 	return b
 }
@@ -635,7 +635,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedSampleLimit(value ui
 // WithEnforcedTargetLimit sets the EnforcedTargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedTargetLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedTargetLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedTargetLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedTargetLimit = &value
 	return b
 }
@@ -643,7 +643,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedTargetLimit(value ui
 // WithEnforcedLabelLimit sets the EnforcedLabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelLimit = &value
 	return b
 }
@@ -651,7 +651,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelLimit(value uin
 // WithEnforcedLabelNameLengthLimit sets the EnforcedLabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelNameLengthLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelNameLengthLimit = &value
 	return b
 }
@@ -659,7 +659,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelNameLengthLimit
 // WithEnforcedLabelValueLengthLimit sets the EnforcedLabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedLabelValueLengthLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelValueLengthLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelValueLengthLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedLabelValueLengthLimit = &value
 	return b
 }
@@ -667,7 +667,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedLabelValueLengthLimi
 // WithEnforcedKeepDroppedTargets sets the EnforcedKeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnforcedKeepDroppedTargets field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedKeepDroppedTargets(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithEnforcedKeepDroppedTargets(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.EnforcedKeepDroppedTargets = &value
 	return b
 }
@@ -812,7 +812,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithBodySizeLimit(value monitori
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithSampleLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithSampleLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.SampleLimit = &value
 	return b
 }
@@ -820,7 +820,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithSampleLimit(value uint64) *P
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithTargetLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithTargetLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.TargetLimit = &value
 	return b
 }
@@ -828,7 +828,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithTargetLimit(value uint64) *P
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithLabelLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithLabelLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelLimit = &value
 	return b
 }
@@ -836,7 +836,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithLabelLimit(value uint64) *Pr
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelNameLengthLimit = &value
 	return b
 }
@@ -844,7 +844,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithLabelNameLengthLimit(value u
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.LabelValueLengthLimit = &value
 	return b
 }
@@ -852,7 +852,7 @@ func (b *PrometheusAgentSpecApplyConfiguration) WithLabelValueLengthLimit(value 
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *PrometheusAgentSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *PrometheusAgentSpecApplyConfiguration {
+func (b *PrometheusAgentSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *PrometheusAgentSpecApplyConfiguration {
 	b.CommonPrometheusFieldsApplyConfiguration.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1alpha1/scrapeconfigspec.go
@@ -135,18 +135,18 @@ type ScrapeConfigSpecApplyConfiguration struct {
 	// tlsConfig defines the TLS configuration to use on every scrape request
 	TLSConfig *v1.SafeTLSConfigApplyConfiguration `json:"tlsConfig,omitempty"`
 	// sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	SampleLimit *uint64 `json:"sampleLimit,omitempty"`
+	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
-	TargetLimit *uint64 `json:"targetLimit,omitempty"`
+	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelLimit *uint64 `json:"labelLimit,omitempty"`
+	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelNameLengthLimit *uint64 `json:"labelNameLengthLimit,omitempty"`
+	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	LabelValueLengthLimit *uint64 `json:"labelValueLengthLimit,omitempty"`
+	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 	// bodySizeLimit defines a per-scrape limit on the size of the uncompressed
 	// response body that will be accepted by Prometheus. Targets responding with
 	// a body larger than this many bytes will cause the scrape to fail.
@@ -158,7 +158,7 @@ type ScrapeConfigSpecApplyConfiguration struct {
 	// that will be kept in memory. 0 means no limit.
 	//
 	// It requires Prometheus >= v2.47.0.
-	KeepDroppedTargets *uint64 `json:"keepDroppedTargets,omitempty"`
+	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// metricRelabelings defines the metricRelabelings to apply to samples before ingestion.
 	MetricRelabelConfigs []v1.RelabelConfigApplyConfiguration `json:"metricRelabelings,omitempty"`
 	// ProxyConfig allows customizing the proxy behaviour for this scrape config.
@@ -640,7 +640,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithTLSConfig(value *v1.SafeTLSConf
 // WithSampleLimit sets the SampleLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SampleLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithSampleLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithSampleLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.SampleLimit = &value
 	return b
 }
@@ -648,7 +648,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithSampleLimit(value uint64) *Scra
 // WithTargetLimit sets the TargetLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithTargetLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithTargetLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.TargetLimit = &value
 	return b
 }
@@ -656,7 +656,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithTargetLimit(value uint64) *Scra
 // WithLabelLimit sets the LabelLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithLabelLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithLabelLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.LabelLimit = &value
 	return b
 }
@@ -664,7 +664,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithLabelLimit(value uint64) *Scrap
 // WithLabelNameLengthLimit sets the LabelNameLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelNameLengthLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithLabelNameLengthLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithLabelNameLengthLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.LabelNameLengthLimit = &value
 	return b
 }
@@ -672,7 +672,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithLabelNameLengthLimit(value uint
 // WithLabelValueLengthLimit sets the LabelValueLengthLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LabelValueLengthLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithLabelValueLengthLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithLabelValueLengthLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.LabelValueLengthLimit = &value
 	return b
 }
@@ -704,7 +704,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithScrapeClassicHistograms(value b
 // WithNativeHistogramBucketLimit sets the NativeHistogramBucketLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the NativeHistogramBucketLimit field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithNativeHistogramBucketLimit(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithNativeHistogramBucketLimit(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.NativeHistogramConfigApplyConfiguration.NativeHistogramBucketLimit = &value
 	return b
 }
@@ -728,7 +728,7 @@ func (b *ScrapeConfigSpecApplyConfiguration) WithConvertClassicHistogramsToNHCB(
 // WithKeepDroppedTargets sets the KeepDroppedTargets field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KeepDroppedTargets field is set to the value of the last call.
-func (b *ScrapeConfigSpecApplyConfiguration) WithKeepDroppedTargets(value uint64) *ScrapeConfigSpecApplyConfiguration {
+func (b *ScrapeConfigSpecApplyConfiguration) WithKeepDroppedTargets(value int64) *ScrapeConfigSpecApplyConfiguration {
 	b.KeepDroppedTargets = &value
 	return b
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -422,7 +422,7 @@ var (
 
 // AddLimitsToYAML appends the given limit key to the configuration if
 // supported by the Prometheus version.
-func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit *uint64, enforcedLimit *uint64) yaml.MapSlice {
+func (cg *ConfigGenerator) AddLimitsToYAML(cfg yaml.MapSlice, k limitKey, limit *int64, enforcedLimit *int64) yaml.MapSlice {
 	finalLimit := cg.getLimit(limit, enforcedLimit)
 	if finalLimit == nil {
 		return cfg
@@ -2219,7 +2219,7 @@ func generateRunningFilter() yaml.MapSlice {
 	}
 }
 
-func (cg *ConfigGenerator) getLimit(user *uint64, enforced *uint64) *uint64 {
+func (cg *ConfigGenerator) getLimit(user *int64, enforced *int64) *int64 {
 	if ptr.Deref(enforced, 0) == 0 {
 		return user
 	}
@@ -2387,7 +2387,7 @@ func generateRelabelConfig(rc []monitoringv1.RelabelConfig) []yaml.MapSlice {
 			relabeling = append(relabeling, yaml.MapItem{Key: "regex", Value: c.Regex})
 		}
 
-		if c.Modulus != uint64(0) {
+		if c.Modulus != 0 {
 			relabeling = append(relabeling, yaml.MapItem{Key: "modulus", Value: c.Modulus})
 		}
 
@@ -2898,7 +2898,7 @@ func (cg *ConfigGenerator) GenerateRemoteWriteConfig(rws []monitoringv1.RemoteWr
 				relabeling = append(relabeling, yaml.MapItem{Key: "regex", Value: c.Regex})
 			}
 
-			if c.Modulus != uint64(0) {
+			if c.Modulus != 0 {
 				relabeling = append(relabeling, yaml.MapItem{Key: "modulus", Value: c.Modulus})
 			}
 
@@ -3108,7 +3108,7 @@ func (cg *ConfigGenerator) appendEvaluationInterval(slice yaml.MapSlice, evaluat
 	return append(slice, yaml.MapItem{Key: "evaluation_interval", Value: evaluationInterval})
 }
 
-func (cg *ConfigGenerator) appendGlobalLimits(slice yaml.MapSlice, limitKey string, limit *uint64, enforcedLimit *uint64) yaml.MapSlice {
+func (cg *ConfigGenerator) appendGlobalLimits(slice yaml.MapSlice, limitKey string, limit *int64, enforcedLimit *int64) yaml.MapSlice {
 	if ptr.Deref(limit, 0) > 0 {
 		if ptr.Deref(enforcedLimit, 0) > 0 && *limit > *enforcedLimit {
 			cg.logger.Warn(fmt.Sprintf("%q is greater than the enforced limit, using enforced limit", limitKey), "limit", *limit, "enforced_limit", *enforcedLimit)

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -109,12 +109,12 @@ func TestGlobalSettings(t *testing.T) {
 	var (
 		expectedBodySizeLimit         monitoringv1.ByteSize = "1000MB"
 		expectedRuleQueryOffset       monitoringv1.Duration = "30s"
-		expectedSampleLimit           uint64                = 10000
-		expectedTargetLimit           uint64                = 1000
-		expectedLabelLimit            uint64                = 50
-		expectedLabelNameLengthLimit  uint64                = 40
-		expectedLabelValueLengthLimit uint64                = 30
-		expectedkeepDroppedTargets    uint64                = 50
+		expectedSampleLimit           int64                 = 10000
+		expectedTargetLimit           int64                 = 1000
+		expectedLabelLimit            int64                 = 50
+		expectedLabelNameLengthLimit  int64                 = 40
+		expectedLabelValueLengthLimit int64                 = 30
+		expectedkeepDroppedTargets    int64                 = 50
 	)
 
 	for _, tc := range []struct {
@@ -131,12 +131,12 @@ func TestGlobalSettings(t *testing.T) {
 		ScrapeFailureLogFile        *string
 		Version                     string
 		BodySizeLimit               *monitoringv1.ByteSize
-		SampleLimit                 *uint64
-		TargetLimit                 *uint64
-		LabelLimit                  *uint64
-		LabelNameLengthLimit        *uint64
-		LabelValueLengthLimit       *uint64
-		KeepDroppedTargets          *uint64
+		SampleLimit                 *int64
+		TargetLimit                 *int64
+		LabelLimit                  *int64
+		LabelNameLengthLimit        *int64
+		LabelValueLengthLimit       *int64
+		KeepDroppedTargets          *int64
 		ExpectError                 bool
 		Golden                      string
 	}{
@@ -3627,9 +3627,9 @@ func TestTrackTimestampsStaleness(t *testing.T) {
 
 func TestSampleLimits(t *testing.T) {
 	for _, tc := range []struct {
-		globalLimit   int
-		enforcedLimit int
-		limit         int
+		globalLimit   int64
+		enforcedLimit int64
+		limit         int64
 		golden        string
 		version       string
 	}{
@@ -3694,7 +3694,7 @@ func TestSampleLimits(t *testing.T) {
 			p := defaultPrometheus()
 			p.Spec.CommonPrometheusFields.Version = tc.version
 			if tc.globalLimit >= 0 {
-				p.Spec.SampleLimit = new(uint64(tc.globalLimit))
+				p.Spec.SampleLimit = new(tc.globalLimit)
 			}
 
 			if tc.golden == "SampleLimits_GlobalLimit1000_Enforce2000.golden" {
@@ -3702,8 +3702,7 @@ func TestSampleLimits(t *testing.T) {
 			}
 
 			if tc.enforcedLimit >= 0 {
-				i := uint64(tc.enforcedLimit)
-				p.Spec.EnforcedSampleLimit = &i
+				p.Spec.EnforcedSampleLimit = new(tc.enforcedLimit)
 			}
 
 			serviceMonitor := monitoringv1.ServiceMonitor{
@@ -3724,8 +3723,7 @@ func TestSampleLimits(t *testing.T) {
 				},
 			}
 			if tc.limit >= 0 {
-				sampleLimit := uint64(tc.limit)
-				serviceMonitor.Spec.SampleLimit = &sampleLimit
+				serviceMonitor.Spec.SampleLimit = new(tc.limit)
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -3752,8 +3750,8 @@ func TestSampleLimits(t *testing.T) {
 func TestTargetLimits(t *testing.T) {
 	for _, tc := range []struct {
 		version       string
-		enforcedLimit int
-		limit         int
+		enforcedLimit int64
+		limit         int64
 		expected      string
 		golden        string
 	}{
@@ -3811,8 +3809,7 @@ func TestTargetLimits(t *testing.T) {
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLimit >= 0 {
-				i := uint64(tc.enforcedLimit)
-				p.Spec.EnforcedTargetLimit = &i
+				p.Spec.EnforcedTargetLimit = new(tc.enforcedLimit)
 			}
 
 			serviceMonitor := monitoringv1.ServiceMonitor{
@@ -3833,8 +3830,7 @@ func TestTargetLimits(t *testing.T) {
 				},
 			}
 			if tc.limit >= 0 {
-				limit := uint64(tc.limit)
-				serviceMonitor.Spec.TargetLimit = &limit
+				serviceMonitor.Spec.TargetLimit = new(tc.limit)
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -4828,8 +4824,8 @@ func TestRemoteWriteConfig(t *testing.T) {
 func TestLabelLimits(t *testing.T) {
 	for _, tc := range []struct {
 		version            string
-		enforcedLabelLimit int
-		labelLimit         int
+		enforcedLabelLimit int64
+		labelLimit         int64
 		golden             string
 	}{
 		{
@@ -4890,7 +4886,7 @@ func TestLabelLimits(t *testing.T) {
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelLimit >= 0 {
-				p.Spec.EnforcedLabelLimit = new(uint64(tc.enforcedLabelLimit))
+				p.Spec.EnforcedLabelLimit = new(tc.enforcedLabelLimit)
 			}
 
 			serviceMonitor := monitoringv1.ServiceMonitor{
@@ -4911,8 +4907,7 @@ func TestLabelLimits(t *testing.T) {
 				},
 			}
 			if tc.labelLimit >= 0 {
-				labelLimit := uint64(tc.labelLimit)
-				serviceMonitor.Spec.LabelLimit = &labelLimit
+				serviceMonitor.Spec.LabelLimit = new(tc.labelLimit)
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -4939,8 +4934,8 @@ func TestLabelLimits(t *testing.T) {
 func TestLabelNameLengthLimits(t *testing.T) {
 	for _, tc := range []struct {
 		version                      string
-		enforcedLabelNameLengthLimit int
-		labelNameLengthLimit         int
+		enforcedLabelNameLengthLimit int64
+		labelNameLengthLimit         int64
 		golden                       string
 	}{
 		{
@@ -4997,7 +4992,7 @@ func TestLabelNameLengthLimits(t *testing.T) {
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelNameLengthLimit >= 0 {
-				p.Spec.EnforcedLabelNameLengthLimit = new(uint64(tc.enforcedLabelNameLengthLimit))
+				p.Spec.EnforcedLabelNameLengthLimit = new(tc.enforcedLabelNameLengthLimit)
 			}
 
 			podMonitor := monitoringv1.PodMonitor{
@@ -5018,8 +5013,7 @@ func TestLabelNameLengthLimits(t *testing.T) {
 				},
 			}
 			if tc.labelNameLengthLimit >= 0 {
-				labelNameLengthLimit := uint64(tc.labelNameLengthLimit)
-				podMonitor.Spec.LabelNameLengthLimit = &labelNameLengthLimit
+				podMonitor.Spec.LabelNameLengthLimit = new(tc.labelNameLengthLimit)
 			}
 
 			cg := mustNewConfigGenerator(t, p)
@@ -5046,8 +5040,8 @@ func TestLabelNameLengthLimits(t *testing.T) {
 func TestLabelValueLengthLimits(t *testing.T) {
 	for _, tc := range []struct {
 		version                       string
-		enforcedLabelValueLengthLimit int
-		labelValueLengthLimit         int
+		enforcedLabelValueLengthLimit int64
+		labelValueLengthLimit         int64
 		golden                        string
 	}{
 		{
@@ -5104,7 +5098,7 @@ func TestLabelValueLengthLimits(t *testing.T) {
 			p.Spec.CommonPrometheusFields.Version = tc.version
 
 			if tc.enforcedLabelValueLengthLimit >= 0 {
-				p.Spec.EnforcedLabelValueLengthLimit = new(uint64(tc.enforcedLabelValueLengthLimit))
+				p.Spec.EnforcedLabelValueLengthLimit = new(tc.enforcedLabelValueLengthLimit)
 			}
 
 			probe := monitoringv1.Probe{
@@ -5151,8 +5145,7 @@ func TestLabelValueLengthLimits(t *testing.T) {
 				},
 			}
 			if tc.labelValueLengthLimit >= 0 {
-				labelValueLengthLimit := uint64(tc.labelValueLengthLimit)
-				probe.Spec.LabelValueLengthLimit = &labelValueLengthLimit
+				probe.Spec.LabelValueLengthLimit = new(tc.labelValueLengthLimit)
 			}
 
 			s := assets.NewTestStoreBuilder(
@@ -5191,26 +5184,26 @@ func TestLabelValueLengthLimits(t *testing.T) {
 func TestKeepDroppedTargets(t *testing.T) {
 	for _, tc := range []struct {
 		version                    string
-		enforcedKeepDroppedTargets *uint64
-		keepDroppedTargets         *uint64
+		enforcedKeepDroppedTargets *int64
+		keepDroppedTargets         *int64
 		golden                     string
 	}{
 		{
 			version:                    "v2.46.0",
-			enforcedKeepDroppedTargets: new(uint64(1000)),
-			keepDroppedTargets:         new(uint64(50)),
+			enforcedKeepDroppedTargets: new(int64(1000)),
+			keepDroppedTargets:         new(int64(50)),
 			golden:                     "KeepDroppedTargetsNotAddedInConfig.golden",
 		},
 		{
 			version:                    "v2.47.0",
-			enforcedKeepDroppedTargets: new(uint64(1000)),
-			keepDroppedTargets:         new(uint64(2000)),
+			enforcedKeepDroppedTargets: new(int64(1000)),
+			keepDroppedTargets:         new(int64(2000)),
 			golden:                     "KeepDroppedTargetsOverridedWithEnforcedValue.golden",
 		},
 		{
 			version:                    "v2.47.0",
-			enforcedKeepDroppedTargets: new(uint64(1000)),
-			keepDroppedTargets:         new(uint64(500)),
+			enforcedKeepDroppedTargets: new(int64(1000)),
+			keepDroppedTargets:         new(int64(500)),
 			golden:                     "KeepDroppedTargets.golden",
 		},
 	} {
@@ -5270,7 +5263,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 		{
 			version: "v3.0.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5280,7 +5273,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 		{
 			version: "v2.54.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5290,7 +5283,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 		{
 			version: "v2.46.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5300,7 +5293,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 		{
 			version: "v2.44.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5310,7 +5303,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 		{
 			version: "3.0.0-rc.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5321,7 +5314,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 			version: "v3.8.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
 				ScrapeNativeHistograms:         new(true),
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -5332,7 +5325,7 @@ func TestNativeHistogramConfig(t *testing.T) {
 			version: "v3.7.0",
 			nativeHistogramConfig: monitoringv1.NativeHistogramConfig{
 				ScrapeNativeHistograms:         new(true),
-				NativeHistogramBucketLimit:     new(uint64(10)),
+				NativeHistogramBucketLimit:     new(int64(10)),
 				ScrapeClassicHistograms:        new(true),
 				NativeHistogramMinBucketFactor: new(resource.MustParse("12.124")),
 				ConvertClassicHistogramsToNHCB: new(true),
@@ -6956,11 +6949,11 @@ func TestScrapeConfigSpecConfig(t *testing.T) {
 		{
 			name: "limits",
 			scSpec: monitoringv1alpha1.ScrapeConfigSpec{
-				SampleLimit:           new(uint64(10000)),
-				TargetLimit:           new(uint64(1000)),
-				LabelLimit:            new(uint64(50)),
-				LabelNameLengthLimit:  new(uint64(40)),
-				LabelValueLengthLimit: new(uint64(30)),
+				SampleLimit:           new(int64(10000)),
+				TargetLimit:           new(int64(1000)),
+				LabelLimit:            new(int64(50)),
+				LabelNameLengthLimit:  new(int64(40)),
+				LabelValueLengthLimit: new(int64(30)),
 			},
 			golden: "ScrapeConfigSpecConfig_Limits.golden",
 		},

--- a/pkg/prometheus/validation/validator.go
+++ b/pkg/prometheus/validation/validator.go
@@ -141,8 +141,8 @@ func (lcv *LabelConfigValidator) ValidateRelabelConfig(rc monitoringv1.RelabelCo
 
 	if action == string(relabel.KeepEqual) || action == string(relabel.DropEqual) {
 		if (rc.Regex != "" && rc.Regex != relabel.DefaultRelabelConfig.Regex.String()) ||
-			(rc.Modulus != uint64(0) &&
-				rc.Modulus != relabel.DefaultRelabelConfig.Modulus) ||
+			(rc.Modulus != 0 &&
+				rc.Modulus != int64(relabel.DefaultRelabelConfig.Modulus)) ||
 			(rc.Separator != nil &&
 				*rc.Separator != relabel.DefaultRelabelConfig.Separator) ||
 			(rc.Replacement != nil && *rc.Replacement != relabel.DefaultRelabelConfig.Replacement) {
@@ -154,8 +154,8 @@ func (lcv *LabelConfigValidator) ValidateRelabelConfig(rc monitoringv1.RelabelCo
 		if len(rc.SourceLabels) != 0 ||
 			(rc.TargetLabel != "" &&
 				rc.TargetLabel != relabel.DefaultRelabelConfig.TargetLabel) ||
-			(rc.Modulus != uint64(0) &&
-				rc.Modulus != relabel.DefaultRelabelConfig.Modulus) ||
+			(rc.Modulus != 0 &&
+				rc.Modulus != int64(relabel.DefaultRelabelConfig.Modulus)) ||
 			(rc.Separator != nil &&
 				*rc.Separator != relabel.DefaultRelabelConfig.Separator) ||
 			(rc.Replacement != nil &&

--- a/pkg/prometheus/validation/validator_test.go
+++ b/pkg/prometheus/validation/validator_test.go
@@ -372,7 +372,7 @@ func TestValidateRelabelConfig(t *testing.T) {
 				TargetLabel:  "__port1",
 				Separator:    new(relabel.DefaultRelabelConfig.Separator),
 				Regex:        relabel.DefaultRelabelConfig.Regex.String(),
-				Modulus:      relabel.DefaultRelabelConfig.Modulus,
+				Modulus:      int64(relabel.DefaultRelabelConfig.Modulus),
 				Replacement:  &relabel.DefaultRelabelConfig.Replacement,
 				Action:       "keepequal",
 			},


### PR DESCRIPTION
## Description

The PR #8662 added validation markers for all unsigned integer values. We can now safely change the Go types to comply with the Kubernetes API conventions which strongly recommend signed integers in Go definitions.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
