### PR TITLE
alertmanager: preserve top-level event_recorder configuration

### DIFF
--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -8460,6 +8460,51 @@ func TestLoadConfig(t *testing.T) {
 			},
 			golden: "Discord_url_field.golden",
 		},
+		{
+			name: "event_recorder field",
+			expected: &alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{
+					{
+						Name: "null",
+					},
+				},
+				EventRecorder: &eventRecorderConfig{
+					FileOutputs: []*fileOutputConfig{
+						{
+							Path: "/var/log/alertmanager/events.jsonl",
+						},
+					},
+					WebhookOutputs: []*webhookOutputConfig{
+						{
+							URL: "http://example.com/events",
+							HTTPConfig: &httpClientConfig{
+								BasicAuth: &basicAuth{
+									Username: "user",
+									Password: "secret-pass",
+								},
+							},
+							Timeout:      ptr.To(model.Duration(10 * time.Second)),
+							Workers:      4,
+							MaxRetries:   3,
+							RetryBackoff: ptr.To(model.Duration(500 * time.Millisecond)),
+						},
+					},
+					KafkaOutputs: []*kafkaOutputConfig{
+						{
+							Brokers:     []string{"kafka:9092"},
+							Topic:       "alertmanager-events",
+							Acks:        "all",
+							Compression: "gzip",
+						},
+					},
+				},
+				Templates: []string{},
+			},
+			golden: "event_recorder_field.golden",
+		},
 	}
 
 	for _, tc := range testCase {
@@ -8469,6 +8514,27 @@ func TestLoadConfig(t *testing.T) {
 			require.Equal(t, tc.expected, ac)
 		})
 	}
+}
+
+// TestEventRecorderConfig ensures that a user-provided Alertmanager
+// configuration containing the top-level `event_recorder` field (an
+// Alertmanager auditing feature) is accepted by the operator and that the
+// section, including any secrets provided inline, is preserved verbatim when
+// the configuration is marshalled back out.
+func TestEventRecorderConfig(t *testing.T) {
+	ac, err := alertmanagerConfigFromBytes(golden.Get(t, "event_recorder_field.golden"))
+	require.NoError(t, err)
+
+	out := ac.String()
+	require.Contains(t, out, "event_recorder:")
+	require.Contains(t, out, "alertmanager-events")
+	// Secrets must round-trip verbatim, not be replaced with the "<secret>"
+	// placeholder that Alertmanager's own config types emit.
+	require.Contains(t, out, "secret-pass")
+
+	// The regenerated configuration must still be valid Alertmanager config.
+	_, err = config.Load(out)
+	require.NoError(t, err)
 }
 
 func TestConvertHTTPConfig(t *testing.T) {

--- a/pkg/alertmanager/testdata/event_recorder_field.golden
+++ b/pkg/alertmanager/testdata/event_recorder_field.golden
@@ -1,0 +1,24 @@
+route:
+  receiver: "null"
+receivers:
+- name: "null"
+event_recorder:
+  file_outputs:
+  - path: /var/log/alertmanager/events.jsonl
+  webhook_outputs:
+  - url: http://example.com/events
+    http_config:
+      basic_auth:
+        username: user
+        password: secret-pass
+    timeout: 10s
+    workers: 4
+    max_retries: 3
+    retry_backoff: 500ms
+  kafka_outputs:
+  - brokers:
+    - kafka:9092
+    topic: alertmanager-events
+    acks: all
+    compression: gzip
+templates: []

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -27,13 +27,14 @@ import (
 // marshalling. See the following issue for details:
 // https://github.com/prometheus/alertmanager/issues/1985
 type alertmanagerConfig struct {
-	Global            *globalConfig   `yaml:"global,omitempty"`
-	Route             *route          `yaml:"route,omitempty"`
-	InhibitRules      []*inhibitRule  `yaml:"inhibit_rules,omitempty"`
-	Receivers         []*receiver     `yaml:"receivers,omitempty"`
-	MuteTimeIntervals []*timeInterval `yaml:"mute_time_intervals,omitempty"`
-	TimeIntervals     []*timeInterval `yaml:"time_intervals,omitempty"`
-	Templates         []string        `yaml:"templates"`
+	Global            *globalConfig        `yaml:"global,omitempty"`
+	Route             *route               `yaml:"route,omitempty"`
+	InhibitRules      []*inhibitRule       `yaml:"inhibit_rules,omitempty"`
+	Receivers         []*receiver          `yaml:"receivers,omitempty"`
+	MuteTimeIntervals []*timeInterval      `yaml:"mute_time_intervals,omitempty"`
+	TimeIntervals     []*timeInterval      `yaml:"time_intervals,omitempty"`
+	EventRecorder     *eventRecorderConfig `yaml:"event_recorder,omitempty"`
+	Templates         []string             `yaml:"templates"`
 }
 
 type globalConfig struct {
@@ -110,6 +111,41 @@ type inhibitRule struct {
 	SourceMatchRE  map[string]string `yaml:"source_match_re,omitempty"`
 	SourceMatchers []string          `yaml:"source_matchers,omitempty"`
 	Equal          []string          `yaml:"equal,omitempty"`
+}
+
+// eventRecorderConfig mirrors alertmanager's top-level `event_recorder`
+// auditing configuration. The upstream types embed secret-bearing fields
+// (e.g. webhook URLs and HTTP credentials) that obfuscate their values when
+// marshalled, so - like the rest of this file - we keep a local copy that
+// round-trips the values verbatim.
+type eventRecorderConfig struct {
+	FileOutputs    []*fileOutputConfig    `yaml:"file_outputs,omitempty"`
+	WebhookOutputs []*webhookOutputConfig `yaml:"webhook_outputs,omitempty"`
+	KafkaOutputs   []*kafkaOutputConfig   `yaml:"kafka_outputs,omitempty"`
+}
+
+type fileOutputConfig struct {
+	Path string `yaml:"path"`
+}
+
+type webhookOutputConfig struct {
+	URL          string            `yaml:"url"`
+	HTTPConfig   *httpClientConfig `yaml:"http_config,omitempty"`
+	Timeout      *model.Duration   `yaml:"timeout,omitempty"`
+	Workers      int               `yaml:"workers,omitempty"`
+	MaxRetries   int               `yaml:"max_retries,omitempty"`
+	RetryBackoff *model.Duration   `yaml:"retry_backoff,omitempty"`
+}
+
+type kafkaOutputConfig struct {
+	Brokers     []string   `yaml:"brokers"`
+	Topic       string     `yaml:"topic"`
+	ClientID    string     `yaml:"client_id,omitempty"`
+	Format      string     `yaml:"format,omitempty"`
+	Acks        string     `yaml:"acks,omitempty"`
+	Compression string     `yaml:"compression,omitempty"`
+	BufferSize  int        `yaml:"buffer_size,omitempty"`
+	TLSConfig   *tlsConfig `yaml:"tls_config,omitempty"`
 }
 
 type receiver struct {


### PR DESCRIPTION
## What

Adds support for Alertmanager's top-level `event_recorder` section to the operator's internal Alertmanager config type, so a global configuration that uses it is accepted and preserved.

## Why

`event_recorder` is a new Alertmanager auditing feature configured as a top-level config section (alongside `global`, `route`, `receivers`, ...). When a user provides a global Alertmanager configuration secret containing `event_recorder`, the operator rejects the entire configuration:

```
field event_recorder not found in type alertmanager.alertmanagerConfig
```

Upstream `config.Load` already validates the section; the failure comes only from the operator's own strict unmarshal into its local `alertmanagerConfig` mirror, which did not model the field. Because that mirror exists to avoid the secret obfuscation of Alertmanager's own config types (see issue prometheus/alertmanager#1985), the `event_recorder` outputs are mirrored with the operator's existing secret-preserving types (`httpClientConfig`, `tlsConfig`) rather than importing the upstream types. This makes the section round-trip verbatim into the generated config, including any inline secrets.

Only the file/webhook/kafka outputs supported by the vendored Alertmanager (`v0.33.1`) are modeled. No CRD or public API changes.

## Tests

- `pkg/alertmanager`: added `event_recorder_field` case to `TestLoadConfig` (asserts the section parses into the expected internal struct) and a new `TestEventRecorderConfig` round-trip test (asserts the section — and an inline `basic_auth` secret — survives marshalling and that the regenerated config still passes upstream `config.Load`).

```
$ go test ./pkg/alertmanager/ -run 'TestLoadConfig|TestEventRecorderConfig' -count=1
ok  github.com/prometheus-operator/prometheus-operator/pkg/alertmanager
```

Full `pkg/alertmanager` suite and `golangci-lint run ./pkg/alertmanager/` both pass.

Note: AI tooling assisted with code navigation and drafting; the change was reviewed and verified by the author.

Fixes #8692