### PR TITLE
chore(scrapeconfig): normalize kubebuilder marker syntax

### DIFF
--- a/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
+++ b/pkg/apis/monitoring/v1alpha1/scrapeconfig_types.go
@@ -33,7 +33,7 @@ const (
 type Target string
 
 // SDFile represents a file used for service discovery
-// +kubebuilder:validation:Pattern=`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`
+// +kubebuilder:validation:Pattern="^[^*]*(\\*[^/]*)?\\.(json|yml|yaml|JSON|YML|YAML)$"
 type SDFile string
 
 // NamespaceDiscovery is the configuration for discovering
@@ -74,8 +74,8 @@ type Filter struct {
 	Values []string `json:"values"`
 }
 
-// +listType:=map
-// +listMapKey:=name
+// +listType=map
+// +listMapKey=name
 type Filters []Filter
 
 // +kubebuilder:validation:Enum=Pod;Endpoints;Ingress;Service;Node;EndpointSlice
@@ -294,7 +294,7 @@ type ScrapeConfigSpec struct {
 	// +optional
 	HonorLabels *bool `json:"honorLabels,omitempty"` // nolint:kubeapilinter
 	// params defines optional HTTP URL parameters
-	// +mapType:=atomic
+	// +mapType=atomic
 	// +optional
 	//nolint:kubeapilinter
 	Params map[string][]string `json:"params,omitempty"`
@@ -324,26 +324,26 @@ type ScrapeConfigSpec struct {
 	// +optional
 	TLSConfig *v1.SafeTLSConfig `json:"tlsConfig,omitempty"`
 	// sampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	SampleLimit *int64 `json:"sampleLimit,omitempty"`
 	// targetLimit defines a limit on the number of scraped targets that will be accepted.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	TargetLimit *int64 `json:"targetLimit,omitempty"`
 	// labelLimit defines the per-scrape limit on number of labels that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	LabelLimit *int64 `json:"labelLimit,omitempty"`
 	// labelNameLengthLimit defines the per-scrape limit on length of labels name that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	LabelNameLengthLimit *int64 `json:"labelNameLengthLimit,omitempty"`
 	// labelValueLengthLimit defines the per-scrape limit on length of labels value that will be accepted for a sample.
 	// Only valid in Prometheus versions 2.27.0 and newer.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	LabelValueLengthLimit *int64 `json:"labelValueLengthLimit,omitempty"`
 	// bodySizeLimit defines a per-scrape limit on the size of the uncompressed
@@ -361,7 +361,7 @@ type ScrapeConfigSpec struct {
 	//
 	// It requires Prometheus >= v2.47.0.
 	//
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	KeepDroppedTargets *int64 `json:"keepDroppedTargets,omitempty"`
 	// metricRelabelings defines the metricRelabelings to apply to samples before ingestion.
@@ -399,7 +399,7 @@ type StaticConfig struct {
 	// +required
 	Targets []Target `json:"targets"`
 	// labels defines labels assigned to all metrics scraped from the targets.
-	// +mapType:=atomic
+	// +mapType=atomic
 	// +optional
 	//nolint:kubeapilinter
 	Labels map[string]string `json:"labels,omitempty"`
@@ -548,12 +548,12 @@ type ConsulSDConfig struct {
 	// +optional
 	Scheme *v1.Scheme `json:"scheme,omitempty"`
 	// services defines a list of services for which targets are retrieved. If omitted, all services are scraped.
-	// +listType:=set
+	// +listType=set
 	// +optional
 	Services []string `json:"services,omitempty"`
 	// tags defines an optional list of tags used to filter nodes for a given service. Services must contain all tags in the list.
 	// Starting with Consul 1.14, it is recommended to use `filter` with the `ServiceTags` selector instead.
-	// +listType:=set
+	// +listType=set
 	// +optional
 	Tags []string `json:"tags,omitempty"`
 	// tagSeparator defines the string by which Consul tags are joined into the tag label.
@@ -563,7 +563,7 @@ type ConsulSDConfig struct {
 	TagSeparator *string `json:"tagSeparator,omitempty"`
 	// nodeMeta defines the node metadata key/value pairs to filter nodes for a given service.
 	// Starting with Consul 1.14, it is recommended to use `filter` with the `NodeMeta` selector instead.
-	// +mapType:=atomic
+	// +mapType=atomic
 	// +optional
 	//nolint:kubeapilinter
 	NodeMeta map[string]string `json:"nodeMeta,omitempty"`


### PR DESCRIPTION
Standardize marker assignment syntax across all SD types:

These are pure syntax changes with no behavioral impact on the generated CRD schema.

Related-to: #8420

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Closes: #ISSUE-NUMBER

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
