### PR TITLE
Feat: add MS Teams V2 config in Alertmanager Config E2E test case

### DIFF
--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1088,6 +1088,18 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	_, err = framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), msteamsSecret, metav1.CreateOptions{})
 	require.NoError(t, err)
 
+	msteamsv2WebhookURL := "https://msteamsv2.webhook.url"
+	msteamsv2Secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "msteams",
+		},
+		Data: map[string][]byte{
+			"webhook-url": []byte(msteamsv2WebhookURL),
+		},
+	}
+	_, err = framework.KubeClient.CoreV1().Secrets(configNs).Create(context.Background(), msteamsv2Secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
 	// A valid AlertmanagerConfig resource with many receivers.
 	configCR := &monitoringv1alpha1.AlertmanagerConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1255,6 +1267,15 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 					WebhookURL: corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "msteams",
+						},
+						Key: "webhook-url",
+					},
+					Title: new("Alert"),
+				}},
+				MSTeamsV2Configs: []monitoringv1alpha1.MSTeamsV2Config{{
+					WebhookURL: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "msteamsv2",
 						},
 						Key: "webhook-url",
 					},
@@ -1607,6 +1628,9 @@ receivers:
     room_id: testingRoomID
   msteams_configs:
   - webhook_url: https://msteams.webhook.url
+    title: Alert
+  msteamsv2_configs:
+  - webhook_url: https://msteamsv2.webhook.url
     title: Alert
 - name: %s/e2e-test-amconfig-sub-routes/e2e
   webhook_configs:

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -1091,7 +1091,7 @@ func testAlertmanagerConfigCRD(t *testing.T) {
 	msteamsv2WebhookURL := "https://msteamsv2.webhook.url"
 	msteamsv2Secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "msteams",
+			Name: "msteamsv2",
 		},
 		Data: map[string][]byte{
 			"webhook-url": []byte(msteamsv2WebhookURL),


### PR DESCRIPTION
## Description

This PR extends the E2E test case to generate Alertmanager config to cover MS Teams V2

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
E2E Testing

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add MS Teams V2 in Alertmanager Config E2E Test Case
```
