### PR TITLE
Feat: split OpsGenie validations and extend test coverage

### DIFF
--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -723,7 +723,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
-									APIURL: ptr.To(monitoringv1beta1.URL("www.test.com")),
+									APIURL: ptr.To(monitoringv1beta1.URL("https://www.test.com")),
 								},
 							},
 						},

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -768,7 +768,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
 									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
-										{ID: new("1234abcd")},
+										{Type: "team", ID: new("1234abcd")},
 									},
 								},
 							},
@@ -791,7 +791,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
 									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
-										{Name: new("respondername")},
+										{Type: "team", Name: new("respondername")},
 									},
 								},
 							},
@@ -814,7 +814,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
 									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
-										{Username: new("responderuser")},
+										{Type: "team", Username: new("responderuser")},
 									},
 								},
 							},

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -702,7 +702,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
-									APIURL: new("http://%><invalid.com"),
+									APIURL: ptr.To(monitoringv1beta1.URL("http://%><invalid.com")),
 								},
 							},
 						},
@@ -723,7 +723,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
-									APIURL: new("www.test.com"),
+									APIURL: ptr.To(monitoringv1beta1.URL("www.test.com")),
 								},
 							},
 						},

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -45,29 +45,6 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "Test fail to validate on opsgenie config - missing required fields",
-			in: &monitoringv1beta1.AlertmanagerConfig{
-				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
-					Receivers: []monitoringv1beta1.Receiver{
-						{
-							Name: "same",
-						},
-						{
-							Name: "different",
-							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
-								{
-									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
-										{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-		{
 			name: "Test fail to validate email config - missing to field",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
@@ -687,6 +664,96 @@ func TestValidatePagerDutyAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAlertmanagerConfig(tc.in)
+			if tc.expectErr && err == nil {
+				t.Error("expected error but got none")
+			}
+
+			if err != nil {
+				if tc.expectErr {
+					return
+				}
+				t.Errorf("got error but expected none - %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		in        *monitoringv1beta1.AlertmanagerConfig
+		expectErr bool
+	}{
+		{
+			name: "Test fail to validate on opsgenie config - missing required fields",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
+										{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "validate opsgenie config - url validation failed",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									APIKey: new("http://%><invalid.com"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "validate opsgenie config - url validation success",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									APIKey: new("www.test.com"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
 		},
 	}
 

--- a/pkg/alertmanager/validation/v1beta1/validation_test.go
+++ b/pkg/alertmanager/validation/v1beta1/validation_test.go
@@ -691,7 +691,49 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "Test fail to validate on opsgenie config - missing required fields",
+			name: "validate opsgenie config - url validation failed",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									APIURL: new("http://%><invalid.com"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "validate opsgenie config - url validation success",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									APIURL: new("www.test.com"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Test fail to validate on opsgenie config - missing required fields in responders",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -714,7 +756,7 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "validate opsgenie config - url validation failed",
+			name: "Test fail to validate on opsgenie config - responder with id",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -725,17 +767,19 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
-									APIKey: new("http://%><invalid.com"),
+									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
+										{ID: new("1234abcd")},
+									},
 								},
 							},
 						},
 					},
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
-			name: "validate opsgenie config - url validation success",
+			name: "Test fail to validate on opsgenie config - responder with name",
 			in: &monitoringv1beta1.AlertmanagerConfig{
 				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
 					Receivers: []monitoringv1beta1.Receiver{
@@ -746,7 +790,32 @@ func TestValidateOpsGenieAlertmanagerConfig(t *testing.T) {
 							Name: "different",
 							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
 								{
-									APIKey: new("www.test.com"),
+									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
+										{Name: new("respondername")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Test fail to validate on opsgenie config - responder with username",
+			in: &monitoringv1beta1.AlertmanagerConfig{
+				Spec: monitoringv1beta1.AlertmanagerConfigSpec{
+					Receivers: []monitoringv1beta1.Receiver{
+						{
+							Name: "same",
+						},
+						{
+							Name: "different",
+							OpsGenieConfigs: []monitoringv1beta1.OpsGenieConfig{
+								{
+									Responders: []monitoringv1beta1.OpsGenieConfigResponder{
+										{Username: new("responderuser")},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
## Description

This PR separates a validation test case and create more test cases for an OpsGenie receiver.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Unit Testing

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Split test case and extend test coverage for OpsGenie validation method
```
