### PR TITLE
feat: expose Thanos sidecar HTTP port on the governing service

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -21929,6 +21929,27 @@ of the Pod IP&rsquo;s address for the HTTP endpoints.</p>
 </tr>
 <tr>
 <td>
+<code>serviceHTTPPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>serviceHTTPPort defines the port on which the governing service
+exposes the Thanos sidecar&rsquo;s HTTP endpoints (serving metrics, probes
+and more). The service port targets the container port named <code>http</code>
+(10902) of the <code>thanos-sidecar</code> container.</p>
+<p>If not defined, the governing service doesn&rsquo;t expose the Thanos
+sidecar&rsquo;s HTTP port.</p>
+<p>It only applies when the operator manages the governing service (e.g.
+<code>spec.serviceName</code> isn&rsquo;t defined). Note that the sidecar&rsquo;s HTTP
+endpoints aren&rsquo;t reachable through the service when <code>listenLocal</code> or
+<code>httpListenLocal</code> is true.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tracingConfig</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core">

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -47619,6 +47619,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  serviceHTTPPort:
+                    description: |-
+                      serviceHTTPPort defines the port on which the governing service
+                      exposes the Thanos sidecar's HTTP endpoints (serving metrics, probes
+                      and more). The service port targets the container port named `http`
+                      (10902) of the `thanos-sidecar` container.
+
+                      If not defined, the governing service doesn't expose the Thanos
+                      sidecar's HTTP port.
+
+                      It only applies when the operator manages the governing service (e.g.
+                      `spec.serviceName` isn't defined). Note that the sidecar's HTTP
+                      endpoints aren't reachable through the service when `listenLocal` or
+                      `httpListenLocal` is true.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
                   sha:
                     description: 'sha is deprecated: use ''image'' instead.  The image
                       digest can be specified as part of the image name.'

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -10809,6 +10809,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  serviceHTTPPort:
+                    description: |-
+                      serviceHTTPPort defines the port on which the governing service
+                      exposes the Thanos sidecar's HTTP endpoints (serving metrics, probes
+                      and more). The service port targets the container port named `http`
+                      (10902) of the `thanos-sidecar` container.
+
+                      If not defined, the governing service doesn't expose the Thanos
+                      sidecar's HTTP port.
+
+                      It only applies when the operator manages the governing service (e.g.
+                      `spec.serviceName` isn't defined). Note that the sidecar's HTTP
+                      endpoints aren't reachable through the service when `listenLocal` or
+                      `httpListenLocal` is true.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
                   sha:
                     description: 'sha is deprecated: use ''image'' instead.  The image
                       digest can be specified as part of the image name.'

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -10809,6 +10809,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  serviceHTTPPort:
+                    description: |-
+                      serviceHTTPPort defines the port on which the governing service
+                      exposes the Thanos sidecar's HTTP endpoints (serving metrics, probes
+                      and more). The service port targets the container port named `http`
+                      (10902) of the `thanos-sidecar` container.
+
+                      If not defined, the governing service doesn't expose the Thanos
+                      sidecar's HTTP port.
+
+                      It only applies when the operator manages the governing service (e.g.
+                      `spec.serviceName` isn't defined). Note that the sidecar's HTTP
+                      endpoints aren't reachable through the service when `listenLocal` or
+                      `httpListenLocal` is true.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
                   sha:
                     description: 'sha is deprecated: use ''image'' instead.  The image
                       digest can be specified as part of the image name.'

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -9030,6 +9030,13 @@
                         },
                         "type": "object"
                       },
+                      "serviceHTTPPort": {
+                        "description": "serviceHTTPPort defines the port on which the governing service\nexposes the Thanos sidecar's HTTP endpoints (serving metrics, probes\nand more). The service port targets the container port named `http`\n(10902) of the `thanos-sidecar` container.\n\nIf not defined, the governing service doesn't expose the Thanos\nsidecar's HTTP port.\n\nIt only applies when the operator manages the governing service (e.g.\n`spec.serviceName` isn't defined). Note that the sidecar's HTTP\nendpoints aren't reachable through the service when `listenLocal` or\n`httpListenLocal` is true.",
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
                       "sha": {
                         "description": "sha is deprecated: use 'image' instead.  The image digest can be specified as part of the image name.",
                         "type": "string"

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1644,6 +1644,24 @@ type ThanosSpec struct {
 	// +optional
 	HTTPListenLocal bool `json:"httpListenLocal,omitempty"` // nolint:kubeapilinter
 
+	// serviceHTTPPort defines the port on which the governing service
+	// exposes the Thanos sidecar's HTTP endpoints (serving metrics, probes
+	// and more). The service port targets the container port named `http`
+	// (10902) of the `thanos-sidecar` container.
+	//
+	// If not defined, the governing service doesn't expose the Thanos
+	// sidecar's HTTP port.
+	//
+	// It only applies when the operator manages the governing service (e.g.
+	// `spec.serviceName` isn't defined). Note that the sidecar's HTTP
+	// endpoints aren't reachable through the service when `listenLocal` or
+	// `httpListenLocal` is true.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	ServiceHTTPPort *int32 `json:"serviceHTTPPort,omitempty"`
+
 	// tracingConfig defines the tracing configuration for the Thanos sidecar.
 	//
 	// `tracingConfigFile` takes precedence over this field.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -4257,6 +4257,11 @@ func (in *ThanosSpec) DeepCopyInto(out *ThanosSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceHTTPPort != nil {
+		in, out := &in.ServiceHTTPPort, &out.ServiceHTTPPort
+		*out = new(int32)
+		**out = **in
+	}
 	if in.TracingConfig != nil {
 		in, out := &in.TracingConfig, &out.TracingConfig
 		*out = new(corev1.SecretKeySelector)

--- a/pkg/client/applyconfiguration/monitoring/v1/thanosspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/thanosspec.go
@@ -76,6 +76,19 @@ type ThanosSpecApplyConfiguration struct {
 	//
 	// It has no effect if `listenLocal` is true.
 	HTTPListenLocal *bool `json:"httpListenLocal,omitempty"`
+	// serviceHTTPPort defines the port on which the governing service
+	// exposes the Thanos sidecar's HTTP endpoints (serving metrics, probes
+	// and more). The service port targets the container port named `http`
+	// (10902) of the `thanos-sidecar` container.
+	//
+	// If not defined, the governing service doesn't expose the Thanos
+	// sidecar's HTTP port.
+	//
+	// It only applies when the operator manages the governing service (e.g.
+	// `spec.serviceName` isn't defined). Note that the sidecar's HTTP
+	// endpoints aren't reachable through the service when `listenLocal` or
+	// `httpListenLocal` is true.
+	ServiceHTTPPort *int32 `json:"serviceHTTPPort,omitempty"`
 	// tracingConfig defines the tracing configuration for the Thanos sidecar.
 	//
 	// `tracingConfigFile` takes precedence over this field.
@@ -227,6 +240,14 @@ func (b *ThanosSpecApplyConfiguration) WithGRPCListenLocal(value bool) *ThanosSp
 // If called multiple times, the HTTPListenLocal field is set to the value of the last call.
 func (b *ThanosSpecApplyConfiguration) WithHTTPListenLocal(value bool) *ThanosSpecApplyConfiguration {
 	b.HTTPListenLocal = &value
+	return b
+}
+
+// WithServiceHTTPPort sets the ServiceHTTPPort field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServiceHTTPPort field is set to the value of the last call.
+func (b *ThanosSpecApplyConfiguration) WithServiceHTTPPort(value int32) *ThanosSpecApplyConfiguration {
+	b.ServiceHTTPPort = &value
 	return b
 }
 

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1010,22 +1010,7 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 		}
 	} else {
 		// Reconcile the default governing service.
-		svc := prompkg.BuildStatefulSetService(
-			governingServiceName,
-			map[string]string{
-				operator.ApplicationNameLabelKey: applicationNameLabelValue,
-			},
-			p,
-			c.config,
-		)
-
-		if p.Spec.Thanos != nil {
-			svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
-				Name:       "grpc",
-				Port:       10901,
-				TargetPort: intstr.FromString("grpc"),
-			})
-		}
+		svc := makeGoverningService(p, c.config)
 
 		if _, err := k8s.CreateOrUpdateService(ctx, c.kclient.CoreV1().Services(p.Namespace), svc); err != nil {
 			return closure, fmt.Errorf("synchronizing default governing service failed: %w", err)
@@ -1701,6 +1686,42 @@ func makeSelectorLabels(name string) map[string]string {
 		prompkg.PrometheusNameLabelName:      name,
 		"prometheus":                         name,
 	}
+}
+
+// makeGoverningService returns the default governing service for the given
+// Prometheus object.
+//
+// When the Thanos sidecar is enabled, the service always exposes the gRPC
+// port and, if `spec.thanos.serviceHTTPPort` is defined, the HTTP port too.
+func makeGoverningService(p *monitoringv1.Prometheus, config prompkg.Config) *corev1.Service {
+	svc := prompkg.BuildStatefulSetService(
+		governingServiceName,
+		map[string]string{
+			operator.ApplicationNameLabelKey: applicationNameLabelValue,
+		},
+		p,
+		config,
+	)
+
+	if p.Spec.Thanos == nil {
+		return svc
+	}
+
+	svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+		Name:       "grpc",
+		Port:       10901,
+		TargetPort: intstr.FromString("grpc"),
+	})
+
+	if p.Spec.Thanos.ServiceHTTPPort != nil {
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name:       "http",
+			Port:       *p.Spec.Thanos.ServiceHTTPPort,
+			TargetPort: intstr.FromString("http"),
+		})
+	}
+
+	return svc
 }
 
 func validateAlertmanagerEndpoints(p *monitoringv1.Prometheus, am monitoringv1.AlertmanagerEndpoints) error {

--- a/pkg/prometheus/server/operator_test.go
+++ b/pkg/prometheus/server/operator_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 
@@ -505,6 +506,105 @@ func TestGracePeriodForPrometheusStorage(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedDuration, d)
+		})
+	}
+}
+
+func TestMakeGoverningService(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		thanos *monitoringv1.ThanosSpec
+
+		expectedPorts []corev1.ServicePort
+	}{
+		{
+			name: "without Thanos sidecar",
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+			},
+		},
+		{
+			name:   "with Thanos sidecar",
+			thanos: &monitoringv1.ThanosSpec{},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+				{
+					Name:       "grpc",
+					Port:       10901,
+					TargetPort: intstr.FromString("grpc"),
+				},
+			},
+		},
+		{
+			name: "with Thanos sidecar and HTTP service port",
+			thanos: &monitoringv1.ThanosSpec{
+				ServiceHTTPPort: new(int32(10902)),
+			},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+				{
+					Name:       "grpc",
+					Port:       10901,
+					TargetPort: intstr.FromString("grpc"),
+				},
+				{
+					Name:       "http",
+					Port:       10902,
+					TargetPort: intstr.FromString("http"),
+				},
+			},
+		},
+		{
+			name: "with Thanos sidecar and custom HTTP service port",
+			thanos: &monitoringv1.ThanosSpec{
+				ServiceHTTPPort: new(int32(8080)),
+			},
+			expectedPorts: []corev1.ServicePort{
+				{
+					Name:       "web",
+					Port:       9090,
+					TargetPort: intstr.FromString("web"),
+				},
+				{
+					Name:       "grpc",
+					Port:       10901,
+					TargetPort: intstr.FromString("grpc"),
+				},
+				{
+					Name:       "http",
+					Port:       8080,
+					TargetPort: intstr.FromString("http"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.PrometheusSpec{
+					Thanos: tc.thanos,
+				},
+			}
+
+			svc := makeGoverningService(p, prompkg.Config{})
+
+			require.Equal(t, "prometheus-operated", svc.Name)
+			require.Equal(t, tc.expectedPorts, svc.Spec.Ports)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The default governing service (`prometheus-operated`) exposes the Prometheus web port and, when the Thanos sidecar is enabled, the sidecar's gRPC port — but not the sidecar's HTTP port, so its metrics can't be scraped through the service.

This PR adds an optional `serviceHTTPPort` field to `spec.thanos`. When defined, the governing service gets an additional `http` port with the given number, targeting the `http` container port (10902) of the `thanos-sidecar` container. Following the [maintainer suggestion](https://github.com/prometheus-operator/prometheus-operator/issues/7368#issuecomment-3714031288), the option lives in `ThanosSpec` (rather than a CLI argument) and is opt-in, so the contract of the `prometheus-operated` service is unchanged for existing users.

Closes: #7368

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Added a `TestMakeGoverningService` unit test covering: no Thanos sidecar, sidecar without the new field (behavior unchanged: `web` + `grpc` ports only), and the field set to the default (10902) and a custom port number. Ran `go test ./pkg/prometheus/server ./pkg/apis/monitoring/...`, `make check-api` and `make generate` (regenerated CRDs, clients, docs and bundle are included).

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Add `serviceHTTPPort` field to `spec.thanos` in the Prometheus CRD to expose the Thanos sidecar's HTTP port on the governing service.
```

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
