### PR TITLE
fix: emit repeated flags for Thanos gRPC TLS ciphers and curves

### DIFF
--- a/pkg/prometheus/server/statefulset.go
+++ b/pkg/prometheus/server/statefulset.go
@@ -19,7 +19,6 @@ import (
 	"maps"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	appsv1 "k8s.io/api/apps/v1"
@@ -598,11 +597,15 @@ func createThanosContainer(p *monitoringv1.Prometheus, c prompkg.Config, compact
 		}
 
 		if len(tls.CipherSuites) > 0 && thanosVersion.GTE(semver.MustParse("0.42.0")) {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-ciphers", Value: strings.Join(tls.CipherSuites, ",")})
+			for _, cs := range tls.CipherSuites {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-ciphers", Value: cs})
+			}
 		}
 
 		if len(tls.Curves) > 0 && thanosVersion.GTE(semver.MustParse("0.42.0")) {
-			thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-curves", Value: strings.Join(tls.Curves, ",")})
+			for _, c := range tls.Curves {
+				thanosArgs = append(thanosArgs, monitoringv1.Argument{Name: "grpc-server-tls-curves", Value: c})
+			}
 		}
 	}
 

--- a/pkg/prometheus/server/statefulset_test.go
+++ b/pkg/prometheus/server/statefulset_test.go
@@ -2769,8 +2769,13 @@ func TestGRPCServerTLSCipherSuites(t *testing.T) {
 			require.NoError(t, err)
 
 			thanosArgs := sset.Spec.Template.Spec.Containers[2].Args
-			expectedArg := "--grpc-server-tls-ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"
-			require.Equal(t, tc.shouldHaveArg, slices.Contains(thanosArgs, expectedArg))
+			expectedArgs := []string{
+				"--grpc-server-tls-ciphers=TLS_AES_128_GCM_SHA256",
+				"--grpc-server-tls-ciphers=TLS_AES_256_GCM_SHA384",
+			}
+			for _, expectedArg := range expectedArgs {
+				require.Equal(t, tc.shouldHaveArg, slices.Contains(thanosArgs, expectedArg), "expected %q presence to be %v", expectedArg, tc.shouldHaveArg)
+			}
 		})
 	}
 }
@@ -2817,8 +2822,13 @@ func TestGRPCServerTLSCurves(t *testing.T) {
 			require.NoError(t, err)
 
 			thanosArgs := sset.Spec.Template.Spec.Containers[2].Args
-			expectedArg := "--grpc-server-tls-curves=CurveP256,X25519"
-			require.Equal(t, tc.shouldHaveArg, slices.Contains(thanosArgs, expectedArg))
+			expectedArgs := []string{
+				"--grpc-server-tls-curves=CurveP256",
+				"--grpc-server-tls-curves=X25519",
+			}
+			for _, expectedArg := range expectedArgs {
+				require.Equal(t, tc.shouldHaveArg, slices.Contains(thanosArgs, expectedArg), "expected %q presence to be %v", expectedArg, tc.shouldHaveArg)
+			}
 		})
 	}
 }

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -325,11 +325,15 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 		}
 
 		if len(tls.CipherSuites) > 0 && version.GTE(semver.MustParse("0.42.0")) {
-			trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "grpc-server-tls-ciphers", Value: strings.Join(tls.CipherSuites, ",")})
+			for _, cs := range tls.CipherSuites {
+				trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "grpc-server-tls-ciphers", Value: cs})
+			}
 		}
 
 		if len(tls.Curves) > 0 && version.GTE(semver.MustParse("0.42.0")) {
-			trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "grpc-server-tls-curves", Value: strings.Join(tls.Curves, ",")})
+			for _, c := range tls.Curves {
+				trCLIArgs = append(trCLIArgs, monitoringv1.Argument{Name: "grpc-server-tls-curves", Value: c})
+			}
 		}
 	}
 

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -790,8 +790,13 @@ func TestGRPCServerTLSCipherSuites(t *testing.T) {
 			require.NoError(t, err)
 
 			trArgs := sset.Spec.Template.Spec.Containers[0].Args
-			expectedArg := "--grpc-server-tls-ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"
-			require.Equal(t, tc.shouldHaveArg, slices.Contains(trArgs, expectedArg))
+			expectedArgs := []string{
+				"--grpc-server-tls-ciphers=TLS_AES_128_GCM_SHA256",
+				"--grpc-server-tls-ciphers=TLS_AES_256_GCM_SHA384",
+			}
+			for _, expectedArg := range expectedArgs {
+				require.Equal(t, tc.shouldHaveArg, slices.Contains(trArgs, expectedArg), "expected %q presence to be %v", expectedArg, tc.shouldHaveArg)
+			}
 		})
 	}
 }
@@ -838,8 +843,13 @@ func TestGRPCServerTLSCurves(t *testing.T) {
 			require.NoError(t, err)
 
 			trArgs := sset.Spec.Template.Spec.Containers[0].Args
-			expectedArg := "--grpc-server-tls-curves=CurveP256,X25519"
-			require.Equal(t, tc.shouldHaveArg, slices.Contains(trArgs, expectedArg))
+			expectedArgs := []string{
+				"--grpc-server-tls-curves=CurveP256",
+				"--grpc-server-tls-curves=X25519",
+			}
+			for _, expectedArg := range expectedArgs {
+				require.Equal(t, tc.shouldHaveArg, slices.Contains(trArgs, expectedArg), "expected %q presence to be %v", expectedArg, tc.shouldHaveArg)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The --grpc-server-tls-ciphers and --grpc-server-tls-curves flags in Thanos are defined with kingpin's StringsVar, which accumulates values from repeated flag invocations. It does not split a single comma-separated value.

Previously the operator joined all cipher suites and curves into a single comma-separated value (e.g.
--grpc-server-tls-ciphers=cipher1,cipher2), causing Thanos to treat the entire string as one cipher name and fail with 'invalid cipher suite'.

Emit one flag per value instead, producing repeated flags that kingpin can parse correctly (e.g. --grpc-server-tls-ciphers=cipher1 --grpc-server-tls-ciphers=cipher2).

Assisted-by: claude-opus-4-6

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
