### PR TITLE
feat: configure Alertmanager peer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 * [CHANGE/BUGFIX] Add validation markers to all unsigned int fields to reject negative values. #8662
+* [ENHANCEMENT] Use pod's name as the peer name for Alertmanager >= v0.30.0. #8705
 
 ## 0.92.1 / 2026-06-30
 

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -339,6 +339,10 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.peer-timeout", Value: string(a.Spec.ClusterPeerTimeout)})
 	}
 
+	if version.GTE(semver.MustParse("0.30.0")) {
+		amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.peer-name", Value: fmt.Sprintf("$(%s)", operator.PodNameEnvVar)})
+	}
+
 	// If multiple Alertmanager clusters are deployed on the same cluster, it can happen
 	// that because pod IP addresses are recycled, an Alertmanager instance from cluster B
 	// connects with cluster A.
@@ -698,37 +702,48 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 		return nil, err
 	}
 
-	defaultContainers := []corev1.Container{
-		{
-			Args:            containerArgs,
-			Name:            "alertmanager",
-			Image:           amImagePath,
-			ImagePullPolicy: a.Spec.ImagePullPolicy,
-			Ports:           ports,
-			VolumeMounts:    amVolumeMounts,
-			LivenessProbe:   livenessProbe,
-			ReadinessProbe:  readinessProbe,
-			Resources:       a.Spec.Resources,
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: new(false),
-				ReadOnlyRootFilesystem:   new(true),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
+	alertmanagerContainer := corev1.Container{
+		Args:            containerArgs,
+		Name:            "alertmanager",
+		Image:           amImagePath,
+		ImagePullPolicy: a.Spec.ImagePullPolicy,
+		Ports:           ports,
+		VolumeMounts:    amVolumeMounts,
+		LivenessProbe:   livenessProbe,
+		ReadinessProbe:  readinessProbe,
+		Resources:       a.Spec.Resources,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: new(false),
+			ReadOnlyRootFilesystem:   new(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
 			},
-			Env: []corev1.EnvVar{
-				{
-					// Necessary for '--cluster.listen-address' flag
-					Name: "POD_IP",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "status.podIP",
-						},
+		},
+		Env: []corev1.EnvVar{
+			{
+				// Necessary for '--cluster.listen-address' flag
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIP",
 					},
 				},
 			},
-			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+	}
+
+	if version.GTE(semver.MustParse("0.30.0")) {
+		alertmanagerContainer.Env = append(alertmanagerContainer.Env, corev1.EnvVar{
+			Name: operator.PodNameEnvVar,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		})
+	}
+
+	defaultContainers := []corev1.Container{
+		alertmanagerContainer,
 		operator.CreateConfigReloader(
 			"config-reloader",
 			operator.ReloaderConfig(config.ReloaderConfig),

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -671,6 +671,56 @@ func TestMakeStatefulSetSpecPeersWithClusterDomain(t *testing.T) {
 	require.True(t, slices.Contains(amArgs, expectedArg), "Cluster peer argument %v was not found in %v.", expectedArg, amArgs)
 }
 
+func TestMakeStatefulSetSpecPeerName(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		version     string
+		expPeerName bool
+	}{
+		{
+			name:    "no peer name before 0.30.0",
+			version: "0.29.0",
+		}, {
+			name:        "peer name after 0.30.0",
+			version:     "0.30.0",
+			expPeerName: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "alertmanager",
+					Namespace: "monitoring",
+				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					Replicas: new(int32(1)),
+					Image:    new(operator.DefaultAlertmanagerImage),
+					Version:  tc.version,
+				},
+			}
+
+			statefulSet, err := makeStatefulSetSpec(nil, &a, Config{}, &operator.ShardedSecret{})
+			require.NoError(t, err)
+
+			amArgs := statefulSet.Template.Spec.Containers[0].Args
+			expectedArg := fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar)
+			if tc.expPeerName {
+				require.Contains(t, amArgs, expectedArg)
+				var envVarFound bool
+				for _, envVar := range statefulSet.Template.Spec.Containers[0].Env {
+					if envVar.Name == operator.PodNameEnvVar {
+						envVarFound = true
+						break
+					}
+				}
+				require.True(t, envVarFound)
+			} else {
+				require.NotContains(t, amArgs, expectedArg)
+			}
+		})
+	}
+}
+
 func TestMakeStatefulSetSpecWithCustomServiceName(t *testing.T) {
 	replicas := int32(1)
 	customServiceName := "my-custom-alertmanager-svc"


### PR DESCRIPTION
## Description

This commit adds the `--cluster.peer-name` argument to the Alertmanager arguments which uses the stable pod's identity instead of a random value (different on every container restart).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
