### PR TITLE
Feat: add test cases for Alertmanager Config validation for SNS Receiver

### DIFF
--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -781,7 +781,7 @@ func TestValidatePagerDutyAlertmanagerConfig(t *testing.T) {
 	}
 }
 
-func TestValidateAlertmanagerConfigSNSReceiver(t *testing.T) {
+func TestValidateSNSAlertmanagerConfig(t *testing.T) {
 	testCases := []struct {
 		name      string
 		in        *monitoringv1beta1.AlertmanagerConfig

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -608,3 +608,92 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAlertmanagerConfigSNSReceiver(t *testing.T) {
+	testCases := []struct {
+		name      string
+		in        *monitoringv1beta1.AlertmanagerConfig
+		expectErr bool
+	}{
+
+		{
+			name: "Test fail to validate SNSConfigs - valid",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SNSConfigs: []monitoringv1beta1.SNSConfig{
+								{
+									PhoneNumber: new("+13324653687"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Test fail to validate SNSConfigs - invalid no required field",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SNSConfigs: []monitoringv1beta1.SNSConfig{
+								{
+									ApiURL: new("http://sns.api.url"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate SNSConfigs - invalid URL",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SNSConfigs: []monitoringv1beta1.SNSConfig{
+								{
+									PhoneNumber: new("+13324653687"),
+									ApiURL:      new("http://%><invalid.com"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAlertmanagerConfig(tc.in)
+			if tc.expectErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if err != nil {
+				if tc.expectErr {
+					return
+				}
+				t.Errorf("got error but expected none -%s", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds the test cases to cover SNS Receiver validation for Alertmanager Config.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Add the test cases to cover SNS Receiver validation for Alertmanager Config
```
