### PR TITLE
fix: avoid panic when the kubelet service sync fails

### DIFF
--- a/pkg/kubelet/controller.go
+++ b/pkg/kubelet/controller.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -496,6 +497,10 @@ func (c *Controller) syncService(ctx context.Context) (*corev1.Service, error) {
 
 func (c *Controller) syncEndpointSlice(ctx context.Context, svc *corev1.Service, addresses []nodeAddress) error {
 	c.logger.Debug("Sync endpointslice")
+
+	if svc == nil {
+		return errors.New("kubelet service not available")
+	}
 
 	// Get the list of endpointslice objects associated to the service.
 	client := c.kclient.DiscoveryV1().EndpointSlices(c.kubeletObjectNamespace)

--- a/pkg/kubelet/controller_test.go
+++ b/pkg/kubelet/controller_test.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -566,6 +568,40 @@ func TestSync(t *testing.T) {
 
 		_ = listEndpointSlices(t, esclient, 0)
 	})
+}
+
+func TestSyncEndpointSliceWhenServiceSyncFails(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		fakeClient = fake.NewClientset()
+	)
+
+	fakeClient.PrependReactor(
+		"get", "services",
+		func(_ ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("apiserver is down"))
+		},
+	)
+
+	c, err := New(
+		newLogger(),
+		fakeClient,
+		nil,
+		"kubelet",
+		"test",
+		"",
+		nil,
+		nil,
+		WithEndpoints(), WithEndpointSlice(), WithMaxEndpointsPerSlice(2), WithNodeAddressPriority("internal"),
+	)
+	require.NoError(t, err)
+
+	_, err = c.kclient.CoreV1().Nodes().Create(ctx, newNode("node-0", "10.0.0.1"), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	c.sync(ctx)
+
+	_ = listEndpointSlices(t, c.kclient.DiscoveryV1().EndpointSlices(c.kubeletObjectNamespace), 0)
 }
 
 func newNode(name, address string) *corev1.Node {


### PR DESCRIPTION
## Description

`sync()` carries on after `syncService()` fails, so `svc` is nil and `syncEndpointSlice()` panics dereferencing it for the owner reference. Return an error instead.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

`TestSyncEndpointSliceWhenServiceSyncFails` panics without the change.

## Changelog entry

```release-note
Fix panic in the kubelet controller when the kubelet service cannot be synchronized.
```