### PR TITLE
feat: add OpsGenie test cases in operator_test.go

### DIFF
--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1748,7 +1748,7 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
 									{
 										ID:   new("abcde12345"),
-										Type: new("teams"),
+										Type: "teams",
 									},
 								},
 							},
@@ -1776,7 +1776,7 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
 									{
 										ID:   new("abcde12345"),
-										Type: new("teams"),
+										Type: "teams",
 									},
 								},
 							},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -198,6 +198,12 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 	defaultVersion, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 	require.NoError(t, err)
 
+	version23, err := semver.ParseTolerant("v0.23.0")
+	require.NoError(t, err)
+
+	version24, err := semver.ParseTolerant("v0.24.0")
+	require.NoError(t, err)
+
 	version25, err := semver.ParseTolerant("v0.25.0")
 	require.NoError(t, err)
 
@@ -1682,6 +1688,62 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			version: &version29,
+			ok:      false,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opsgenie-responder-type-teams",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{
+							{
+								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
+									{
+										ID:   "abcde12345",
+										Type: new("teams"),
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			version: &version24,
+			ok:      true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opsgenie-responder-type-teams-version-not-supported",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{
+							{
+								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
+									{
+										ID:   "abcde12345",
+										Type: new("teams"),
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			version: &version23,
 			ok:      false,
 		},
 	} {

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1790,7 +1790,7 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "opsgenie-error-getting-api-key-secret",
+					Name:      "opsgenie-getting-api-key-secret",
 					Namespace: "ns1",
 				},
 				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
@@ -1804,6 +1804,34 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 								APIKey: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "secret",
+									},
+									Key: "token",
+								},
+							},
+						},
+					}},
+				},
+			},
+			version: &version23,
+			ok:      true,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opsgenie-error-getting-api-key-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{
+							{
+								APIKey: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "invalid",
 									},
 									Key: "token",
 								},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -198,12 +198,6 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 	defaultVersion, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
 	require.NoError(t, err)
 
-	version23, err := semver.ParseTolerant("v0.23.0")
-	require.NoError(t, err)
-
-	version24, err := semver.ParseTolerant("v0.24.0")
-	require.NoError(t, err)
-
 	version25, err := semver.ParseTolerant("v0.25.0")
 	require.NoError(t, err)
 
@@ -1690,6 +1684,53 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 			version: &version29,
 			ok:      false,
 		},
+	} {
+		t.Run(tc.amConfig.Name, func(t *testing.T) {
+			store := assets.NewStoreBuilder(c.CoreV1(), c.CoreV1())
+
+			amVersion := defaultVersion
+			if tc.version != nil {
+				amVersion = *tc.version
+			}
+			err := checkAlertmanagerConfigResource(context.Background(), tc.amConfig, amVersion, store)
+			if tc.ok {
+				require.NoError(t, err)
+				return
+			}
+
+			t.Logf("err: %s", err)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
+	defaultVersion, err := semver.ParseTolerant(operator.DefaultAlertmanagerVersion)
+	require.NoError(t, err)
+
+	version23, err := semver.ParseTolerant("v0.23.0")
+	require.NoError(t, err)
+
+	version24, err := semver.ParseTolerant("v0.24.0")
+	require.NoError(t, err)
+
+	c := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "ns1",
+			},
+			Data: map[string][]byte{
+				"token": []byte("abc1243"),
+			},
+		},
+	)
+
+	for _, tc := range []struct {
+		amConfig *monitoringv1alpha1.AlertmanagerConfig
+		version  *semver.Version
+		ok       bool
+	}{
 		{
 			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1737,6 +1778,34 @@ func TestCheckAlertmanagerConfig(t *testing.T) {
 										ID:   "abcde12345",
 										Type: new("teams"),
 									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			version: &version23,
+			ok:      false,
+		},
+		{
+			amConfig: &monitoringv1alpha1.AlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opsgenie-error-getting-api-key-secret",
+					Namespace: "ns1",
+				},
+				Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+					Route: &monitoringv1alpha1.Route{
+						Receiver: "recv1",
+					},
+					Receivers: []monitoringv1alpha1.Receiver{{
+						Name: "recv1",
+						OpsGenieConfigs: []monitoringv1alpha1.OpsGenieConfig{
+							{
+								APIKey: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "secret",
+									},
+									Key: "token",
 								},
 							},
 						},

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -1747,7 +1747,7 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 							{
 								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
 									{
-										ID:   "abcde12345",
+										ID:   new("abcde12345"),
 										Type: new("teams"),
 									},
 								},
@@ -1775,7 +1775,7 @@ func TestCheckOpsGenieAlertmanagerConfig(t *testing.T) {
 							{
 								Responders: []monitoringv1alpha1.OpsGenieConfigResponder{
 									{
-										ID:   "abcde12345",
+										ID:   new("abcde12345"),
 										Type: new("teams"),
 									},
 								},


### PR DESCRIPTION
## Description

This PR adds OpsGenie test cases to cover OpsGenie receiver check method in `operator.go`.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Add OpsGenie test cases to cover OpsGenie receiver check method
```
