### PR TITLE
test: add e2e test for Thanos sidecar delayed compaction

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -294,6 +294,7 @@ func testAllNSPrometheus(t *testing.T) {
 		"PromArbitraryFSAcc":                        testPromArbitraryFSAcc,
 		"PromTLSConfigViaSecret":                    testPromTLSConfigViaSecret,
 		"Thanos":                                    testThanos,
+		"ThanosSidecarDelayedCompaction":            testThanosSidecarDelayedCompaction,
 		"PromStaticProbe":                           testPromStaticProbe,
 		"PromSecurePodMonitor":                      testPromSecurePodMonitor,
 		"PromSharedResourcesReconciliation":         testPromSharedResourcesReconciliation,

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -2660,6 +2660,106 @@ func testThanos(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// testThanosSidecarDelayedCompaction verifies the Thanos sidecar behaviour
+// when delayed compaction is enabled with object storage configured.
+// ref: https://github.com/prometheus-operator/prometheus-operator/issues/8763
+func testThanosSidecarDelayedCompaction(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		thanosVersion   string
+		expectPathError bool
+	}{
+		{name: "v0.42.0", thanosVersion: "v0.42.0"},
+		{name: "v0.41.0", thanosVersion: "v0.41.0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testCtx := framework.NewTestCtx(t)
+			defer testCtx.Cleanup(t)
+			ns := framework.CreateNamespace(context.Background(), t, testCtx)
+			framework.SetupPrometheusRBAC(context.Background(), t, testCtx, ns)
+
+			objStoreSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "thanos-objstore-config",
+				},
+				StringData: map[string]string{
+					"thanos.yaml": `type: S3
+config:
+  bucket: dummy
+  endpoint: localhost:9000
+  insecure: true
+  access_key: dummy
+  secret_key: dummy`,
+				},
+			}
+			_, err := framework.KubeClient.CoreV1().Secrets(ns).Create(context.Background(), objStoreSecret, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			thanosVersion := tc.thanosVersion
+			prom := framework.MakeBasicPrometheus(ns, "thanos-delayed-compaction", "test-group", 1)
+			prom.Spec.Thanos = &monitoringv1.ThanosSpec{
+				Version: &thanosVersion,
+				ObjectStorageConfig: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "thanos-objstore-config",
+					},
+					Key: "thanos.yaml",
+				},
+			}
+
+			_, err = framework.MonClientV1.Prometheuses(ns).Create(context.Background(), prom, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			// Wait for the pod to be running so the sidecar has time to
+			// attempt Prometheus flag validation.
+			err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+				pods, listErr := framework.KubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/name=prometheus",
+				})
+				if listErr != nil || len(pods.Items) == 0 {
+					return false, nil
+				}
+				for _, pod := range pods.Items {
+					if pod.Status.Phase == corev1.PodRunning {
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+			require.NoError(t, err, "prometheus pod did not reach Running phase")
+
+			// The sidecar retries validation every 30s; wait long enough
+			// for at least one retry cycle to complete.
+			time.Sleep(45 * time.Second)
+
+			pods, err := framework.KubeClient.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/name=prometheus",
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, pods.Items)
+
+			podName := pods.Items[0].Name
+			logs, err := framework.KubeClient.CoreV1().Pods(ns).GetLogs(podName, &corev1.PodLogOptions{
+				Container: "thanos-sidecar",
+			}).DoRaw(context.Background())
+			require.NoError(t, err)
+
+			pathMismatchError := "Prometheus and Thanos use different paths for tracking block uploads"
+			logsStr := string(logs)
+
+			if tc.expectPathError {
+				require.Contains(t, logsStr, pathMismatchError,
+					"thanos-sidecar should report path mismatch for %s", tc.thanosVersion)
+			} else {
+				require.NotContains(t, logsStr, pathMismatchError,
+					"thanos-sidecar should not report path mismatch for %s", tc.thanosVersion)
+			}
+		})
+	}
+}
+
 func testPromGetAuthSecret(t *testing.T) {
 	t.Parallel()
 	name := "test"


### PR DESCRIPTION
Add an e2e test that deploys Prometheus with Thanos v0.41.0 sidecar and object storage config to verify the sidecar behaviour when delayed compaction is enabled.

Related-to: #8763

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
