### PR TITLE
Feat: add missing E2E test cases for Alertmanager global config

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2220,9 +2220,9 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
   smtp_auth_identity: dev@smtp.example.org
   smtp_require_tls: true
   slack_api_url: https://slack.api.url
+  pagerduty_url: https://pagerduty.url
   opsgenie_api_url: https://opsgenie.api.url
   opsgenie_api_key: abcdef1234567890
-  pagerduty_url: https://pagerduty.url
   wechat_api_url: https://wechat.api.url
   wechat_api_secret: abcdef1234567890
   wechat_api_corp_id: abc123

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1986,6 +1986,25 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 					},
 				},
 			},
+			SlackAPIURL: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "slack",
+				},
+				Key: "apiurl",
+			},
+			OpsGenieAPIURL: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "opsgenie",
+				},
+				Key: "apiurl",
+			},
+			OpsGenieAPIKey: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "opsgenie",
+				},
+				Key: "apikey",
+			},
+			PagerdutyURL: ptr.To(monitoringv1.URL("https://pagerduty.url")),
 			TelegramConfig: &monitoringv1.GlobalTelegramConfig{
 				APIURL: ptr.To(monitoringv1.URL("https://telegram.api.url")),
 			},
@@ -2135,6 +2154,23 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 			"webhookurl": []byte(`https://mattermost.webhook.url`),
 		},
 	}
+	slack := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "slack",
+		},
+		Data: map[string][]byte{
+			"apiurl": []byte(`https://slack.api.url`),
+		},
+	}
+	opsgenie := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "opsgenie",
+		},
+		Data: map[string][]byte{
+			"apiurl": []byte(`https://opsgenie.api.url`),
+			"apikey": []byte(`abcdef1234567890`),
+		},
+	}
 
 	ctx := context.Background()
 	_, err = framework.KubeClient.CoreV1().ConfigMaps(ns).Create(ctx, &cm, metav1.CreateOptions{})
@@ -2154,6 +2190,10 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &rocketchat, metav1.CreateOptions{})
 	require.NoError(t, err)
 	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &mattermost, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &slack, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = framework.KubeClient.CoreV1().Secrets(ns).Create(ctx, &opsgenie, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	_, err = framework.CreateAlertmanagerAndWaitUntilReady(ctx, alertmanager)
@@ -2179,6 +2219,10 @@ func testUserDefinedAlertmanagerConfigFromCustomResource(t *testing.T) {
   smtp_auth_secret: secret
   smtp_auth_identity: dev@smtp.example.org
   smtp_require_tls: true
+  slack_api_url: https://slack.api.url
+  opsgenie_api_url: https://opsgenie.api.url
+  opsgenie_api_key: abcdef1234567890
+  pagerduty_url: https://pagerduty.url
   wechat_api_url: https://wechat.api.url
   wechat_api_secret: abcdef1234567890
   wechat_api_corp_id: abc123


### PR DESCRIPTION
## Description

This PR adds E2E test cases for Alertmanager global config to extend coverage for Slack, OpsGenie and Pagerduty.

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
E2E test cases

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Extend E2E test to cover Slack, OpsGenie and Pagerduty
```
