### PR TITLE
feat: add tracing to alertmanager toplevel config

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14855,6 +14855,236 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
+                  tracingConfig:
+                    description: tracingConfig defines the tracing configuration of
+                      Alertmanager.
+                    properties:
+                      clientType:
+                        description: clientType defines the client used to export
+                          the traces. Supported values are `HTTP` and `GRPC`.
+                        enum:
+                        - http
+                        - grpc
+                        - HTTP
+                        - GRPC
+                        type: string
+                      compression:
+                        description: compression key for supported compression types.
+                          The only supported value is `Gzip`.
+                        enum:
+                        - gzip
+                        - Gzip
+                        type: string
+                      endpoint:
+                        description: endpoint to send the traces to. Should be provided
+                          in format <host>:<port>.
+                        minLength: 1
+                        type: string
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: headers defines the key-value pairs to be used
+                          as headers associated with gRPC or HTTP requests.
+                        type: object
+                      insecure:
+                        description: insecure if disabled, the client will use a secure
+                          connection.
+                        type: boolean
+                      samplingFraction:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: samplingFraction defines the probability a given
+                          trace will be sampled. Must be a float from 0 through 1.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      timeout:
+                        description: timeout defines the maximum time the exporter
+                          will wait for each batch export.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      tlsConfig:
+                        description: tlsConfig to use when sending traces.
+                        properties:
+                          ca:
+                            description: ca defines the Certificate authority used
+                              when verifying server certificates.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          caFile:
+                            description: caFile defines the path to the CA cert in
+                              the Prometheus container to use for the targets.
+                            type: string
+                          cert:
+                            description: cert defines the Client certificate to present
+                              when doing client-authentication.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          certFile:
+                            description: certFile defines the path to the client cert
+                              file in the Prometheus container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: insecureSkipVerify defines how to disable
+                              target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: keyFile defines the path to the client key
+                              file in the Prometheus container for the targets.
+                            type: string
+                          keySecret:
+                            description: keySecret defines the Secret containing the
+                              client key file for the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          maxVersion:
+                            description: |-
+                              maxVersion defines the maximum acceptable TLS version.
+
+                              It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          minVersion:
+                            description: |-
+                              minVersion defines the minimum acceptable TLS version.
+
+                              It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          serverName:
+                            description: serverName is used to verify the hostname
+                              for the targets.
+                            type: string
+                        type: object
+                    required:
+                    - endpoint
+                    type: object
                 type: object
               automountServiceAccountToken:
                 description: |-

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2473,6 +2473,236 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
+                  tracingConfig:
+                    description: tracingConfig defines the tracing configuration of
+                      Alertmanager.
+                    properties:
+                      clientType:
+                        description: clientType defines the client used to export
+                          the traces. Supported values are `HTTP` and `GRPC`.
+                        enum:
+                        - http
+                        - grpc
+                        - HTTP
+                        - GRPC
+                        type: string
+                      compression:
+                        description: compression key for supported compression types.
+                          The only supported value is `Gzip`.
+                        enum:
+                        - gzip
+                        - Gzip
+                        type: string
+                      endpoint:
+                        description: endpoint to send the traces to. Should be provided
+                          in format <host>:<port>.
+                        minLength: 1
+                        type: string
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: headers defines the key-value pairs to be used
+                          as headers associated with gRPC or HTTP requests.
+                        type: object
+                      insecure:
+                        description: insecure if disabled, the client will use a secure
+                          connection.
+                        type: boolean
+                      samplingFraction:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: samplingFraction defines the probability a given
+                          trace will be sampled. Must be a float from 0 through 1.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      timeout:
+                        description: timeout defines the maximum time the exporter
+                          will wait for each batch export.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      tlsConfig:
+                        description: tlsConfig to use when sending traces.
+                        properties:
+                          ca:
+                            description: ca defines the Certificate authority used
+                              when verifying server certificates.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          caFile:
+                            description: caFile defines the path to the CA cert in
+                              the Prometheus container to use for the targets.
+                            type: string
+                          cert:
+                            description: cert defines the Client certificate to present
+                              when doing client-authentication.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          certFile:
+                            description: certFile defines the path to the client cert
+                              file in the Prometheus container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: insecureSkipVerify defines how to disable
+                              target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: keyFile defines the path to the client key
+                              file in the Prometheus container for the targets.
+                            type: string
+                          keySecret:
+                            description: keySecret defines the Secret containing the
+                              client key file for the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          maxVersion:
+                            description: |-
+                              maxVersion defines the maximum acceptable TLS version.
+
+                              It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          minVersion:
+                            description: |-
+                              minVersion defines the minimum acceptable TLS version.
+
+                              It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          serverName:
+                            description: serverName is used to verify the hostname
+                              for the targets.
+                            type: string
+                        type: object
+                    required:
+                    - endpoint
+                    type: object
                 type: object
               automountServiceAccountToken:
                 description: |-

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2473,6 +2473,236 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
+                  tracingConfig:
+                    description: tracingConfig defines the tracing configuration of
+                      Alertmanager.
+                    properties:
+                      clientType:
+                        description: clientType defines the client used to export
+                          the traces. Supported values are `HTTP` and `GRPC`.
+                        enum:
+                        - http
+                        - grpc
+                        - HTTP
+                        - GRPC
+                        type: string
+                      compression:
+                        description: compression key for supported compression types.
+                          The only supported value is `Gzip`.
+                        enum:
+                        - gzip
+                        - Gzip
+                        type: string
+                      endpoint:
+                        description: endpoint to send the traces to. Should be provided
+                          in format <host>:<port>.
+                        minLength: 1
+                        type: string
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: headers defines the key-value pairs to be used
+                          as headers associated with gRPC or HTTP requests.
+                        type: object
+                      insecure:
+                        description: insecure if disabled, the client will use a secure
+                          connection.
+                        type: boolean
+                      samplingFraction:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: samplingFraction defines the probability a given
+                          trace will be sampled. Must be a float from 0 through 1.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      timeout:
+                        description: timeout defines the maximum time the exporter
+                          will wait for each batch export.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      tlsConfig:
+                        description: tlsConfig to use when sending traces.
+                        properties:
+                          ca:
+                            description: ca defines the Certificate authority used
+                              when verifying server certificates.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          caFile:
+                            description: caFile defines the path to the CA cert in
+                              the Prometheus container to use for the targets.
+                            type: string
+                          cert:
+                            description: cert defines the Client certificate to present
+                              when doing client-authentication.
+                            properties:
+                              configMap:
+                                description: configMap defines the ConfigMap containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: secret defines the Secret containing
+                                  data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          certFile:
+                            description: certFile defines the path to the client cert
+                              file in the Prometheus container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: insecureSkipVerify defines how to disable
+                              target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: keyFile defines the path to the client key
+                              file in the Prometheus container for the targets.
+                            type: string
+                          keySecret:
+                            description: keySecret defines the Secret containing the
+                              client key file for the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          maxVersion:
+                            description: |-
+                              maxVersion defines the maximum acceptable TLS version.
+
+                              It requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          minVersion:
+                            description: |-
+                              minVersion defines the minimum acceptable TLS version.
+
+                              It requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.
+                            enum:
+                            - TLS10
+                            - TLS11
+                            - TLS12
+                            - TLS13
+                            type: string
+                          serverName:
+                            description: serverName is used to verify the hostname
+                              for the targets.
+                            type: string
+                        type: object
+                    required:
+                    - endpoint
+                    type: object
                 type: object
               automountServiceAccountToken:
                 description: |-

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2210,6 +2210,240 @@
                           "type": "object"
                         },
                         "type": "array"
+                      },
+                      "tracingConfig": {
+                        "description": "tracingConfig defines the tracing configuration of Alertmanager.",
+                        "properties": {
+                          "clientType": {
+                            "description": "clientType defines the client used to export the traces. Supported values are `HTTP` and `GRPC`.",
+                            "enum": [
+                              "http",
+                              "grpc",
+                              "HTTP",
+                              "GRPC"
+                            ],
+                            "type": "string"
+                          },
+                          "compression": {
+                            "description": "compression key for supported compression types. The only supported value is `Gzip`.",
+                            "enum": [
+                              "gzip",
+                              "Gzip"
+                            ],
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "description": "endpoint to send the traces to. Should be provided in format <host>:<port>.",
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "headers": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "headers defines the key-value pairs to be used as headers associated with gRPC or HTTP requests.",
+                            "type": "object"
+                          },
+                          "insecure": {
+                            "description": "insecure if disabled, the client will use a secure connection.",
+                            "type": "boolean"
+                          },
+                          "samplingFraction": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "samplingFraction defines the probability a given trace will be sampled. Must be a float from 0 through 1.",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "timeout": {
+                            "description": "timeout defines the maximum time the exporter will wait for each batch export.",
+                            "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                            "type": "string"
+                          },
+                          "tlsConfig": {
+                            "description": "tlsConfig to use when sending traces.",
+                            "properties": {
+                              "ca": {
+                                "description": "ca defines the Certificate authority used when verifying server certificates.",
+                                "properties": {
+                                  "configMap": {
+                                    "description": "configMap defines the ConfigMap containing data to use for the targets.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "secret": {
+                                    "description": "secret defines the Secret containing data to use for the targets.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "caFile": {
+                                "description": "caFile defines the path to the CA cert in the Prometheus container to use for the targets.",
+                                "type": "string"
+                              },
+                              "cert": {
+                                "description": "cert defines the Client certificate to present when doing client-authentication.",
+                                "properties": {
+                                  "configMap": {
+                                    "description": "configMap defines the ConfigMap containing data to use for the targets.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "secret": {
+                                    "description": "secret defines the Secret containing data to use for the targets.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "certFile": {
+                                "description": "certFile defines the path to the client cert file in the Prometheus container for the targets.",
+                                "type": "string"
+                              },
+                              "insecureSkipVerify": {
+                                "description": "insecureSkipVerify defines how to disable target certificate validation.",
+                                "type": "boolean"
+                              },
+                              "keyFile": {
+                                "description": "keyFile defines the path to the client key file in the Prometheus container for the targets.",
+                                "type": "string"
+                              },
+                              "keySecret": {
+                                "description": "keySecret defines the Secret containing the client key file for the targets.",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "maxVersion": {
+                                "description": "maxVersion defines the maximum acceptable TLS version.\n\nIt requires Prometheus >= v2.41.0 or Thanos >= v0.31.0.",
+                                "enum": [
+                                  "TLS10",
+                                  "TLS11",
+                                  "TLS12",
+                                  "TLS13"
+                                ],
+                                "type": "string"
+                              },
+                              "minVersion": {
+                                "description": "minVersion defines the minimum acceptable TLS version.\n\nIt requires Prometheus >= v2.35.0 or Thanos >= v0.28.0.",
+                                "enum": [
+                                  "TLS10",
+                                  "TLS11",
+                                  "TLS12",
+                                  "TLS13"
+                                ],
+                                "type": "string"
+                              },
+                              "serverName": {
+                                "description": "serverName is used to verify the hostname for the targets.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "endpoint"
+                        ],
+                        "type": "object"
                       }
                     },
                     "type": "object"

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -271,7 +271,7 @@ func (cb *ConfigBuilder) MarshalJSON() ([]byte, error) {
 }
 
 // initializeFromAlertmanagerConfig initializes the configuration from an AlertmanagerConfig object.
-func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, globalConfig *monitoringv1.AlertmanagerGlobalConfig, amConfig *monitoringv1alpha1.AlertmanagerConfig) error {
+func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, globalConfig *monitoringv1.AlertmanagerGlobalConfig, tracingCfg *monitoringv1.TracingConfig, amConfig *monitoringv1alpha1.AlertmanagerConfig) error {
 	globalAlertmanagerConfig := &alertmanagerConfig{}
 
 	crKey := types.NamespacedName{
@@ -292,6 +292,12 @@ func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 		return err
 	}
 	globalAlertmanagerConfig.Global = global
+
+	tracingConfig, err := cb.convertTracingConfig(tracingCfg, crKey)
+	if err != nil {
+		return fmt.Errorf("invalid tracingConfig: %w", err)
+	}
+	globalAlertmanagerConfig.TracingConfig = tracingConfig
 
 	// This is need to check required fields are set either at global or receiver level at later step.
 	if global != nil {
@@ -334,6 +340,69 @@ func (cb *ConfigBuilder) initializeFromAlertmanagerConfig(ctx context.Context, g
 
 	cb.cfg = globalAlertmanagerConfig
 	return nil
+}
+
+func (cb *ConfigBuilder) convertTracingConfig(in *monitoringv1.TracingConfig, crKey types.NamespacedName) (*tracingConfig, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	if err := in.Validate(); err != nil {
+		return nil, err
+	}
+
+	out := &tracingConfig{
+		Endpoint: in.Endpoint,
+	}
+
+	if in.ClientType != nil {
+		out.ClientType = strings.ToLower(*in.ClientType)
+	}
+
+	if in.SamplingFraction != nil {
+		out.SamplingFraction = in.SamplingFraction.AsApproximateFloat64()
+	}
+
+	if in.Insecure != nil {
+		out.Insecure = *in.Insecure
+	}
+
+	if in.TLSConfig != nil {
+		tlsConfig := cb.convertTLSConfig(&in.TLSConfig.SafeTLSConfig, crKey)
+		if in.TLSConfig.CAFile != "" {
+			tlsConfig.CAFile = in.TLSConfig.CAFile
+		}
+		if in.TLSConfig.CertFile != "" {
+			tlsConfig.CertFile = in.TLSConfig.CertFile
+		}
+		if in.TLSConfig.KeyFile != "" {
+			tlsConfig.KeyFile = in.TLSConfig.KeyFile
+		}
+		out.TLSConfig = tlsConfig
+	}
+
+	if len(in.Headers) > 0 {
+		headers := make(map[string]commoncfg.Header, len(in.Headers))
+		for key, value := range in.Headers {
+			headers[key] = commoncfg.Header{Values: []string{value}}
+		}
+
+		out.Headers = &commoncfg.Headers{Headers: headers}
+	}
+
+	if in.Compression != nil {
+		out.Compression = strings.ToLower(*in.Compression)
+	}
+
+	if in.Timeout != nil {
+		timeout, err := model.ParseDuration(string(*in.Timeout))
+		if err != nil {
+			return nil, fmt.Errorf("parse tracing timeout: %w", err)
+		}
+		out.Timeout = &timeout
+	}
+
+	return out, nil
 }
 
 // InitializeFromRawConfiguration initializes the configuration from raw data.

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -33,6 +33,7 @@ import (
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -115,11 +116,53 @@ func TestInitializeFromAlertmanagerConfig(t *testing.T) {
 		name            string
 		amVersion       *semver.Version
 		globalConfig    *monitoringv1.AlertmanagerGlobalConfig
+		tracingConfig   *monitoringv1.TracingConfig
 		matcherStrategy monitoringv1.AlertmanagerConfigMatcherStrategy
 		amConfig        *monitoringv1alpha1.AlertmanagerConfig
 		wantErr         bool
 		golden          string
 	}{
+		{
+			name:      "valid tracing config",
+			amVersion: &version32,
+			tracingConfig: &monitoringv1.TracingConfig{
+				ClientType:       new("grpc"),
+				Endpoint:         "tempo.monitoring.svc:4317",
+				SamplingFraction: func(v resource.Quantity) *resource.Quantity { return &v }(resource.MustParse("0.5")),
+				Insecure:         new(true),
+				Headers: map[string]string{
+					"X-Scope-OrgID": "tenant-a",
+				},
+				Compression: new("gzip"),
+				Timeout:     ptr.To(monitoringv1.Duration("10s")),
+			},
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "global-config",
+					Namespace: "mynamespace",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1alpha1.Receiver{
+						{
+							Name: "null",
+						},
+						{
+							Name: "myreceiver",
+						},
+					},
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "null",
+						Routes: []apiextensionsv1.JSON{
+							{
+								Raw: myrouteJSON,
+							},
+						},
+					},
+				},
+			},
+			matcherStrategy: monitoringv1.AlertmanagerConfigMatcherStrategy{Type: "OnNamespace"},
+			golden:          "valid_tracing_config.golden",
+		},
 		{
 			name:      "valid global config",
 			amVersion: &version28,
@@ -2257,7 +2300,7 @@ Z8Ja2z8jw1xUKxfurno8wsAgFAQLuUZ0sTpwHBtwzFEdIeaAHBbNkkuGq7leIw/u
 			},
 		)
 		t.Run(tt.name, func(t *testing.T) {
-			err := cb.initializeFromAlertmanagerConfig(context.TODO(), tt.globalConfig, tt.amConfig)
+			err := cb.initializeFromAlertmanagerConfig(context.TODO(), tt.globalConfig, tt.tracingConfig, tt.amConfig)
 			if tt.wantErr {
 				t.Logf("err: %s", err)
 				require.Error(t, err)

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -940,7 +940,7 @@ func (c *Operator) provisionAlertmanagerConfiguration(ctx context.Context, am *m
 			return fmt.Errorf("failed to get global AlertmanagerConfig: %w", err)
 		}
 
-		err = cfgBuilder.initializeFromAlertmanagerConfig(ctx, am.Spec.AlertmanagerConfiguration.Global, globalAmConfig)
+		err = cfgBuilder.initializeFromAlertmanagerConfig(ctx, am.Spec.AlertmanagerConfiguration.Global, am.Spec.AlertmanagerConfiguration.TracingConfig, globalAmConfig)
 		if err != nil {
 			return fmt.Errorf("failed to initialize from global AlertmanagerConfig: %w", err)
 		}

--- a/pkg/alertmanager/testdata/valid_tracing_config.golden
+++ b/pkg/alertmanager/testdata/valid_tracing_config.golden
@@ -1,0 +1,22 @@
+route:
+  receiver: mynamespace/global-config/null
+  routes:
+  - receiver: mynamespace/global-config/myreceiver
+    matchers:
+    - mykey="myvalue"
+    - mykey1="myvalue1"
+receivers:
+- name: mynamespace/global-config/null
+- name: mynamespace/global-config/myreceiver
+tracing:
+  client_type: grpc
+  endpoint: tempo.monitoring.svc:4317
+  sampling_fraction: 0.5
+  insecure: true
+  headers:
+    X-Scope-OrgID:
+      values:
+      - tenant-a
+  compression: gzip
+  timeout: 10s
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -33,7 +33,19 @@ type alertmanagerConfig struct {
 	Receivers         []*receiver     `yaml:"receivers,omitempty"`
 	MuteTimeIntervals []*timeInterval `yaml:"mute_time_intervals,omitempty"`
 	TimeIntervals     []*timeInterval `yaml:"time_intervals,omitempty"`
+	TracingConfig     *tracingConfig  `yaml:"tracing,omitempty"`
 	Templates         []string        `yaml:"templates"`
+}
+
+type tracingConfig struct {
+	ClientType       string             `yaml:"client_type,omitempty"`
+	Endpoint         string             `yaml:"endpoint,omitempty"`
+	SamplingFraction float64            `yaml:"sampling_fraction,omitempty"`
+	Insecure         bool               `yaml:"insecure,omitempty"`
+	TLSConfig        *tlsConfig         `yaml:"tls_config,omitempty"`
+	Headers          *commoncfg.Headers `yaml:"headers,omitempty"`
+	Compression      string             `yaml:"compression,omitempty"`
+	Timeout          *model.Duration    `yaml:"timeout,omitempty"`
 }
 
 type globalConfig struct {

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -496,6 +496,9 @@ type AlertmanagerConfiguration struct {
 	// global defines the global parameters of the Alertmanager configuration.
 	// +optional
 	Global *AlertmanagerGlobalConfig `json:"global,omitempty"`
+	// tracingConfig defines the tracing configuration of Alertmanager.
+	// +optional
+	TracingConfig *TracingConfig `json:"tracingConfig,omitempty"`
 	// templates defines the custom notification templates.
 	// +optional
 	Templates []SecretOrConfigMap `json:"templates,omitempty"`

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *AlertmanagerConfiguration) DeepCopyInto(out *AlertmanagerConfiguration
 		*out = new(AlertmanagerGlobalConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TracingConfig != nil {
+		in, out := &in.TracingConfig, &out.TracingConfig
+		*out = new(TracingConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Templates != nil {
 		in, out := &in.Templates, &out.Templates
 		*out = make([]SecretOrConfigMap, len(*in))

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerconfiguration.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerconfiguration.go
@@ -27,6 +27,8 @@ type AlertmanagerConfigurationApplyConfiguration struct {
 	Name *string `json:"name,omitempty"`
 	// global defines the global parameters of the Alertmanager configuration.
 	Global *AlertmanagerGlobalConfigApplyConfiguration `json:"global,omitempty"`
+	// tracingConfig defines the tracing configuration of Alertmanager.
+	TracingConfig *TracingConfigApplyConfiguration `json:"tracingConfig,omitempty"`
 	// templates defines the custom notification templates.
 	Templates []SecretOrConfigMapApplyConfiguration `json:"templates,omitempty"`
 }
@@ -50,6 +52,14 @@ func (b *AlertmanagerConfigurationApplyConfiguration) WithName(value string) *Al
 // If called multiple times, the Global field is set to the value of the last call.
 func (b *AlertmanagerConfigurationApplyConfiguration) WithGlobal(value *AlertmanagerGlobalConfigApplyConfiguration) *AlertmanagerConfigurationApplyConfiguration {
 	b.Global = value
+	return b
+}
+
+// WithTracingConfig sets the TracingConfig field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TracingConfig field is set to the value of the last call.
+func (b *AlertmanagerConfigurationApplyConfiguration) WithTracingConfig(value *TracingConfigApplyConfiguration) *AlertmanagerConfigurationApplyConfiguration {
+	b.TracingConfig = value
 	return b
 }
 

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2223,6 +2223,72 @@ templates:
 	require.NoError(t, err, "%v: %v", err, lastErr)
 }
 
+func testAlertmanagerConfigTracing(t *testing.T) {
+	// Don't run Alertmanager tests in parallel. See
+	// https://github.com/prometheus/alertmanager/issues/1835 for details.
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup(t)
+
+	ns := framework.CreateNamespace(context.Background(), t, testCtx)
+	framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+	alertmanager := framework.MakeBasicAlertmanager(ns, "user-amconfig-tracing", 1)
+	alertmanagerConfig, err := framework.CreateAlertmanagerConfig(context.Background(), ns, "user-amconfig-tracing")
+	require.NoError(t, err)
+
+	alertmanager.Spec.AlertmanagerConfiguration = &monitoringv1.AlertmanagerConfiguration{
+		Name: alertmanagerConfig.Name,
+		TracingConfig: &monitoringv1.TracingConfig{
+			ClientType: new("grpc"),
+			Endpoint:   "tempo.monitoring.svc:4317",
+		},
+	}
+
+	_, err = framework.CreateAlertmanagerAndWaitUntilReady(context.Background(), alertmanager)
+	require.NoError(t, err)
+
+	var lastErr error
+	generatedConfigSecretName := fmt.Sprintf("alertmanager-%s-generated", alertmanager.Name)
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		cfgSecret, err := framework.KubeClient.CoreV1().Secrets(ns).Get(ctx, generatedConfigSecretName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			lastErr = err
+			return false, nil
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		if cfgSecret.Data["alertmanager.yaml.gz"] == nil {
+			lastErr = errors.New("'alertmanager.yaml.gz' key is missing")
+			return false, nil
+		}
+
+		uncompressed, err := operator.GunzipConfig(cfgSecret.Data["alertmanager.yaml.gz"])
+		require.NoError(t, err)
+
+		if !strings.Contains(uncompressed, "tracing:\n") {
+			lastErr = errors.New("generated configuration doesn't include tracing block")
+			return false, nil
+		}
+
+		if !strings.Contains(uncompressed, "client_type: grpc") {
+			lastErr = errors.New("generated configuration doesn't include tracing client_type")
+			return false, nil
+		}
+
+		if !strings.Contains(uncompressed, "endpoint: tempo.monitoring.svc:4317") {
+			lastErr = errors.New("generated configuration doesn't include tracing endpoint")
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	require.NoError(t, err, "%v: %v", err, lastErr)
+}
+
 func testAMPreserveUserAddedMetadata(t *testing.T) {
 	t.Parallel()
 	testCtx := framework.NewTestCtx(t)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -245,6 +245,7 @@ func testAllNSAlertmanager(t *testing.T) {
 		"AMAlertmanagerConfigVersions":            testAlertmanagerConfigVersions,
 		"AMUserDefinedAMConfigFromSecret":         testUserDefinedAlertmanagerConfigFromSecret,
 		"AMUserDefinedAMConfigFromCustomResource": testUserDefinedAlertmanagerConfigFromCustomResource,
+		"AMConfigTracing":                         testAlertmanagerConfigTracing,
 		"AMPreserveUserAddedMetadata":             testAMPreserveUserAddedMetadata,
 		"AMRollbackManualChanges":                 testAMRollbackManualChanges,
 		"AMMinReadySeconds":                       testAlertManagerMinReadySeconds,


### PR DESCRIPTION
## Description

Add configuration option to alertmanager to set tracing config

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
added some unit tests and a simple e2e test

## Changelog entry

[FEATURE] Add tracing to alertmanager toplevel config
<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
