### PR TITLE
Chore: separate Wechat validation test case

### DIFF
--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -68,27 +68,6 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate wechat config - invalid URL",
-			in: &monitoringv1beta1.AlertmanagerConfig{
-				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
-					Receivers: []monitoringv1beta1.Receiver{
-						{
-							Name: "same",
-						},
-						{
-							Name: "different",
-							WeChatConfigs: []monitoringv1beta1.WeChatConfig{
-								{
-									APIURL: ptr.To(monitoringv1beta1.URL("http://%><invalid.com")),
-								},
-							},
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-		{
 			name: "Test fail to validate email config - missing to field",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
@@ -1056,13 +1035,57 @@ func TestValidateWebhookAlertmanagerConfig(t *testing.T) {
 	}
 }
 
+func TestValidateWechatAlertmanagerConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		in        *monitoringv1beta1.AlertmanagerConfig
+		expectErr bool
+	}{
+		{
+			name: "Test fail to validate wechat config - invalid URL",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							WeChatConfigs: []monitoringv1beta1.WeChatConfig{
+								{
+									APIURL: ptr.To(monitoringv1beta1.URL("http://%><invalid.com")),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAlertmanagerConfig(tc.in)
+			if tc.expectErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if err != nil {
+				if tc.expectErr {
+					return
+				}
+				t.Errorf("got error but expected none -%s", err.Error())
+			}
+		})
+	}
+}
+
 func TestValidateSNSAlertmanagerConfig(t *testing.T) {
 	testCases := []struct {
 		name      string
 		in        *monitoringv1beta1.AlertmanagerConfig
 		expectErr bool
 	}{
-
 		{
 			name: "Test fail to validate SNSConfigs - valid",
 			in: &monitoringv1beta1.AlertmanagerConfig{


### PR DESCRIPTION
## Description

This PR separates the Wechat test cases in Alertmanager validation to a new function.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

```release-note
Separate WeChat config test cases in Alertmanager validation
```
