### PR TITLE
fix: disable metadata send when remote-write v2 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 * [CHANGE/BUGFIX] Add validation markers to all unsigned int fields to reject negative values. #8662
+* [CHANGE/BUGFIX] Disable metadata sending when the remote-write configuration uses message version v2.0. #8700
 * [ENHANCEMENT] Use pod's name as the peer name for Alertmanager >= v0.30.0. #8705
 
 ## 0.92.1 / 2026-06-30

--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -12846,6 +12846,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>send defines whether metric metadata is sent to the remote storage or not.</p>
+<p>The setting is ignored when Remote Write message&rsquo;s version 2.0 is used.</p>
 </td>
 </tr>
 <tr>

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -5767,8 +5767,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -7372,8 +7372,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5117,8 +5117,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -5767,8 +5767,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -7372,8 +7372,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5117,8 +5117,10 @@ spec:
                           minimum: -1
                           type: integer
                         send:
-                          description: send defines whether metric metadata is sent
-                            to the remote storage or not.
+                          description: |-
+                            send defines whether metric metadata is sent to the remote storage or not.
+
+                            The setting is ignored when Remote Write message's version 2.0 is used.
                           type: boolean
                         sendInterval:
                           description: sendInterval defines how frequently metric

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -4830,7 +4830,7 @@
                               "type": "integer"
                             },
                             "send": {
-                              "description": "send defines whether metric metadata is sent to the remote storage or not.",
+                              "description": "send defines whether metric metadata is sent to the remote storage or not.\n\nThe setting is ignored when Remote Write message's version 2.0 is used.",
                               "type": "boolean"
                             },
                             "sendInterval": {

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -6232,7 +6232,7 @@
                               "type": "integer"
                             },
                             "send": {
-                              "description": "send defines whether metric metadata is sent to the remote storage or not.",
+                              "description": "send defines whether metric metadata is sent to the remote storage or not.\n\nThe setting is ignored when Remote Write message's version 2.0 is used.",
                               "type": "boolean"
                             },
                             "sendInterval": {

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -4400,7 +4400,7 @@
                               "type": "integer"
                             },
                             "send": {
-                              "description": "send defines whether metric metadata is sent to the remote storage or not.",
+                              "description": "send defines whether metric metadata is sent to the remote storage or not.\n\nThe setting is ignored when Remote Write message's version 2.0 is used.",
                               "type": "boolean"
                             },
                             "sendInterval": {

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -2433,6 +2433,8 @@ type RulesAlert struct {
 type MetadataConfig struct {
 	// send defines whether metric metadata is sent to the remote storage or not.
 	//
+	// The setting is ignored when Remote Write message's version 2.0 is used.
+	//
 	// +optional
 	Send bool `json:"send,omitempty"` // nolint:kubeapilinter
 

--- a/pkg/client/applyconfiguration/monitoring/v1/metadataconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/metadataconfig.go
@@ -26,6 +26,8 @@ import (
 // MetadataConfig configures the sending of series metadata to the remote storage.
 type MetadataConfigApplyConfiguration struct {
 	// send defines whether metric metadata is sent to the remote storage or not.
+	//
+	// The setting is ignored when Remote Write message's version 2.0 is used.
 	Send *bool `json:"send,omitempty"`
 	// sendInterval defines how frequently metric metadata is sent to the remote storage.
 	SendInterval *monitoringv1.Duration `json:"sendInterval,omitempty"`

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1263,9 +1263,13 @@ func (cg *ConfigGenerator) BuildCommonPrometheusArgs() []monitoringv1.Argument {
 		}
 	}
 
-	// Since metadata-wal-records is in the process of being deprecated as part of remote write v2 stabilization as described in issue.
-	// Also seems to be cause some increase in resource usage overall, will stop being automatically added on prometheus 3.4.0 onwards.
-	// For more context see https://github.com/prometheus-operator/prometheus-operator/issues/7889
+	// metadata-wal-records is in the process of being deprecated as part of
+	// remote write v2 stabilization: it causes some increase in resource usage
+	// overall. The feature used to be automatically enabled in older Prometheus
+	// versions but it isn't anymore since v3.4.0.
+	// For more context, see:
+	// https://github.com/prometheus-operator/prometheus-operator/issues/7889
+	// https://github.com/prometheus/prometheus/issues/16944.
 	for _, rw := range cpf.RemoteWrite {
 		if ptr.Deref(rw.MessageVersion, monitoringv1.RemoteWriteMessageVersion1_0) == monitoringv1.RemoteWriteMessageVersion2_0 {
 			cg = cg.WithMinimumVersion("2.54.0")
@@ -3049,7 +3053,13 @@ func (cg *ConfigGenerator) GenerateRemoteWriteConfig(rws []monitoringv1.RemoteWr
 		}
 
 		if spec.MetadataConfig != nil {
-			metadataConfig := append(yaml.MapSlice{}, yaml.MapItem{Key: "send", Value: spec.MetadataConfig.Send})
+			var metadataConfig yaml.MapSlice
+			if ptr.Deref(spec.MessageVersion, "") == monitoringv1.RemoteWriteMessageVersion2_0 {
+				// Prometheus automatically turns off metadata sending when remote-write v2 is used.
+				metadataConfig = append(metadataConfig, yaml.MapItem{Key: "send", Value: false})
+			} else {
+				metadataConfig = append(metadataConfig, yaml.MapItem{Key: "send", Value: spec.MetadataConfig.Send})
+			}
 			if spec.MetadataConfig.SendInterval != "" {
 				metadataConfig = append(metadataConfig, yaml.MapItem{Key: "send_interval", Value: spec.MetadataConfig.SendInterval})
 			}

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -4722,6 +4722,28 @@ func TestRemoteWriteConfig(t *testing.T) {
 			},
 			golden: "RemoteWriteConfig_AzureADScope_v3.9.0.golden",
 		},
+		{
+			// Using message version v1 honors the metadata config.
+			remoteWrite: monitoringv1.RemoteWriteSpec{
+				URL:            "http://example.com",
+				MessageVersion: ptr.To(monitoringv1.RemoteWriteMessageVersion1_0),
+				MetadataConfig: &monitoringv1.MetadataConfig{
+					Send: true,
+				},
+			},
+			golden: "RemoteWriteConfig_MessageVersion1_with_metadata.golden",
+		},
+		{
+			// Using message version v2 automatically disables metadata sending.
+			remoteWrite: monitoringv1.RemoteWriteSpec{
+				URL:            "http://example.com",
+				MessageVersion: ptr.To(monitoringv1.RemoteWriteMessageVersion2_0),
+				MetadataConfig: &monitoringv1.MetadataConfig{
+					Send: true,
+				},
+			},
+			golden: "RemoteWriteConfig_MessageVersion2_with_metadata.golden",
+		},
 	} {
 		t.Run(fmt.Sprintf("i=%d,version=%s", i, tc.version), func(t *testing.T) {
 			p := defaultPrometheus()

--- a/pkg/prometheus/testdata/RemoteWriteConfig_MessageVersion1_with_metadata.golden
+++ b/pkg/prometheus/testdata/RemoteWriteConfig_MessageVersion1_with_metadata.golden
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+storage:
+  tsdb:
+    retention:
+      time: 24h
+remote_write:
+- url: http://example.com
+  protobuf_message: prometheus.WriteRequest
+  metadata_config:
+    send: true

--- a/pkg/prometheus/testdata/RemoteWriteConfig_MessageVersion2_with_metadata.golden
+++ b/pkg/prometheus/testdata/RemoteWriteConfig_MessageVersion2_with_metadata.golden
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+storage:
+  tsdb:
+    retention:
+      time: 24h
+remote_write:
+- url: http://example.com
+  protobuf_message: io.prometheus.write.v2.Request
+  metadata_config:
+    send: false


### PR DESCRIPTION
## Description

This commit disables metadata sending when the remote-write message version is set to v2.

This is aligned with the Prometheus server's behavior:

https://github.com/prometheus/prometheus/blob/57a1157b7e2feec429dce9fa8441c74d2f1a59c1/storage/remote/queue_manager.go#L543-L550

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
