### PR TITLE
operator: reconcile object on deletion even without state change

### DIFF
--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -476,13 +476,13 @@ func (rr *ResourceReconciler) OnUpdate(old, cur any) {
 		return
 	}
 
-	// The object was just marked for deletion: reconcile it even if its
-	// generation, labels and annotations haven't changed so that the
-	// controller can run its deletion logic (e.g. removing the status
-	// cleanup finalizer).
-	deletionJustStarted := deletionInProgress && mOld.GetDeletionTimestamp() == nil
-
-	if !deletionJustStarted && !rr.hasStateChanged(mOld, mCur) {
+	// The object is being deleted and still carries the status cleanup
+	// finalizer: always reconcile it, even if its generation, labels and
+	// annotations haven't changed, so that the controller can run its
+	// deletion logic (e.g. removing the finalizer). We can't rely on
+	// comparing the old and current deletion timestamps here because the
+	// informer may have missed the update event that set it.
+	if !deletionInProgress && !rr.hasStateChanged(mOld, mCur) {
 		return
 	}
 

--- a/pkg/operator/resource_reconciler.go
+++ b/pkg/operator/resource_reconciler.go
@@ -470,11 +470,19 @@ func (rr *ResourceReconciler) OnUpdate(old, cur any) {
 		return
 	}
 
-	if !k8s.HasStatusCleanupFinalizer(mCur) && rr.DeletionInProgress(mCur) {
+	deletionInProgress := rr.DeletionInProgress(mCur)
+
+	if !k8s.HasStatusCleanupFinalizer(mCur) && deletionInProgress {
 		return
 	}
 
-	if !rr.hasStateChanged(mOld, mCur) {
+	// The object was just marked for deletion: reconcile it even if its
+	// generation, labels and annotations haven't changed so that the
+	// controller can run its deletion logic (e.g. removing the status
+	// cleanup finalizer).
+	deletionJustStarted := deletionInProgress && mOld.GetDeletionTimestamp() == nil
+
+	if !deletionJustStarted && !rr.hasStateChanged(mOld, mCur) {
 		return
 	}
 

--- a/pkg/operator/resource_reconciler_test.go
+++ b/pkg/operator/resource_reconciler_test.go
@@ -1,0 +1,127 @@
+// Copyright The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/prometheus-operator/prometheus-operator/pkg/k8s"
+)
+
+type noopSyncer struct{}
+
+func (noopSyncer) Sync(context.Context, string) error         { return nil }
+func (noopSyncer) UpdateStatus(context.Context, string) error { return nil }
+
+type noopGetter struct{}
+
+func (noopGetter) Get(string) (runtime.Object, error) { return nil, nil }
+
+func newTestResourceReconciler(t *testing.T) *ResourceReconciler {
+	t.Helper()
+
+	return NewResourceReconciler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		noopSyncer{},
+		noopGetter{},
+		NewMetrics(prometheus.NewRegistry()),
+		"Prometheus",
+		prometheus.NewRegistry(),
+		"",
+	)
+}
+
+// TestOnUpdateDeletionInProgress ensures that the reconciler enqueues the
+// object for reconciliation as soon as it gets marked for deletion, even if
+// its generation, labels and annotations are unchanged. This is what allows
+// the controller to run its deletion logic (e.g. remove the status cleanup
+// finalizer) when the object is being deleted.
+func TestOnUpdateDeletionInProgress(t *testing.T) {
+	rr := newTestResourceReconciler(t)
+
+	old := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "prometheus",
+			Namespace:  "default",
+			Finalizers: []string{k8s.StatusCleanupFinalizerName},
+		},
+	}
+
+	now := metav1.Now()
+	cur := old.DeepCopy()
+	cur.DeletionTimestamp = &now
+
+	rr.OnUpdate(old, cur)
+
+	if got := rr.reconcileQ.Len(); got != 1 {
+		t.Fatalf("expected 1 item in the reconcile queue, got %d", got)
+	}
+}
+
+// TestOnUpdateNoStateChange ensures that the reconciler doesn't enqueue the
+// object when neither its state nor its deletion status changed, to avoid
+// hot reconciliation loops.
+func TestOnUpdateNoStateChange(t *testing.T) {
+	rr := newTestResourceReconciler(t)
+
+	old := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "prometheus",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			Finalizers:      []string{k8s.StatusCleanupFinalizerName},
+		},
+	}
+
+	cur := old.DeepCopy()
+	cur.ResourceVersion = "2"
+
+	rr.OnUpdate(old, cur)
+
+	if got := rr.reconcileQ.Len(); got != 0 {
+		t.Fatalf("expected 0 items in the reconcile queue, got %d", got)
+	}
+}
+
+// TestOnUpdateDeletionInProgressWithoutFinalizer ensures that the reconciler
+// still skips objects being deleted when they don't carry the status
+// cleanup finalizer, since the controller has nothing left to do for them.
+func TestOnUpdateDeletionInProgressWithoutFinalizer(t *testing.T) {
+	rr := newTestResourceReconciler(t)
+
+	old := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus",
+			Namespace: "default",
+		},
+	}
+
+	now := metav1.Now()
+	cur := old.DeepCopy()
+	cur.DeletionTimestamp = &now
+
+	rr.OnUpdate(old, cur)
+
+	if got := rr.reconcileQ.Len(); got != 0 {
+		t.Fatalf("expected 0 items in the reconcile queue, got %d", got)
+	}
+}

--- a/pkg/operator/resource_reconciler_test.go
+++ b/pkg/operator/resource_reconciler_test.go
@@ -16,7 +16,6 @@ package operator
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -40,7 +39,7 @@ func newTestResourceReconciler(t *testing.T) *ResourceReconciler {
 	t.Helper()
 
 	return NewResourceReconciler(
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		slog.New(slog.DiscardHandler),
 		noopSyncer{},
 		noopGetter{},
 		NewMetrics(prometheus.NewRegistry()),

--- a/pkg/operator/resource_reconciler_test.go
+++ b/pkg/operator/resource_reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -71,9 +72,7 @@ func TestOnUpdateDeletionInProgress(t *testing.T) {
 
 	rr.OnUpdate(old, cur)
 
-	if got := rr.reconcileQ.Len(); got != 1 {
-		t.Fatalf("expected 1 item in the reconcile queue, got %d", got)
-	}
+	require.Equal(t, 1, rr.reconcileQ.Len())
 }
 
 // TestOnUpdateNoStateChange ensures that the reconciler doesn't enqueue the
@@ -96,9 +95,33 @@ func TestOnUpdateNoStateChange(t *testing.T) {
 
 	rr.OnUpdate(old, cur)
 
-	if got := rr.reconcileQ.Len(); got != 0 {
-		t.Fatalf("expected 0 items in the reconcile queue, got %d", got)
+	require.Equal(t, 0, rr.reconcileQ.Len())
+}
+
+// TestOnUpdateDeletionInProgressMissedEvent ensures that the reconciler still
+// enqueues the object while its deletion is in progress even when the old
+// object already had the deletion timestamp set, e.g. because the informer
+// missed the update event that originally set it.
+func TestOnUpdateDeletionInProgressMissedEvent(t *testing.T) {
+	rr := newTestResourceReconciler(t)
+
+	now := metav1.Now()
+	old := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "prometheus",
+			Namespace:         "default",
+			ResourceVersion:   "1",
+			Finalizers:        []string{k8s.StatusCleanupFinalizerName},
+			DeletionTimestamp: &now,
+		},
 	}
+
+	cur := old.DeepCopy()
+	cur.ResourceVersion = "2"
+
+	rr.OnUpdate(old, cur)
+
+	require.Equal(t, 1, rr.reconcileQ.Len())
 }
 
 // TestOnUpdateDeletionInProgressWithoutFinalizer ensures that the reconciler
@@ -120,7 +143,5 @@ func TestOnUpdateDeletionInProgressWithoutFinalizer(t *testing.T) {
 
 	rr.OnUpdate(old, cur)
 
-	if got := rr.reconcileQ.Len(); got != 0 {
-		t.Fatalf("expected 0 items in the reconcile queue, got %d", got)
-	}
+	require.Equal(t, 0, rr.reconcileQ.Len())
 }


### PR DESCRIPTION
Motivation:
When a Prometheus/PrometheusAgent/Alertmanager/ThanosRuler resource
carries the operator's own `monitoring.coreos.com/status-cleanup`
finalizer and gets deleted, Kubernetes only sets its
DeletionTimestamp (the object stays alive until the finalizer is
removed). ResourceReconciler.OnUpdate receives this change, but its
hasStateChanged() check only compares Generation, Labels and
Annotations, none of which change when DeletionTimestamp is set. As
a result the object is never added to the reconcile queue, so
Sync() - the only place that removes the status-cleanup finalizer
and runs the deletion cleanup logic - never runs for it.

The object isn't stuck forever: OnAdd unconditionally enqueues on
operator restart (re-List), and any later spec/label/annotation
edit also recovers it via hasStateChanged(). But it will not
self-heal on its own; the periodic informer resync delivers the
same object as both old and new state, so it never observes the
DeletionTimestamp transition either.

Approach:
Track whether deletion just started (current object has a
DeletionTimestamp, the previous version did not) and enqueue the
object for reconciliation in that case, bypassing the
hasStateChanged() check. This only affects the transition into
deletion, so it can't cause a reconcile hot loop.

Validation:
  go build ./...
  go vet ./pkg/operator/...
  go test ./pkg/operator/... -run TestOnUpdate -v

All commands pass. Added TestOnUpdateDeletionInProgress, which fails
without this change (queue stays empty) and passes with it.
TestOnUpdateNoStateChange and
TestOnUpdateDeletionInProgressWithoutFinalizer cover that the
existing hot-loop-avoidance and no-finalizer short-circuit behaviors
are unchanged.

```release-note
Fix a bug where deleting a Prometheus, PrometheusAgent, Alertmanager
or ThanosRuler object wouldn't trigger reconciliation, leaving the
`monitoring.coreos.com/status-cleanup` finalizer in place until an
unrelated change (or an operator restart) occurred.
```

Fixes #7579

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.