### PR TITLE
chore: standardize log field names on camelCase

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -286,11 +286,11 @@ func start() int {
 		return 1
 	}
 
-	logger.Info("Starting Prometheus Operator", "version", version.Info(), "build_context", version.BuildContext(), "feature_gates", cfg.Gates.String())
+	logger.Info("Starting Prometheus Operator", "version", version.Info(), "buildContext", version.BuildContext(), "featureGates", cfg.Gates.String())
 	logger.Info("Operator's configuration",
-		"watch_referenced_objects_in_all_namespaces", cfg.WatchObjectRefsInAllNamespaces,
-		"controller_id", cfg.ControllerID,
-		"enable_config_reloader_probes", cfg.ReloaderConfig.EnableProbes)
+		"watchReferencedObjectsInAllNamespaces", cfg.WatchObjectRefsInAllNamespaces,
+		"controllerID", cfg.ControllerID,
+		"enableConfigReloaderProbes", cfg.ReloaderConfig.EnableProbes)
 	goruntime.SetMemLimit(logger, memlimitRatio)
 
 	if len(cfg.Namespaces.AllowList) > 0 && len(cfg.Namespaces.DenyList) > 0 {
@@ -341,7 +341,7 @@ func start() int {
 		cfg.KubernetesVersion = semver.MustParse("1.16.0")
 		logger.Warn("failed to parse Kubernetes version", "version", kubernetesVersion.String(), "err", err)
 	}
-	logger.Info("connection established", "kubernetes_version", cfg.KubernetesVersion.String())
+	logger.Info("connection established", "kubernetesVersion", cfg.KubernetesVersion.String())
 
 	var (
 		alertmanagerControllerOptions = []alertmanagercontroller.ControllerOption{}
@@ -436,7 +436,7 @@ func start() int {
 	// It injects topology.kubernetes.io/zone as a pod label, removing the need
 	// for attach_metadata.node=true in topology sharding configurations.
 	podTopologyLabelsSupported := cfg.KubernetesVersion.GTE(semver.MustParse("1.35.0"))
-	logger.Info("Kubernetes API capabilities", "pod_topology_labels", podTopologyLabelsSupported)
+	logger.Info("Kubernetes API capabilities", "podTopologyLabels", podTopologyLabelsSupported)
 	if podTopologyLabelsSupported {
 		promControllerOptions = append(promControllerOptions, prometheuscontroller.WithPodTopologyLabels())
 		promAgentControllerOptions = append(promAgentControllerOptions, prometheusagentcontroller.WithPodTopologyLabels())

--- a/cmd/prometheus-config-reloader/main.go
+++ b/cmd/prometheus-config-reloader/main.go
@@ -145,7 +145,7 @@ func main() {
 		}
 	}
 
-	logger.Info("Starting prometheus-config-reloader", "version", version.Info(), "build_context", version.BuildContext())
+	logger.Info("Starting prometheus-config-reloader", "version", version.Info(), "buildContext", version.BuildContext())
 	goruntime.SetMemLimit(logger, *memlimitRatio)
 
 	r := metrics.NewRegistry("prometheus_config_reloader")

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -2211,7 +2211,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.SMTPTLSConfig != nil && amVersion.LT(semver.MustParse("0.28.0")) {
 		msg := "'smtp_tls_config' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SMTPTLSConfig = nil
 	}
 
@@ -2226,26 +2226,26 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 		if amVersion.LT(semver.MustParse("0.22.0")) {
 			msg := "'slack_api_url_file' supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
-			logger.Warn(msg, "current_version", amVersion.String())
+			logger.Warn(msg, "currentVersion", amVersion.String())
 			gc.SlackAPIURLFile = ""
 		}
 	}
 
 	if gc.SlackAppToken != "" && amVersion.LT(semver.MustParse("0.30.0")) {
 		msg := "'slack_app_token' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SlackAppToken = ""
 	}
 
 	if gc.SlackAppTokenFile != "" && amVersion.LT(semver.MustParse("0.30.0")) {
 		msg := "'slack_app_token_file' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SlackAppTokenFile = ""
 	}
 
 	if gc.SlackAppURL != nil && amVersion.LT(semver.MustParse("0.30.0")) {
 		msg := "'slack_app_url' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SlackAppURL = nil
 	}
 
@@ -2263,13 +2263,13 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.OpsGenieAPIKeyFile != "" && amVersion.LT(semver.MustParse("0.24.0")) {
 		msg := "'opsgenie_api_key_file' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.OpsGenieAPIKeyFile = ""
 	}
 
 	if gc.SMTPAuthPasswordFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
 		msg := "'smtp_auth_password_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SMTPAuthPasswordFile = ""
 	}
 
@@ -2281,7 +2281,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.VictorOpsAPIKeyFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
 		msg := "'victorops_api_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.VictorOpsAPIKeyFile = ""
 	}
 
@@ -2293,7 +2293,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.WeChatAPISecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'wechat_api_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.WeChatAPISecretFile = ""
 	}
 
@@ -2305,13 +2305,13 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.TelegramBotToken != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'telegram_bot_token' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.TelegramBotToken = ""
 	}
 
 	if gc.TelegramBotTokenFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'telegram_bot_token_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.TelegramBotTokenFile = ""
 	}
 
@@ -2323,7 +2323,7 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.SMTPAuthSecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'smtp_auth_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SMTPAuthSecretFile = ""
 	}
 
@@ -2335,19 +2335,19 @@ func (gc *globalConfig) sanitize(amVersion semver.Version, logger *slog.Logger) 
 
 	if gc.SMTPForceImplicitTLS != nil && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'smtp_force_implicit_tls' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.SMTPForceImplicitTLS = nil
 	}
 
 	if gc.MattermostWebhookURL != nil && amVersion.LT(semver.MustParse("0.32.0")) {
 		msg := "'mattermost_webhook_url' supported in Alertmanager >= 0.32.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.MattermostWebhookURL = nil
 	}
 
 	if gc.MattermostWebhookURLFile != "" && amVersion.LT(semver.MustParse("0.32.0")) {
 		msg := "'mattermost_webhook_url_file' supported in Alertmanager >= 0.32.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		gc.MattermostWebhookURLFile = ""
 	}
 
@@ -2375,13 +2375,13 @@ func (hc *httpClientConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 
 	if hc.FollowRedirects != nil && !amVersion.GTE(semver.MustParse("0.22.0")) {
 		msg := "'follow_redirects' set in 'http_config' but supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		hc.FollowRedirects = nil
 	}
 
 	if hc.EnableHTTP2 != nil && !amVersion.GTE(semver.MustParse("0.25.0")) {
 		msg := "'enable_http2' set in 'http_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		hc.EnableHTTP2 = nil
 	}
 
@@ -2392,7 +2392,7 @@ func (hc *httpClientConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 
 		if !amVersion.GTE(semver.MustParse("0.28.0")) {
 			msg := "'http_headers' set in 'http_config' but supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-			logger.Warn(msg, "current_version", amVersion.String())
+			logger.Warn(msg, "currentVersion", amVersion.String())
 			hc.HTTPHeaders = nil
 		}
 	}
@@ -2423,13 +2423,13 @@ func (tc *tlsConfig) sanitize(amVersion semver.Version, logger *slog.Logger) err
 
 	if tc.MinVersion != "" && !amVersion.GTE(semver.MustParse("0.25.0")) {
 		msg := "'min_version' set in 'tls_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.MinVersion = ""
 	}
 
 	if tc.MaxVersion != "" && !amVersion.GTE(semver.MustParse("0.25.0")) {
 		msg := "'max_version' set in 'tls_config' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.MaxVersion = ""
 	}
 
@@ -2479,19 +2479,19 @@ func (pc *proxyConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 
 	if pc.ProxyFromEnvironment {
 		msg := "'proxy_from_environment' set to true but supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pc.ProxyFromEnvironment = false
 	}
 
 	if pc.NoProxy != "" {
 		msg := "'no_proxy' configured but supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pc.NoProxy = ""
 	}
 
 	if len(pc.ProxyConnectHeader) > 0 {
 		msg := "'proxy_connect_header' configured but supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pc.ProxyConnectHeader = nil
 	}
 
@@ -2506,7 +2506,7 @@ func (o *oauth2) sanitize(amVersion semver.Version, logger *slog.Logger) error {
 	if (o.ProxyURL != "" || o.NoProxy != "" || len(o.ProxyConnectHeader) > 0) &&
 		!amVersion.GTE(semver.MustParse("0.25.0")) {
 		msg := "'proxyConfig' set in 'oauth2' but supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		o.ProxyURL = ""
 		o.NoProxy = ""
 		o.ProxyFromEnvironment = false
@@ -2643,7 +2643,7 @@ func (r *receiver) sanitize(amVersion semver.Version, logger *slog.Logger) error
 func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) error {
 	if ec.AuthPasswordFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
 		msg := "'auth_password_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ec.AuthPasswordFile = ""
 	}
 
@@ -2654,13 +2654,13 @@ func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 
 	if ec.ForceImplicitTLS != nil && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'force_implicit_tls' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ec.ForceImplicitTLS = nil
 	}
 
 	if ec.AuthSecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'auth_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ec.AuthSecretFile = ""
 	}
 
@@ -2671,7 +2671,7 @@ func (ec *emailConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 
 	if ec.Threading != nil && amVersion.LT(semver.MustParse("0.30.0")) {
 		msg := "'threading' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ec.Threading = nil
 	}
 
@@ -2693,18 +2693,18 @@ func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 
 	if ogc.Actions != "" && lessThanV0_24 {
 		msg := "opsgenie_config 'actions' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ogc.Actions = ""
 	}
 
 	if ogc.Entity != "" && lessThanV0_24 {
 		msg := "opsgenie_config 'entity' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ogc.Entity = ""
 	}
 	if ogc.UpdateAlerts != nil && lessThanV0_24 {
 		msg := "update_alerts 'entity' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ogc.UpdateAlerts = nil
 	}
 	for _, responder := range ogc.Responders {
@@ -2730,7 +2730,7 @@ func (ogc *opsgenieConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 
 	if lessThanV0_24 {
 		msg := "'api_key_file' supported in Alertmanager >= 0.24.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		ogc.APIKeyFile = ""
 	}
 
@@ -2750,19 +2750,19 @@ func (pdc *pagerdutyConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 
 	if pdc.Source != "" && lessThanV0_25 {
 		msg := "'source' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pdc.Source = ""
 	}
 
 	if pdc.RoutingKeyFile != "" && lessThanV0_25 {
 		msg := "'routing_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pdc.RoutingKeyFile = ""
 	}
 
 	if pdc.ServiceKeyFile != "" && lessThanV0_25 {
 		msg := "'service_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pdc.ServiceKeyFile = ""
 	}
 
@@ -2780,7 +2780,7 @@ func (pdc *pagerdutyConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 
 	if pdc.Timeout != nil && lessThanV0_30 {
 		msg := "'timeout' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		pdc.Timeout = nil
 	}
 
@@ -2802,7 +2802,7 @@ func (poc *pushoverConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 
 	if poc.UserKeyFile != "" && lessThanV0_26 {
 		msg := "'user_key_file' supported in Alertmanager >= 0.26.0 only - dropping field from pushover receiver config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		poc.UserKeyFile = ""
 	}
 
@@ -2818,7 +2818,7 @@ func (poc *pushoverConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 
 	if poc.TokenFile != "" && lessThanV0_26 {
 		msg := "'token_file' supported in Alertmanager >= 0.26.0 only - dropping field from pushover receiver config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		poc.TokenFile = ""
 	}
 
@@ -2834,19 +2834,19 @@ func (poc *pushoverConfig) sanitize(amVersion semver.Version, logger *slog.Logge
 
 	if poc.TTL != "" && lessThanV0_27 {
 		msg := "'ttl' supported in Alertmanager >= 0.27.0 only - dropping field from pushover receiver config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		poc.TTL = ""
 	}
 
 	if poc.Device != "" && lessThanV0_26 {
 		msg := "'device' supported in Alertmanager >= 0.26.0 only - dropping field from pushover receiver config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		poc.Device = ""
 	}
 
 	if poc.Monospace != nil && *poc.Monospace && lessThanV0_29 {
 		msg := "'monospace' supported in Alertmanager >= 0.29.0 only - dropping field from pushover receiver config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		*poc.Monospace = false
 	}
 
@@ -2874,31 +2874,31 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 
 	if sc.Timeout != nil && lessThanV0_30 {
 		msg := "'timeout' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.Timeout = nil
 	}
 
 	if sc.AppToken != "" && lessThanV0_30 {
 		msg := "'app_token' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.AppToken = ""
 	}
 
 	if sc.AppTokenFile != "" && lessThanV0_30 {
 		msg := "'app_token_file' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.AppTokenFile = ""
 	}
 
 	if sc.AppURL != "" && lessThanV0_30 {
 		msg := "'app_url' supported in Alertmanager >= 0.30.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.AppURL = ""
 	}
 
 	if sc.MessageText != "" && lessThanV0_31 {
 		msg := "'message_text' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.MessageText = ""
 	}
 
@@ -2932,7 +2932,7 @@ func (sc *slackConfig) sanitize(amVersion semver.Version, logger *slog.Logger) e
 	// As of v0.22.0 Alertmanager config supports passing URL via file name
 	if sc.APIURLFile != "" && amVersion.LT(semver.MustParse("0.22.0")) {
 		msg := "'api_url_file' supported in Alertmanager >= 0.22.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.APIURLFile = ""
 	}
 
@@ -2952,7 +2952,7 @@ func (voc *victorOpsConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 
 	if voc.APIKeyFile != "" && amVersion.LT(semver.MustParse("0.25.0")) {
 		msg := "'api_key_file' supported in Alertmanager >= 0.25.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		voc.APIKeyFile = ""
 	}
 
@@ -2978,7 +2978,7 @@ func (whc *webhookConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 
 	if whc.URLFile != "" && amVersion.LT(semver.MustParse("0.26.0")) {
 		msg := "'url_file' supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		whc.URLFile = ""
 	}
 
@@ -2990,13 +2990,13 @@ func (whc *webhookConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 
 	if whc.Timeout != nil && amVersion.LT(semver.MustParse("0.28.0")) {
 		msg := "'timeout' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		whc.Timeout = nil
 	}
 
 	if whc.Payload != nil && amVersion.LT(semver.MustParse("0.32.0")) {
 		msg := "'payload' supported in Alertmanager >= 0.32.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		whc.Payload = nil
 	}
 
@@ -3024,7 +3024,7 @@ func (tc *msTeamsConfig) sanitize(amVersion semver.Version, logger *slog.Logger)
 
 	if tc.Summary != "" && amVersion.LT(semver.MustParse("0.27.0")) {
 		msg := "'summary' supported in Alertmanager >= 0.27.0 only - dropping field `summary` from msteams config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.Summary = ""
 	}
 
@@ -3063,7 +3063,7 @@ func (wcc *weChatConfig) sanitize(amVersion semver.Version, logger *slog.Logger)
 
 	if wcc.APISecretFile != "" && amVersion.LT(semver.MustParse("0.31.0")) {
 		msg := "'api_secret_file' supported in Alertmanager >= 0.31.0 only - dropping field `api_secret_file` from wechat config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		wcc.APISecretFile = ""
 	}
 
@@ -3096,7 +3096,7 @@ func (sc *snsConfig) sanitize(amVersion semver.Version, logger *slog.Logger) err
 
 	if sc.UseAWSHTTPClient && amVersion.LT(semver.MustParse("0.33.0")) {
 		msg := "'use_aws_http_client' supported in Alertmanager >= 0.33.0 only - dropping field `use_aws_http_client` from sns config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		sc.UseAWSHTTPClient = false
 	}
 
@@ -3114,7 +3114,7 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 
 	if tc.ChatIDFile != "" && lessThanV0_31 {
 		msg := "'chat_id_file' supported in Alertmanager >= 0.31.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.ChatIDFile = ""
 	}
 
@@ -3130,7 +3130,7 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 
 	if tc.BotTokenFile != "" && lessThanV0_26 {
 		msg := "'bot_token_file' supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.BotTokenFile = ""
 	}
 
@@ -3146,7 +3146,7 @@ func (tc *telegramConfig) sanitize(amVersion semver.Version, logger *slog.Logger
 
 	if tc.MessageThreadID != 0 && lessThanV0_26 {
 		msg := "'message_thread_id' supported in Alertmanager >= 0.26.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		tc.MessageThreadID = 0
 	}
 
@@ -3169,19 +3169,19 @@ func (dc *discordConfig) sanitize(amVersion semver.Version, logger *slog.Logger)
 
 	if dc.Content != "" && lessThanV0_28 {
 		msg := "'content' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		dc.Content = ""
 	}
 
 	if dc.Username != "" && lessThanV0_28 {
 		msg := "'username' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		dc.Username = ""
 	}
 
 	if dc.AvatarURL != "" && lessThanV0_28 {
 		msg := "'avatar_url' supported in Alertmanager >= 0.28.0 only - dropping field from provided config"
-		logger.Warn(msg, "current_version", amVersion.String())
+		logger.Warn(msg, "currentVersion", amVersion.String())
 		dc.AvatarURL = ""
 	}
 
@@ -3224,7 +3224,7 @@ func (jc *jiraConfig) sanitize(amVersion semver.Version, logger *slog.Logger) er
 	if jc.APIType != "" {
 		if !apiTypeAllowed {
 			msg := "'api_type' supported in Alertmanager >= 0.29.0 only - dropping field from provided config"
-			logger.Warn(msg, "current_version", amVersion.String())
+			logger.Warn(msg, "currentVersion", amVersion.String())
 			jc.APIType = ""
 		} else {
 			if jc.APIType != "auto" && jc.APIType != "cloud" && jc.APIType != "datacenter" {
@@ -3294,14 +3294,14 @@ func (mc *mattermostConfig) sanitize(amVersion semver.Version, logger *slog.Logg
 		for fieldName, valuePtr := range fieldNameMapping {
 			if *valuePtr != "" {
 				msg := fmt.Sprintf("'%s'"+commonErrorMsg, fieldName)
-				logger.Warn(msg, "current_version", amVersion.String())
+				logger.Warn(msg, "currentVersion", amVersion.String())
 				*valuePtr = ""
 			}
 		}
 
 		if len(mc.Fields) > 0 {
 			msg := "'fields'" + commonErrorMsg
-			logger.Warn(msg, "current_version", amVersion.String())
+			logger.Warn(msg, "currentVersion", amVersion.String())
 			mc.Fields = nil
 		}
 	}
@@ -3360,7 +3360,7 @@ func (ir *inhibitRule) sanitize(amVersion semver.Version, logger *slog.Logger) e
 	// to the namespace label we have injected - but we won't convert these
 	if checkNotEmptyMap(ir.SourceMatch, ir.TargetMatch, ir.SourceMatchRE, ir.TargetMatchRE) {
 		msg := "inhibit rule is using a deprecated match syntax which will be removed in future versions"
-		logger.Warn(msg, "source_match", ir.SourceMatch, "target_match", ir.TargetMatch, "source_match_re", ir.SourceMatchRE, "target_match_re", ir.TargetMatchRE)
+		logger.Warn(msg, "sourceMatch", ir.SourceMatch, "targetMatch", ir.TargetMatch, "sourceMatchRE", ir.SourceMatchRE, "targetMatchRE", ir.TargetMatchRE)
 	}
 
 	// ensure empty data structures are assigned nil so their yaml output is sanitized
@@ -3409,18 +3409,18 @@ func (r *route) sanitize(amVersion semver.Version, logger *slog.Logger) error {
 
 	if matchersV2Allowed && checkNotEmptyMap(r.Match, r.MatchRE) {
 		msg := "'matchers' field is using a deprecated syntax which will be removed in future versions"
-		withLogger.Warn(msg, "match", fmt.Sprint(r.Match), "match_re", fmt.Sprint(r.MatchRE))
+		withLogger.Warn(msg, "match", fmt.Sprint(r.Match), "matchRE", fmt.Sprint(r.MatchRE))
 	}
 
 	if !muteTimeIntervalsAllowed {
 		msg := "named mute time intervals in route is supported in Alertmanager >= 0.22.0 only - dropping config"
-		withLogger.Warn(msg, "mute_time_intervals", fmt.Sprint(r.MuteTimeIntervals))
+		withLogger.Warn(msg, "muteTimeIntervals", fmt.Sprint(r.MuteTimeIntervals))
 		r.MuteTimeIntervals = nil
 	}
 
 	if !activeTimeIntervalsAllowed {
 		msg := "active time intervals in route is supported in Alertmanager >= 0.24.0 only - dropping config"
-		withLogger.Warn(msg, "active_time_intervals", fmt.Sprint(r.ActiveTimeIntervals))
+		withLogger.Warn(msg, "activeTimeIntervals", fmt.Sprint(r.ActiveTimeIntervals))
 		r.ActiveTimeIntervals = nil
 	}
 

--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -219,7 +219,7 @@ func New(
 		),
 	)
 
-	c.logger = logger.With("kubelet_object", fmt.Sprintf("%s/%s", c.kubeletObjectNamespace, c.kubeletObjectName))
+	c.logger = logger.With("kubeletObject", fmt.Sprintf("%s/%s", c.kubeletObjectNamespace, c.kubeletObjectName))
 
 	return c, nil
 }
@@ -396,7 +396,7 @@ func (c *Controller) sync(ctx context.Context) {
 	slices.SortStableFunc(nodes, func(a, b corev1.Node) int {
 		return strings.Compare(a.Name, b.Name)
 	})
-	c.logger.Debug("Nodes retrieved from the Kubernetes API", "num_nodes", len(nodes))
+	c.logger.Debug("Nodes retrieved from the Kubernetes API", "numNodes", len(nodes))
 
 	addresses, errs := c.getNodeAddresses(nodes)
 	if len(errs) > 0 {
@@ -405,7 +405,7 @@ func (c *Controller) sync(ctx context.Context) {
 		}
 		c.nodeAddressLookupErrors.Add(float64(len(errs)))
 	}
-	c.logger.Debug("Nodes converted to endpoint addresses", "num_addresses", len(addresses))
+	c.logger.Debug("Nodes converted to endpoint addresses", "numAddresses", len(addresses))
 
 	svc, err := c.syncService(ctx)
 	if err != nil {

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -727,7 +727,7 @@ func (rr *ResourceReconciler) isManagedByController(obj metav1.Object) bool {
 	}
 
 	if controllerID != rr.controllerID {
-		rr.logger.Debug("skipping object not managed by the controller", "object", KeyForObject(obj), "object_id", controllerID, "controller_id", rr.controllerID)
+		rr.logger.Debug("skipping object not managed by the controller", "object", KeyForObject(obj), "objectID", controllerID, "controllerID", rr.controllerID)
 		return false
 	}
 

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -122,7 +122,7 @@ func NewPrometheusRuleSelector(ruleFormat RuleConfigurationFormat, version strin
 }
 
 func (prs *PrometheusRuleSelector) generateRulesConfiguration(promRule *monitoringv1.PrometheusRule) (string, error) {
-	logger := prs.logger.With("prometheusrule", promRule.Name, "prometheusrule-namespace", promRule.Namespace)
+	logger := prs.logger.With("prometheusRule", promRule.Name, "prometheusrule-namespace", promRule.Namespace)
 	promRuleSpec := promRule.Spec
 
 	promRuleSpec = prs.sanitizePrometheusRulesSpec(promRuleSpec, logger)
@@ -171,12 +171,12 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 	for i := range promRuleSpec.Groups {
 		if promRuleSpec.Groups[i].Limit != nil && prs.version.LT(minVersionLimits) {
 			promRuleSpec.Groups[i].Limit = nil
-			logger.Warn(fmt.Sprintf("ignoring `limit` not supported by %s", component), "minimum_version", minVersionLimits)
+			logger.Warn(fmt.Sprintf("ignoring `limit` not supported by %s", component), "minimumVersion", minVersionLimits)
 		}
 
 		if promRuleSpec.Groups[i].QueryOffset != nil && prs.version.LT(minVersionQueryOffset) {
 			promRuleSpec.Groups[i].QueryOffset = nil
-			logger.Warn(fmt.Sprintf("ignoring `query_offset` not supported by %s", component), "minimum_version", minVersionQueryOffset)
+			logger.Warn(fmt.Sprintf("ignoring `query_offset` not supported by %s", component), "minimumVersion", minVersionQueryOffset)
 		}
 
 		if prs.ruleFormat == PrometheusFormat {
@@ -186,13 +186,13 @@ func (prs *PrometheusRuleSelector) sanitizePrometheusRulesSpec(promRuleSpec moni
 
 		if len(promRuleSpec.Groups[i].Labels) > 0 && prs.version.LT(minVersionRuleGroupLabels) {
 			promRuleSpec.Groups[i].Labels = nil
-			logger.Warn(fmt.Sprintf("ignoring group labels since not supported by %s", component), "minimum_version", minVersionRuleGroupLabels)
+			logger.Warn(fmt.Sprintf("ignoring group labels since not supported by %s", component), "minimumVersion", minVersionRuleGroupLabels)
 		}
 
 		for j := range promRuleSpec.Groups[i].Rules {
 			if promRuleSpec.Groups[i].Rules[j].KeepFiringFor != nil && prs.version.LT(minVersionKeepFiringFor) {
 				promRuleSpec.Groups[i].Rules[j].KeepFiringFor = nil
-				logger.Warn(fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimum_version", minVersionKeepFiringFor)
+				logger.Warn(fmt.Sprintf("ignoring 'keep_firing_for' not supported by %s", component), "minimumVersion", minVersionKeepFiringFor)
 			}
 		}
 	}

--- a/pkg/prometheus/agent/operator.go
+++ b/pkg/prometheus/agent/operator.go
@@ -878,8 +878,8 @@ func (c *Operator) syncStatefulSet(ctx context.Context, key string, p *monitorin
 		}
 
 		logger.Debug("updating current statefulset because of hash divergence",
-			"new_hash", newSSetInputHash,
-			"existing_hash", existingStatefulSet.Annotations[operator.InputHashAnnotationKey],
+			"newHash", newSSetInputHash,
+			"existingHash", existingStatefulSet.Annotations[operator.InputHashAnnotationKey],
 		)
 
 		if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -301,7 +301,7 @@ func (cg *ConfigGenerator) WithMinimumVersion(version string) *ConfigGenerator {
 
 	if cg.version.LT(semver.MustParse(version)) {
 		return &ConfigGenerator{
-			logger:                      cg.logger.With("minimum_version", version),
+			logger:                      cg.logger.With("minimumVersion", version),
 			version:                     cg.version,
 			notCompatible:               true,
 			prom:                        cg.prom,
@@ -331,7 +331,7 @@ func (cg *ConfigGenerator) WithMaximumVersion(version string) *ConfigGenerator {
 
 	if cg.version.GTE(semver.MustParse(version)) {
 		return &ConfigGenerator{
-			logger:                      cg.logger.With("maximum_version", version),
+			logger:                      cg.logger.With("maximumVersion", version),
 			version:                     cg.version,
 			notCompatible:               true,
 			prom:                        cg.prom,
@@ -3121,7 +3121,7 @@ func (cg *ConfigGenerator) appendEvaluationInterval(slice yaml.MapSlice, evaluat
 func (cg *ConfigGenerator) appendGlobalLimits(slice yaml.MapSlice, limitKey string, limit *int64, enforcedLimit *int64) yaml.MapSlice {
 	if ptr.Deref(limit, 0) > 0 {
 		if ptr.Deref(enforcedLimit, 0) > 0 && *limit > *enforcedLimit {
-			cg.logger.Warn(fmt.Sprintf("%q is greater than the enforced limit, using enforced limit", limitKey), "limit", *limit, "enforced_limit", *enforcedLimit)
+			cg.logger.Warn(fmt.Sprintf("%q is greater than the enforced limit, using enforced limit", limitKey), "limit", *limit, "enforcedLimit", *enforcedLimit)
 			return cg.AppendMapItem(slice, limitKey, *enforcedLimit)
 		}
 		return cg.AppendMapItem(slice, limitKey, *limit)

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1098,8 +1098,8 @@ func (c *Operator) sync(ctx context.Context, key string) (func(context.Context) 
 
 		logger.Debug(
 			"updating current statefulset because of hash divergence",
-			"new_hash", newSSetInputHash,
-			"existing_hash", existingStatefulSet.Annotations[operator.InputHashAnnotationKey],
+			"newHash", newSSetInputHash,
+			"existingHash", existingStatefulSet.Annotations[operator.InputHashAnnotationKey],
 		)
 
 		if err = k8s.ForceUpdateStatefulSet(ctx, ssetClient, sset, func(reason string) {

--- a/pkg/prometheus/validation/validator.go
+++ b/pkg/prometheus/validation/validator.go
@@ -116,15 +116,15 @@ func (lcv *LabelConfigValidator) ValidateRelabelConfig(rc monitoringv1.RelabelCo
 	}
 
 	if (action == string(relabel.Replace)) && !varInRegexTemplate(rc.TargetLabel) && !lcv.isValidLabelName(rc.TargetLabel) {
-		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+		return fmt.Errorf("%q is invalid 'targetLabel' for %s action", rc.TargetLabel, rc.Action)
 	}
 
 	if (action == string(relabel.Replace)) && varInRegexTemplate(rc.TargetLabel) && !lcv.isValidLabelName(rc.TargetLabel) {
-		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+		return fmt.Errorf("%q is invalid 'targetLabel' for %s action", rc.TargetLabel, rc.Action)
 	}
 
 	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && !lcv.isValidLabelName(rc.TargetLabel) {
-		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+		return fmt.Errorf("%q is invalid 'targetLabel' for %s action", rc.TargetLabel, rc.Action)
 	}
 
 	if (action == string(relabel.Lowercase) || action == string(relabel.Uppercase) || action == string(relabel.KeepEqual) || action == string(relabel.DropEqual)) && (rc.Replacement != nil && *rc.Replacement != relabel.DefaultRelabelConfig.Replacement) {
@@ -136,7 +136,7 @@ func (lcv *LabelConfigValidator) ValidateRelabelConfig(rc monitoringv1.RelabelCo
 	}
 
 	if action == string(relabel.HashMod) && !lcv.isValidLabelName(rc.TargetLabel) {
-		return fmt.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+		return fmt.Errorf("%q is invalid 'targetLabel' for %s action", rc.TargetLabel, rc.Action)
 	}
 
 	if action == string(relabel.KeepEqual) || action == string(relabel.DropEqual) {
@@ -146,7 +146,7 @@ func (lcv *LabelConfigValidator) ValidateRelabelConfig(rc monitoringv1.RelabelCo
 			(rc.Separator != nil &&
 				*rc.Separator != relabel.DefaultRelabelConfig.Separator) ||
 			(rc.Replacement != nil && *rc.Replacement != relabel.DefaultRelabelConfig.Replacement) {
-			return fmt.Errorf("%s action requires only 'source_labels' and `target_label`, and no other fields", rc.Action)
+			return fmt.Errorf("%s action requires only 'sourceLabels' and 'targetLabel', and no other fields", rc.Action)
 		}
 	}
 

--- a/pkg/prometheus/validation/validator_test.go
+++ b/pkg/prometheus/validation/validator_test.go
@@ -47,10 +47,11 @@ func TestValidateRelabelConfig(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		scenario      string
-		relabelConfig monitoringv1.RelabelConfig
-		prometheus    monitoringv1.Prometheus
-		expectedErr   bool
+		scenario       string
+		relabelConfig  monitoringv1.RelabelConfig
+		prometheus     monitoringv1.Prometheus
+		expectedErr    bool
+		expectedErrMsg string
 	}{
 		// Test invalid regex expression
 		{
@@ -68,8 +69,9 @@ func TestValidateRelabelConfig(t *testing.T) {
 				Action:      "replace",
 				TargetLabel: "l\\${3}",
 			},
-			prometheus:  defaultPrometheusSpec,
-			expectedErr: true,
+			prometheus:     defaultPrometheusSpec,
+			expectedErr:    true,
+			expectedErrMsg: "is invalid 'targetLabel' for replace action",
 		},
 		// Test empty target label for action replace
 		{
@@ -364,6 +366,25 @@ func TestValidateRelabelConfig(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		// Test keepequal with non default separator
+		{
+			scenario: "keepequal config with non default separator",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"__tmp_port"},
+				TargetLabel:  "__port1",
+				Separator:    new("^"),
+				Action:       "keepequal",
+			},
+			prometheus: monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+						Version: "v2.41.0",
+					},
+				},
+			},
+			expectedErr:    true,
+			expectedErrMsg: "keepequal action requires only 'sourceLabels' and 'targetLabel', and no other fields",
+		},
 		// Test valid keepequal with default values for other fields
 		{
 			scenario: "valid keepequal config with default values for other fields",
@@ -410,6 +431,9 @@ func TestValidateRelabelConfig(t *testing.T) {
 			err = lcv.ValidateRelabelConfig(tc.relabelConfig)
 			if tc.expectedErr {
 				require.Error(t, err)
+				if tc.expectedErrMsg != "" {
+					require.ErrorContains(t, err, tc.expectedErrMsg)
+				}
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -190,15 +190,15 @@ func (tc *TLSConfig) Convert(logger *slog.Logger) (*tls.Config, error) {
 	info, err := os.Stat(tc.ClientCAFile)
 	switch {
 	case err != nil:
-		logger.Warn("server TLS client verification disabled", "client_ca_file", tc.ClientCAFile, "err", err)
+		logger.Warn("server TLS client verification disabled", "clientCAFile", tc.ClientCAFile, "err", err)
 
 	case !info.Mode().IsRegular():
-		logger.Warn("server TLS client verification disabled", "client_ca_file", tc.ClientCAFile, "file_mode", info.Mode().String())
+		logger.Warn("server TLS client verification disabled", "clientCAFile", tc.ClientCAFile, "fileMode", info.Mode().String())
 
 	default:
 		// The client CA content will be checked by the cert controller.
 		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
-		logger.Info("server TLS client verification enabled", "client_ca_file", tc.ClientCAFile)
+		logger.Info("server TLS client verification enabled", "clientCAFile", tc.ClientCAFile)
 	}
 
 	return tlsCfg, nil

--- a/pkg/thanos/operator.go
+++ b/pkg/thanos/operator.go
@@ -966,7 +966,7 @@ func (o *Operator) createOrUpdateRulerConfigSecret(ctx context.Context, store *a
 			if elem.IsNil() {
 				return
 			}
-			o.logger.Warn(fmt.Sprintf("ignoring %q not supported by Thanos", field), "minimum_version", minVersion)
+			o.logger.Warn(fmt.Sprintf("ignoring %q not supported by Thanos", field), "minimumVersion", minVersion)
 			elem.Set(reflect.Zero(elem.Type()))
 		}
 	}
@@ -986,7 +986,7 @@ func (o *Operator) createOrUpdateRulerConfigSecret(ctx context.Context, store *a
 
 		// Thanos does not support sigv4.externalId in any version
 		if rw.Sigv4 != nil && rw.Sigv4.ExternalID != "" {
-			o.logger.Warn("ignoring \"sigv4.externalId\" not supported by Thanos", "minimum_version", "none")
+			o.logger.Warn("ignoring \"sigv4.externalId\" not supported by Thanos", "minimumVersion", "none")
 			rw.Sigv4.ExternalID = ""
 		}
 


### PR DESCRIPTION
## Description

The operator mixes snake_case and camelCase for structured log field names. This PR standardizes on camelCase, as requested in #7952:

- Rename all snake_case structured log keys in `pkg/` and `cmd/` to camelCase (e.g. `current_version` -> `currentVersion`, `minimum_version` -> `minimumVersion`, `build_context` -> `buildContext`, `client_ca_file` -> `clientCAFile`).
- Spell CRD fields correctly in the relabel configuration validation errors, per https://github.com/prometheus-operator/prometheus-operator/pull/8104#issuecomment-3552824342: `'target_label'` -> `'targetLabel'` and `'source_labels'` -> `'sourceLabels'`, matching the `RelabelConfig` field names users set in their manifests.

Intentionally left unchanged:

- Prometheus metric names/labels (e.g. the `triggered_by` label of `prometheus_operator_triggered_total`) — metric naming convention is snake_case.
- Generated Prometheus/Alertmanager/web configuration keys (`source_labels`, `min_version`, ...) — actual configuration syntax.
- Field names quoted in messages that refer to the native Alertmanager configuration (`pkg/alertmanager/amcfg.go` sanitize functions) — those structs are the snake_case YAML the user wrote.
- `'keep_firing_for'` / `query_offset` in `pkg/operator/rules.go` messages: unlike `RelabelConfig`, the `PrometheusRule` CRD uses snake_case JSON tags (`keep_firing_for`, `query_offset`), so these already match the CRD spelling. This deliberately diverges from the earlier attempt in #8104 which camelCased them — happy to change if you prefer.

Follow-up to the review discussion in #8104 (closed by its author).

Closes: #7952

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

- Extended `TestValidateRelabelConfig` with error-message assertions that fail without this change (added an `expectedErrMsg` field and a `keepequal` case with a non-default separator to cover the `'sourceLabels' and 'targetLabel'` message).
- `go test ./pkg/prometheus/... ./pkg/alertmanager/ ./pkg/operator/ ./pkg/kubelet/ ./pkg/server/ ./pkg/thanos/` — all pass.
- `golangci-lint run` on all changed packages — 0 issues.
- Verified via grep that no other code, tests, golden files or docs reference the old key/message spellings, and that the remaining snake_case strings on log lines are metric labels or values, not keys.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

```release-note
Standardize structured log field names on camelCase (e.g. `current_version` becomes `currentVersion`); update relabel validation errors to use the CRD field spellings `targetLabel` and `sourceLabels`.
```

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
