### PR TITLE
Feat: add E2E test coverage for Alertmanager Mattermost global config

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2029,6 +2029,14 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			WebexConfig: &monitoringv1.GlobalWebexConfig{
 				APIURL: ptr.To(monitoringv1.URL("https://webex.api.url")),
 			},
+			MattermostConfig: &monitoringv1.GlobalMattermostConfig{
+				WebhookURL: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "mattermost",
+					},
+					Key: "webhookurl",
+				},
+			},
 		},
 		Templates: []monitoringv1.SecretOrConfigMap{
 			{
@@ -2119,6 +2127,14 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"tokenid": []byte(`abc123`),
 		},
 	}
+	mattermost := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mattermost",
+		},
+		Data: map[string][]byte{
+			"webhookurl": []byte(`https://mattermost.webhook.url`),
+		},
+	}
 
 	ctx := context.Background()
 	_, err = framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, &cm, metav1.CreateOptions{})
@@ -2136,6 +2152,8 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &wechat, metav1.CreateOptions{})
 	require.NoError(t, err)
 	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &rocketchat, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &mattermost, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, alertmanager)
@@ -2172,6 +2190,7 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
   rocketchat_api_url: https://rocketchat.api.url
   rocketchat_token: abcdef1234567890
   rocketchat_token_id: abc123
+  mattermost_webhook_url: https://mattermost.webhook.url
 route:
   receiver: %[1]s
   routes:


### PR DESCRIPTION
## Description

This PR adds E2E test coverage for Alertmanager Mattermost global config

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
E2E Testing

## Changelog entry

```release-note
Add E2E test coverage for Alertmanager Mattermost global config
```
