### PR TITLE
chore: embed timezone information

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata" // Embed timezone information which is required by the Alertmanager controller.
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus/promhttp"


### PR DESCRIPTION
## Description

This commit imports `time/tzdata` which embeds the timezone information in the binary (the Alertmanager controller depends on Alertmanager which may look up time locations when used in mute/active intervals).

While not strictly required, it helps downstream consumers which may use scratch/distroless images not including zone information like traditional OSes do.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
