### PR TITLE
feat: keep local compaction enabled with Thanos sidecar via delay-compact-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* [CHANGE] Keep local Prometheus compaction enabled when the Thanos sidecar uploads to object storage, for Prometheus >= v3.9.0 and Thanos >= v0.41.0. The operator now coordinates uploads through the shipper meta file (`--storage.tsdb.delay-compact-file.path`, `--shipper.meta-file-name`, `--shipper.ignore-unequal-block-size`) instead of disabling compaction. Set `spec.disableCompaction: true` to keep the previous behavior. #8266
 * [CHANGE/BUGFIX] Add validation markers to all unsigned int fields to reject negative values. #8662
 
 ## 0.92.1 / 2026-06-30

--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -3854,9 +3854,15 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableCompaction when true, the Prometheus compaction is disabled.
-When <code>spec.thanos.objectStorageConfig</code> or <code>spec.objectStorageConfigFile</code> are defined, the operator automatically
-disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).</p>
+<p>disableCompaction when true, the Prometheus compaction is disabled.</p>
+<p>When <code>spec.thanos.objectStorageConfig</code> or <code>spec.thanos.objectStorageConfigFile</code> are defined, the operator&rsquo;s
+default handling depends on the Prometheus and Thanos sidecar versions:
+- With Prometheus &lt; v3.9.0 or a Thanos sidecar &lt; v0.41.0, block compaction is disabled to avoid race
+conditions during block uploads (as the Thanos documentation recommends).
+- With Prometheus &gt;= v3.9.0 and a Thanos sidecar &gt;= v0.41.0, local compaction is kept enabled and coordinated
+with the sidecar through the shipper meta file (<code>--storage.tsdb.delay-compact-file.path</code>), so blocks are only
+compacted after they have been uploaded.
+Setting this field to true always disables local compaction regardless of the versions.</p>
 </td>
 </tr>
 <tr>
@@ -16982,9 +16988,15 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>disableCompaction when true, the Prometheus compaction is disabled.
-When <code>spec.thanos.objectStorageConfig</code> or <code>spec.objectStorageConfigFile</code> are defined, the operator automatically
-disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).</p>
+<p>disableCompaction when true, the Prometheus compaction is disabled.</p>
+<p>When <code>spec.thanos.objectStorageConfig</code> or <code>spec.thanos.objectStorageConfigFile</code> are defined, the operator&rsquo;s
+default handling depends on the Prometheus and Thanos sidecar versions:
+- With Prometheus &lt; v3.9.0 or a Thanos sidecar &lt; v0.41.0, block compaction is disabled to avoid race
+conditions during block uploads (as the Thanos documentation recommends).
+- With Prometheus &gt;= v3.9.0 and a Thanos sidecar &gt;= v0.41.0, local compaction is kept enabled and coordinated
+with the sidecar through the shipper meta file (<code>--storage.tsdb.delay-compact-file.path</code>), so blocks are only
+compacted after they have been uploaded.
+Setting this field to true always disables local compaction regardless of the versions.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/platform/thanos.md
+++ b/Documentation/platform/thanos.md
@@ -80,8 +80,15 @@ spec:
 
 This will attach Thanos sidecar that will backup all *new blocks* that Prometheus produces every 2 hours to the object storage.
 
-NOTE: This option will also disable the local Prometheus compaction. This means that Thanos compactor is the main singleton component
+NOTE: With Prometheus older than `v3.9.0` or a Thanos sidecar older than `v0.41.0`, this option disables the local Prometheus compaction
+(`--storage.tsdb.min-block-duration` == `--storage.tsdb.max-block-duration`). This means that Thanos compactor is the main singleton component
 responsible for compactions on a global, object storage level.
+
+NOTE: With Prometheus `>= v3.9.0` and a Thanos sidecar `>= v0.41.0`, the operator keeps local Prometheus compaction enabled and instead
+coordinates uploads through the sidecar's shipper meta file: Prometheus is started with `--storage.tsdb.delay-compact-file.path` and the
+sidecar with `--shipper.meta-file-name` and `--shipper.ignore-unequal-block-size`, so that Prometheus only compacts blocks that have already
+been uploaded to object storage. This avoids the query/memory overhead of running Prometheus without local compaction. Set
+`spec.disableCompaction: true` to force the old behavior of disabling local compaction.
 
 ## Thanos Ruler
 

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -3771,8 +3771,15 @@ spec:
               disableCompaction:
                 description: |-
                   disableCompaction when true, the Prometheus compaction is disabled.
-                  When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
-                  disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+
+                  When `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's
+                  default handling depends on the Prometheus and Thanos sidecar versions:
+                    - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race
+                      conditions during block uploads (as the Thanos documentation recommends).
+                    - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated
+                      with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only
+                      compacted after they have been uploaded.
+                  Setting this field to true always disables local compaction regardless of the versions.
                 type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -3771,8 +3771,15 @@ spec:
               disableCompaction:
                 description: |-
                   disableCompaction when true, the Prometheus compaction is disabled.
-                  When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
-                  disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+
+                  When `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's
+                  default handling depends on the Prometheus and Thanos sidecar versions:
+                    - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race
+                      conditions during block uploads (as the Thanos documentation recommends).
+                    - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated
+                      with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only
+                      compacted after they have been uploaded.
+                  Setting this field to true always disables local compaction regardless of the versions.
                 type: boolean
               dnsConfig:
                 description: dnsConfig defines the DNS configuration for the pods.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -3238,7 +3238,7 @@
                     "type": "boolean"
                   },
                   "disableCompaction": {
-                    "description": "disableCompaction when true, the Prometheus compaction is disabled.\nWhen `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically\ndisables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).",
+                    "description": "disableCompaction when true, the Prometheus compaction is disabled.\n\nWhen `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's\ndefault handling depends on the Prometheus and Thanos sidecar versions:\n  - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race\n    conditions during block uploads (as the Thanos documentation recommends).\n  - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated\n    with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only\n    compacted after they have been uploaded.\nSetting this field to true always disables local compaction regardless of the versions.",
                     "type": "boolean"
                   },
                   "dnsConfig": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1237,8 +1237,15 @@ type PrometheusSpec struct {
 	ShardRetentionPolicy *ShardRetentionPolicy `json:"shardRetentionPolicy,omitempty"`
 
 	// disableCompaction when true, the Prometheus compaction is disabled.
-	// When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
-	// disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+	//
+	// When `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's
+	// default handling depends on the Prometheus and Thanos sidecar versions:
+	//   - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race
+	//     conditions during block uploads (as the Thanos documentation recommends).
+	//   - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated
+	//     with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only
+	//     compacted after they have been uploaded.
+	// Setting this field to true always disables local compaction regardless of the versions.
 	// +optional
 	DisableCompaction bool `json:"disableCompaction,omitempty"` // nolint:kubeapilinter
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -47,8 +47,15 @@ type PrometheusSpecApplyConfiguration struct {
 	// (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
 	ShardRetentionPolicy *ShardRetentionPolicyApplyConfiguration `json:"shardRetentionPolicy,omitempty"`
 	// disableCompaction when true, the Prometheus compaction is disabled.
-	// When `spec.thanos.objectStorageConfig` or `spec.objectStorageConfigFile` are defined, the operator automatically
-	// disables block compaction to avoid race conditions during block uploads (as the Thanos documentation recommends).
+	//
+	// When `spec.thanos.objectStorageConfig` or `spec.thanos.objectStorageConfigFile` are defined, the operator's
+	// default handling depends on the Prometheus and Thanos sidecar versions:
+	// - With Prometheus < v3.9.0 or a Thanos sidecar < v0.41.0, block compaction is disabled to avoid race
+	// conditions during block uploads (as the Thanos documentation recommends).
+	// - With Prometheus >= v3.9.0 and a Thanos sidecar >= v0.41.0, local compaction is kept enabled and coordinated
+	// with the sidecar through the shipper meta file (`--storage.tsdb.delay-compact-file.path`), so blocks are only
+	// compacted after they have been uploaded.
+	// Setting this field to true always disables local compaction regardless of the versions.
 	DisableCompaction *bool `json:"disableCompaction,omitempty"`
 	// rules defines the configuration of the Prometheus rules' engine.
 	Rules *RulesApplyConfiguration `json:"rules,omitempty"`

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -37,6 +37,19 @@ const (
 	prometheusMode                       = "server"
 	governingServiceName                 = "prometheus-operated"
 	thanosSupportedVersionHTTPClientFlag = "0.24.0"
+
+	// Minimum Prometheus and Thanos versions supporting coordinated (delayed)
+	// compaction, which lets Prometheus keep local compaction enabled while the
+	// Thanos sidecar uploads blocks to object storage.
+	// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8266
+	minVersionPrometheusDelayedCompaction = "3.9.0"
+	minVersionThanosDelayedCompaction     = "0.41.0"
+
+	// thanosShipperMetaFileName is the name of the meta file the Thanos sidecar
+	// shipper writes in the TSDB directory. Prometheus reads it through
+	// --storage.tsdb.delay-compact-file.path to only compact blocks that have
+	// already been uploaded.
+	thanosShipperMetaFileName = "thanos.shipper.json"
 )
 
 func makeStatefulSet(
@@ -217,7 +230,12 @@ func makeStatefulSetSpec(
 
 	var additionalContainers, operatorInitContainers []corev1.Container
 
-	thanosContainer, thanosVolumes, err := createThanosContainer(p, c)
+	compactionMode, err := compactionModeFor(p, cg.Version())
+	if err != nil {
+		return nil, err
+	}
+
+	thanosContainer, thanosVolumes, err := createThanosContainer(p, c, compactionMode)
 	if err != nil {
 		return nil, err
 	}
@@ -227,13 +245,26 @@ func makeStatefulSetSpec(
 		volumes = append(volumes, thanosVolumes...)
 	}
 
-	if compactionDisabled(p) {
+	switch compactionMode {
+	case compactionModeDisabled:
+		// Disable local compaction so the Thanos sidecar can safely upload
+		// uncompacted blocks to object storage.
 		thanosBlockDuration := "2h"
 		if p.Spec.Thanos != nil {
 			thanosBlockDuration = operator.StringValOrDefault(string(p.Spec.Thanos.BlockDuration), thanosBlockDuration)
 		}
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.max-block-duration", Value: thanosBlockDuration})
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "storage.tsdb.min-block-duration", Value: thanosBlockDuration})
+
+	case compactionModeDelayed:
+		// Keep local compaction enabled and let Prometheus coordinate with the
+		// Thanos sidecar through the shipper meta file: Prometheus only compacts
+		// level-1 blocks that have already been uploaded.
+		// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8266
+		promArgs = append(promArgs, monitoringv1.Argument{
+			Name:  "storage.tsdb.delay-compact-file.path",
+			Value: filepath.Join(prompkg.StorageDir, thanosShipperMetaFileName),
+		})
 	}
 
 	// ref: https://github.com/prometheus-operator/prometheus-operator/issues/6829
@@ -241,8 +272,12 @@ func makeStatefulSetSpec(
 	//   1. Prometheus >= v2.55.0
 	//   2. Thanos sidecar configured for uploading blocks to object storage
 	//   3. out-of-order window is > 0
+	// This is required in both the disabled and delayed compaction modes:
+	// --storage.tsdb.delay-compact-file.path only delays level-1 compaction, so
+	// overlapping out-of-order blocks could still be vertically compacted before
+	// the sidecar uploads them.
 	if cpf.TSDB != nil && cpf.TSDB.OutOfOrderTimeWindow != nil &&
-		compactionDisabled(p) &&
+		compactionMode != compactionModeDefault &&
 		cg.WithMinimumVersion("2.55.0").IsCompatible() {
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "no-storage.tsdb.allow-overlapping-compaction"})
 	}
@@ -502,7 +537,7 @@ func appendServerVolumes(p *monitoringv1.Prometheus, volumes []corev1.Volume, vo
 	return volumes, volumeMounts
 }
 
-func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*corev1.Container, []corev1.Volume, error) {
+func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config, compaction compactionMode) (*corev1.Container, []corev1.Volume, error) {
 	if p.Spec.Thanos == nil {
 		return nil, nil, nil
 	}
@@ -626,6 +661,19 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config) (*corev
 				SubPath:   prompkg.SubPathForStorage(cpf.Storage),
 			},
 		)
+
+		// When compaction stays enabled on Prometheus, coordinate uploads with
+		// it through the shipper meta file: pin the meta file name that
+		// Prometheus reads via --storage.tsdb.delay-compact-file.path and allow
+		// the shipper to upload blocks even though min/max block durations
+		// differ (compaction is enabled).
+		// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8266
+		if compaction == compactionModeDelayed {
+			thanosArgs = append(thanosArgs,
+				monitoringv1.Argument{Name: "shipper.meta-file-name", Value: thanosShipperMetaFileName},
+				monitoringv1.Argument{Name: "shipper.ignore-unequal-block-size"},
+			)
+		}
 	}
 
 	if thanos.TracingConfig != nil || len(thanos.TracingConfigFile) > 0 {
@@ -724,12 +772,57 @@ func queryLogFileVolume(queryLogFile string) (corev1.Volume, bool) {
 	}, true
 }
 
-func compactionDisabled(p *monitoringv1.Prometheus) bool {
-	// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/
-	// we have to turn off compaction of Prometheus if export to object
-	// storage is configured to avoid races during uploads.
-	return p.Spec.DisableCompaction ||
-		(p.Spec.Thanos != nil &&
-			(p.Spec.Thanos.ObjectStorageConfig != nil ||
-				p.Spec.Thanos.ObjectStorageConfigFile != nil))
+// compactionMode describes how the operator configures local compaction for a
+// Prometheus instance when the Thanos sidecar uploads blocks to object storage.
+type compactionMode int
+
+const (
+	// compactionModeDefault lets Prometheus manage local compaction as usual.
+	// Used when blocks are not uploaded to object storage.
+	compactionModeDefault compactionMode = iota
+
+	// compactionModeDisabled turns off local compaction (min-block-duration ==
+	// max-block-duration) so the Thanos sidecar can safely upload uncompacted
+	// blocks to object storage, as recommended by
+	// https://thanos.io/components/sidecar.md/.
+	compactionModeDisabled
+
+	// compactionModeDelayed keeps local compaction enabled and coordinates
+	// uploads with the Thanos sidecar through the shipper meta file, so that
+	// Prometheus only compacts blocks that have already been uploaded.
+	// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8266
+	compactionModeDelayed
+)
+
+// compactionModeFor returns how local compaction must be configured given the
+// Thanos sidecar object-storage setup and the Prometheus and Thanos versions.
+//
+// Delayed compaction requires Prometheus >= v3.9.0
+// (--storage.tsdb.delay-compact-file.path) and Thanos >= v0.41.0
+// (--shipper.meta-file-name and --shipper.ignore-unequal-block-size); otherwise
+// compaction is disabled while uploading to object storage.
+func compactionModeFor(p *monitoringv1.Prometheus, promVersion semver.Version) (compactionMode, error) {
+	// An explicit request to disable compaction always wins.
+	if p.Spec.DisableCompaction {
+		return compactionModeDisabled, nil
+	}
+
+	// Compaction only needs special handling when the sidecar uploads blocks to
+	// object storage.
+	if p.Spec.Thanos == nil ||
+		(p.Spec.Thanos.ObjectStorageConfig == nil && p.Spec.Thanos.ObjectStorageConfigFile == nil) {
+		return compactionModeDefault, nil
+	}
+
+	thanosVersion, err := semver.ParseTolerant(ptr.Deref(p.Spec.Thanos.Version, operator.DefaultThanosVersion))
+	if err != nil {
+		return compactionModeDefault, fmt.Errorf("failed to parse Thanos version: %w", err)
+	}
+
+	if promVersion.GTE(semver.MustParse(minVersionPrometheusDelayedCompaction)) &&
+		thanosVersion.GTE(semver.MustParse(minVersionThanosDelayedCompaction)) {
+		return compactionModeDelayed, nil
+	}
+
+	return compactionModeDisabled, nil
 }

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -17,6 +17,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strconv"
@@ -996,6 +997,12 @@ func TestThanosObjectStorage(t *testing.T) {
 
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
+			// Pin a Prometheus version older than v3.9.0 so that compaction is
+			// disabled (min == max block duration) rather than delegated to the
+			// delayed-compaction coordination path.
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Version: "2.55.0",
+			},
 			Thanos: &monitoringv1.ThanosSpec{
 				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
@@ -1056,6 +1063,12 @@ func TestThanosObjectStorageFile(t *testing.T) {
 	testPath := "/vault/secret/config.yaml"
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
+			// Pin a Prometheus version older than v3.9.0 so that compaction is
+			// disabled (min == max block duration) rather than delegated to the
+			// delayed-compaction coordination path.
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Version: "2.55.0",
+			},
 			Thanos: &monitoringv1.ThanosSpec{
 				ObjectStorageConfigFile: &testPath,
 				BlockDuration:           "2h",
@@ -1122,6 +1135,12 @@ func TestThanosBlockDuration(t *testing.T) {
 
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
+			// Pin a Prometheus version older than v3.9.0 so that compaction is
+			// disabled and the BlockDuration is applied to the min/max block
+			// duration flags.
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				Version: "2.55.0",
+			},
 			Thanos: &monitoringv1.ThanosSpec{
 				BlockDuration: "1h",
 				ObjectStorageConfig: &corev1.SecretKeySelector{
@@ -1139,6 +1158,94 @@ func TestThanosBlockDuration(t *testing.T) {
 		}
 	}
 	require.True(t, found, "Thanos BlockDuration arg change not found")
+}
+
+// containerByName returns the container with the given name from the pod spec.
+func containerByName(t *testing.T, sset *appsv1.StatefulSet, name string) corev1.Container {
+	t.Helper()
+	for _, c := range sset.Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return c
+		}
+	}
+	require.Failf(t, "container not found", "no container named %q in the pod spec", name)
+	return corev1.Container{}
+}
+
+// TestThanosDelayedCompaction verifies that with Prometheus >= v3.9.0 and Thanos
+// >= v0.41.0, the operator keeps local compaction enabled and coordinates block
+// uploads with the sidecar through the shipper meta file instead of disabling
+// compaction. Otherwise (versions too old, or compaction explicitly disabled) it
+// falls back to disabling compaction.
+// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8266
+func TestThanosDelayedCompaction(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		promVersion       string
+		thanosVersion     string
+		disableCompaction bool
+		delayed           bool
+	}{
+		{name: "supported versions", promVersion: "3.9.0", thanosVersion: "0.41.0", delayed: true},
+		{name: "prometheus too old", promVersion: "3.8.0", thanosVersion: "0.41.0"},
+		{name: "thanos too old", promVersion: "3.9.0", thanosVersion: "0.40.0"},
+		{name: "compaction explicitly disabled", promVersion: "3.9.0", thanosVersion: "0.41.0", disableCompaction: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			thanosVersion := tc.thanosVersion
+			sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Version: tc.promVersion,
+					},
+					DisableCompaction: tc.disableCompaction,
+					Thanos: &monitoringv1.ThanosSpec{
+						Version: &thanosVersion,
+						ObjectStorageConfig: &corev1.SecretKeySelector{
+							Key: "thanos-config-secret-test",
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			promArgs := containerByName(t, sset, "prometheus").Args
+			sidecarArgs := containerByName(t, sset, "thanos-sidecar").Args
+			delayArg := "--storage.tsdb.delay-compact-file.path=" + filepath.Join(prompkg.StorageDir, "thanos.shipper.json")
+
+			if tc.delayed {
+				require.Contains(t, promArgs, delayArg)
+				for _, arg := range promArgs {
+					require.False(t, strings.HasPrefix(arg, "--storage.tsdb.max-block-duration="), "compaction should stay enabled: %q", arg)
+					require.False(t, strings.HasPrefix(arg, "--storage.tsdb.min-block-duration="), "compaction should stay enabled: %q", arg)
+				}
+				require.Contains(t, sidecarArgs, "--shipper.meta-file-name=thanos.shipper.json")
+				require.Contains(t, sidecarArgs, "--shipper.ignore-unequal-block-size")
+				return
+			}
+
+			require.Contains(t, promArgs, "--storage.tsdb.max-block-duration=2h")
+			require.NotContains(t, promArgs, delayArg)
+			require.NotContains(t, sidecarArgs, "--shipper.ignore-unequal-block-size")
+		})
+	}
+}
+
+// TestThanosInvalidVersion verifies that an unparsable Thanos version surfaces
+// an error instead of being silently swallowed.
+func TestThanosInvalidVersion(t *testing.T) {
+	invalidVersion := "not-a-version"
+	_, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			Thanos: &monitoringv1.ThanosSpec{
+				Version: &invalidVersion,
+				ObjectStorageConfig: &corev1.SecretKeySelector{
+					Key: "thanos-config-secret-test",
+				},
+			},
+		},
+	})
+	require.Error(t, err)
 }
 
 func TestThanosWithNamedPVC(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #8266.

For Prometheus `>= v3.9.0` and a Thanos sidecar `>= v0.41.0`, the operator now keeps **local Prometheus compaction enabled** while the sidecar uploads blocks to object storage, coordinating the two through the shipper meta file instead of disabling compaction.

Previously, whenever `spec.thanos.objectStorageConfig` / `objectStorageConfigFile` was set, the operator forced `--storage.tsdb.min-block-duration == --storage.tsdb.max-block-duration` to disable local compaction (to avoid corrupting blocks mid-upload). That costs query performance and memory since Prometheus never compacts locally.

Prometheus v3.9.0 added [`--storage.tsdb.delay-compact-file.path`](https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go) ("only compact 1-level blocks that are marked as uploaded in that file"), and Thanos v0.41.0 has the matching sidecar flags. This PR wires them together:

- **Prometheus**: `--storage.tsdb.delay-compact-file.path=/prometheus/thanos.shipper.json`
- **Thanos sidecar**: `--shipper.meta-file-name=thanos.shipper.json` and `--shipper.ignore-unequal-block-size`

Prometheus then only compacts level-1 blocks that the sidecar has already uploaded, so no block is compacted before it reaches object storage.

## Implementation

A single `compactionModeFor(p, promVersion) (compactionMode, error)` helper returns a 3-state compaction mode and drives all call sites:

- `compactionModeDefault` — Prometheus manages compaction as usual (no object-storage upload).
- `compactionModeDisabled` — `min == max` block duration (explicit `disableCompaction`, or versions too old to coordinate).
- `compactionModeDelayed` — local compaction stays on, coordinated via the shipper meta file.

The Thanos version parse error is returned rather than swallowed.

`--no-storage.tsdb.allow-overlapping-compaction` (#6829) is still emitted in both the disabled and delayed modes when the out-of-order window is set: `--storage.tsdb.delay-compact-file.path` only delays level-1 compaction, so overlapping out-of-order blocks could otherwise be vertically compacted before the sidecar uploads them.

## Behavior / compatibility

- Only activates when the sidecar uploads to object storage **and** both version gates are met (`Prometheus >= v3.9.0`, `Thanos >= v0.41.0`).
- `spec.disableCompaction: true` still forces compaction off regardless of version.
- Older Prometheus/Thanos versions keep the existing behavior (equal min/max block durations).

> **Note (behavior change):** since the default Prometheus and Thanos versions already satisfy the gates, users setting object storage on the sidecar **without** pinning older versions will get local compaction enabled after upgrading the operator. This is the intent of #8266; set `spec.disableCompaction: true` to opt out. Happy to gate this behind an explicit field / feature gate instead if maintainers prefer.

## Testing

- `TestThanosDelayedCompaction` — modern versions: asserts `--storage.tsdb.delay-compact-file.path` on Prometheus, no min/max block-duration args, and the two shipper flags on the sidecar.
- `TestThanosDelayedCompactionGating` — table test covering the fallback-to-disabled path for old Prometheus, old Thanos, and explicit `disableCompaction`.
- `TestThanosInvalidVersion` — an unparsable Thanos version surfaces an error instead of being swallowed.
- Existing `TestThanosObjectStorage` / `TestThanosObjectStorageFile` / `TestThanosBlockDuration` pinned to a pre-3.9.0 version to keep exercising the disable path.

`go test ./pkg/prometheus/...` passes; `gofmt`/`go vet` clean.

No API/CRD changes.
