### PR TITLE
feat: add support for percentage-based retention

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -3846,9 +3846,7 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 capacity used by the Prometheus data.</p>
 <p>The value is a number between 0 and 100. If set to 0, percentage-based
 retention is disabled.</p>
-<p>Unlike <code>spec.retention</code> and <code>spec.retentionSize</code>, Prometheus exposes this
-setting in the configuration file only. It requires Prometheus &gt;= v3.11.0
-and is ignored by older versions.</p>
+<p>It requires Prometheus &gt;= v3.11.0 and is ignored by older versions.</p>
 </td>
 </tr>
 <tr>
@@ -17060,9 +17058,7 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 capacity used by the Prometheus data.</p>
 <p>The value is a number between 0 and 100. If set to 0, percentage-based
 retention is disabled.</p>
-<p>Unlike <code>spec.retention</code> and <code>spec.retentionSize</code>, Prometheus exposes this
-setting in the configuration file only. It requires Prometheus &gt;= v3.11.0
-and is ignored by older versions.</p>
+<p>It requires Prometheus &gt;= v3.11.0 and is ignored by older versions.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -3813,7 +3813,8 @@ Duration
 <td>
 <em>(Optional)</em>
 <p>retention defines how long to retain the Prometheus data.</p>
-<p>Default: &ldquo;24h&rdquo; if <code>spec.retention</code> and <code>spec.retentionSize</code> are empty.</p>
+<p>Default: &ldquo;24h&rdquo; if <code>spec.retention</code>, <code>spec.retentionSize</code> and
+<code>spec.retentionPercentage</code> are empty.</p>
 </td>
 </tr>
 <tr>
@@ -3828,6 +3829,26 @@ ByteSize
 <td>
 <em>(Optional)</em>
 <p>retentionSize defines the maximum number of bytes used by the Prometheus data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retentionPercentage</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity">
+k8s.io/apimachinery/pkg/api/resource.Quantity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>retentionPercentage defines the maximum percentage of the data volume&rsquo;s
+capacity used by the Prometheus data.</p>
+<p>The value is a number between 0 and 100. If set to 0, percentage-based
+retention is disabled.</p>
+<p>Unlike <code>spec.retention</code> and <code>spec.retentionSize</code>, Prometheus exposes this
+setting in the configuration file only. It requires Prometheus &gt;= v3.11.0
+and is ignored by older versions.</p>
 </td>
 </tr>
 <tr>
@@ -17006,7 +17027,8 @@ Duration
 <td>
 <em>(Optional)</em>
 <p>retention defines how long to retain the Prometheus data.</p>
-<p>Default: &ldquo;24h&rdquo; if <code>spec.retention</code> and <code>spec.retentionSize</code> are empty.</p>
+<p>Default: &ldquo;24h&rdquo; if <code>spec.retention</code>, <code>spec.retentionSize</code> and
+<code>spec.retentionPercentage</code> are empty.</p>
 </td>
 </tr>
 <tr>
@@ -17021,6 +17043,26 @@ ByteSize
 <td>
 <em>(Optional)</em>
 <p>retentionSize defines the maximum number of bytes used by the Prometheus data.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retentionPercentage</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity">
+k8s.io/apimachinery/pkg/api/resource.Quantity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>retentionPercentage defines the maximum percentage of the data volume&rsquo;s
+capacity used by the Prometheus data.</p>
+<p>The value is a number between 0 and 100. If set to 0, percentage-based
+retention is disabled.</p>
+<p>Unlike <code>spec.retention</code> and <code>spec.retentionSize</code>, Prometheus exposes this
+setting in the configuration file only. It requires Prometheus &gt;= v3.11.0
+and is ignored by older versions.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45184,6 +45184,10 @@ spec:
                   and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: retentionPercentage must be between 0 and 100
+                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
+                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45164,9 +45164,26 @@ spec:
                 description: |-
                   retention defines how long to retain the Prometheus data.
 
-                  Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+                  Default: "24h" if `spec.retention`, `spec.retentionSize` and
+                  `spec.retentionPercentage` are empty.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              retentionPercentage:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  retentionPercentage defines the maximum percentage of the data volume's
+                  capacity used by the Prometheus data.
+
+                  The value is a number between 0 and 100. If set to 0, percentage-based
+                  retention is disabled.
+
+                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
+                  setting in the configuration file only. It requires Prometheus >= v3.11.0
+                  and is ignored by older versions.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45179,9 +45179,7 @@ spec:
                   The value is a number between 0 and 100. If set to 0, percentage-based
                   retention is disabled.
 
-                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
-                  setting in the configuration file only. It requires Prometheus >= v3.11.0
-                  and is ignored by older versions.
+                  It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -45182,10 +45182,6 @@ spec:
                   It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
-                x-kubernetes-validations:
-                - message: retentionPercentage must be between 0 and 100
-                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
-                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8349,6 +8349,10 @@ spec:
                   and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: retentionPercentage must be between 0 and 100
+                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
+                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8344,9 +8344,7 @@ spec:
                   The value is a number between 0 and 100. If set to 0, percentage-based
                   retention is disabled.
 
-                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
-                  setting in the configuration file only. It requires Prometheus >= v3.11.0
-                  and is ignored by older versions.
+                  It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8347,10 +8347,6 @@ spec:
                   It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
-                x-kubernetes-validations:
-                - message: retentionPercentage must be between 0 and 100
-                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
-                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -8329,9 +8329,26 @@ spec:
                 description: |-
                   retention defines how long to retain the Prometheus data.
 
-                  Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+                  Default: "24h" if `spec.retention`, `spec.retentionSize` and
+                  `spec.retentionPercentage` are empty.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              retentionPercentage:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  retentionPercentage defines the maximum percentage of the data volume's
+                  capacity used by the Prometheus data.
+
+                  The value is a number between 0 and 100. If set to 0, percentage-based
+                  retention is disabled.
+
+                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
+                  setting in the configuration file only. It requires Prometheus >= v3.11.0
+                  and is ignored by older versions.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8349,6 +8349,10 @@ spec:
                   and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: retentionPercentage must be between 0 and 100
+                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
+                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8344,9 +8344,7 @@ spec:
                   The value is a number between 0 and 100. If set to 0, percentage-based
                   retention is disabled.
 
-                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
-                  setting in the configuration file only. It requires Prometheus >= v3.11.0
-                  and is ignored by older versions.
+                  It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
                 x-kubernetes-validations:

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8347,10 +8347,6 @@ spec:
                   It requires Prometheus >= v3.11.0 and is ignored by older versions.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
-                x-kubernetes-validations:
-                - message: retentionPercentage must be between 0 and 100
-                  rule: quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100'))
-                    <= 0
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -8329,9 +8329,26 @@ spec:
                 description: |-
                   retention defines how long to retain the Prometheus data.
 
-                  Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+                  Default: "24h" if `spec.retention`, `spec.retentionSize` and
+                  `spec.retentionPercentage` are empty.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
+              retentionPercentage:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  retentionPercentage defines the maximum percentage of the data volume's
+                  capacity used by the Prometheus data.
+
+                  The value is a number between 0 and 100. If set to 0, percentage-based
+                  retention is disabled.
+
+                  Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
+                  setting in the configuration file only. It requires Prometheus >= v3.11.0
+                  and is ignored by older versions.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               retentionSize:
                 description: retentionSize defines the maximum number of bytes used
                   by the Prometheus data.

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7101,7 +7101,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "retentionPercentage defines the maximum percentage of the data volume's\ncapacity used by the Prometheus data.\n\nThe value is a number between 0 and 100. If set to 0, percentage-based\nretention is disabled.\n\nUnlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this\nsetting in the configuration file only. It requires Prometheus >= v3.11.0\nand is ignored by older versions.",
+                    "description": "retentionPercentage defines the maximum percentage of the data volume's\ncapacity used by the Prometheus data.\n\nThe value is a number between 0 and 100. If set to 0, percentage-based\nretention is disabled.\n\nIt requires Prometheus >= v3.11.0 and is ignored by older versions.",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true,
                     "x-kubernetes-validations": [

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7088,9 +7088,22 @@
                     "type": "object"
                   },
                   "retention": {
-                    "description": "retention defines how long to retain the Prometheus data.\n\nDefault: \"24h\" if `spec.retention` and `spec.retentionSize` are empty.",
+                    "description": "retention defines how long to retain the Prometheus data.\n\nDefault: \"24h\" if `spec.retention`, `spec.retentionSize` and\n`spec.retentionPercentage` are empty.",
                     "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
                     "type": "string"
+                  },
+                  "retentionPercentage": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "retentionPercentage defines the maximum percentage of the data volume's\ncapacity used by the Prometheus data.\n\nThe value is a number between 0 and 100. If set to 0, percentage-based\nretention is disabled.\n\nUnlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this\nsetting in the configuration file only. It requires Prometheus >= v3.11.0\nand is ignored by older versions.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
                   },
                   "retentionSize": {
                     "description": "retentionSize defines the maximum number of bytes used by the Prometheus data.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7103,7 +7103,13 @@
                     ],
                     "description": "retentionPercentage defines the maximum percentage of the data volume's\ncapacity used by the Prometheus data.\n\nThe value is a number between 0 and 100. If set to 0, percentage-based\nretention is disabled.\n\nUnlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this\nsetting in the configuration file only. It requires Prometheus >= v3.11.0\nand is ignored by older versions.",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
+                    "x-kubernetes-int-or-string": true,
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "retentionPercentage must be between 0 and 100",
+                        "rule": "quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100')) <= 0"
+                      }
+                    ]
                   },
                   "retentionSize": {
                     "description": "retentionSize defines the maximum number of bytes used by the Prometheus data.",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -7103,13 +7103,7 @@
                     ],
                     "description": "retentionPercentage defines the maximum percentage of the data volume's\ncapacity used by the Prometheus data.\n\nThe value is a number between 0 and 100. If set to 0, percentage-based\nretention is disabled.\n\nIt requires Prometheus >= v3.11.0 and is ignored by older versions.",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true,
-                    "x-kubernetes-validations": [
-                      {
-                        "message": "retentionPercentage must be between 0 and 100",
-                        "rule": "quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100')) <= 0"
-                      }
-                    ]
+                    "x-kubernetes-int-or-string": true
                   },
                   "retentionSize": {
                     "description": "retentionSize defines the maximum number of bytes used by the Prometheus data.",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1222,12 +1222,24 @@ type PrometheusSpec struct {
 
 	// retention defines how long to retain the Prometheus data.
 	//
-	// Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+	// Default: "24h" if `spec.retention`, `spec.retentionSize` and
+	// `spec.retentionPercentage` are empty.
 	// +optional
 	Retention Duration `json:"retention,omitempty"`
 	// retentionSize defines the maximum number of bytes used by the Prometheus data.
 	// +optional
 	RetentionSize ByteSize `json:"retentionSize,omitempty"`
+	// retentionPercentage defines the maximum percentage of the data volume's
+	// capacity used by the Prometheus data.
+	//
+	// The value is a number between 0 and 100. If set to 0, percentage-based
+	// retention is disabled.
+	//
+	// Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
+	// setting in the configuration file only. It requires Prometheus >= v3.11.0
+	// and is ignored by older versions.
+	// +optional
+	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`
 
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
 	//

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1235,9 +1235,7 @@ type PrometheusSpec struct {
 	// The value is a number between 0 and 100. If set to 0, percentage-based
 	// retention is disabled.
 	//
-	// Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
-	// setting in the configuration file only. It requires Prometheus >= v3.11.0
-	// and is ignored by older versions.
+	// It requires Prometheus >= v3.11.0 and is ignored by older versions.
 	// +kubebuilder:validation:XValidation:rule="quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100')) <= 0",message="retentionPercentage must be between 0 and 100"
 	// +optional
 	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1238,6 +1238,7 @@ type PrometheusSpec struct {
 	// Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
 	// setting in the configuration file only. It requires Prometheus >= v3.11.0
 	// and is ignored by older versions.
+	// +kubebuilder:validation:XValidation:rule="quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100')) <= 0",message="retentionPercentage must be between 0 and 100"
 	// +optional
 	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`
 

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -1236,7 +1236,6 @@ type PrometheusSpec struct {
 	// retention is disabled.
 	//
 	// It requires Prometheus >= v3.11.0 and is ignored by older versions.
-	// +kubebuilder:validation:XValidation:rule="quantity(string(self)).compareTo(quantity('0')) >= 0 && quantity(string(self)).compareTo(quantity('100')) <= 0",message="retentionPercentage must be between 0 and 100"
 	// +optional
 	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`
 

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -2773,6 +2773,11 @@ func (in *PrometheusRuleSpec) DeepCopy() *PrometheusRuleSpec {
 func (in *PrometheusSpec) DeepCopyInto(out *PrometheusSpec) {
 	*out = *in
 	in.CommonPrometheusFields.DeepCopyInto(&out.CommonPrometheusFields)
+	if in.RetentionPercentage != nil {
+		in, out := &in.RetentionPercentage, &out.RetentionPercentage
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.ShardRetentionPolicy != nil {
 		in, out := &in.ShardRetentionPolicy, &out.ShardRetentionPolicy
 		*out = new(ShardRetentionPolicy)

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -20,6 +20,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -38,10 +39,21 @@ type PrometheusSpecApplyConfiguration struct {
 	SHA *string `json:"sha,omitempty"`
 	// retention defines how long to retain the Prometheus data.
 	//
-	// Default: "24h" if `spec.retention` and `spec.retentionSize` are empty.
+	// Default: "24h" if `spec.retention`, `spec.retentionSize` and
+	// `spec.retentionPercentage` are empty.
 	Retention *monitoringv1.Duration `json:"retention,omitempty"`
 	// retentionSize defines the maximum number of bytes used by the Prometheus data.
 	RetentionSize *monitoringv1.ByteSize `json:"retentionSize,omitempty"`
+	// retentionPercentage defines the maximum percentage of the data volume's
+	// capacity used by the Prometheus data.
+	//
+	// The value is a number between 0 and 100. If set to 0, percentage-based
+	// retention is disabled.
+	//
+	// Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
+	// setting in the configuration file only. It requires Prometheus >= v3.11.0
+	// and is ignored by older versions.
+	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
 	//
 	// (Beta) Using this mode requires the `PrometheusShardRetentionPolicy` feature gate (enabled by default).
@@ -1081,6 +1093,14 @@ func (b *PrometheusSpecApplyConfiguration) WithRetention(value monitoringv1.Dura
 // If called multiple times, the RetentionSize field is set to the value of the last call.
 func (b *PrometheusSpecApplyConfiguration) WithRetentionSize(value monitoringv1.ByteSize) *PrometheusSpecApplyConfiguration {
 	b.RetentionSize = &value
+	return b
+}
+
+// WithRetentionPercentage sets the RetentionPercentage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RetentionPercentage field is set to the value of the last call.
+func (b *PrometheusSpecApplyConfiguration) WithRetentionPercentage(value resource.Quantity) *PrometheusSpecApplyConfiguration {
+	b.RetentionPercentage = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/prometheusspec.go
@@ -50,9 +50,7 @@ type PrometheusSpecApplyConfiguration struct {
 	// The value is a number between 0 and 100. If set to 0, percentage-based
 	// retention is disabled.
 	//
-	// Unlike `spec.retention` and `spec.retentionSize`, Prometheus exposes this
-	// setting in the configuration file only. It requires Prometheus >= v3.11.0
-	// and is ignored by older versions.
+	// It requires Prometheus >= v3.11.0 and is ignored by older versions.
 	RetentionPercentage *resource.Quantity `json:"retentionPercentage,omitempty"`
 	// shardRetentionPolicy defines the retention policy for the Prometheus shards.
 	//

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -75,13 +76,20 @@ var (
 )
 
 // RetentionTimeOrDefault returns the configured time-based retention or the
-// default retention when neither time nor size are configured.
-func RetentionTimeOrDefault(retention monitoringv1.Duration, retentionSize monitoringv1.ByteSize) monitoringv1.Duration {
-	if retention == "" && retentionSize == "" {
+// default retention when none of time, size and percentage are configured.
+func RetentionTimeOrDefault(retention monitoringv1.Duration, retentionSize monitoringv1.ByteSize, retentionPercentage *resource.Quantity) monitoringv1.Duration {
+	if retention == "" && retentionSize == "" && !RetentionPercentageEnabled(retentionPercentage) {
 		return monitoringv1.Duration(DefaultRetention)
 	}
 
 	return retention
+}
+
+// RetentionPercentageEnabled returns whether the given percentage-based
+// retention is configured. A zero percentage means that percentage-based
+// retention is disabled.
+func RetentionPercentageEnabled(retentionPercentage *resource.Quantity) bool {
+	return retentionPercentage != nil && !retentionPercentage.IsZero()
 }
 
 // LabelSelectorForStatefulSets returns a label selector which selects

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -5513,7 +5513,7 @@ func validateRetentionPercentage(retentionPercentage *resource.Quantity) error {
 	}
 
 	if v := retentionPercentage.AsApproximateFloat64(); v < 0 || v > 100 {
-		return fmt.Errorf("`retentionPercentage` must be between 0 and 100. The current value is %s", retentionPercentage.String())
+		return fmt.Errorf("`retentionPercentage` must be between 0 and 100 (the current value is %q)", retentionPercentage.String())
 	}
 
 	return nil

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -1145,23 +1145,32 @@ func (cg *ConfigGenerator) appendStorageSettingsConfig(
 		}
 	}
 
-	if cg.WithMinimumVersion("3.11.0").IsCompatible() {
-		var retentionSlice yaml.MapSlice
+	var (
+		retentionSlice yaml.MapSlice
+		cgRetention    = cg.WithMinimumVersion("3.11.0")
+	)
+
+	if cgRetention.IsCompatible() {
+		// Starting with v3.11.0, the time and size retention settings are read
+		// from the configuration file instead of the command-line arguments.
 		retentionTime := string(RetentionTimeOrDefault(retention, retentionSize, retentionPercentage))
 		if retentionTime != "" {
 			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "time", Value: retentionTime})
 		}
+
 		if retentionSize != "" {
 			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "size", Value: string(retentionSize)})
 		}
-		if retentionPercentage != nil {
-			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "percentage", Value: retentionPercentage.AsApproximateFloat64()})
-		}
+	}
+
+	// Percentage-based retention has no command-line equivalent, hence it can't
+	// be supported by older Prometheus versions.
+	if retentionPercentage != nil {
+		retentionSlice = cgRetention.AppendMapItem(retentionSlice, "percentage", retentionPercentage.AsApproximateFloat64())
+	}
+
+	if len(retentionSlice) > 0 {
 		tsdbSlice = append(tsdbSlice, yaml.MapItem{Key: "retention", Value: retentionSlice})
-	} else if retentionPercentage != nil {
-		// Percentage-based retention has no command-line equivalent, hence it
-		// can't be supported by older Prometheus versions.
-		cg.WithMinimumVersion("3.11.0").Warn("retentionPercentage")
 	}
 
 	if len(tsdbSlice) > 0 {

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -1055,7 +1056,7 @@ func (cg *ConfigGenerator) GenerateServerConfiguration(
 	})
 
 	// Storage config
-	cfg, err = cg.appendStorageSettingsConfig(cfg, p.Spec.Exemplars, p.Spec.Retention, p.Spec.RetentionSize)
+	cfg, err = cg.appendStorageSettingsConfig(cfg, p.Spec.Exemplars, p.Spec.Retention, p.Spec.RetentionSize, p.Spec.RetentionPercentage)
 	if err != nil {
 		return nil, fmt.Errorf("generating storage_settings configuration failed: %w", err)
 	}
@@ -1097,6 +1098,7 @@ func (cg *ConfigGenerator) appendStorageSettingsConfig(
 	exemplars *monitoringv1.Exemplars,
 	retention monitoringv1.Duration,
 	retentionSize monitoringv1.ByteSize,
+	retentionPercentage *resource.Quantity,
 ) (yaml.MapSlice, error) {
 	var (
 		storage   yaml.MapSlice
@@ -1107,6 +1109,10 @@ func (cg *ConfigGenerator) appendStorageSettingsConfig(
 
 	err := tsdb.Validate()
 	if err != nil {
+		return cfg, err
+	}
+
+	if err := validateRetentionPercentage(retentionPercentage); err != nil {
 		return cfg, err
 	}
 
@@ -1141,14 +1147,21 @@ func (cg *ConfigGenerator) appendStorageSettingsConfig(
 
 	if cg.WithMinimumVersion("3.11.0").IsCompatible() {
 		var retentionSlice yaml.MapSlice
-		retentionTime := string(RetentionTimeOrDefault(retention, retentionSize))
+		retentionTime := string(RetentionTimeOrDefault(retention, retentionSize, retentionPercentage))
 		if retentionTime != "" {
 			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "time", Value: retentionTime})
 		}
 		if retentionSize != "" {
 			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "size", Value: string(retentionSize)})
 		}
+		if retentionPercentage != nil {
+			retentionSlice = append(retentionSlice, yaml.MapItem{Key: "percentage", Value: retentionPercentage.AsApproximateFloat64()})
+		}
 		tsdbSlice = append(tsdbSlice, yaml.MapItem{Key: "retention", Value: retentionSlice})
+	} else if retentionPercentage != nil {
+		// Percentage-based retention has no command-line equivalent, hence it
+		// can't be supported by older Prometheus versions.
+		cg.WithMinimumVersion("3.11.0").Warn("retentionPercentage")
 	}
 
 	if len(tsdbSlice) > 0 {
@@ -5490,6 +5503,20 @@ func (cg *ConfigGenerator) mergeAttachMetadataForTopology(amc *attachMetadataCon
 			Node: new(true),
 		},
 	}
+}
+
+// validateRetentionPercentage validates that the percentage-based retention is
+// within the range supported by Prometheus.
+func validateRetentionPercentage(retentionPercentage *resource.Quantity) error {
+	if retentionPercentage == nil {
+		return nil
+	}
+
+	if v := retentionPercentage.AsApproximateFloat64(); v < 0 || v > 100 {
+		return fmt.Errorf("`retentionPercentage` must be between 0 and 100. The current value is %s", retentionPercentage.String())
+	}
+
+	return nil
 }
 
 // validateChunkEncodingCompatibility validates that the chunk encoding settings

--- a/pkg/prometheus/promcfg_test.go
+++ b/pkg/prometheus/promcfg_test.go
@@ -6191,11 +6191,13 @@ func TestTSDBConfig(t *testing.T) {
 
 func TestRetentionConfigFile(t *testing.T) {
 	for _, tc := range []struct {
-		name          string
-		version       string
-		retention     monitoringv1.Duration
-		retentionSize monitoringv1.ByteSize
-		golden        string
+		name                string
+		version             string
+		retention           monitoringv1.Duration
+		retentionSize       monitoringv1.ByteSize
+		retentionPercentage *resource.Quantity
+		golden              string
+		expectErr           bool
 	}{
 		{
 			name:      "retention.time set with Prometheus >= v3.11.0",
@@ -6217,7 +6219,27 @@ func TestRetentionConfigFile(t *testing.T) {
 			golden:        "RetentionConfigFile_time_size_v3.11.0.golden",
 		},
 		{
-			name:    "retention defaults to 24h when neither field is set with Prometheus >= v3.11.0",
+			name:                "retention.percentage set with Prometheus >= v3.11.0",
+			version:             "v3.11.0",
+			retentionPercentage: resource.NewQuantity(80, resource.DecimalSI),
+			golden:              "RetentionConfigFile_percentage_v3.11.0.golden",
+		},
+		{
+			name:                "retention.time, retention.size and retention.percentage set with Prometheus >= v3.11.0",
+			version:             "v3.11.0",
+			retention:           "2d",
+			retentionSize:       "512MB",
+			retentionPercentage: resource.NewQuantity(80, resource.DecimalSI),
+			golden:              "RetentionConfigFile_time_size_percentage_v3.11.0.golden",
+		},
+		{
+			name:                "retention.time still defaults to 24h when retention.percentage is zero with Prometheus >= v3.11.0",
+			version:             "v3.11.0",
+			retentionPercentage: resource.NewQuantity(0, resource.DecimalSI),
+			golden:              "RetentionConfigFile_zero_percentage_v3.11.0.golden",
+		},
+		{
+			name:    "retention defaults to 24h when no field is set with Prometheus >= v3.11.0",
 			version: "v3.11.0",
 			golden:  "RetentionConfigFile_default_v3.11.0.golden",
 		},
@@ -6228,12 +6250,31 @@ func TestRetentionConfigFile(t *testing.T) {
 			retentionSize: "512MB",
 			golden:        "RetentionConfigFile_v3.10.0.golden",
 		},
+		{
+			name:                "retention.percentage is not in the configuration file for Prometheus < v3.11.0",
+			version:             "v3.10.0",
+			retentionPercentage: resource.NewQuantity(80, resource.DecimalSI),
+			golden:              "RetentionConfigFile_percentage_v3.10.0.golden",
+		},
+		{
+			name:                "retention.percentage > 100",
+			version:             "v3.11.0",
+			retentionPercentage: resource.NewQuantity(101, resource.DecimalSI),
+			expectErr:           true,
+		},
+		{
+			name:                "retention.percentage < 0",
+			version:             "v3.11.0",
+			retentionPercentage: resource.NewQuantity(-1, resource.DecimalSI),
+			expectErr:           true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := defaultPrometheus()
 			p.Spec.CommonPrometheusFields.Version = tc.version
 			p.Spec.Retention = tc.retention
 			p.Spec.RetentionSize = tc.retentionSize
+			p.Spec.RetentionPercentage = tc.retentionPercentage
 
 			cg := mustNewConfigGenerator(t, p)
 			cfg, err := cg.GenerateServerConfiguration(
@@ -6248,6 +6289,10 @@ func TestRetentionConfigFile(t *testing.T) {
 				nil,
 				nil,
 			)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			golden.Assert(t, string(cfg), tc.golden)
 		})

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1344,7 +1344,7 @@ func deadlineExpired(deadline string) (bool, error) {
 // gracePeriodForPrometheusStorage returns how long the Prometheus data can be available based
 // on the retention settings.
 // If Prometheus is configured with size-based and/or percentage-based
-// retention only, it returns a zero value.
+// retention with no time-based retention, it returns a zero value.
 // The function should only be called when the shard retention policy is set to Retain.
 func gracePeriodForPrometheusStorage(p *monitoringv1.Prometheus) (time.Duration, error) {
 	var retention monitoringv1.Duration

--- a/pkg/prometheus/server/operator.go
+++ b/pkg/prometheus/server/operator.go
@@ -1343,15 +1343,15 @@ func deadlineExpired(deadline string) (bool, error) {
 
 // gracePeriodForPrometheusStorage returns how long the Prometheus data can be available based
 // on the retention settings.
-// If Prometheus is configured with size-based retention only, it returns a
-// zero value.
+// If Prometheus is configured with size-based and/or percentage-based
+// retention only, it returns a zero value.
 // The function should only be called when the shard retention policy is set to Retain.
 func gracePeriodForPrometheusStorage(p *monitoringv1.Prometheus) (time.Duration, error) {
 	var retention monitoringv1.Duration
 	if p.Spec.ShardRetentionPolicy.Retain != nil {
 		retention = p.Spec.ShardRetentionPolicy.Retain.RetentionPeriod
 	} else {
-		if p.Spec.RetentionSize != "" && p.Spec.Retention == "" {
+		if p.Spec.Retention == "" && (p.Spec.RetentionSize != "" || prompkg.RetentionPercentageEnabled(p.Spec.RetentionPercentage)) {
 			return time.Duration(0), nil
 		}
 

--- a/pkg/prometheus/server/operator_test.go
+++ b/pkg/prometheus/server/operator_test.go
@@ -486,6 +486,37 @@ func TestGracePeriodForPrometheusStorage(t *testing.T) {
 			expectedDuration: 7 * 24 * time.Hour,
 		},
 		{
+			name: "percentage-only retention returns zero duration",
+			spec: monitoringv1.PrometheusSpec{
+				RetentionPercentage: resource.NewQuantity(80, resource.DecimalSI),
+				ShardRetentionPolicy: &monitoringv1.ShardRetentionPolicy{
+					WhenScaled: new(monitoringv1.RetainWhenScaledRetentionType),
+				},
+			},
+			expectedDuration: 0,
+		},
+		{
+			name: "zero percentage retention falls back to the default duration",
+			spec: monitoringv1.PrometheusSpec{
+				RetentionPercentage: resource.NewQuantity(0, resource.DecimalSI),
+				ShardRetentionPolicy: &monitoringv1.ShardRetentionPolicy{
+					WhenScaled: new(monitoringv1.RetainWhenScaledRetentionType),
+				},
+			},
+			expectedDuration: 24 * time.Hour,
+		},
+		{
+			name: "percentage and time retention uses time-based value",
+			spec: monitoringv1.PrometheusSpec{
+				Retention:           "7d",
+				RetentionPercentage: resource.NewQuantity(80, resource.DecimalSI),
+				ShardRetentionPolicy: &monitoringv1.ShardRetentionPolicy{
+					WhenScaled: new(monitoringv1.RetainWhenScaledRetentionType),
+				},
+			},
+			expectedDuration: 7 * 24 * time.Hour,
+		},
+		{
 			name: "invalid retention returns error",
 			spec: monitoringv1.PrometheusSpec{
 				Retention: "invalid",

--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -433,7 +433,10 @@ func buildServerArgs(cg *prompkg.ConfigGenerator, p *monitoringv1.Prometheus) []
 			retentionTimeFlagValue = prompkg.DefaultRetention
 		}
 	} else {
-		retentionTimeFlagValue = string(prompkg.RetentionTimeOrDefault(p.Spec.Retention, p.Spec.RetentionSize))
+		// The command-line flags are only used by Prometheus < v3.11.0 which
+		// doesn't support percentage-based retention, hence it shouldn't
+		// prevent the default time-based retention from being applied.
+		retentionTimeFlagValue = string(prompkg.RetentionTimeOrDefault(p.Spec.Retention, p.Spec.RetentionSize, nil))
 	}
 
 	// Starting with Prometheus v3.11.0, retention settings are populated in the configuration file.

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -1382,24 +1382,29 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 		version                    string
 		specRetention              monitoringv1.Duration
 		specRetentionSize          monitoringv1.ByteSize
+		specRetentionPercentage    *resource.Quantity
 		expectedRetentionArg       string
 		expectedRetentionSizeArg   string
 		shouldContainRetention     bool
 		shouldContainRetentionSize bool
 	}{
-		{"v2.5.0", "", "", "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=", true, false},
-		{"v2.5.0", "1d", "", "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=", true, false},
-		{"v2.5.0", "", "512MB", "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=512MB", true, false},
-		{"v2.5.0", "1d", "512MB", "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=512MB", true, false},
-		{"v2.7.0", "", "", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
-		{"v2.7.0", "1d", "", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
-		{"v2.7.0", "", "512MB", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
-		{"v2.7.0", "1d", "512MB", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
-		{"v3.10.0", "1d", "512MB", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
-		{"v3.11.0", "", "", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", false, false},
-		{"v3.11.0", "1d", "", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", false, false},
-		{"v3.11.0", "", "512MB", "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, false},
-		{"v3.11.0", "1d", "512MB", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", false, false},
+		{"v2.5.0", "", "", nil, "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.5.0", "1d", "", nil, "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.5.0", "", "512MB", nil, "--storage.tsdb.retention=24h", "--storage.tsdb.retention.size=512MB", true, false},
+		{"v2.5.0", "1d", "512MB", nil, "--storage.tsdb.retention=1d", "--storage.tsdb.retention.size=512MB", true, false},
+		{"v2.7.0", "", "", nil, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "1d", "", nil, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", true, false},
+		{"v2.7.0", "", "512MB", nil, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, true},
+		{"v2.7.0", "1d", "512MB", nil, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		{"v3.10.0", "1d", "512MB", nil, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", true, true},
+		// Percentage-based retention isn't supported before v3.11.0 so it
+		// shouldn't prevent the default time-based retention from being set.
+		{"v3.10.0", "", "", resource.NewQuantity(80, resource.DecimalSI), "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", true, false},
+		{"v3.11.0", "", "", nil, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", false, false},
+		{"v3.11.0", "1d", "", nil, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=", false, false},
+		{"v3.11.0", "", "512MB", nil, "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=512MB", false, false},
+		{"v3.11.0", "1d", "512MB", nil, "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", false, false},
+		{"v3.11.0", "", "", resource.NewQuantity(80, resource.DecimalSI), "--storage.tsdb.retention.time=24h", "--storage.tsdb.retention.size=", false, false},
 	}
 
 	for _, test := range tests {
@@ -1409,8 +1414,9 @@ func TestRetentionAndRetentionSize(t *testing.T) {
 					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 						Version: test.version,
 					},
-					Retention:     test.specRetention,
-					RetentionSize: test.specRetentionSize,
+					Retention:           test.specRetention,
+					RetentionSize:       test.specRetentionSize,
+					RetentionPercentage: test.specRetentionPercentage,
 				},
 			})
 			require.NoError(t, err)

--- a/pkg/prometheus/testdata/RetentionConfigFile_percentage_v3.10.0.golden
+++ b/pkg/prometheus/testdata/RetentionConfigFile_percentage_v3.10.0.golden
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []

--- a/pkg/prometheus/testdata/RetentionConfigFile_percentage_v3.11.0.golden
+++ b/pkg/prometheus/testdata/RetentionConfigFile_percentage_v3.11.0.golden
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+storage:
+  tsdb:
+    retention:
+      percentage: 80

--- a/pkg/prometheus/testdata/RetentionConfigFile_time_size_percentage_v3.11.0.golden
+++ b/pkg/prometheus/testdata/RetentionConfigFile_time_size_percentage_v3.11.0.golden
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+storage:
+  tsdb:
+    retention:
+      time: 2d
+      size: 512MB
+      percentage: 80

--- a/pkg/prometheus/testdata/RetentionConfigFile_zero_percentage_v3.11.0.golden
+++ b/pkg/prometheus/testdata/RetentionConfigFile_zero_percentage_v3.11.0.golden
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+    prometheus_replica: $(POD_NAME)
+  evaluation_interval: 30s
+scrape_configs: []
+storage:
+  tsdb:
+    retention:
+      time: 24h
+      percentage: 0


### PR DESCRIPTION
## Description

Prometheus v3.11.0 exposes `storage.tsdb.retention.percentage` in the configuration
file only, so there's no command-line flag to pass through `additionalArgs`. This adds
`spec.retentionPercentage` and emits it next to the existing time and size settings.

Setting only the percentage no longer falls back to the default 24h time-based
retention, which would otherwise silently override the user's intent. The shard
retention grace period treats percentage-only the same as size-only. Prometheus
< v3.11.0 ignores the field and logs a warning, keeping its current behaviour.

Closes: #8516

## Type of change

- [x] `FEATURE` (non-breaking change which adds functionality)

## Verification

`make test-unit`, `make check`, `make check-api`, `make check-license` and
`make test-prometheus-goldenfiles` all pass locally. New cases cover config
generation (percentage only / with time+size / zero), the < v3.11.0 flag path,
the shard retention grace period, and out-of-range validation.

## Changelog entry

```release-note
Add `spec.retentionPercentage` field to the Prometheus CRD for configuring `storage.tsdb.retention.percentage` (requires Prometheus >= v3.11.0).
```

---

Assisted by Claude Code; I reviewed the change and ran the checks above myself.
