### PR TITLE
api: do not persist RelabelConfig action CRD default

### DIFF
--- a/Documentation/api-reference/api.md
+++ b/Documentation/api-reference/api.md
@@ -17939,6 +17939,10 @@ string
 <p><code>Uppercase</code> and <code>Lowercase</code> actions require Prometheus &gt;= v2.36.0.
 <code>DropEqual</code> and <code>KeepEqual</code> actions require Prometheus &gt;= v2.41.0.</p>
 <p>Default: &ldquo;Replace&rdquo;</p>
+<p>An omitted action is treated as replace by the operator and by Prometheus.
+There is no CRD OpenAPI default: Kubernetes would persist <code>action: replace</code>
+on the stored object, and GitOps tools that compare desired manifests
+(field omitted) against live state report permanent drift.</p>
 </td>
 </tr>
 </tbody>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -22761,7 +22761,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -22769,6 +22768,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -23286,7 +23290,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -23294,6 +23297,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -24066,7 +24074,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -24074,6 +24081,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -24716,7 +24728,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -24724,6 +24735,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace
@@ -24867,7 +24883,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -24875,6 +24890,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace
@@ -31773,7 +31793,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -31781,6 +31800,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -32090,7 +32114,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -32098,6 +32121,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -32190,7 +32218,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -32198,6 +32225,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -37986,7 +38018,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -37994,6 +38025,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -38271,7 +38307,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -38279,6 +38314,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -44987,7 +45027,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -44995,6 +45034,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -45449,7 +45493,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -45457,6 +45500,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -45549,7 +45597,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -45557,6 +45604,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -60827,7 +60879,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -60835,6 +60886,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -63169,7 +63225,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -63177,6 +63232,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -64250,7 +64310,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -64258,6 +64317,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -64751,7 +64815,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -64759,6 +64822,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -71287,7 +71355,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -71295,6 +71362,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_podmonitors.yaml
@@ -366,7 +366,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -374,6 +373,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -891,7 +895,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -899,6 +902,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml
@@ -259,7 +259,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -267,6 +266,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -909,7 +913,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -917,6 +920,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace
@@ -1060,7 +1068,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -1068,6 +1075,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusagents.yaml
@@ -6540,7 +6540,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6548,6 +6547,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -6857,7 +6861,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6865,6 +6868,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -6957,7 +6965,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6965,6 +6972,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheuses.yaml
@@ -1151,7 +1151,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -1159,6 +1158,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -1436,7 +1440,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -1444,6 +1447,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -8152,7 +8160,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8160,6 +8167,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -8614,7 +8626,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8622,6 +8633,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -8714,7 +8730,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8722,6 +8737,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml
@@ -9797,7 +9797,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -9805,6 +9804,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -12139,7 +12143,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -12147,6 +12150,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
@@ -282,7 +282,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -290,6 +289,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -783,7 +787,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -791,6 +794,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_thanosrulers.yaml
@@ -5890,7 +5890,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -5898,6 +5897,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -366,7 +366,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -374,6 +373,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -891,7 +895,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -899,6 +902,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
@@ -259,7 +259,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -267,6 +266,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -909,7 +913,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -917,6 +920,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace
@@ -1060,7 +1068,6 @@ spec:
                             More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                           properties:
                             action:
-                              default: replace
                               description: |-
                                 action to perform based on the regex matching.
 
@@ -1068,6 +1075,11 @@ spec:
                                 `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                 Default: "Replace"
+
+                                An omitted action is treated as replace by the operator and by Prometheus.
+                                There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                on the stored object, and GitOps tools that compare desired manifests
+                                (field omitted) against live state report permanent drift.
                               enum:
                               - replace
                               - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
@@ -6540,7 +6540,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6548,6 +6547,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -6857,7 +6861,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6865,6 +6868,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -6957,7 +6965,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -6965,6 +6972,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
@@ -1151,7 +1151,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -1159,6 +1158,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -1436,7 +1440,6 @@ spec:
                               More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                             properties:
                               action:
-                                default: replace
                                 description: |-
                                   action to perform based on the regex matching.
 
@@ -1444,6 +1447,11 @@ spec:
                                   `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                                   Default: "Replace"
+
+                                  An omitted action is treated as replace by the operator and by Prometheus.
+                                  There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                                  on the stored object, and GitOps tools that compare desired manifests
+                                  (field omitted) against live state report permanent drift.
                                 enum:
                                 - replace
                                 - Replace
@@ -8152,7 +8160,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8160,6 +8167,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -8614,7 +8626,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8622,6 +8633,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -8714,7 +8730,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -8722,6 +8737,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
@@ -9797,7 +9797,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -9805,6 +9804,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace
@@ -12139,7 +12143,6 @@ spec:
                     More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                   properties:
                     action:
-                      default: replace
                       description: |-
                         action to perform based on the regex matching.
 
@@ -12147,6 +12150,11 @@ spec:
                         `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                         Default: "Replace"
+
+                        An omitted action is treated as replace by the operator and by Prometheus.
+                        There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                        on the stored object, and GitOps tools that compare desired manifests
+                        (field omitted) against live state report permanent drift.
                       enum:
                       - replace
                       - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
@@ -282,7 +282,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -290,6 +289,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace
@@ -783,7 +787,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -791,6 +794,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
@@ -5890,7 +5890,6 @@ spec:
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
-                            default: replace
                             description: |-
                               action to perform based on the regex matching.
 
@@ -5898,6 +5897,11 @@ spec:
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 
                               Default: "Replace"
+
+                              An omitted action is treated as replace by the operator and by Prometheus.
+                              There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+                              on the stored object, and GitOps tools that compare desired manifests
+                              (field omitted) against live state report permanent drift.
                             enum:
                             - replace
                             - Replace

--- a/jsonnet/prometheus-operator/podmonitors-crd.json
+++ b/jsonnet/prometheus-operator/podmonitors-crd.json
@@ -282,8 +282,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -730,8 +729,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",

--- a/jsonnet/prometheus-operator/probes-crd.json
+++ b/jsonnet/prometheus-operator/probes-crd.json
@@ -214,8 +214,7 @@
                       "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                       "properties": {
                         "action": {
-                          "default": "replace",
-                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                           "enum": [
                             "replace",
                             "Replace",
@@ -790,8 +789,7 @@
                               "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                               "properties": {
                                 "action": {
-                                  "default": "replace",
-                                  "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                  "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                   "enum": [
                                     "replace",
                                     "Replace",
@@ -917,8 +915,7 @@
                               "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                               "properties": {
                                 "action": {
-                                  "default": "replace",
-                                  "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                  "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                   "enum": [
                                     "replace",
                                     "Replace",

--- a/jsonnet/prometheus-operator/prometheusagents-crd.json
+++ b/jsonnet/prometheus-operator/prometheusagents-crd.json
@@ -5529,8 +5529,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -5784,8 +5783,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -5858,8 +5856,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",

--- a/jsonnet/prometheus-operator/prometheuses-crd.json
+++ b/jsonnet/prometheus-operator/prometheuses-crd.json
@@ -946,8 +946,7 @@
                                 "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                                 "properties": {
                                   "action": {
-                                    "default": "replace",
-                                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                     "enum": [
                                       "replace",
                                       "Replace",
@@ -1189,8 +1188,7 @@
                                 "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                                 "properties": {
                                   "action": {
-                                    "default": "replace",
-                                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                    "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                     "enum": [
                                       "replace",
                                       "Replace",
@@ -6931,8 +6929,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -7315,8 +7312,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -7389,8 +7385,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",

--- a/jsonnet/prometheus-operator/scrapeconfigs-crd.json
+++ b/jsonnet/prometheus-operator/scrapeconfigs-crd.json
@@ -9124,8 +9124,7 @@
                       "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                       "properties": {
                         "action": {
-                          "default": "replace",
-                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                           "enum": [
                             "replace",
                             "Replace",
@@ -11292,8 +11291,7 @@
                       "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                       "properties": {
                         "action": {
-                          "default": "replace",
-                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                          "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                           "enum": [
                             "replace",
                             "Replace",

--- a/jsonnet/prometheus-operator/servicemonitors-crd.json
+++ b/jsonnet/prometheus-operator/servicemonitors-crd.json
@@ -211,8 +211,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",
@@ -652,8 +651,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",

--- a/jsonnet/prometheus-operator/thanosrulers-crd.json
+++ b/jsonnet/prometheus-operator/thanosrulers-crd.json
@@ -5099,8 +5099,7 @@
                             "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts,\nscraped samples and remote write samples.\n\nMore info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
                             "properties": {
                               "action": {
-                                "default": "replace",
-                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"",
+                                "description": "action to perform based on the regex matching.\n\n`Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.\n`DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.\n\nDefault: \"Replace\"\n\nAn omitted action is treated as replace by the operator and by Prometheus.\nThere is no CRD OpenAPI default: Kubernetes would persist `action: replace`\non the stored object, and GitOps tools that compare desired manifests\n(field omitted) against live state report permanent drift.",
                                 "enum": [
                                   "replace",
                                   "Replace",

--- a/pkg/apis/monitoring/v1/prometheus_types.go
+++ b/pkg/apis/monitoring/v1/prometheus_types.go
@@ -2236,8 +2236,12 @@ type RelabelConfig struct {
 	//
 	// Default: "Replace"
 	//
+	// An omitted action is treated as replace by the operator and by Prometheus.
+	// There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+	// on the stored object, and GitOps tools that compare desired manifests
+	// (field omitted) against live state report permanent drift.
+	//
 	// +kubebuilder:validation:Enum=replace;Replace;keep;Keep;drop;Drop;hashmod;HashMod;labelmap;LabelMap;labeldrop;LabelDrop;labelkeep;LabelKeep;lowercase;Lowercase;uppercase;Uppercase;keepequal;KeepEqual;dropequal;DropEqual
-	// +kubebuilder:default=replace
 	// +optional
 	Action string `json:"action,omitempty"`
 }

--- a/pkg/client/applyconfiguration/monitoring/v1/relabelconfig.go
+++ b/pkg/client/applyconfiguration/monitoring/v1/relabelconfig.go
@@ -58,6 +58,11 @@ type RelabelConfigApplyConfiguration struct {
 	// `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
 	//
 	// Default: "Replace"
+	//
+	// An omitted action is treated as replace by the operator and by Prometheus.
+	// There is no CRD OpenAPI default: Kubernetes would persist `action: replace`
+	// on the stored object, and GitOps tools that compare desired manifests
+	// (field omitted) against live state report permanent drift.
 	Action *string `json:"action,omitempty"`
 }
 

--- a/pkg/prometheus/validation/validator_test.go
+++ b/pkg/prometheus/validation/validator_test.go
@@ -201,6 +201,16 @@ func TestValidateRelabelConfig(t *testing.T) {
 			},
 			prometheus: defaultPrometheusSpec,
 		},
+		// Omitted action is replace (Prometheus default). Must stay valid when
+		// the CRD does not persist action via OpenAPI default.
+		{
+			scenario: "valid replace config with omitted action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				TargetLabel: "abc",
+				Replacement: new("static"),
+			},
+			prometheus: defaultPrometheusSpec,
+		},
 		// Test valid labeldrop relabel config with default value
 		{
 			scenario: "valid labeldrop config with default values",


### PR DESCRIPTION
## Description

Stop writing `action: replace` onto stored RelabelConfig objects when the field is omitted.

The operator already treats an empty action as replace (`ValidateRelabelConfig`). Generated Prometheus YAML omits `action` when unset so Prometheus applies its own default. The CRD OpenAPI default was the only thing persisting the field, which makes GitOps desired-vs-live diffs never match.

Closes: #8777

## Type of change

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

Existing objects already stored with `action: replace` keep that value until they are applied without the field. New applies that omit `action` no longer have Kubernetes fill it in.

## Verification

`go test -count=1 ./pkg/prometheus/validation/ -run TestValidateRelabelConfig` (32 tests, including omitted action treated as replace). Regenerated CRDs, bundle, jsonnet, and API docs with controller-gen / gen-crd-api-reference-docs.

## Changelog entry

```release-note
Stop persisting the RelabelConfig action CRD default so GitOps tools no longer see permanent drift when manifests omit action (still replace at scrape time).
```
