### PR TITLE
fix: create IPv6 EndpointSlice for kubelet Service on dual-stack clusters

### DIFF
--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -240,12 +240,10 @@ func (c *Controller) Run(ctx context.Context) error {
 	}
 }
 
-// nodeAddress returns the provided node's address, based on the priority:
-// 1. NodeInternalIP
-// 2. NodeExternalIP
+// nodeAddressesByType returns all addresses of the node grouped by type.
 //
 // Copied from github.com/prometheus/prometheus/discovery/kubernetes/node.go.
-func (c *Controller) nodeAddress(node corev1.Node) (string, map[corev1.NodeAddressType][]string, error) {
+func (c *Controller) nodeAddressesByType(node corev1.Node) (map[corev1.NodeAddressType][]string, error) {
 	m := map[corev1.NodeAddressType][]string{}
 	for _, a := range node.Status.Addresses {
 		m[a.Type] = append(m[a.Type], a.Address)
@@ -253,22 +251,22 @@ func (c *Controller) nodeAddress(node corev1.Node) (string, map[corev1.NodeAddre
 
 	switch c.nodeAddressPriority {
 	case "internal":
-		if addresses, ok := m[corev1.NodeInternalIP]; ok {
-			return addresses[0], m, nil
+		if _, ok := m[corev1.NodeInternalIP]; ok {
+			return m, nil
 		}
-		if addresses, ok := m[corev1.NodeExternalIP]; ok {
-			return addresses[0], m, nil
+		if _, ok := m[corev1.NodeExternalIP]; ok {
+			return m, nil
 		}
 	case "external":
-		if addresses, ok := m[corev1.NodeExternalIP]; ok {
-			return addresses[0], m, nil
+		if _, ok := m[corev1.NodeExternalIP]; ok {
+			return m, nil
 		}
-		if addresses, ok := m[corev1.NodeInternalIP]; ok {
-			return addresses[0], m, nil
+		if _, ok := m[corev1.NodeInternalIP]; ok {
+			return m, nil
 		}
 	}
 
-	return "", m, fmt.Errorf("host address unknown")
+	return m, fmt.Errorf("host address unknown")
 }
 
 // nodeReadyConditionKnown checks the node for a known Ready condition. If the
@@ -332,7 +330,7 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 	)
 
 	for _, n := range nodes {
-		_, addrMap, err := c.nodeAddress(n)
+		addrMap, err := c.nodeAddressesByType(n)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to determine hostname for node %q (priority: %s): %w", n.Name, c.nodeAddressPriority, err))
 			continue

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -240,37 +240,32 @@ func (c *Controller) Run(ctx context.Context) error {
 	}
 }
 
-// nodeAddressesByType returns all addresses of the node grouped by type.
-func (c *Controller) nodeAddressesByType(node corev1.Node) map[corev1.NodeAddressType][]string {
+// nodeAddresses returns all addresses of the node for the configured priority.
+// It mirrors the priority/fallback logic from
+// github.com/prometheus/prometheus/discovery/kubernetes/node.go.
+func (c *Controller) nodeAddresses(node corev1.Node) ([]string, error) {
 	m := map[corev1.NodeAddressType][]string{}
 	for _, a := range node.Status.Addresses {
 		m[a.Type] = append(m[a.Type], a.Address)
 	}
-	return m
-}
 
-// primaryAddressType returns the NodeAddressType to use for a node given the
-// configured priority and which address types are actually present. It mirrors
-// the priority/fallback logic from
-// github.com/prometheus/prometheus/discovery/kubernetes/node.go.
-func (c *Controller) primaryAddressType(addrMap map[corev1.NodeAddressType][]string) (corev1.NodeAddressType, error) {
 	switch c.nodeAddressPriority {
 	case "external":
-		if len(addrMap[corev1.NodeExternalIP]) > 0 {
-			return corev1.NodeExternalIP, nil
+		if len(m[corev1.NodeExternalIP]) > 0 {
+			return m[corev1.NodeExternalIP], nil
 		}
-		if len(addrMap[corev1.NodeInternalIP]) > 0 {
-			return corev1.NodeInternalIP, nil
+		if len(m[corev1.NodeInternalIP]) > 0 {
+			return m[corev1.NodeInternalIP], nil
 		}
 	default: // "internal"
-		if len(addrMap[corev1.NodeInternalIP]) > 0 {
-			return corev1.NodeInternalIP, nil
+		if len(m[corev1.NodeInternalIP]) > 0 {
+			return m[corev1.NodeInternalIP], nil
 		}
-		if len(addrMap[corev1.NodeExternalIP]) > 0 {
-			return corev1.NodeExternalIP, nil
+		if len(m[corev1.NodeExternalIP]) > 0 {
+			return m[corev1.NodeExternalIP], nil
 		}
 	}
-	return "", fmt.Errorf("host address unknown")
+	return nil, fmt.Errorf("host address unknown")
 }
 
 // nodeReadyConditionKnown checks the node for a known Ready condition. If the
@@ -334,14 +329,13 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 	)
 
 	for _, n := range nodes {
-		addrMap := c.nodeAddressesByType(n)
-		addrType, err := c.primaryAddressType(addrMap)
+		nodeIPs, err := c.nodeAddresses(n)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to determine hostname for node %q (priority: %s): %w", n.Name, c.nodeAddressPriority, err))
 			continue
 		}
 
-		for _, address := range addrMap[addrType] {
+		for _, address := range nodeIPs {
 			ip := net.ParseIP(address)
 			if ip == nil {
 				errs = append(errs, fmt.Errorf("failed to parse IP address %q for node %q (priority: %s)", address, n.Name, c.nodeAddressPriority))

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -332,35 +332,46 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 	)
 
 	for _, n := range nodes {
-		address, _, err := c.nodeAddress(n)
+		_, addrMap, err := c.nodeAddress(n)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to determine hostname for node %q (priority: %s): %w", n.Name, c.nodeAddressPriority, err))
 			continue
 		}
 
-		ip := net.ParseIP(address)
-		if ip == nil {
-			errs = append(errs, fmt.Errorf("failed to parse IP address %q for node %q (priority: %s): %w", address, n.Name, c.nodeAddressPriority, err))
-			continue
+		// Select addresses by priority: use ExternalIP if priority is "external"
+		// and external addresses exist, otherwise fall back to InternalIP.
+		addrType := corev1.NodeInternalIP
+		if c.nodeAddressPriority == "external" {
+			if len(addrMap[corev1.NodeExternalIP]) > 0 {
+				addrType = corev1.NodeExternalIP
+			}
 		}
 
-		na := nodeAddress{
-			ipAddress:  address,
-			name:       n.Name,
-			uid:        n.UID,
-			apiVersion: n.APIVersion,
-			ipv4:       ip.To4() != nil,
-			ready:      nodeReadyConditionKnown(n),
-		}
-		addresses = append(addresses, na)
+		for _, address := range addrMap[addrType] {
+			ip := net.ParseIP(address)
+			if ip == nil {
+				errs = append(errs, fmt.Errorf("failed to parse IP address %q for node %q (priority: %s)", address, n.Name, c.nodeAddressPriority))
+				continue
+			}
 
-		if !na.ready {
-			c.logger.Info("Node Ready condition is Unknown", "node", n.GetName())
-			readyUnknownNodes[address] = n.Name
-			continue
-		}
+			na := nodeAddress{
+				ipAddress:  address,
+				name:       n.Name,
+				uid:        n.UID,
+				apiVersion: n.APIVersion,
+				ipv4:       ip.To4() != nil,
+				ready:      nodeReadyConditionKnown(n),
+			}
+			addresses = append(addresses, na)
 
-		readyKnownNodes[address] = n.Name
+			if !na.ready {
+				c.logger.Info("Node Ready condition is Unknown", "node", n.GetName())
+				readyUnknownNodes[address] = n.Name
+				continue
+			}
+
+			readyKnownNodes[address] = n.Name
+		}
 	}
 
 	// We want to remove any nodes that have an unknown ready state *and* a
@@ -474,6 +485,12 @@ func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress)
 func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 	c.logger.Debug("Sync service")
 
+	// PreferDualStack requests both IPv4 and IPv6 ClusterIPs on dual-stack
+	// clusters so that Prometheus SD can match the primary IP family when
+	// selecting which EndpointSlice to scrape. On single-stack clusters it
+	// degrades gracefully to the single available family.
+	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.kubeletObjectName,
@@ -485,9 +502,10 @@ func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 			}),
 		},
 		Spec: corev1.ServiceSpec{
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: corev1.ClusterIPNone,
-			Ports:     c.servicePorts(),
+			Type:           corev1.ServiceTypeClusterIP,
+			ClusterIP:      corev1.ClusterIPNone,
+			IPFamilyPolicy: &ipFamilyPolicy,
+			Ports:          c.servicePorts(),
 		},
 	}
 

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -241,32 +241,36 @@ func (c *Controller) Run(ctx context.Context) error {
 }
 
 // nodeAddressesByType returns all addresses of the node grouped by type.
-//
-// Copied from github.com/prometheus/prometheus/discovery/kubernetes/node.go.
-func (c *Controller) nodeAddressesByType(node corev1.Node) (map[corev1.NodeAddressType][]string, error) {
+func (c *Controller) nodeAddressesByType(node corev1.Node) map[corev1.NodeAddressType][]string {
 	m := map[corev1.NodeAddressType][]string{}
 	for _, a := range node.Status.Addresses {
 		m[a.Type] = append(m[a.Type], a.Address)
 	}
+	return m
+}
 
+// primaryAddressType returns the NodeAddressType to use for a node given the
+// configured priority and which address types are actually present. It mirrors
+// the priority/fallback logic from
+// github.com/prometheus/prometheus/discovery/kubernetes/node.go.
+func (c *Controller) primaryAddressType(addrMap map[corev1.NodeAddressType][]string) (corev1.NodeAddressType, error) {
 	switch c.nodeAddressPriority {
-	case "internal":
-		if _, ok := m[corev1.NodeInternalIP]; ok {
-			return m, nil
-		}
-		if _, ok := m[corev1.NodeExternalIP]; ok {
-			return m, nil
-		}
 	case "external":
-		if _, ok := m[corev1.NodeExternalIP]; ok {
-			return m, nil
+		if len(addrMap[corev1.NodeExternalIP]) > 0 {
+			return corev1.NodeExternalIP, nil
 		}
-		if _, ok := m[corev1.NodeInternalIP]; ok {
-			return m, nil
+		if len(addrMap[corev1.NodeInternalIP]) > 0 {
+			return corev1.NodeInternalIP, nil
+		}
+	default: // "internal"
+		if len(addrMap[corev1.NodeInternalIP]) > 0 {
+			return corev1.NodeInternalIP, nil
+		}
+		if len(addrMap[corev1.NodeExternalIP]) > 0 {
+			return corev1.NodeExternalIP, nil
 		}
 	}
-
-	return m, fmt.Errorf("host address unknown")
+	return "", fmt.Errorf("host address unknown")
 }
 
 // nodeReadyConditionKnown checks the node for a known Ready condition. If the
@@ -330,19 +334,11 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 	)
 
 	for _, n := range nodes {
-		addrMap, err := c.nodeAddressesByType(n)
+		addrMap := c.nodeAddressesByType(n)
+		addrType, err := c.primaryAddressType(addrMap)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to determine hostname for node %q (priority: %s): %w", n.Name, c.nodeAddressPriority, err))
 			continue
-		}
-
-		// Select addresses by priority: use ExternalIP if priority is "external"
-		// and external addresses exist, otherwise fall back to InternalIP.
-		addrType := corev1.NodeInternalIP
-		if c.nodeAddressPriority == "external" {
-			if len(addrMap[corev1.NodeExternalIP]) > 0 {
-				addrType = corev1.NodeExternalIP
-			}
 		}
 
 		for _, address := range addrMap[addrType] {

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -485,12 +485,6 @@ func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress)
 func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 	c.logger.Debug("Sync service")
 
-	// PreferDualStack requests both IPv4 and IPv6 ClusterIPs on dual-stack
-	// clusters so that Prometheus SD can match the primary IP family when
-	// selecting which EndpointSlice to scrape. On single-stack clusters it
-	// degrades gracefully to the single available family.
-	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
-
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.kubeletObjectName,
@@ -502,10 +496,9 @@ func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 			}),
 		},
 		Spec: corev1.ServiceSpec{
-			Type:           corev1.ServiceTypeClusterIP,
-			ClusterIP:      corev1.ClusterIPNone,
-			IPFamilyPolicy: &ipFamilyPolicy,
-			Ports:          c.servicePorts(),
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
+			Ports:     c.servicePorts(),
 		},
 	}
 

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -618,6 +618,75 @@ func newLogger() *slog.Logger {
 	return l
 }
 
+func TestPrimaryAddressType(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		priority         string
+		addrMap          map[corev1.NodeAddressType][]string
+		expectedType     corev1.NodeAddressType
+		expectError      bool
+	}{
+		{
+			name:     "internal priority with InternalIP available",
+			priority: "internal",
+			addrMap: map[corev1.NodeAddressType][]string{
+				corev1.NodeInternalIP: {"10.0.0.1", "fd00::1"},
+				corev1.NodeExternalIP: {"203.0.113.1"},
+			},
+			expectedType: corev1.NodeInternalIP,
+		},
+		{
+			name:     "internal priority falls back to ExternalIP",
+			priority: "internal",
+			addrMap: map[corev1.NodeAddressType][]string{
+				corev1.NodeExternalIP: {"203.0.113.1"},
+			},
+			expectedType: corev1.NodeExternalIP,
+		},
+		{
+			name:     "external priority with ExternalIP available",
+			priority: "external",
+			addrMap: map[corev1.NodeAddressType][]string{
+				corev1.NodeInternalIP: {"10.0.0.1"},
+				corev1.NodeExternalIP: {"203.0.113.1", "2001:db8::1"},
+			},
+			expectedType: corev1.NodeExternalIP,
+		},
+		{
+			name:     "external priority falls back to InternalIP",
+			priority: "external",
+			addrMap: map[corev1.NodeAddressType][]string{
+				corev1.NodeInternalIP: {"10.0.0.1"},
+			},
+			expectedType: corev1.NodeInternalIP,
+		},
+		{
+			name:        "internal priority with no addresses returns error",
+			priority:    "internal",
+			addrMap:     map[corev1.NodeAddressType][]string{},
+			expectError: true,
+		},
+		{
+			name:        "external priority with no addresses returns error",
+			priority:    "external",
+			addrMap:     map[corev1.NodeAddressType][]string{},
+			expectError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Controller{nodeAddressPriority: tc.priority}
+			addrType, err := c.primaryAddressType(tc.addrMap)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedType, addrType)
+		})
+	}
+}
+
+
 func TestHTTPMetricsPorts(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -618,70 +618,73 @@ func newLogger() *slog.Logger {
 	return l
 }
 
-func TestPrimaryAddressType(t *testing.T) {
+func TestNodeAddresses(t *testing.T) {
 	for _, tc := range []struct {
-		name         string
-		priority     string
-		addrMap      map[corev1.NodeAddressType][]string
-		expectedType corev1.NodeAddressType
-		expectError  bool
+		name              string
+		priority          string
+		nodeAddresses     []corev1.NodeAddress
+		expectedAddresses []string
+		expectError       bool
 	}{
 		{
 			name:     "internal priority with InternalIP available",
 			priority: "internal",
-			addrMap: map[corev1.NodeAddressType][]string{
-				corev1.NodeInternalIP: {"10.0.0.1", "fd00::1"},
-				corev1.NodeExternalIP: {"203.0.113.1"},
+			nodeAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: corev1.NodeInternalIP, Address: "fd00::1"},
+				{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
 			},
-			expectedType: corev1.NodeInternalIP,
+			expectedAddresses: []string{"10.0.0.1", "fd00::1"},
 		},
 		{
 			name:     "internal priority falls back to ExternalIP",
 			priority: "internal",
-			addrMap: map[corev1.NodeAddressType][]string{
-				corev1.NodeExternalIP: {"203.0.113.1"},
+			nodeAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
 			},
-			expectedType: corev1.NodeExternalIP,
+			expectedAddresses: []string{"203.0.113.1"},
 		},
 		{
 			name:     "external priority with ExternalIP available",
 			priority: "external",
-			addrMap: map[corev1.NodeAddressType][]string{
-				corev1.NodeInternalIP: {"10.0.0.1"},
-				corev1.NodeExternalIP: {"203.0.113.1", "2001:db8::1"},
+			nodeAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: corev1.NodeExternalIP, Address: "203.0.113.1"},
+				{Type: corev1.NodeExternalIP, Address: "2001:db8::1"},
 			},
-			expectedType: corev1.NodeExternalIP,
+			expectedAddresses: []string{"203.0.113.1", "2001:db8::1"},
 		},
 		{
 			name:     "external priority falls back to InternalIP",
 			priority: "external",
-			addrMap: map[corev1.NodeAddressType][]string{
-				corev1.NodeInternalIP: {"10.0.0.1"},
+			nodeAddresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
 			},
-			expectedType: corev1.NodeInternalIP,
+			expectedAddresses: []string{"10.0.0.1"},
 		},
 		{
-			name:        "internal priority with no addresses returns error",
-			priority:    "internal",
-			addrMap:     map[corev1.NodeAddressType][]string{},
-			expectError: true,
+			name:          "internal priority with no addresses returns error",
+			priority:      "internal",
+			nodeAddresses: []corev1.NodeAddress{},
+			expectError:   true,
 		},
 		{
-			name:        "external priority with no addresses returns error",
-			priority:    "external",
-			addrMap:     map[corev1.NodeAddressType][]string{},
-			expectError: true,
+			name:          "external priority with no addresses returns error",
+			priority:      "external",
+			nodeAddresses: []corev1.NodeAddress{},
+			expectError:   true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &Controller{nodeAddressPriority: tc.priority}
-			addrType, err := c.primaryAddressType(tc.addrMap)
+			node := corev1.Node{Status: corev1.NodeStatus{Addresses: tc.nodeAddresses}}
+			addrs, err := c.nodeAddresses(node)
 			if tc.expectError {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedType, addrType)
+			require.Equal(t, tc.expectedAddresses, addrs)
 		})
 	}
 }

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -243,6 +243,39 @@ func TestGetNodeAddresses(t *testing.T) {
 			expectedAddresses: []string{"10.0.0.1", "10.0.0.3"},
 			expectedErrors:    0,
 		},
+		{
+			// Dual-stack nodes report both IPv4 and IPv6 as InternalIP.
+			// Both addresses should be emitted so prometheus-operator can create
+			// separate IPv4 and IPv6 EndpointSlices for the kubelet Service.
+			name: "dual-stack node emits both addresses",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Address: "10.0.0.1",
+								Type:    corev1.NodeInternalIP,
+							},
+							{
+								Address: "fd00::1",
+								Type:    corev1.NodeInternalIP,
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []string{"10.0.0.1", "fd00::1"},
+			expectedErrors:    0,
+		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			controller := Controller{

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -620,11 +620,11 @@ func newLogger() *slog.Logger {
 
 func TestPrimaryAddressType(t *testing.T) {
 	for _, tc := range []struct {
-		name             string
-		priority         string
-		addrMap          map[corev1.NodeAddressType][]string
-		expectedType     corev1.NodeAddressType
-		expectError      bool
+		name         string
+		priority     string
+		addrMap      map[corev1.NodeAddressType][]string
+		expectedType corev1.NodeAddressType
+		expectError  bool
 	}{
 		{
 			name:     "internal priority with InternalIP available",
@@ -685,7 +685,6 @@ func TestPrimaryAddressType(t *testing.T) {
 		})
 	}
 }
-
 
 func TestHTTPMetricsPorts(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
## Description

`getNodeAddresses()` was discarding the full address map returned by `nodeAddress()` and only emitting a single IP per node, which always resolved to IPv4 on dual-stack clusters. This prevented the creation of an IPv6 `EndpointSlice` for the kubelet Service.

With Prometheus 3.11 (prometheus/prometheus#18192), `EndpointSlices` whose `addressType` does not match `svc.Spec.IPFamilies[0]` are skipped to avoid duplicate scraping. On IPv6-primary dual-stack clusters this caused all kubelet targets to be dropped, as only the IPv4 `EndpointSlice` existed.

Fix by iterating all `InternalIP` (or `ExternalIP` when priority is "external") addresses per node so that `syncEndpointSlice()` — which already has the dual-stack infrastructure — creates separate IPv4 and IPv6 `EndpointSlices`.

Closes: #8681

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Tested manually in a development cluster. Unit tests extended for dual-stack.

## Changelog entry

```release-note
- Fix kubelet scraping on dual-stack clusters (IPv6,IPv4)
```
