### PR TITLE
Feat: add test case for Alertmanager Config validation Slack receiver

### DIFF
--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -735,7 +735,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "Test fail to validate on slack config - valid action fields - invalid fields field",
+			name: "Test validate on slack config - all fields valid",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -769,7 +769,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "Test fail to validate on slack config - valid action fields - invalid fields field",
+			name: "Test validate on slack config - valid action fields - invalid fields field",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -803,7 +803,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on slack config - invalid action fields missing type",
+			name: "Test validate on slack config - invalid action fields missing type",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -836,7 +836,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on slack config - invalid action fields missing text",
+			name: "Test validate on slack config - invalid action fields missing text",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -869,7 +869,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on slack config - invalid action fields missing url and name",
+			name: "Test validate on slack config - invalid action fields missing url and name",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -901,7 +901,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on slack config - invalid action fields missing text in confirm field",
+			name: "Test validate on slack config - invalid action fields missing text in confirm field",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -68,40 +68,6 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on slack config - valid action fields - invalid fields field",
-			in: &monitoringv1beta1.AlertmanagerConfig{
-				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
-					Receivers: []monitoringv1beta1.Receiver{
-						{
-							Name: "same",
-						},
-						{
-							Name: "different",
-							SlackConfigs: []monitoringv1beta1.SlackConfig{
-								{
-									Actions: []monitoringv1beta1.SlackAction{
-										{
-											Type: "a",
-											Text: "b",
-											URL:  "www.test.com",
-											Name: new("c"),
-											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
-												Text: "d",
-											},
-										},
-									},
-									Fields: []monitoringv1beta1.SlackField{
-										{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-		{
 			name: "Test fail to validate wechat config - invalid URL",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
@@ -757,6 +723,64 @@ func TestValidatePagerDutyAlertmanagerConfig(t *testing.T) {
 					return
 				}
 				t.Errorf("got error but expected none - %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateSlackAlertmanagerConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		in        *monitoringv1beta1.AlertmanagerConfig
+		expectErr bool
+	}{
+		{
+			name: "Test fail to validate on slack config - valid action fields - invalid fields field",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type: "a",
+											Text: "b",
+											URL:  "www.test.com",
+											Name: new("c"),
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
+												Text: "d",
+											},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAlertmanagerConfig(tc.in)
+			if tc.expectErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if err != nil {
+				if tc.expectErr {
+					return
+				}
+				t.Errorf("got error but expected none -%s", err.Error())
 			}
 		})
 	}

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -758,6 +758,40 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 										},
 									},
 									Fields: []monitoringv1beta1.SlackField{
+										{Title: "a", Value: "b"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Test fail to validate on slack config - valid action fields - invalid fields field",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type: "a",
+											Text: "b",
+											URL:  "www.test.com",
+											Name: new("c"),
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
+												Text: "d",
+											},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
 										{},
 									},
 								},
@@ -782,7 +816,6 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 								{
 									Actions: []monitoringv1beta1.SlackAction{
 										{
-											Type: "",
 											Text: "b",
 											URL:  "www.test.com",
 											Name: new("c"),
@@ -792,7 +825,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 										},
 									},
 									Fields: []monitoringv1beta1.SlackField{
-										{},
+										{Title: "a", Value: "b"},
 									},
 								},
 							},
@@ -817,7 +850,6 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 									Actions: []monitoringv1beta1.SlackAction{
 										{
 											Type: "a",
-											Text: "",
 											URL:  "www.test.com",
 											Name: new("c"),
 											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
@@ -826,7 +858,7 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 										},
 									},
 									Fields: []monitoringv1beta1.SlackField{
-										{},
+										{Title: "a", Value: "b"},
 									},
 								},
 							},
@@ -852,14 +884,13 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 										{
 											Type: "a",
 											Text: "b",
-											URL:  "",
 											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
 												Text: "d",
 											},
 										},
 									},
 									Fields: []monitoringv1beta1.SlackField{
-										{},
+										{Title: "a", Value: "b"},
 									},
 								},
 							},

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -768,6 +768,139 @@ func TestValidateSlackAlertmanagerConfig(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "Test fail to validate on slack config - invalid action fields missing type",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type: "",
+											Text: "b",
+											URL:  "www.test.com",
+											Name: new("c"),
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
+												Text: "d",
+											},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate on slack config - invalid action fields missing text",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type: "a",
+											Text: "",
+											URL:  "www.test.com",
+											Name: new("c"),
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
+												Text: "d",
+											},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate on slack config - invalid action fields missing url and name",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type: "a",
+											Text: "b",
+											URL:  "",
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{
+												Text: "d",
+											},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Test fail to validate on slack config - invalid action fields missing text in confirm field",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							SlackConfigs: []monitoringv1beta1.SlackConfig{
+								{
+									Actions: []monitoringv1beta1.SlackAction{
+										{
+											Type:         "a",
+											Text:         "b",
+											URL:          "www.test.com",
+											Name:         new("c"),
+											ConfirmField: &monitoringv1beta1.SlackConfirmationField{},
+										},
+									},
+									Fields: []monitoringv1beta1.SlackField{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds test case coverage for Alertmanager Config validation Slack receiver

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Add test coverage for Slack receiver in AlertmanagerConfig validation
```
