### PR TITLE
feat: make compactionDisabled version-aware for Thanos >= v0.42.0

### DIFF
--- a/Documentation/getting-started/compatibility.md
+++ b/Documentation/getting-started/compatibility.md
@@ -106,5 +106,5 @@ The Prometheus Operator is compatible with Thanos v0.10 and above.
 The end-to-end tests are mostly tested against
 
 ```$ mdox-exec="go run ./cmd/po-docgen/. compatibility defaultThanosVersion"
-* v0.41.0
+* v0.42.0
 ```

--- a/example/thanos/prometheus.yaml
+++ b/example/thanos/prometheus.yaml
@@ -15,4 +15,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus
   thanos:
-    version: v0.38.0
+    version: v0.42.0

--- a/example/thanos/query-deployment.yaml
+++ b/example/thanos/query-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --query.replica-label=thanos_ruler_replica
         - --endpoint=dnssrv+_grpc._tcp.thanos-sidecar.default.svc.cluster.local
         - --endpoint=dnssrv+_grpc._tcp.thanos-ruler.default.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.38.0
+        image: quay.io/thanos/thanos:v0.42.0
         name: thanos-query
         ports:
         - containerPort: 10902

--- a/example/thanos/thanos-ruler.yaml
+++ b/example/thanos/thanos-ruler.yaml
@@ -6,11 +6,11 @@ metadata:
   name: thanos-ruler
   namespace: default
 spec:
-  image: quay.io/thanos/thanos:v0.38.0
+  image: quay.io/thanos/thanos:v0.42.0
   queryConfig:
     key: query.yaml
     name: thanos-ruler
   ruleSelector:
     matchLabels:
       role: thanos-example
-  version: v0.38.0
+  version: v0.42.0

--- a/jsonnet/thanos/config.libsonnet
+++ b/jsonnet/thanos/config.libsonnet
@@ -20,7 +20,7 @@ local service(name, namespace, labels, selector, ports) = {
     thanosRulerName: 'thanos-ruler',
     thanosSidecarName: 'thanos-sidecar',
     versions+:: {
-      thanos: 'v0.38.0',
+      thanos: 'v0.42.0',
     },
 
     imageRepos+:: {

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -227,7 +227,12 @@ func makeStatefulSetSpec(
 		volumes = append(volumes, thanosVolumes...)
 	}
 
-	if compactionDisabled(p) {
+	var thanosVersion semver.Version
+	if p.Spec.Thanos != nil {
+		thanosVersion, _ = semver.ParseTolerant(ptr.Deref(p.Spec.Thanos.Version, operator.DefaultThanosVersion))
+	}
+
+	if compactionDisabled(p, thanosVersion) {
 		thanosBlockDuration := "2h"
 		if p.Spec.Thanos != nil {
 			thanosBlockDuration = operator.StringValOrDefault(string(p.Spec.Thanos.BlockDuration), thanosBlockDuration)
@@ -242,7 +247,7 @@ func makeStatefulSetSpec(
 	//   2. Thanos sidecar configured for uploading blocks to object storage
 	//   3. out-of-order window is > 0
 	if cpf.TSDB != nil && cpf.TSDB.OutOfOrderTimeWindow != nil &&
-		compactionDisabled(p) &&
+		compactionDisabled(p, thanosVersion) &&
 		cg.WithMinimumVersion("2.55.0").IsCompatible() {
 		promArgs = append(promArgs, monitoringv1.Argument{Name: "no-storage.tsdb.allow-overlapping-compaction"})
 	}
@@ -724,12 +729,21 @@ func queryLogFileVolume(queryLogFile string) (corev1.Volume, bool) {
 	}, true
 }
 
-func compactionDisabled(p *monitoringv1.Prometheus) bool {
+func compactionDisabled(p *monitoringv1.Prometheus, thanosVersion semver.Version) bool {
 	// NOTE(bwplotka): As described in https://thanos.io/components/sidecar.md/
 	// we have to turn off compaction of Prometheus if export to object
 	// storage is configured to avoid races during uploads.
-	return p.Spec.DisableCompaction ||
-		(p.Spec.Thanos != nil &&
-			(p.Spec.Thanos.ObjectStorageConfig != nil ||
-				p.Spec.Thanos.ObjectStorageConfigFile != nil))
+	//
+	// Thanos >= v0.42.0 handles compaction/upload ordering internally.
+	if p.Spec.DisableCompaction {
+		return true
+	}
+
+	if p.Spec.Thanos != nil &&
+		(p.Spec.Thanos.ObjectStorageConfig != nil ||
+			p.Spec.Thanos.ObjectStorageConfigFile != nil) {
+		return thanosVersion.LT(semver.MustParse("0.42.0"))
+	}
+
+	return false
 }

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -994,9 +994,12 @@ func TestThanosNoObjectStorage(t *testing.T) {
 func TestThanosObjectStorage(t *testing.T) {
 	testKey := "thanos-config-secret-test"
 
+	// Use Thanos < v0.42.0 where compaction is disabled when object storage is configured.
+	thanosVersion := "v0.41.0"
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
+				Version: &thanosVersion,
 				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
 				},
@@ -1054,9 +1057,12 @@ func TestThanosObjectStorage(t *testing.T) {
 
 func TestThanosObjectStorageFile(t *testing.T) {
 	testPath := "/vault/secret/config.yaml"
+	// Use Thanos < v0.42.0 where compaction is disabled when object storage is configured.
+	thanosVersion := "v0.41.0"
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
+				Version:                 &thanosVersion,
 				ObjectStorageConfigFile: &testPath,
 				BlockDuration:           "2h",
 			},
@@ -1120,9 +1126,12 @@ func TestThanosObjectStorageFile(t *testing.T) {
 func TestThanosBlockDuration(t *testing.T) {
 	testKey := "thanos-config-secret-test"
 
+	// Use Thanos < v0.42.0 where compaction is disabled when object storage is configured.
+	thanosVersion := "v0.41.0"
 	sset, err := makeStatefulSetFromPrometheus(monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			Thanos: &monitoringv1.ThanosSpec{
+				Version:       &thanosVersion,
 				BlockDuration: "1h",
 				ObjectStorageConfig: &corev1.SecretKeySelector{
 					Key: testKey,
@@ -1139,6 +1148,74 @@ func TestThanosBlockDuration(t *testing.T) {
 		}
 	}
 	require.True(t, found, "Thanos BlockDuration arg change not found")
+}
+
+// TestCompactionDisabledThanosVersion verifies that compaction is only
+// disabled when object storage is configured for Thanos < v0.42.0.
+// Starting with Thanos v0.42.0, TSDB delays compaction until blocks have been
+// uploaded by the shipper, so disabling compaction externally is no longer needed.
+func TestCompactionDisabledThanosVersion(t *testing.T) {
+	testKey := "thanos-config-secret-test"
+
+	for _, tc := range []struct {
+		name              string
+		version           string
+		objectStorage     bool
+		disableCompaction bool
+		expectDisabled    bool
+	}{
+		{
+			name:           "Thanos < v0.42.0 with object storage disables compaction",
+			version:        "v0.41.0",
+			objectStorage:  true,
+			expectDisabled: true,
+		},
+		{
+			name:           "Thanos >= v0.42.0 with object storage does not disable compaction",
+			version:        "v0.42.0",
+			objectStorage:  true,
+			expectDisabled: false,
+		},
+		{
+			name:           "Thanos >= v0.42.0 without object storage does not disable compaction",
+			version:        "v0.42.0",
+			objectStorage:  false,
+			expectDisabled: false,
+		},
+		{
+			name:              "Explicit DisableCompaction always disables compaction regardless of version",
+			version:           "v0.42.0",
+			disableCompaction: true,
+			expectDisabled:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					DisableCompaction: tc.disableCompaction,
+					Thanos:            &monitoringv1.ThanosSpec{Version: &tc.version},
+				},
+			}
+			if tc.objectStorage {
+				p.Spec.Thanos.ObjectStorageConfig = &corev1.SecretKeySelector{Key: testKey}
+			}
+
+			sset, err := makeStatefulSetFromPrometheus(p)
+			require.NoError(t, err)
+
+			const arg = "--storage.tsdb.max-block-duration="
+			var found bool
+			for _, a := range sset.Spec.Template.Spec.Containers[0].Args {
+				if strings.HasPrefix(a, arg) {
+					found = true
+					break
+				}
+			}
+			require.Equal(t, tc.expectDisabled, found,
+				"expected compaction disabled=%v but got disabled=%v for version=%s",
+				tc.expectDisabled, found, tc.version)
+		})
+	}
 }
 
 func TestThanosWithNamedPVC(t *testing.T) {
@@ -1534,9 +1611,11 @@ func TestTSDBAllowOverlappingBlocks(t *testing.T) {
 
 func TestTSDBAllowOverlappingCompaction(t *testing.T) {
 	expectedArg := "--no-storage.tsdb.allow-overlapping-compaction"
+	thanosVersion := "v0.41.0" // Thanos < v0.42.0 where object storage disables compaction.
 	tests := []struct {
 		name                    string
 		version                 string
+		thanosVersion           *string
 		outOfOrderTimeWindow    monitoringv1.Duration
 		objectStorageConfigFile *string
 		shouldContain           bool
@@ -1544,16 +1623,19 @@ func TestTSDBAllowOverlappingCompaction(t *testing.T) {
 		{
 			name:          "Prometheus version less than or equal to v2.55.0",
 			version:       "v2.54.0",
+			thanosVersion: &thanosVersion,
 			shouldContain: false,
 		},
 		{
 			name:          "outOfOrderTimeWindow equal to 0s",
 			version:       "v2.55.0",
+			thanosVersion: &thanosVersion,
 			shouldContain: false,
 		},
 		{
 			name:                    "Thanos is not object storage",
 			version:                 "v2.55.0",
+			thanosVersion:           &thanosVersion,
 			outOfOrderTimeWindow:    "1s",
 			objectStorageConfigFile: nil,
 			shouldContain:           false,
@@ -1561,6 +1643,7 @@ func TestTSDBAllowOverlappingCompaction(t *testing.T) {
 		{
 			name:                    "Verify AllowOverlappingCompaction",
 			version:                 "v2.55.0",
+			thanosVersion:           &thanosVersion,
 			outOfOrderTimeWindow:    "1s",
 			objectStorageConfigFile: new("/etc/thanos.cfg"),
 			shouldContain:           true,
@@ -1578,6 +1661,7 @@ func TestTSDBAllowOverlappingCompaction(t *testing.T) {
 						},
 					},
 					Thanos: &monitoringv1.ThanosSpec{
+						Version:                 test.thanosVersion,
 						ListenLocal:             true,
 						ObjectStorageConfigFile: test.objectStorageConfigFile,
 					},


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

  Thanos v0.42.0 introduced an internal change ([thanos-io/thanos#8670](https://github.com/thanos-io/thanos/pull/8670)) where TSDB now delays compaction until blocks have been uploaded by the shipper. This means it is no longer necessary for the operator to disable Prometheus compaction when object storage is configured for the Thanos sidecar, as long as Thanos >= v0.42.0 is used.
                                                                                                                                                                                                                                                                               
  This PR makes the `compactionDisabled()` function version-aware so that:                                                                                                                                                                                                     
  - For **Thanos < v0.42.0**: behavior is unchanged — compaction is still disabled when object storage is configured (to avoid race conditions during uploads).
  - For **Thanos >= v0.42.0**: compaction is no longer automatically disabled when object storage is configured, allowing Prometheus to benefit from concurrent compaction and block uploads.                                                                                  
  - **Explicit `DisableCompaction: true`** still always takes effect regardless of Thanos version.                                                                                                                                                                             
                                                                                                                                                                                                                                                                               
  Additionally:                                                                                                                                                                                                                                                                
  - Bumps `example/thanos/` manifests from `v0.38.0` to `v0.42.0`.                                                                                                                                                                                                             
  - Updates `Documentation/getting-started/compatibility.md` from `v0.41.0` to `v0.42.0`. 

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Do not automatically disable Prometheus compaction when Thanos sidecar object storage is configured and Thanos >= v0.42.0, since Thanos now handles compaction/upload ordering internally. 
```
