### PR TITLE
fix: restrict kubelet Endpoints to the service's primary IP family

### DIFF
--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -335,6 +335,10 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 			continue
 		}
 
+		// A node with several interfaces reports several addresses per family,
+		// all reaching the same kubelet.
+		var seenIPv4, seenIPv6 bool
+
 		for _, address := range nodeIPs {
 			ip := net.ParseIP(address)
 			if ip == nil {
@@ -342,12 +346,26 @@ func (c *Controller) getNodeAddresses(nodes []corev1.Node) ([]nodeAddress, []err
 				continue
 			}
 
+			ipv4 := ip.To4() != nil
+			if ipv4 && seenIPv4 {
+				continue
+			}
+			if !ipv4 && seenIPv6 {
+				continue
+			}
+
+			if ipv4 {
+				seenIPv4 = true
+			} else {
+				seenIPv6 = true
+			}
+
 			na := nodeAddress{
 				ipAddress:  address,
 				name:       n.Name,
 				uid:        n.UID,
 				apiVersion: n.APIVersion,
-				ipv4:       ip.To4() != nil,
+				ipv4:       ipv4,
 				ready:      nodeReadyConditionKnown(n),
 			}
 			addresses = append(addresses, na)
@@ -413,7 +431,7 @@ func (c *Controller) sync(ctx context.Context) {
 
 	if c.manageEndpoints {
 		c.nodeEndpointSyncs.WithLabelValues(endpointsLabel).Inc()
-		if err = c.syncEndpoints(ctx, addresses); err != nil {
+		if err = c.syncEndpoints(ctx, svc, addresses); err != nil {
 			c.nodeEndpointSyncErrors.WithLabelValues(endpointsLabel).Inc()
 			c.logger.Error("Failed to synchronize kubelet endpoints", "err", err)
 		}
@@ -428,8 +446,48 @@ func (c *Controller) sync(ctx context.Context) {
 	}
 }
 
-func (c *Controller) syncEndpoints(ctx context.Context, addresses []nodeAddress) error {
+// singleAddressPerNode returns one address per node, preferring the service's
+// primary IP family. The Endpoints API has no address family filter, unlike the
+// endpointslice one, so keeping every address would make Prometheus scrape
+// dual-stack nodes once per address. Nodes reporting no address of the primary
+// family keep their first address rather than being dropped.
+func singleAddressPerNode(svc *corev1.Service, addresses []nodeAddress) []nodeAddress {
+	var primaryIPv4, hasPrimary bool
+	if svc != nil && len(svc.Spec.IPFamilies) > 0 {
+		hasPrimary = true
+		primaryIPv4 = svc.Spec.IPFamilies[0] == corev1.IPv4Protocol
+	}
+
+	indexes := make(map[string]int, len(addresses))
+
+	filtered := make([]nodeAddress, 0, len(addresses))
+	for _, a := range addresses {
+		i, found := indexes[a.name]
+		if !found {
+			indexes[a.name] = len(filtered)
+			filtered = append(filtered, a)
+
+			continue
+		}
+
+		if !hasPrimary {
+			continue
+		}
+
+		if a.ipv4 != primaryIPv4 {
+			continue
+		}
+
+		filtered[i] = a
+	}
+
+	return filtered
+}
+
+func (c *Controller) syncEndpoints(ctx context.Context, svc *corev1.Service, addresses []nodeAddress) error {
 	c.logger.Debug("Sync endpoints")
+
+	addresses = singleAddressPerNode(svc, addresses)
 
 	//nolint:staticcheck // Ignore SA1019 Endpoints is marked as deprecated.
 	eps := &corev1.Endpoints{

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -274,6 +276,44 @@ func TestGetNodeAddresses(t *testing.T) {
 				},
 			},
 			expectedAddresses: []string{"10.0.0.1", "fd00::1"},
+			expectedErrors:    0,
+		},
+		{
+			name: "node with several addresses of the same family keeps the first of each",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Address: "fd00::1",
+								Type:    corev1.NodeInternalIP,
+							},
+							{
+								Address: "fd01::1",
+								Type:    corev1.NodeInternalIP,
+							},
+							{
+								Address: "10.0.0.1",
+								Type:    corev1.NodeInternalIP,
+							},
+							{
+								Address: "10.0.1.1",
+								Type:    corev1.NodeInternalIP,
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedAddresses: []string{"fd00::1", "10.0.0.1"},
 			expectedErrors:    0,
 		},
 	} {
@@ -566,6 +606,307 @@ func TestSync(t *testing.T) {
 
 		_ = listEndpointSlices(t, esclient, 0)
 	})
+}
+
+func TestSyncDualStackNode(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		nodeAddresses     []string
+		ipFamilies        []corev1.IPFamily
+		expectedAddresses []string
+	}{
+		{
+			name:              "IPv4 primary service keeps the IPv4 address",
+			nodeAddresses:     []string{"10.0.0.1", "fd00::1"},
+			ipFamilies:        []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+			expectedAddresses: []string{"10.0.0.1"},
+		},
+		{
+			name:              "IPv6 primary service keeps the IPv6 address",
+			nodeAddresses:     []string{"10.0.0.1", "fd00::1"},
+			ipFamilies:        []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+			expectedAddresses: []string{"fd00::1"},
+		},
+		{
+			name:              "service without IP family keeps one address per node",
+			nodeAddresses:     []string{"10.0.0.1", "fd00::1"},
+			expectedAddresses: []string{"10.0.0.1"},
+		},
+		{
+			name:              "node with several addresses of the same family keeps one",
+			nodeAddresses:     []string{"10.0.0.1", "10.0.1.1", "fd00::1", "fd01::1"},
+			ipFamilies:        []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+			expectedAddresses: []string{"fd00::1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				ctx        = context.Background()
+				id         = int32(0)
+				fakeClient = fake.NewClientset()
+			)
+
+			fakeClient.PrependReactor(
+				"create", "*",
+				func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					ret = action.(ktesting.CreateAction).GetObject()
+					meta, ok := ret.(metav1.Object)
+					if !ok {
+						return
+					}
+
+					if meta.GetName() == "" && meta.GetGenerateName() != "" {
+						meta.SetName(names.SimpleNameGenerator.GenerateName(meta.GetGenerateName()))
+						meta.SetUID(types.UID(string('A' + id)))
+						id++
+					}
+
+					return
+				},
+			)
+
+			c, err := New(
+				newLogger(),
+				fakeClient,
+				nil,
+				"kubelet",
+				"test",
+				"",
+				nil,
+				nil,
+				WithEndpoints(), WithEndpointSlice(), WithMaxEndpointsPerSlice(2), WithNodeAddressPriority("internal"),
+			)
+			require.NoError(t, err)
+
+			_, err = c.kclient.CoreV1().Services(c.kubeletObjectNamespace).Create(
+				ctx,
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      c.kubeletObjectName,
+						Namespace: c.kubeletObjectNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						Type:       corev1.ServiceTypeClusterIP,
+						ClusterIP:  corev1.ClusterIPNone,
+						IPFamilies: tc.ipFamilies,
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			nodeAddresses := make([]corev1.NodeAddress, 0, len(tc.nodeAddresses))
+			for _, a := range tc.nodeAddresses {
+				nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+					Address: a,
+					Type:    corev1.NodeInternalIP,
+				})
+			}
+
+			_, err = c.kclient.CoreV1().Nodes().Create(
+				ctx,
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+						UID:  types.UID("node-0"),
+					},
+					Status: corev1.NodeStatus{
+						Addresses: nodeAddresses,
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			c.sync(ctx)
+
+			ep, err := c.kclient.CoreV1().Endpoints(c.kubeletObjectNamespace).Get(ctx, c.kubeletObjectName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Len(t, ep.Subsets, 1)
+
+			addresses := make([]string, 0, len(ep.Subsets[0].Addresses))
+			for _, a := range ep.Subsets[0].Addresses {
+				addresses = append(addresses, a.IP)
+			}
+			require.Equal(t, tc.expectedAddresses, addresses)
+
+			// The endpointslices keep both families whatever the primary one is.
+			eps := listEndpointSlices(t, c.kclient.DiscoveryV1().EndpointSlices(c.kubeletObjectNamespace), 2)
+
+			byAddressType := map[discoveryv1.AddressType]string{}
+			for _, e := range eps {
+				require.Len(t, e.Endpoints, 1)
+				require.Len(t, e.Endpoints[0].Addresses, 1)
+				byAddressType[e.AddressType] = e.Endpoints[0].Addresses[0]
+			}
+			require.Equal(
+				t,
+				map[discoveryv1.AddressType]string{
+					discoveryv1.AddressTypeIPv4: "10.0.0.1",
+					discoveryv1.AddressTypeIPv6: "fd00::1",
+				},
+				byAddressType,
+			)
+		})
+	}
+}
+
+func TestSyncEndpointsWhenServiceSyncFails(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		fakeClient = fake.NewClientset()
+	)
+
+	fakeClient.PrependReactor(
+		"get", "services",
+		func(_ ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("apiserver is down"))
+		},
+	)
+
+	c, err := New(
+		newLogger(),
+		fakeClient,
+		nil,
+		"kubelet",
+		"test",
+		"",
+		nil,
+		nil,
+		WithEndpoints(), WithNodeAddressPriority("internal"),
+	)
+	require.NoError(t, err)
+
+	_, err = c.kclient.CoreV1().Nodes().Create(
+		ctx,
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				UID:  types.UID("node-0"),
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{
+						Address: "10.0.0.1",
+						Type:    corev1.NodeInternalIP,
+					},
+					{
+						Address: "fd00::1",
+						Type:    corev1.NodeInternalIP,
+					},
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	c.sync(ctx)
+
+	ep, err := c.kclient.CoreV1().Endpoints(c.kubeletObjectNamespace).Get(ctx, c.kubeletObjectName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ep.Subsets, 1)
+
+	addresses := make([]string, 0, len(ep.Subsets[0].Addresses))
+	for _, a := range ep.Subsets[0].Addresses {
+		addresses = append(addresses, a.IP)
+	}
+	require.Equal(t, []string{"10.0.0.1"}, addresses)
+}
+
+func TestSyncEndpointsNodeWithoutPrimaryFamilyAddress(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		fakeClient = fake.NewClientset()
+	)
+
+	c, err := New(
+		newLogger(),
+		fakeClient,
+		nil,
+		"kubelet",
+		"test",
+		"",
+		nil,
+		nil,
+		WithEndpoints(), WithNodeAddressPriority("internal"),
+	)
+	require.NoError(t, err)
+
+	_, err = c.kclient.CoreV1().Services(c.kubeletObjectNamespace).Create(
+		ctx,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      c.kubeletObjectName,
+				Namespace: c.kubeletObjectNamespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Type:       corev1.ServiceTypeClusterIP,
+				ClusterIP:  corev1.ClusterIPNone,
+				IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	for _, n := range [][]string{
+		{"node-0", "10.0.0.1", "fd00::1"},
+		{"node-1", "10.0.0.2"},
+	} {
+		nodeAddresses := make([]corev1.NodeAddress, 0, len(n)-1)
+		for _, a := range n[1:] {
+			nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+				Address: a,
+				Type:    corev1.NodeInternalIP,
+			})
+		}
+
+		_, err = c.kclient.CoreV1().Nodes().Create(
+			ctx,
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: n[0],
+					UID:  types.UID(n[0]),
+				},
+				Status: corev1.NodeStatus{
+					Addresses: nodeAddresses,
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+
+	c.sync(ctx)
+
+	ep, err := c.kclient.CoreV1().Endpoints(c.kubeletObjectNamespace).Get(ctx, c.kubeletObjectName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, ep.Subsets, 1)
+
+	nodes := make([]string, 0, len(ep.Subsets[0].Addresses))
+	for _, a := range ep.Subsets[0].Addresses {
+		nodes = append(nodes, *a.NodeName)
+	}
+	require.Equal(t, []string{"node-0", "node-1"}, nodes)
 }
 
 func newNode(name, address string) *corev1.Node {


### PR DESCRIPTION
## Description

Since #8682 every node address lands in the kubelet Endpoints object, so a dual-stack node is scraped once per address. The `endpoints` role has no address family filter, unlike `endpointslice`. The Endpoints API represents a single IP family, so keep only the service's primary one. The endpointslices are unchanged.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

`TestSyncDualStackNode` covers IPv4-primary, IPv6-primary and a service with no declared family. The first two fail without the change. `go test ./pkg/kubelet/` and `golangci-lint run ./pkg/kubelet/...` pass.

## Changelog entry

```release-note
Fix duplicate kubelet targets for nodes reporting several addresses of the same IP family.
```