### PR TITLE
change: update default Alertmanager to v0.34.0 and reject zero durations

### DIFF
--- a/Documentation/getting-started/compatibility.md
+++ b/Documentation/getting-started/compatibility.md
@@ -105,7 +105,7 @@ The Prometheus Operator is compatible with Alertmanager v0.15 and above.
 The end-to-end tests are mostly tested against
 
 ```$ mdox-exec="go run ./cmd/po-docgen/. compatibility defaultAlertmanagerVersion"
-* v0.33.1
+* v0.34.0
 ```
 
 ## Thanos

--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -629,6 +629,10 @@ func (c *Operator) sync(ctx context.Context, key string) error {
 		return err
 	}
 
+	if ignored := discardZeroDurations(am); len(ignored) > 0 {
+		c.reconciliations.SetReasonAndMessage(key, operator.IgnoredFieldsReason, ignoredFieldsMessage(ignored))
+	}
+
 	assetStore := assets.NewStoreBuilder(c.kclient.CoreV1(), c.kclient.CoreV1())
 
 	if err := c.provisionAlertmanagerConfiguration(ctx, am, assetStore); err != nil {

--- a/pkg/alertmanager/statefulset.go
+++ b/pkg/alertmanager/statefulset.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/units"
 	"github.com/blang/semver/v4"
@@ -76,6 +77,46 @@ var (
 	minReplicas         int32 = 1
 	probeTimeoutSeconds int32 = 3
 )
+
+func isZeroGoDuration(value monitoringv1.GoDuration) bool {
+	if value == "" {
+		return false
+	}
+
+	d, err := time.ParseDuration(string(value))
+	return err == nil && d <= 0
+}
+
+func discardZeroDurations(am *monitoringv1.Alertmanager) []string {
+	var ignored []string
+
+	for _, field := range []struct {
+		name  string
+		value *monitoringv1.GoDuration
+	}{
+		{"retention", &am.Spec.Retention},
+		{"clusterGossipInterval", &am.Spec.ClusterGossipInterval},
+		{"clusterPushpullInterval", &am.Spec.ClusterPushpullInterval},
+		{"clusterPeerTimeout", &am.Spec.ClusterPeerTimeout},
+	} {
+		if field.value == nil {
+			continue
+		}
+
+		if !isZeroGoDuration(*field.value) {
+			continue
+		}
+
+		*field.value = ""
+		ignored = append(ignored, fmt.Sprintf("%s (zero value not supported)", field.name))
+	}
+
+	return ignored
+}
+
+func ignoredFieldsMessage(fields []string) string {
+	return "The following fields were ignored: " + strings.Join(fields, ", ")
+}
 
 func getServiceName(a *monitoringv1.Alertmanager) string {
 	return ptr.Deref(a.Spec.ServiceName, defaultOperatedServiceName)

--- a/pkg/alertmanager/statefulset_test.go
+++ b/pkg/alertmanager/statefulset_test.go
@@ -1022,6 +1022,117 @@ func TestRetention(t *testing.T) {
 	}
 }
 
+func TestDiscardZeroDurations(t *testing.T) {
+	replicas := int32(1)
+
+	tests := []struct {
+		name          string
+		spec          monitoringv1.AlertmanagerSpec
+		expectIgnored []string
+	}{
+		{
+			name: "empty retention",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas: &replicas,
+			},
+		},
+		{
+			name: "positive retention",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:  &replicas,
+				Retention: "48h",
+			},
+		},
+		{
+			name: "zero retention",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:  &replicas,
+				Retention: "0",
+			},
+			expectIgnored: []string{"retention (zero value not supported)"},
+		},
+		{
+			name: "zero retention in seconds",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:  &replicas,
+				Retention: "0s",
+			},
+			expectIgnored: []string{"retention (zero value not supported)"},
+		},
+		{
+			name: "zero cluster gossip interval",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:              &replicas,
+				ClusterGossipInterval: "0s",
+			},
+			expectIgnored: []string{"clusterGossipInterval (zero value not supported)"},
+		},
+		{
+			name: "zero cluster pushpull interval",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:                &replicas,
+				ClusterPushpullInterval: "0m",
+			},
+			expectIgnored: []string{"clusterPushpullInterval (zero value not supported)"},
+		},
+		{
+			name: "zero cluster peer timeout",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:           &replicas,
+				ClusterPeerTimeout: "0",
+			},
+			expectIgnored: []string{"clusterPeerTimeout (zero value not supported)"},
+		},
+		{
+			name: "multiple zero durations",
+			spec: monitoringv1.AlertmanagerSpec{
+				Replicas:                &replicas,
+				Retention:               "0",
+				ClusterPushpullInterval: "0s",
+			},
+			expectIgnored: []string{
+				"retention (zero value not supported)",
+				"clusterPushpullInterval (zero value not supported)",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			am := &monitoringv1.Alertmanager{Spec: test.spec}
+
+			ignored := discardZeroDurations(am)
+			require.Equal(t, test.expectIgnored, ignored)
+
+			for _, ignoredField := range test.expectIgnored {
+				switch {
+				case strings.HasPrefix(ignoredField, "retention "):
+					require.Empty(t, am.Spec.Retention)
+				case strings.HasPrefix(ignoredField, "clusterGossipInterval "):
+					require.Empty(t, am.Spec.ClusterGossipInterval)
+				case strings.HasPrefix(ignoredField, "clusterPushpullInterval "):
+					require.Empty(t, am.Spec.ClusterPushpullInterval)
+				case strings.HasPrefix(ignoredField, "clusterPeerTimeout "):
+					require.Empty(t, am.Spec.ClusterPeerTimeout)
+				default:
+					t.Fatalf("unexpected ignored field %q", ignoredField)
+				}
+			}
+		})
+	}
+}
+
+func TestIgnoredFieldsMessage(t *testing.T) {
+	require.Equal(
+		t,
+		"The following fields were ignored: retention (zero value not supported), clusterGossipInterval (zero value not supported)",
+		ignoredFieldsMessage([]string{
+			"retention (zero value not supported)",
+			"clusterGossipInterval (zero value not supported)",
+		}),
+	)
+}
+
 func TestAdditionalConfigMap(t *testing.T) {
 	sset, err := makeStatefulSet(nil, &monitoringv1.Alertmanager{
 		Spec: monitoringv1.AlertmanagerSpec{

--- a/pkg/operator/defaults.go
+++ b/pkg/operator/defaults.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// DefaultAlertmanagerVersion is a default image tag for the prometheus alertmanager.
-	DefaultAlertmanagerVersion = "v0.33.1"
+	DefaultAlertmanagerVersion = "v0.34.0"
 	// DefaultAlertmanagerBaseImage is a base container registry address for the prometheus alertmanager.
 	DefaultAlertmanagerBaseImage = "quay.io/prometheus/alertmanager"
 	// DefaultAlertmanagerImage is a default image pulling address for the prometheus alertmanager.

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -31,6 +31,10 @@ const (
 	// DeprecatedFieldsInUseReason is used in status conditions to indicate that
 	// the resource uses deprecated fields.
 	DeprecatedFieldsInUseReason = "DeprecatedFieldsInUse"
+
+	// IgnoredFieldsReason is used in status conditions to indicate that one or
+	// more spec fields were ignored because their values aren't supported.
+	IgnoredFieldsReason = "IgnoredFields"
 )
 
 // StatusGetter represents a workload resource implementing the interface

--- a/test/e2e/alertmanager_test.go
+++ b/test/e2e/alertmanager_test.go
@@ -2661,13 +2661,6 @@ func testAlertmanagerCRDValidation(t *testing.T) {
 		// Retention Validation:
 		//
 		{
-			name: "zero-time-without-unit",
-			alertmanagerSpec: monitoringv1.AlertmanagerSpec{
-				Replicas:  &replicas,
-				Retention: "0",
-			},
-		},
-		{
 			name: "time-in-hours",
 			alertmanagerSpec: monitoringv1.AlertmanagerSpec{
 				Replicas:  &replicas,
@@ -3042,4 +3035,84 @@ func testAMScaleUpWithoutLabels(t *testing.T) {
 	sts, err := stsClient.Get(ctx, stsName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.NotEmpty(t, sts.GetLabels(), "expected labels to be restored on the StatefulSet by the operator")
+}
+
+func testAlertmanagerZeroDuration(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*monitoringv1.Alertmanager)
+	}{
+		{
+			name: "retention",
+			apply: func(am *monitoringv1.Alertmanager) {
+				am.Spec.Retention = "0"
+			},
+		},
+		{
+			name: "clusterGossipInterval",
+			apply: func(am *monitoringv1.Alertmanager) {
+				am.Spec.ClusterGossipInterval = "0s"
+			},
+		},
+		{
+			name: "clusterPushpullInterval",
+			apply: func(am *monitoringv1.Alertmanager) {
+				am.Spec.ClusterPushpullInterval = "0m"
+			},
+		},
+		{
+			name: "clusterPeerTimeout",
+			apply: func(am *monitoringv1.Alertmanager) {
+				am.Spec.ClusterPeerTimeout = "0"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Don't run Alertmanager tests in parallel. See
+			// https://github.com/prometheus/alertmanager/issues/1835 for details.
+			ctx := context.Background()
+			testCtx := framework.NewTestCtx(t)
+			defer testCtx.Cleanup(t)
+			ns := framework.CreateNamespace(ctx, t, testCtx)
+			framework.SetupPrometheusRBAC(ctx, t, testCtx, ns)
+
+			name := "test"
+			am := framework.MakeBasicAlertmanager(ns, name, 1)
+			tc.apply(am)
+
+			am, err := framework.CreateAlertmanagerAndWaitUntilReady(ctx, am)
+			require.NoError(t, err)
+
+			var reconciled *monitoringv1.Condition
+			for i := range am.Status.Conditions {
+				if am.Status.Conditions[i].Type == monitoringv1.Reconciled {
+					reconciled = &am.Status.Conditions[i]
+					break
+				}
+			}
+
+			require.NotNil(t, reconciled, "expected Reconciled condition in status subresource")
+			require.Equal(t, monitoringv1.ConditionTrue, reconciled.Status)
+			require.Equal(t, operator.IgnoredFieldsReason, reconciled.Reason)
+			require.Contains(t, reconciled.Message, tc.name+" (zero value not supported)")
+
+			sts, err := framework.KubeClient.AppsV1().StatefulSets(ns).Get(ctx, fmt.Sprintf("alertmanager-%s", name), metav1.GetOptions{})
+			require.NoError(t, err)
+
+			switch tc.name {
+			case "retention":
+				require.NotContains(t, sts.Spec.Template.Spec.Containers[0].Args, "--data.retention=0")
+			case "clusterGossipInterval":
+				require.NotContains(t, sts.Spec.Template.Spec.Containers[0].Args, "--cluster.gossip-interval=0s")
+			case "clusterPushpullInterval":
+				require.NotContains(t, sts.Spec.Template.Spec.Containers[0].Args, "--cluster.pushpull-interval=0m")
+			case "clusterPeerTimeout":
+				require.NotContains(t, sts.Spec.Template.Spec.Containers[0].Args, "--cluster.peer-timeout=0")
+			}
+
+			require.NoError(t, framework.DeleteAlertmanagerAndWaitUntilGone(ctx, ns, name))
+		})
+	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -253,6 +253,7 @@ func testAllNSAlertmanager(t *testing.T) {
 		"AMStatusScale":                           testAlertmanagerStatusScale,
 		"AMServiceName":                           testAlertManagerServiceName,
 		"AMScaleUpWithoutLabels":                  testAMScaleUpWithoutLabels,
+		"AMZeroDuration":                          testAlertmanagerZeroDuration,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request._

<!-- If it fixes an existing issue (bug or feature), use the following keyword -->

Alertmanager v0.34.0 rejects non-positive durations at startup ([options.go](https://github.com/prometheus/alertmanager/blob/main/app/options.go#L170-L182)). Rather than failing reconciliation or changing the CRD API, the operator silently drops zero values and surfaces them via status a less disruptive approach than rejecting the spec outright.

If you're contributing for the first-time, check our [contribution guidelines](../CONTRIBUTING.md).

## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update default Alertmanager version to v0.34.0 and discard zero duration fields with IgnoredFields status reporting.
```
