### PR TITLE
feat: clusterpeername spec

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -792,6 +792,26 @@ GoDuration
 </tr>
 <tr>
 <td>
+<code>clusterPeerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>clusterPeerName defines the name that this Alertmanager instance uses to
+advertise itself to other cluster peers (the <code>--cluster.peer-name</code> flag,
+available since Alertmanager v0.30.0).</p>
+<p>If not set, the operator defaults to the pod&rsquo;s name (<code>$(POD_NAME)</code>),
+which is injected via the Kubernetes downward API. Setting this field
+lets you override that default with either a literal value or a string
+referencing environment variables that are already available in the
+Alertmanager container (for example <code>$(POD_NAME).$(NAMESPACE)</code>).</p>
+<p>This field only takes effect for Alertmanager v0.30.0 and above.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>portName</code><br/>
 <em>
 string
@@ -7397,6 +7417,26 @@ GoDuration
 <td>
 <em>(Optional)</em>
 <p>clusterPeerTimeout defines the timeout for cluster peering.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterPeerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>clusterPeerName defines the name that this Alertmanager instance uses to
+advertise itself to other cluster peers (the <code>--cluster.peer-name</code> flag,
+available since Alertmanager v0.30.0).</p>
+<p>If not set, the operator defaults to the pod&rsquo;s name (<code>$(POD_NAME)</code>),
+which is injected via the Kubernetes downward API. Setting this field
+lets you override that default with either a literal value or a string
+referencing environment variables that are already available in the
+Alertmanager container (for example <code>$(POD_NAME).$(NAMESPACE)</code>).</p>
+<p>This field only takes effect for Alertmanager v0.30.0 and above.</p>
 </td>
 </tr>
 <tr>

--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -807,7 +807,7 @@ which is injected via the Kubernetes downward API. Setting this field
 lets you override that default with either a literal value or a string
 referencing environment variables that are already available in the
 Alertmanager container (for example <code>$(POD_NAME).$(NAMESPACE)</code>).</p>
-<p>This field only takes effect for Alertmanager v0.30.0 and above.</p>
+<p>/ It requires Alertmanager &gt;= 0.30.0.</p>
 </td>
 </tr>
 <tr>
@@ -7436,7 +7436,7 @@ which is injected via the Kubernetes downward API. Setting this field
 lets you override that default with either a literal value or a string
 referencing environment variables that are already available in the
 Alertmanager container (for example <code>$(POD_NAME).$(NAMESPACE)</code>).</p>
-<p>This field only takes effect for Alertmanager v0.30.0 and above.</p>
+<p>/ It requires Alertmanager &gt;= 0.30.0.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14894,7 +14894,8 @@ spec:
                   referencing environment variables that are already available in the
                   Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
 
-                  This field only takes effect for Alertmanager v0.30.0 and above.
+                  / It requires Alertmanager >= 0.30.0.
+                minLength: 1
                 type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -14882,6 +14882,20 @@ spec:
                   clusterLabel defines the identifier that uniquely identifies the Alertmanager cluster.
                   You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
                 type: string
+              clusterPeerName:
+                description: |-
+                  clusterPeerName defines the name that this Alertmanager instance uses to
+                  advertise itself to other cluster peers (the `--cluster.peer-name` flag,
+                  available since Alertmanager v0.30.0).
+
+                  If not set, the operator defaults to the pod's name (`$(POD_NAME)`),
+                  which is injected via the Kubernetes downward API. Setting this field
+                  lets you override that default with either a literal value or a string
+                  referencing environment variables that are already available in the
+                  Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
+
+                  This field only takes effect for Alertmanager v0.30.0 and above.
+                type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2500,6 +2500,20 @@ spec:
                   clusterLabel defines the identifier that uniquely identifies the Alertmanager cluster.
                   You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
                 type: string
+              clusterPeerName:
+                description: |-
+                  clusterPeerName defines the name that this Alertmanager instance uses to
+                  advertise itself to other cluster peers (the `--cluster.peer-name` flag,
+                  available since Alertmanager v0.30.0).
+
+                  If not set, the operator defaults to the pod's name (`$(POD_NAME)`),
+                  which is injected via the Kubernetes downward API. Setting this field
+                  lets you override that default with either a literal value or a string
+                  referencing environment variables that are already available in the
+                  Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
+
+                  This field only takes effect for Alertmanager v0.30.0 and above.
+                type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagers.yaml
@@ -2512,7 +2512,8 @@ spec:
                   referencing environment variables that are already available in the
                   Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
 
-                  This field only takes effect for Alertmanager v0.30.0 and above.
+                  / It requires Alertmanager >= 0.30.0.
+                minLength: 1
                 type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2500,6 +2500,20 @@ spec:
                   clusterLabel defines the identifier that uniquely identifies the Alertmanager cluster.
                   You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
                 type: string
+              clusterPeerName:
+                description: |-
+                  clusterPeerName defines the name that this Alertmanager instance uses to
+                  advertise itself to other cluster peers (the `--cluster.peer-name` flag,
+                  available since Alertmanager v0.30.0).
+
+                  If not set, the operator defaults to the pod's name (`$(POD_NAME)`),
+                  which is injected via the Kubernetes downward API. Setting this field
+                  lets you override that default with either a literal value or a string
+                  referencing environment variables that are already available in the
+                  Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
+
+                  This field only takes effect for Alertmanager v0.30.0 and above.
+                type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
@@ -2512,7 +2512,8 @@ spec:
                   referencing environment variables that are already available in the
                   Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
 
-                  This field only takes effect for Alertmanager v0.30.0 and above.
+                  / It requires Alertmanager >= 0.30.0.
+                minLength: 1
                 type: string
               clusterPeerTimeout:
                 description: clusterPeerTimeout defines the timeout for cluster peering.

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2235,6 +2235,10 @@
                     "description": "clusterLabel defines the identifier that uniquely identifies the Alertmanager cluster.\nYou should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.",
                     "type": "string"
                   },
+                  "clusterPeerName": {
+                    "description": "clusterPeerName defines the name that this Alertmanager instance uses to\nadvertise itself to other cluster peers (the `--cluster.peer-name` flag,\navailable since Alertmanager v0.30.0).\n\nIf not set, the operator defaults to the pod's name (`$(POD_NAME)`),\nwhich is injected via the Kubernetes downward API. Setting this field\nlets you override that default with either a literal value or a string\nreferencing environment variables that are already available in the\nAlertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).\n\nThis field only takes effect for Alertmanager v0.30.0 and above.",
+                    "type": "string"
+                  },
                   "clusterPeerTimeout": {
                     "description": "clusterPeerTimeout defines the timeout for cluster peering.",
                     "pattern": "^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",

--- a/jsonnet/prometheus-operator/alertmanagers-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagers-crd.json
@@ -2236,7 +2236,8 @@
                     "type": "string"
                   },
                   "clusterPeerName": {
-                    "description": "clusterPeerName defines the name that this Alertmanager instance uses to\nadvertise itself to other cluster peers (the `--cluster.peer-name` flag,\navailable since Alertmanager v0.30.0).\n\nIf not set, the operator defaults to the pod's name (`$(POD_NAME)`),\nwhich is injected via the Kubernetes downward API. Setting this field\nlets you override that default with either a literal value or a string\nreferencing environment variables that are already available in the\nAlertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).\n\nThis field only takes effect for Alertmanager v0.30.0 and above.",
+                    "description": "clusterPeerName defines the name that this Alertmanager instance uses to\nadvertise itself to other cluster peers (the `--cluster.peer-name` flag,\navailable since Alertmanager v0.30.0).\n\nIf not set, the operator defaults to the pod's name (`$(POD_NAME)`),\nwhich is injected via the Kubernetes downward API. Setting this field\nlets you override that default with either a literal value or a string\nreferencing environment variables that are already available in the\nAlertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).\n\n/ It requires Alertmanager >= 0.30.0.",
+                    "minLength": 1,
                     "type": "string"
                   },
                   "clusterPeerTimeout": {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -340,7 +340,14 @@ func makeStatefulSetSpec(logger *slog.Logger, a *monitoringv1.Alertmanager, conf
 	}
 
 	if version.GTE(semver.MustParse("0.30.0")) {
-		amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.peer-name", Value: fmt.Sprintf("$(%s)", operator.PodNameEnvVar)})
+		// Default the peer name to the pod's own name (injected via the
+		// downward API as $(POD_NAME)). Users can override this default by
+		// setting `.spec.clusterPeerName` on the Alertmanager CR.
+		peerName := fmt.Sprintf("$(%s)", operator.PodNameEnvVar)
+		if a.Spec.ClusterPeerName != nil && *a.Spec.ClusterPeerName != "" {
+			peerName = *a.Spec.ClusterPeerName
+		}
+		amArgs = append(amArgs, monitoringv1.Argument{Name: "cluster.peer-name", Value: peerName})
 	}
 
 	// If multiple Alertmanager clusters are deployed on the same cluster, it can happen

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -697,7 +697,7 @@ func TestMakeStatefulSetSpecPeerName(t *testing.T) {
 		}, {
 			name:           "empty custom peer name falls back to default",
 			version:        "0.30.0",
-			clusterPeer:    ptr.To(""),
+			clusterPeer:    new(""),
 			expPeerName:    true,
 			expPeerNameArg: fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar),
 		},

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -672,18 +672,34 @@ func TestMakeStatefulSetSpecPeersWithClusterDomain(t *testing.T) {
 }
 
 func TestMakeStatefulSetSpecPeerName(t *testing.T) {
+	customPeer := "my-peer-name"
 	for _, tc := range []struct {
-		name        string
-		version     string
-		expPeerName bool
+		name           string
+		version        string
+		clusterPeer    *string
+		expPeerName    bool
+		expPeerNameArg string
 	}{
 		{
 			name:    "no peer name before 0.30.0",
 			version: "0.29.0",
 		}, {
-			name:        "peer name after 0.30.0",
-			version:     "0.30.0",
-			expPeerName: true,
+			name:           "peer name after 0.30.0",
+			version:        "0.30.0",
+			expPeerName:    true,
+			expPeerNameArg: fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar),
+		}, {
+			name:           "custom peer name overrides default",
+			version:        "0.30.0",
+			clusterPeer:    &customPeer,
+			expPeerName:    true,
+			expPeerNameArg: "--cluster.peer-name=" + customPeer,
+		}, {
+			name:           "empty custom peer name falls back to default",
+			version:        "0.30.0",
+			clusterPeer:    ptr.To(""),
+			expPeerName:    true,
+			expPeerNameArg: fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -693,9 +709,10 @@ func TestMakeStatefulSetSpecPeerName(t *testing.T) {
 					Namespace: "monitoring",
 				},
 				Spec: monitoringv1.AlertmanagerSpec{
-					Replicas: new(int32(1)),
-					Image:    new(operator.DefaultAlertmanagerImage),
-					Version:  tc.version,
+					Replicas:        new(int32(1)),
+					Image:           new(operator.DefaultAlertmanagerImage),
+					Version:         tc.version,
+					ClusterPeerName: tc.clusterPeer,
 				},
 			}
 
@@ -703,9 +720,9 @@ func TestMakeStatefulSetSpecPeerName(t *testing.T) {
 			require.NoError(t, err)
 
 			amArgs := statefulSet.Template.Spec.Containers[0].Args
-			expectedArg := fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar)
+			defaultArg := fmt.Sprintf("--cluster.peer-name=$(%s)", operator.PodNameEnvVar)
 			if tc.expPeerName {
-				require.Contains(t, amArgs, expectedArg)
+				require.Contains(t, amArgs, tc.expPeerNameArg)
 				var envVarFound bool
 				for _, envVar := range statefulSet.Template.Spec.Containers[0].Env {
 					if envVar.Name == operator.PodNameEnvVar {
@@ -715,7 +732,7 @@ func TestMakeStatefulSetSpecPeerName(t *testing.T) {
 				}
 				require.True(t, envVarFound)
 			} else {
-				require.NotContains(t, amArgs, expectedArg)
+				require.NotContains(t, amArgs, defaultArg)
 			}
 		})
 	}

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -335,6 +335,19 @@ type AlertmanagerSpec struct {
 	// clusterPeerTimeout defines the timeout for cluster peering.
 	// +optional
 	ClusterPeerTimeout GoDuration `json:"clusterPeerTimeout,omitempty"`
+	// clusterPeerName defines the name that this Alertmanager instance uses to
+	// advertise itself to other cluster peers (the `--cluster.peer-name` flag,
+	// available since Alertmanager v0.30.0).
+	//
+	// If not set, the operator defaults to the pod's name (`$(POD_NAME)`),
+	// which is injected via the Kubernetes downward API. Setting this field
+	// lets you override that default with either a literal value or a string
+	// referencing environment variables that are already available in the
+	// Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
+	//
+	// This field only takes effect for Alertmanager v0.30.0 and above.
+	// +optional
+	ClusterPeerName *string `json:"clusterPeerName,omitempty"`
 	// portName defines the port's name for the pods and governing service.
 	// Defaults to `web`.
 	// +kubebuilder:default:="web"

--- a/pkg/apis/monitoring/v1/alertmanager_types.go
+++ b/pkg/apis/monitoring/v1/alertmanager_types.go
@@ -345,8 +345,9 @@ type AlertmanagerSpec struct {
 	// referencing environment variables that are already available in the
 	// Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
 	//
-	// This field only takes effect for Alertmanager v0.30.0 and above.
+	/// It requires Alertmanager >= 0.30.0.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
 	ClusterPeerName *string `json:"clusterPeerName,omitempty"`
 	// portName defines the port's name for the pods and governing service.
 	// Defaults to `web`.

--- a/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -492,6 +492,11 @@ func (in *AlertmanagerSpec) DeepCopyInto(out *AlertmanagerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterPeerName != nil {
+		in, out := &in.ClusterPeerName, &out.ClusterPeerName
+		*out = new(string)
+		**out = **in
+	}
 	if in.AlertmanagerConfigSelector != nil {
 		in, out := &in.AlertmanagerConfigSelector, &out.AlertmanagerConfigSelector
 		*out = new(metav1.LabelSelector)

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
@@ -225,6 +225,18 @@ type AlertmanagerSpecApplyConfiguration struct {
 	ClusterPushpullInterval *monitoringv1.GoDuration `json:"clusterPushpullInterval,omitempty"`
 	// clusterPeerTimeout defines the timeout for cluster peering.
 	ClusterPeerTimeout *monitoringv1.GoDuration `json:"clusterPeerTimeout,omitempty"`
+	// clusterPeerName defines the name that this Alertmanager instance uses to
+	// advertise itself to other cluster peers (the `--cluster.peer-name` flag,
+	// available since Alertmanager v0.30.0).
+	//
+	// If not set, the operator defaults to the pod's name (`$(POD_NAME)`),
+	// which is injected via the Kubernetes downward API. Setting this field
+	// lets you override that default with either a literal value or a string
+	// referencing environment variables that are already available in the
+	// Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
+	//
+	// This field only takes effect for Alertmanager v0.30.0 and above.
+	ClusterPeerName *string `json:"clusterPeerName,omitempty"`
 	// portName defines the port's name for the pods and governing service.
 	// Defaults to `web`.
 	PortName *string `json:"portName,omitempty"`
@@ -706,6 +718,14 @@ func (b *AlertmanagerSpecApplyConfiguration) WithClusterPushpullInterval(value m
 // If called multiple times, the ClusterPeerTimeout field is set to the value of the last call.
 func (b *AlertmanagerSpecApplyConfiguration) WithClusterPeerTimeout(value monitoringv1.GoDuration) *AlertmanagerSpecApplyConfiguration {
 	b.ClusterPeerTimeout = &value
+	return b
+}
+
+// WithClusterPeerName sets the ClusterPeerName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ClusterPeerName field is set to the value of the last call.
+func (b *AlertmanagerSpecApplyConfiguration) WithClusterPeerName(value string) *AlertmanagerSpecApplyConfiguration {
+	b.ClusterPeerName = &value
 	return b
 }
 

--- a/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/alertmanagerspec.go
@@ -235,7 +235,7 @@ type AlertmanagerSpecApplyConfiguration struct {
 	// referencing environment variables that are already available in the
 	// Alertmanager container (for example `$(POD_NAME).$(NAMESPACE)`).
 	//
-	// This field only takes effect for Alertmanager v0.30.0 and above.
+	// / It requires Alertmanager >= 0.30.0.
 	ClusterPeerName *string `json:"clusterPeerName,omitempty"`
 	// portName defines the port's name for the pods and governing service.
 	// Defaults to `web`.


### PR DESCRIPTION
## Description

Follow-up of #8705

When running HA Alertmanager with instances in different regions, we get clashing peer names

Adding ClusterPeerName field to over write `--cluster.peer-name` flag in the Statefulset

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

extending statefulset tests

## Changelog entry



<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: customizable `--cluster.peer-name` spec
```
