### PR TITLE
feat: add goheader linter to enforce license header

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - exptostd
     - godot
     - godoclint
+    - goheader
     - iface
     - importas
     - iotamixing
@@ -34,6 +35,25 @@ linters:
       exclude-functions:
         # Any error in HTTP handlers is handled by the server itself.
         - (net/http.ResponseWriter).Write
+    goheader:
+      values:
+        const:
+          COMPANY: The prometheus-operator Authors
+      template: |-
+        Copyright {{ COMPANY }}
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+      
     importas:
       alias:
         # Kubernetes

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/namespacelabeler/labeler_test.go
+++ b/pkg/namespacelabeler/labeler_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package namespacelabeler
 
 import (


### PR DESCRIPTION
## Description

_Enable the `goheader` linter in `.golangci.yml` to enforce the Apache 2.0 license header across all Go source files, and fix 2 existing files whose headers didn't match the expected template._

Consistent license headers are important for open-source projects. The `goheader` linter automatically checks that every `.go` file starts with the correct Apache 2.0 header, catching formatting inconsistencies like the ones fixed in this PR.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Ran `golangci-lint run` locally — all files pass the new `goheader` check. CI should also pass as only lint/ formatting changes are included.

## Changelog entry

```release-note
Enable goheader linter to enforce Apache 2.0 license header consistency.
```