### PR TITLE
fix: avoid panic for pushover receivers using userKeyFile or tokenFile

### DIFF
--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1432,7 +1432,7 @@ func (cb *ConfigBuilder) convertPushoverConfig(ctx context.Context, in monitorin
 	}
 
 	{
-		// Either userKey or userKeyFile is set, the validation webhook
+		// Either userKey or userKeyFile is set, the controller
 		// rejects configurations that set neither.
 		if in.UserKey != nil {
 			userKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.UserKey)

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -1432,25 +1432,33 @@ func (cb *ConfigBuilder) convertPushoverConfig(ctx context.Context, in monitorin
 	}
 
 	{
-		userKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.UserKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user key: %w", err)
+		// Either userKey or userKeyFile is set, the validation webhook
+		// rejects configurations that set neither.
+		if in.UserKey != nil {
+			userKey, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.UserKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get user key: %w", err)
+			}
+			if userKey == "" {
+				return nil, fmt.Errorf("mandatory field %q is empty", "userKey")
+			}
+			out.UserKey = userKey
 		}
-		if userKey == "" {
-			return nil, fmt.Errorf("mandatory field %q is empty", "userKey")
-		}
-		out.UserKey = userKey
+		out.UserKeyFile = ptr.Deref(in.UserKeyFile, "")
 	}
 
 	{
-		token, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Token)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get token: %w", err)
+		if in.Token != nil {
+			token, err := cb.store.GetSecretKey(ctx, crKey.Namespace, *in.Token)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get token: %w", err)
+			}
+			if token == "" {
+				return nil, fmt.Errorf("mandatory field %q is empty", "token")
+			}
+			out.Token = token
 		}
-		if token == "" {
-			return nil, fmt.Errorf("mandatory field %q is empty", "token")
-		}
-		out.Token = token
+		out.TokenFile = ptr.Deref(in.TokenFile, "")
 	}
 
 	{

--- a/pkg/alertmanager/amcfg_test.go
+++ b/pkg/alertmanager/amcfg_test.go
@@ -3197,6 +3197,38 @@ func TestGenerateConfig(t *testing.T) {
 			golden: "CR_with_Pushover_Receiver.golden",
 		},
 		{
+			name:      "CR with Pushover Receiver and file-based credentials",
+			amVersion: &version28,
+			kclient:   fake.NewClientset(),
+			baseConfig: alertmanagerConfig{
+				Route: &route{
+					Receiver: "null",
+				},
+				Receivers: []*receiver{{Name: "null"}},
+			},
+			amConfigs: map[string]*monitoringv1alpha1.AlertmanagerConfig{
+				"mynamespace": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "myamc",
+						Namespace: "mynamespace",
+					},
+					Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
+						Route: &monitoringv1alpha1.Route{
+							Receiver: "test",
+						},
+						Receivers: []monitoringv1alpha1.Receiver{{
+							Name: "test",
+							PushoverConfigs: []monitoringv1alpha1.PushoverConfig{{
+								UserKeyFile: new("/etc/pushover/user_key"),
+								TokenFile:   new("/etc/pushover/token"),
+							}},
+						}},
+					},
+				},
+			},
+			golden: "CR_with_Pushover_Receiver_and_file_credentials.golden",
+		},
+		{
 			name:      "CR with Telegram Receiver",
 			amVersion: &version24,
 			kclient: fake.NewClientset(

--- a/pkg/alertmanager/testdata/CR_with_Pushover_Receiver_and_file_credentials.golden
+++ b/pkg/alertmanager/testdata/CR_with_Pushover_Receiver_and_file_credentials.golden
@@ -1,0 +1,14 @@
+route:
+  receiver: "null"
+  routes:
+  - receiver: mynamespace/myamc/test
+    matchers:
+    - namespace="mynamespace"
+    continue: true
+receivers:
+- name: "null"
+- name: mynamespace/myamc/test
+  pushover_configs:
+  - user_key_file: /etc/pushover/user_key
+    token_file: /etc/pushover/token
+templates: []


### PR DESCRIPTION
## Description

An `AlertmanagerConfig` may configure a pushover receiver with `userKeyFile`/`tokenFile` instead of the `userKey`/`token` secret selectors — validation accepts either form:

```go
if conf.UserKey == nil && conf.UserKeyFile == nil {
    return errors.New("one of 'userKey' or 'userKeyFile' must be configured")
}
```

`convertPushoverConfig` nevertheless dereferenced `in.UserKey` and `in.Token` unconditionally, so such a receiver crashed the operator:

```
panic: runtime error: invalid memory address or nil pointer dereference
    pkg/alertmanager.(*ConfigBuilder).convertPushoverConfig
        pkg/alertmanager/amcfg.go:1435
    pkg/alertmanager.(*ConfigBuilder).convertReceiver
        pkg/alertmanager/amcfg.go:705
```

This reads the secrets only when the selectors are set and carries the two file fields into the generated config. `sanitizePushoverConfig` already handles them — the mutual exclusivity with `user_key`/`token`, the "one of them is mandatory" check, and the Alertmanager >= 0.26 gating — so it only ever saw empty values before.

The neighbouring receivers (telegram, rocketchat, slack, discord) already guard their selector dereferences the same way; pushover was the outlier.

Closes: #5234

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification

Added a `TestGenerateConfig` case with a pushover receiver that sets only `userKeyFile` and `tokenFile`, pinned to Alertmanager v0.28. On main it panics at `amcfg.go:1435`; with the change it produces:

```yaml
  pushover_configs:
  - user_key_file: /etc/pushover/user_key
    token_file: /etc/pushover/token
```

`go build ./...` and `go test ./pkg/... ./cmd/...` pass on darwin/arm64, go1.26.5. No existing golden file changed.

## Changelog entry

```
[BUGFIX] Fix panic when an AlertmanagerConfig pushover receiver uses `userKeyFile` or `tokenFile`.
```