### PR TITLE
feat: report unbalanced topology sharding in Reconciled condition

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -31,6 +31,12 @@ const (
 	// DeprecatedFieldsInUseReason is used in status conditions to indicate that
 	// the resource uses deprecated fields.
 	DeprecatedFieldsInUseReason = "DeprecatedFieldsInUse"
+
+	// UnbalancedTopologyShardingReason is used in status conditions to indicate
+	// that topology sharding is configured with a number of shards that isn't a
+	// multiple of the number of topology zones. In that case, some targets are
+	// scraped by more than one shard, which results in duplicated samples.
+	UnbalancedTopologyShardingReason = "UnbalancedTopologySharding"
 )
 
 // StatusGetter represents a workload resource implementing the interface

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -35,6 +35,12 @@ const (
 	// IgnoredFieldsReason is used in status conditions to indicate that one or
 	// more spec fields were ignored because their values aren't supported.
 	IgnoredFieldsReason = "IgnoredFields"
+
+	// UnbalancedTopologyShardingReason is used in status conditions to indicate
+	// that topology sharding is configured with a number of shards that isn't a
+	// multiple of the number of topology zones. In that case, some targets are
+	// scraped by more than one shard, which results in duplicated samples.
+	UnbalancedTopologyShardingReason = "UnbalancedTopologySharding"
 )
 
 // StatusGetter represents a workload resource implementing the interface

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -680,6 +680,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("feature gate for Prometheus Agent's DaemonSet mode is not enabled")
 	}
 
+	if c.topologyShardingEnabled {
+		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+			logger.Warn(msg)
+			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
+		}
+	}
+
 	// Generate the configuration data.
 	var (
 		assetStore = assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -682,6 +682,13 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return fmt.Errorf("feature gate for Prometheus Agent's DaemonSet mode is not enabled")
 	}
 
+	if c.topologyShardingEnabled {
+		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+			logger.Warn(msg)
+			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
+		}
+	}
+
 	// Generate the configuration data.
 	var (
 		assetStore = assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -683,7 +683,7 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 	}
 
 	if c.topologyShardingEnabled {
-		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+		if ok, msg := prompkg.UnbalancedTopologyShardingMessage(p); ok {
 			logger.Warn(msg)
 			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
 		}

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -120,6 +120,39 @@ func shardsNumber(
 	return *cpf.Shards
 }
 
+// UnbalancedTopologyShardingMessage returns a warning message and true when the
+// resource uses topology sharding with a number of shards that isn't a multiple
+// of the number of topology zones. In that case, shard indices wrap around and
+// some targets end up being scraped by more than one shard, resulting in
+// duplicated samples. It returns an empty string and false otherwise.
+//
+// Callers are expected to only invoke it when the PrometheusTopologySharding
+// feature gate is enabled.
+func UnbalancedTopologyShardingMessage(p monitoringv1.PrometheusInterface) (string, bool) {
+	ss := p.GetCommonPrometheusFields().ShardingStrategy
+	if ss == nil ||
+		ss.Mode == nil ||
+		*ss.Mode != monitoringv1.TopologyShardingStrategyMode ||
+		ss.Topology == nil {
+		return "", false
+	}
+
+	numZones := int32(len(ss.Topology.Values))
+	if numZones == 0 {
+		return "", false
+	}
+
+	shards := shardsNumber(p)
+	if shards%numZones == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf(
+		"the number of shards (%d) isn't a multiple of the number of topology zones (%d); some targets will be scraped by more than one shard, resulting in duplicated samples",
+		shards, numZones,
+	), true
+}
+
 // ReplicasNumberPtr returns a ptr to the normalized number of replicas.
 func ReplicasNumberPtr(
 	p monitoringv1.PrometheusInterface,

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -128,6 +128,39 @@ func shardsNumber(
 	return *cpf.Shards
 }
 
+// UnbalancedTopologyShardingMessage returns a warning message and true when the
+// resource uses topology sharding with a number of shards that isn't a multiple
+// of the number of topology zones. In that case, shard indices wrap around and
+// some targets end up being scraped by more than one shard, resulting in
+// duplicated samples. It returns an empty string and false otherwise.
+//
+// Callers are expected to only invoke it when the PrometheusTopologySharding
+// feature gate is enabled.
+func UnbalancedTopologyShardingMessage(p monitoringv1.PrometheusInterface) (string, bool) {
+	ss := p.GetCommonPrometheusFields().ShardingStrategy
+	if ss == nil ||
+		ss.Mode == nil ||
+		*ss.Mode != monitoringv1.TopologyShardingStrategyMode ||
+		ss.Topology == nil {
+		return "", false
+	}
+
+	numZones := int32(len(ss.Topology.Values))
+	if numZones == 0 {
+		return "", false
+	}
+
+	shards := shardsNumber(p)
+	if shards%numZones == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf(
+		"the number of shards (%d) isn't a multiple of the number of topology zones (%d); some targets will be scraped by more than one shard, resulting in duplicated samples",
+		shards, numZones,
+	), true
+}
+
 // ReplicasNumberPtr returns a ptr to the normalized number of replicas.
 func ReplicasNumberPtr(
 	p monitoringv1.PrometheusInterface,

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -128,37 +128,37 @@ func shardsNumber(
 	return *cpf.Shards
 }
 
-// UnbalancedTopologyShardingMessage returns a warning message and true when the
+// UnbalancedTopologyShardingMessage returns true and a warning message when the
 // resource uses topology sharding with a number of shards that isn't a multiple
 // of the number of topology zones. In that case, shard indices wrap around and
 // some targets end up being scraped by more than one shard, resulting in
-// duplicated samples. It returns an empty string and false otherwise.
+// duplicated samples. It returns false and an empty string otherwise.
 //
 // Callers are expected to only invoke it when the PrometheusTopologySharding
 // feature gate is enabled.
-func UnbalancedTopologyShardingMessage(p monitoringv1.PrometheusInterface) (string, bool) {
+func UnbalancedTopologyShardingMessage(p monitoringv1.PrometheusInterface) (bool, string) {
 	ss := p.GetCommonPrometheusFields().ShardingStrategy
 	if ss == nil ||
 		ss.Mode == nil ||
 		*ss.Mode != monitoringv1.TopologyShardingStrategyMode ||
 		ss.Topology == nil {
-		return "", false
+		return false, ""
 	}
 
 	numZones := int32(len(ss.Topology.Values))
 	if numZones == 0 {
-		return "", false
+		return false, ""
 	}
 
 	shards := shardsNumber(p)
 	if shards%numZones == 0 {
-		return "", false
+		return false, ""
 	}
 
-	return fmt.Sprintf(
+	return true, fmt.Sprintf(
 		"the number of shards (%d) isn't a multiple of the number of topology zones (%d); some targets will be scraped by more than one shard, resulting in duplicated samples",
 		shards, numZones,
-	), true
+	)
 }
 
 // ReplicasNumberPtr returns a ptr to the normalized number of replicas.

--- a/pkg/prometheus/common_test.go
+++ b/pkg/prometheus/common_test.go
@@ -430,6 +430,101 @@ func TestNodeSelectorWithTopologyZone(t *testing.T) {
 	}
 }
 
+func TestUnbalancedTopologyShardingMessage(t *testing.T) {
+	topologyMode := monitoringv1.TopologyShardingStrategyMode
+
+	for _, tc := range []struct {
+		name             string
+		shards           *int32
+		shardingStrategy *monitoringv1.ShardingStrategy
+		expectedWarn     bool
+	}{
+		{
+			name:             "no sharding strategy",
+			shards:           ptr.To(int32(3)),
+			shardingStrategy: nil,
+			expectedWarn:     false,
+		},
+		{
+			name:   "address mode is never unbalanced",
+			shards: ptr.To(int32(3)),
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     ptr.To(monitoringv1.AddressShardingStrategyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b"}},
+			},
+			expectedWarn: false,
+		},
+		{
+			name:   "shards is a multiple of the number of zones",
+			shards: ptr.To(int32(4)),
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     new(topologyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b"}},
+			},
+			expectedWarn: false,
+		},
+		{
+			name:   "shards equals the number of zones",
+			shards: ptr.To(int32(3)),
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     new(topologyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b", "zone-c"}},
+			},
+			expectedWarn: false,
+		},
+		{
+			name:   "shards isn't a multiple of the number of zones",
+			shards: ptr.To(int32(10)),
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     new(topologyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b", "zone-c"}},
+			},
+			expectedWarn: true,
+		},
+		{
+			// nil shards normalizes to 1 which isn't a multiple of 2 zones.
+			name:   "nil shards with more than one zone",
+			shards: nil,
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     new(topologyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b"}},
+			},
+			expectedWarn: true,
+		},
+		{
+			// This case isn't possible in practice because the API enforces
+			// that topology is only set when mode is Topology.
+			name:   "topology mode with no values",
+			shards: ptr.To(int32(3)),
+			shardingStrategy: &monitoringv1.ShardingStrategy{
+				Mode:     new(topologyMode),
+				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{}},
+			},
+			expectedWarn: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Shards:           tc.shards,
+						ShardingStrategy: tc.shardingStrategy,
+					},
+				},
+			}
+
+			msg, ok := UnbalancedTopologyShardingMessage(p)
+			require.Equal(t, tc.expectedWarn, ok)
+			if tc.expectedWarn {
+				require.NotEmpty(t, msg)
+			} else {
+				require.Empty(t, msg)
+			}
+		})
+	}
+}
+
 func TestLabelSelectorForStatefulSets(t *testing.T) {
 	for _, tc := range []struct {
 		mode string

--- a/pkg/prometheus/common_test.go
+++ b/pkg/prometheus/common_test.go
@@ -441,13 +441,13 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 	}{
 		{
 			name:             "no sharding strategy",
-			shards:           ptr.To(int32(3)),
+			shards:           new(int32(3)),
 			shardingStrategy: nil,
 			expectedWarn:     false,
 		},
 		{
 			name:   "address mode is never unbalanced",
-			shards: ptr.To(int32(3)),
+			shards: new(int32(3)),
 			shardingStrategy: &monitoringv1.ShardingStrategy{
 				Mode:     ptr.To(monitoringv1.AddressShardingStrategyMode),
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b"}},
@@ -456,7 +456,7 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 		},
 		{
 			name:   "shards is a multiple of the number of zones",
-			shards: ptr.To(int32(4)),
+			shards: new(int32(4)),
 			shardingStrategy: &monitoringv1.ShardingStrategy{
 				Mode:     new(topologyMode),
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b"}},
@@ -465,7 +465,7 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 		},
 		{
 			name:   "shards equals the number of zones",
-			shards: ptr.To(int32(3)),
+			shards: new(int32(3)),
 			shardingStrategy: &monitoringv1.ShardingStrategy{
 				Mode:     new(topologyMode),
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b", "zone-c"}},
@@ -474,7 +474,7 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 		},
 		{
 			name:   "shards isn't a multiple of the number of zones",
-			shards: ptr.To(int32(10)),
+			shards: new(int32(10)),
 			shardingStrategy: &monitoringv1.ShardingStrategy{
 				Mode:     new(topologyMode),
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{"zone-a", "zone-b", "zone-c"}},
@@ -495,7 +495,7 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 			// This case isn't possible in practice because the API enforces
 			// that topology is only set when mode is Topology.
 			name:   "topology mode with no values",
-			shards: ptr.To(int32(3)),
+			shards: new(int32(3)),
 			shardingStrategy: &monitoringv1.ShardingStrategy{
 				Mode:     new(topologyMode),
 				Topology: &monitoringv1.TopologyShardingStrategy{Values: []string{}},

--- a/pkg/prometheus/common_test.go
+++ b/pkg/prometheus/common_test.go
@@ -514,7 +514,7 @@ func TestUnbalancedTopologyShardingMessage(t *testing.T) {
 				},
 			}
 
-			msg, ok := UnbalancedTopologyShardingMessage(p)
+			ok, msg := UnbalancedTopologyShardingMessage(p)
 			require.Equal(t, tc.expectedWarn, ok)
 			if tc.expectedWarn {
 				require.NotEmpty(t, msg)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -938,6 +938,13 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 
 	c.recordDeprecatedFields(key, logger, p)
 
+	if c.topologyShardingEnabled {
+		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+			logger.Warn(msg)
+			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
+		}
+	}
+
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, p.Spec.Storage); err != nil {
 		return closure, err
 	}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -940,6 +940,13 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 
 	c.recordDeprecatedFields(key, logger, p)
 
+	if c.topologyShardingEnabled {
+		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+			logger.Warn(msg)
+			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
+		}
+	}
+
 	if err := operator.CheckStorageClass(ctx, c.canReadStorageClass, c.kclient, p.Spec.Storage); err != nil {
 		return closure, err
 	}

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -941,7 +941,7 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 	c.recordDeprecatedFields(key, logger, p)
 
 	if c.topologyShardingEnabled {
-		if msg, ok := prompkg.UnbalancedTopologyShardingMessage(p); ok {
+		if ok, msg := prompkg.UnbalancedTopologyShardingMessage(p); ok {
 			logger.Warn(msg)
 			c.reconciliations.SetReasonAndMessage(key, operator.UnbalancedTopologyShardingReason, msg)
 		}


### PR DESCRIPTION
## Description

When topology sharding is enabled, the operator already blocks the severe case where `shards` is smaller than the number of zones (a zone would never get scraped). But the other edge case from the proposal, where `shards` isn't a multiple of the number of zones, was going through silently. In that case shard indices wrap around and some targets end up scraped by more than one shard, so you get duplicated samples with no hint that anything is off.

As discussed in the issue, this reports the situation on the `Reconciled` condition instead of failing the reconciliation. The status stays `True` with an `UnbalancedTopologySharding` reason and a message explaining it, so it doesn't block rollouts for people who set this up on purpose.

Wired for both Prometheus and PrometheusAgent, behind the existing `PrometheusTopologySharding` feature gate.

closes #8664 

## Type of change

- [x] `FEATURE` (non-breaking change which adds functionality)

## Verification

Added a unit test (`TestUnbalancedTopologyShardingMessage`) covering address mode, exact multiples, `shards == zones`, non-multiples, nil shards and empty values. Happy to add an e2e asserting the condition on a live object if you'd prefer.

## Changelog entry

```release-note
Report unbalanced topology sharding (shards not a multiple of the number of zones) in the Reconciled status condition.
