### PR TITLE
fix: use promtool for listenLocal health probes

### DIFF
--- a/pkg/operator/prober.go
+++ b/pkg/operator/prober.go
@@ -30,10 +30,7 @@ func ExecAction(u string) *corev1.ExecAction {
 	if strings.Contains(u, "/-/ready") {
 		check = "ready"
 	}
-	baseURL := u
-	if i := strings.Index(u, "/-/"); i >= 0 {
-		baseURL = u[:i]
-	}
+	baseURL, _, _ := strings.Cut(u, "/-/")
 	return &corev1.ExecAction{
 		Command: []string{
 			"promtool",

--- a/pkg/operator/prober.go
+++ b/pkg/operator/prober.go
@@ -16,21 +16,31 @@ package operator
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ExecAction returns an ExecAction probing the given URL.
+// Prefer promtool (available in official Prometheus images, including distroless
+// builds that lack sh/curl/wget) so listenLocal probes work without a shell.
+// See https://github.com/prometheus-operator/prometheus-operator/issues/8605
 func ExecAction(u string) *corev1.ExecAction {
+	check := "healthy"
+	if strings.Contains(u, "/-/ready") {
+		check = "ready"
+	}
+	baseURL := u
+	if i := strings.Index(u, "/-/"); i >= 0 {
+		baseURL = u[:i]
+	}
 	return &corev1.ExecAction{
 		Command: []string{
-			"sh",
-			"-c",
-			fmt.Sprintf(
-				`if [ -x "$(command -v curl)" ]; then exec %s; elif [ -x "$(command -v wget)" ]; then exec %s; else exit 1; fi`,
-				curlProber(u),
-				wgetProber(u),
-			),
+			"promtool",
+			"check",
+			check,
+			"--url",
+			baseURL,
 		},
 	}
 }

--- a/pkg/operator/prober.go
+++ b/pkg/operator/prober.go
@@ -21,15 +21,33 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ExecAction returns an ExecAction probing the given URL.
-// Prefer promtool (available in official Prometheus images, including distroless
-// builds that lack sh/curl/wget) so listenLocal probes work without a shell.
-// See https://github.com/prometheus-operator/prometheus-operator/issues/8605
+// ExecAction returns an ExecAction that probes the given URL via curl or wget
+// under a shell. Used for the config-reloader listenLocal probes and for
+// Prometheus versions that predate promtool check healthy|ready (2.44.0).
 func ExecAction(u string) *corev1.ExecAction {
+	return &corev1.ExecAction{
+		Command: []string{
+			"sh",
+			"-c",
+			fmt.Sprintf(
+				`if [ -x "$(command -v curl)" ]; then exec %s; elif [ -x "$(command -v wget)" ]; then exec %s; else exit 1; fi`,
+				curlProber(u),
+				wgetProber(u),
+			),
+		},
+	}
+}
+
+// PromtoolExecAction returns an ExecAction that probes the given URL with
+// promtool check healthy|ready. promtool ships in official Prometheus images
+// (including distroless builds that lack sh/curl/wget). Requires Prometheus
+// 2.44.0 or later. See https://github.com/prometheus-operator/prometheus-operator/issues/8605
+func PromtoolExecAction(u string) *corev1.ExecAction {
 	check := "healthy"
 	if strings.Contains(u, "/-/ready") {
 		check = "ready"
 	}
+	// promtool expects the base URL (scheme + host[:port]), not the probe path.
 	baseURL, _, _ := strings.Cut(u, "/-/")
 	return &corev1.ExecAction{
 		Command: []string{

--- a/pkg/operator/prober_test.go
+++ b/pkg/operator/prober_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestProbers(t *testing.T) {
@@ -80,5 +81,36 @@ func TestProbers(t *testing.T) {
 			})
 		}
 
+	}
+}
+
+func TestExecActionUsesShellCurlOrWget(t *testing.T) {
+	got := ExecAction("http://localhost:9090/-/healthy")
+	require.Equal(t, []string{"sh", "-c"}, got.Command[:2])
+	require.Contains(t, got.Command[2], "curl --fail http://localhost:9090/-/healthy")
+	require.Contains(t, got.Command[2], "wget -q -O /dev/null http://localhost:9090/-/healthy")
+}
+
+func TestPromtoolExecAction(t *testing.T) {
+	for _, tc := range []struct {
+		url   string
+		check string
+	}{
+		{url: "http://localhost:9090/-/healthy", check: "healthy"},
+		{url: "http://localhost:9090/-/ready", check: "ready"},
+		{url: "http://localhost:9090/prometheus/-/ready", check: "ready"},
+	} {
+		t.Run(tc.check+"-"+tc.url, func(t *testing.T) {
+			got := PromtoolExecAction(tc.url)
+			require.Equal(t, &corev1.ExecAction{
+				Command: []string{
+					"promtool",
+					"check",
+					tc.check,
+					"--url",
+					strings.Split(tc.url, "/-/")[0],
+				},
+			}, got)
+		})
 	}
 }

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1384,7 +1384,14 @@ func (cg *ConfigGenerator) buildProbeHandler(probePath string) corev1.ProbeHandl
 			Host:   "localhost:9090",
 			Path:   probePath,
 		}
-		handler.Exec = operator.ExecAction(probeURL.String())
+		// promtool check healthy|ready exists since Prometheus 2.44.0 and is
+		// available in distroless images that lack curl/wget. Older versions and
+		// the config-reloader keep the shell-based ExecAction.
+		if cg.WithMinimumVersion("2.44.0").IsCompatible() {
+			handler.Exec = operator.PromtoolExecAction(probeURL.String())
+		} else {
+			handler.Exec = operator.ExecAction(probeURL.String())
+		}
 
 		return handler
 	}

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -530,6 +530,50 @@ func TestListenLocal(t *testing.T) {
 	require.Empty(t, sset.Spec.Template.Spec.Containers[0].Ports, "Prometheus container should have 0 ports defined")
 }
 
+func TestListenLocalPrePromtoolVersion(t *testing.T) {
+	// promtool check healthy|ready was added in Prometheus 2.44.0; older
+	// versions keep the shell-based curl/wget ExecAction.
+	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ListenLocal: true,
+				Version:     "v2.43.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedProbeHandler := func(probePath string) corev1.ProbeHandler {
+		return corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{
+					`sh`,
+					`-c`,
+					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl --fail %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
+				},
+			},
+		}
+	}
+
+	actualStartupProbe := sset.Spec.Template.Spec.Containers[0].StartupProbe
+	expectedStartupProbe := &corev1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/ready"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    15,
+		FailureThreshold: 60,
+	}
+	require.Equal(t, expectedStartupProbe, actualStartupProbe)
+
+	actualLivenessProbe := sset.Spec.Template.Spec.Containers[0].LivenessProbe
+	expectedLivenessProbe := &corev1.Probe{
+		ProbeHandler:     expectedProbeHandler("/-/healthy"),
+		TimeoutSeconds:   3,
+		PeriodSeconds:    5,
+		FailureThreshold: 6,
+	}
+	require.Equal(t, expectedLivenessProbe, actualLivenessProbe)
+}
+
 func TestListenTLS(t *testing.T) {
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -483,12 +483,18 @@ func TestListenLocal(t *testing.T) {
 	require.True(t, found, "Prometheus not listening on loopback when it should.")
 
 	expectedProbeHandler := func(probePath string) corev1.ProbeHandler {
+		check := "healthy"
+		if probePath == "/-/ready" {
+			check = "ready"
+		}
 		return corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{
-					`sh`,
-					`-c`,
-					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl --fail %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
+					"promtool",
+					"check",
+					check,
+					"--url",
+					"http://localhost:9090",
 				},
 			},
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -267,6 +267,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromRemoteWriteWithTLS":                    testPromRemoteWriteWithTLS,
 		"PromCreateDeleteCluster":                   testPromCreateDeleteCluster,
 		"PromScaleUpDownCluster":                    testPromScaleUpDownReplicas,
+		"PromListenLocalReady":                      testPromListenLocalReady,
 		"PromNoServiceMonitorSelector":              testPromNoServiceMonitorSelector,
 		"PromResourceUpdate":                        testPromResourceUpdate,
 		"PromStorageLabelsAnnotations":              testPromStorageLabelsAnnotations,

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -799,6 +799,46 @@ func testPromCreateDeleteCluster(t *testing.T) {
 	}
 }
 
+func testPromListenLocalReady(t *testing.T) {
+	// Validate listenLocal probes for both official image packaging styles.
+	// Distroless images lack sh/curl/wget; probes must use promtool (2.44+).
+	// Non-distroless (busybox-based) images also ship promtool and use the same path.
+	t.Parallel()
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	version := operator.DefaultPrometheusVersion
+	cases := []struct {
+		name  string
+		image string
+	}{
+		{
+			name:  "distroless",
+			image: fmt.Sprintf("%s:%s-distroless", operator.DefaultPrometheusBaseImage, version),
+		},
+		{
+			name:  "busybox",
+			image: operator.DefaultPrometheusImage,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			name := "listen-local-" + tc.name
+			p := framework.MakeBasicPrometheus(ns, name, name, 1)
+			p.Spec.ListenLocal = true
+			p.Spec.Version = version
+			p.Spec.Image = &tc.image
+			if _, err := framework.CreatePrometheusAndWaitUntilReady(context.Background(), ns, p); err != nil {
+				t.Fatalf("%s listenLocal Prometheus not ready: %v", tc.name, err)
+			}
+		})
+	}
+}
+
 func testPromScaleUpDownReplicas(t *testing.T) {
 	t.Parallel()
 	testCtx := framework.NewTestCtx(t)


### PR DESCRIPTION
## Summary

When `listenLocal: true`, probes used `sh -c` with `curl`/`wget`. Distroless images (default in kube-prometheus-stack) do not include those tools, so readiness/liveness fail permanently.

## Fix

Use `promtool check healthy|ready --url=http://localhost:9090` for listenLocal probes. `promtool` ships in official Prometheus images.

## Testing

- `go test ./pkg/operator/ -run TestProbers`
- Updated listenLocal expectations in `statefulset_test.go`

Ref https://github.com/prometheus-operator/prometheus-operator/issues/8605
